### PR TITLE
Jh builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ input/
 
 .pytest_cache/
 .mypy_cache/
+.claude/CLAUDE.md

--- a/builder/readers/existing_crate.py
+++ b/builder/readers/existing_crate.py
@@ -6,7 +6,7 @@ import json
 import logging
 from pathlib import Path
 
-from builder.state import CrateState, Entity, EntityProvenance
+from builder.state import CrateState, Entity, EntityProvenance, EntityType
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,37 @@ _VALID_TYPES = frozenset({
     "Sample", "MolecularEntity", "CellLineSample", "Person",
     "Organization", "Publication", "DefinedTerm", "PropertyValue", "File",
 })
+_DATASET_SUBTYPES = frozenset({"Investigation", "Study", "Assay"})
+
+
+def _crate_type(node: dict) -> EntityType | None:
+    """Map a graph node's @type/additionalType to a CrateState entity type.
+
+    A valid ISA-Tox crate types Investigation/Study/Assay as ``Dataset`` +
+    ``additionalType`` and the cell-based test system as ``Sample`` +
+    ``additionalType "CellLine"``; LabProcess subtypes keep ``@type LabProcess``
+    with the subtype carried in ``additionalType``. Returns None for nodes that
+    are not reconstructable CrateState entities (e.g. Profile descriptors).
+    """
+    t = node.get("@type")
+    primary = t[0] if isinstance(t, list) else t
+    add = node.get("additionalType")
+    if isinstance(add, list):
+        add = add[0] if add else None
+
+    if primary == "Dataset":
+        return add if add in _DATASET_SUBTYPES else None
+    if primary == "LabProcess":
+        return "LabProcess"
+    if primary == "Sample":
+        return "CellLineSample" if add == "CellLine" else "Sample"
+    if primary == "ScholarlyArticle":
+        return "Publication"
+    if primary == "MediaObject":
+        return "File"
+    if primary in _VALID_TYPES:
+        return primary
+    return None
 
 
 def read_existing_crate(crate_dir: str) -> CrateState:
@@ -50,27 +81,28 @@ def read_existing_crate(crate_dir: str) -> CrateState:
         graph = data.get("@graph", [])
         for node in graph:
             node_id = node.get("@id", "")
-            node_type = node.get("@type", "")
 
-            if node_id == "./" or node_type == "Dataset":
-                state.metadata.title = node.get("name", state.metadata.title)
-                state.metadata.description = node.get("description", state.metadata.description)
-                state.metadata.accession = node.get("identifier", state.metadata.accession)
+            # Only the Root Data Entity (@id "./") describes the crate as a whole;
+            # the metadata descriptor is skipped. Study/Assay are real entities.
+            if node_id == "./":
+                md = state.metadata
+                md.title = node.get("name", md.title)
+                md.description = node.get("description", md.description)
+                md.accession = node.get("identifier", md.accession)
+                continue
+            if node_id == "ro-crate-metadata.json":
                 continue
 
-            if not node_type:
+            ctype = _crate_type(node)
+            if ctype is None:
                 continue
 
-            primary_type = node_type[0] if isinstance(node_type, list) else node_type
-            if primary_type in ("CreativeWork", None):
-                continue
-            if primary_type not in _VALID_TYPES:
-                continue
-
+            # Recover the local entity_id by stripping a single leading '#'.
+            entity_id = node_id[1:] if node_id.startswith("#") else node_id
             fields = {k: v for k, v in node.items() if not k.startswith("@")}
             entity = Entity(
-                entity_id=node_id,
-                type=primary_type,
+                entity_id=entity_id,
+                type=ctype,
                 fields=fields,
                 _provenance=EntityProvenance(created_by="scanner"),
             )

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -18,6 +18,7 @@ local fragment; Files use a relative URI path.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any
 
 from rocrate.model import ContextEntity, DataEntity, File, Person
@@ -34,7 +35,9 @@ from profiles.models.tox import (
 )
 
 ROCRATE_SPEC = "https://w3id.org/ro/crate/1.1"
-PROFILE_ISA = "https://w3id.org/ro/crate/isa/1.0"
+# The ISA layer the tox profile actually extends (profiles/shapes/tox/profile.ttl
+# prof:isProfileOf) and that resolves — the w3id ISA permalink is not yet live.
+PROFILE_ISA = "https://github.com/nfdi4plants/isa-ro-crate-profile"
 PROFILE_ISATOX = "https://w3id.org/ro/crate/isa-tox/1.0"
 CELL_LINE_TERM_ID = "http://purl.obolibrary.org/obo/NCIT_C16403"
 
@@ -70,16 +73,19 @@ _STRUCT_FIELDS = frozenset({
     "process_type", "orcid", "ror", "pubchem_cid", "doi", "dest_path", "path",
     "contentUrl",
 })
-_DATASET_SUBTYPES = frozenset({"Investigation", "Study", "Assay"})
 
 
-def populate_crate(state: CrateState, crate: ROCrate) -> None:
-    """Populate `crate` from `state` using the ISA-Tox domain model."""
+def populate_crate(state: CrateState, crate: ROCrate, output_dir: Path) -> None:
+    """Populate `crate` from `state` using the ISA-Tox domain model.
+
+    output_dir is the crate root being written; the Exposure condition table is
+    materialised there as a (placeholder) CSV so it is a valid in-payload File.
+    """
     idx: dict[str, Any] = {}
     _populate_root_and_conformance(state, crate)
     _add_leaves(state, crate, idx)
     _add_structural(state, crate, idx)
-    _add_processes(state, crate, idx)
+    _add_processes(state, crate, idx, output_dir)
     _wire_mentions(state, idx)
 
 
@@ -305,7 +311,38 @@ def _synth_sample(
     return Sample(crate, identifier=ident, name=name, properties=props or None)
 
 
-def _add_processes(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+_CONDITION_TABLE_HEADER = "cell_line,compound,concentration,unit,duration\n"
+
+
+def _synth_condition_table(
+    crate: ROCrate, output_dir: Path, exp_pid: str,
+    cells: list[Any], chems: list[Any]) -> File:
+    """The Exposure's result: the CSVW condition table (the per-well design table).
+
+    Modelled as a ``File`` (the CSV) that is also a ``csvw:Table`` — a bare
+    csvw:Table is rejected by the base ISA shape, which requires a process result
+    to be a File/Sample/BioSample. A header-only placeholder CSV is materialised
+    so the File is valid in-payload; per-row CSVW population (tableSchema columns
+    with valueUrl, CSV intake) is planned — see the wizard's
+    intake/condition_table.py. The table links (schema:about) the cell line(s) and
+    compound(s) it concerns, so the compound is connected to the Exposure THROUGH
+    its result (a MolecularEntity cannot be a process object under the ISA shape).
+    """
+    rel = f"data/{_slug(exp_pid)}_condition_table.csv"
+    dest = output_dir / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not dest.exists():
+        dest.write_text(_CONDITION_TABLE_HEADER, encoding="utf-8")
+    table = crate.add(File(
+        crate, None, dest_path=rel,
+        properties={"@type": ["File", "csvw:Table"], "name": "Condition table"}))
+    for ent in list(cells) + list(chems):
+        table.append_to("about", ent)
+    return table
+
+
+def _add_processes(
+    state: CrateState, crate: ROCrate, idx: dict[str, Any], output_dir: Path) -> None:
     proto_cache: dict[str, Any] = {}
     for proc in state.list_entities("LabProcess"):
         f = proc.fields
@@ -314,7 +351,7 @@ def _add_processes(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> No
         name = f.get("name") or ptype or "Process"
         protocol = (_resolve_one(idx, f.get("labprotocol"))
                     or _synth_protocol(crate, f.get("assay_id"), proto_cache))
-        node = _build_process(crate, ptype, pid, name, f, protocol, idx)
+        node = _build_process(crate, ptype, pid, name, f, protocol, idx, output_dir)
         idx[proc.entity_id] = node
         assay = _resolve_one(idx, f.get("assay_id"))
         if assay is not None:
@@ -323,7 +360,7 @@ def _add_processes(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> No
 
 def _build_process(
     crate: ROCrate, ptype: str, pid: str, name: str,
-    f: dict[str, Any], protocol: Any, idx: dict[str, Any],
+    f: dict[str, Any], protocol: Any, idx: dict[str, Any], output_dir: Path,
 ) -> Any:
     samples = _resolve_many(idx, f.get("samples"))
     obj = _resolve_many(idx, f.get("object"))
@@ -349,22 +386,23 @@ def _build_process(
             result=out, labprotocol=protocol)
 
     if ptype == "Exposure":
-        # ISA forbids a MolecularEntity as a process object (objects MUST be
-        # File/Sample/BioSample — verified by the bundled isa-ro-crate shape), so
-        # the exposed compound is NOT placed in `object`. It is carried at the
-        # Study level (mentions/chemicals) and, in full crates, per-well by the
-        # Exposure's CSVW condition table — matching the paper and the wizard.
+        # The Exposure takes the cultured cell Sample(s) as object and emits the
+        # CSVW condition table as its result. ISA forbids a MolecularEntity as a
+        # process object (objects MUST be File/Sample/BioSample — bundled
+        # isa-ro-crate shape), so the compound is NOT in `object`; it is connected
+        # THROUGH the condition table (table --about--> MolecularEntity) and, at a
+        # glance, on the Study via schema:mentions. Per-well CSVW population
+        # (tableSchema columns + CSV intake) is planned — see the wizard's
+        # intake/condition_table.py.
         cells = samples or obj
-        out = result or [_synth_sample(
-            crate, pid + "_exposed", f"{name} (exposed)",
-            cells[0] if cells else None)]
+        chems = _resolve_many(idx, f.get("chemicals"))
+        out = result or [_synth_condition_table(crate, output_dir, pid, cells, chems)]
         return LabProcessExposure(
             crate, identifier=pid, name=name,
             duration=f.get("duration", "unknown"),
             cell_seeding_density=f.get("cell_seeding_density", "NA"),
             microplate=f.get("microplate", "unknown"),
-            samples=cells, labprotocol=protocol,
-            properties={"output": out})
+            samples=cells, labprotocol=protocol, result=out)
 
     if ptype == "EndpointReadout":
         return LabProcessEndpointReadout(

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1,0 +1,432 @@
+"""Map a CrateState onto an ro-crate-py ROCrate using the ISA-Tox domain model.
+
+This is the heart of crate assembly: each CrateState entity becomes a typed
+graph node built from the `profiles/models` classes (the same classes the
+ISA-Tox SHACL shapes target), with cross-entity references resolved and the
+Investigation → Study → Assay → LabProcess derivation graph wired together.
+
+Build order is dependency-first (leaves → structural datasets → processes) so a
+process can resolve the Samples, Files and LabProtocol it references. Missing
+structured data is defaulted or synthesized rather than fabricated, matching the
+profile's "guidance over strictness" stance.
+
+Identifiers follow RO-Crate best practice (ro-crate-1.2.0.md §Recommended
+Identifiers): a resolvable URI when a field provides one, else a `#`-prefixed
+local fragment; Files use a relative URI path.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from rocrate.model import ContextEntity, DataEntity, File, Person
+from rocrate.rocrate import ROCrate
+
+from builder.state import CrateState, Entity
+from profiles.models.isa import LabProcess, Sample
+from profiles.models.tox import (
+    CellLineSample,
+    LabProcessCellCulture,
+    LabProcessDataAnalysis,
+    LabProcessEndpointReadout,
+    LabProcessExposure,
+)
+
+ROCRATE_SPEC = "https://w3id.org/ro/crate/1.1"
+PROFILE_ISA = "https://w3id.org/ro/crate/isa/1.0"
+PROFILE_ISATOX = "https://w3id.org/ro/crate/isa-tox/1.0"
+CELL_LINE_TERM_ID = "http://purl.obolibrary.org/obo/NCIT_C16403"
+
+# Fields that hold references to other entities (resolved via the index), not literals.
+_REF_FIELDS = frozenset({
+    "samples", "labprotocol", "cell_line", "object", "result", "input", "output",
+    "investigation_id", "study_id", "assay_id", "author", "mentions", "chemicals",
+    "cell_lines", "biological_models", "biologicalModels", "has_part", "hasPart",
+    "about", "aop", "organism", "anatomy", "key_event", "keyEvent", "key_events",
+    "derives_from", "derivesFrom",
+})
+
+# Study/Assay annotation fields that expand to schema:mentions via the @context
+# (paper §Methods: Study ← linked AOP; Assay endpoint ← corresponding Key Event).
+_STUDY_MENTION_FIELDS = {
+    "aop": "aop",
+    "organism": "organism",
+    "anatomy": "anatomy",
+    "chemicals": "chemicals",
+    "biological_models": "biologicalModels",
+    "biologicalModels": "biologicalModels",
+    "cell_lines": "biologicalModels",
+    "mentions": "mentions",
+}
+_ASSAY_MENTION_FIELDS = {
+    "key_event": "keyEvent",
+    "keyEvent": "keyEvent",
+    "key_events": "keyEvent",
+    "mentions": "mentions",
+}
+# Discriminator / id-source fields consumed structurally, never emitted as literals.
+_STRUCT_FIELDS = frozenset({
+    "process_type", "orcid", "ror", "pubchem_cid", "doi", "dest_path", "path",
+    "contentUrl",
+})
+_DATASET_SUBTYPES = frozenset({"Investigation", "Study", "Assay"})
+
+
+def populate_crate(state: CrateState, crate: ROCrate) -> None:
+    """Populate `crate` from `state` using the ISA-Tox domain model."""
+    idx: dict[str, Any] = {}
+    _populate_root_and_conformance(state, crate)
+    _add_leaves(state, crate, idx)
+    _add_structural(state, crate, idx)
+    _add_processes(state, crate, idx)
+    _wire_mentions(state, idx)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^\w.-]", "_", str(text)).strip("_") or "x"
+
+
+def _scalar_props(entity: Entity, skip: tuple[str, ...] = ()) -> dict[str, Any]:
+    """Plain-value properties of an entity (references/discriminators removed)."""
+    drop = _REF_FIELDS | _STRUCT_FIELDS | set(skip)
+    return {
+        k: v for k, v in entity.fields.items()
+        if k not in drop and not k.startswith("@")
+    }
+
+
+def _mint_id(entity: Entity) -> str:
+    """A spec-correct @id: resolvable URI when available, else `#`-fragment."""
+    t, f, eid = entity.type, entity.fields, entity.entity_id
+    if t == "Person" and f.get("orcid"):
+        o = str(f["orcid"]).strip()
+        return o if o.startswith("http") else f"https://orcid.org/{o}"
+    if t == "Organization" and f.get("ror"):
+        r = str(f["ror"]).strip()
+        return r if r.startswith("http") else f"https://ror.org/{r.lstrip('/')}"
+    if t == "MolecularEntity" and f.get("pubchem_cid"):
+        return f"https://pubchem.ncbi.nlm.nih.gov/compound/{f['pubchem_cid']}"
+    if t == "Publication":
+        ident = str(f.get("identifier", ""))
+        doi = f.get("doi") or (ident if ident.startswith("10.") else None)
+        if doi:
+            d = str(doi).strip()
+            return d if d.startswith("http") else f"https://doi.org/{d}"
+    if eid.startswith(("#", "http://", "https://", "./")) or "://" in eid:
+        return eid
+    return "#" + eid
+
+
+def _file_dest(fe: Entity) -> str:
+    """A relative URI path for a File data entity."""
+    f = fe.fields
+    path = f.get("dest_path") or f.get("path") or f.get("contentUrl")
+    return str(path) if path else f"data/{_slug(f.get('name') or fe.entity_id)}"
+
+
+def _resolve_many(idx: dict[str, Any], value: Any) -> list[Any]:
+    """Resolve an entity reference (id, {@id}, or list thereof) to crate entities."""
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    out: list[Any] = []
+    for v in items:
+        key = v.get("@id") if isinstance(v, dict) else v
+        if key is None:
+            continue
+        ent = idx.get(key) or idx.get(str(key).lstrip("#"))
+        if ent is not None:
+            out.append(ent)
+    return out
+
+
+def _resolve_one(idx: dict[str, Any], value: Any) -> Any:
+    found = _resolve_many(idx, value)
+    return found[0] if found else None
+
+
+# ---------------------------------------------------------------------------
+# Root, conformance & contextual/leaf entities
+# ---------------------------------------------------------------------------
+
+
+def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
+    m = state.metadata
+    # Base RO-Crate MUST: the Root Data Entity has a name and a description.
+    crate.root_dataset["name"] = m.title or "Untitled Investigation"
+    crate.root_dataset["description"] = (
+        m.description or m.title or "RO-Crate generated by vitro-crate."
+    )
+    if m.accession:
+        crate.root_dataset["identifier"] = m.accession
+    crate.root_dataset["additionalType"] = "Investigation"
+    # Base RO-Crate MUST: the Root Data Entity has a license. The ISA-Tox shape
+    # endorses this exact placeholder when none is available.
+    if not crate.root_dataset.get("license"):
+        crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+
+    # conformsTo lives on the metadata descriptor (RO-Crate 1.1 placement,
+    # isa_tox.md §Conformance) and asserts only layers the crate satisfies.
+    conforms: list[dict[str, str]] = [{"@id": ROCRATE_SPEC}]
+    if state.validation.isa_passed:
+        conforms.append({"@id": PROFILE_ISA})
+        crate.add(ContextEntity(crate, PROFILE_ISA, properties={
+            "@type": ["CreativeWork", "Profile"], "name": "ISA RO-Crate Profile"}))
+    if state.validation.tox_passed:
+        conforms.append({"@id": PROFILE_ISATOX})
+        crate.add(ContextEntity(crate, PROFILE_ISATOX, properties={
+            "@type": ["CreativeWork", "Profile"],
+            "name": "ISA-Tox RO-Crate Profile", "version": "0.1.0-draft.1"}))
+    crate.metadata["conformsTo"] = conforms
+
+
+def _cell_line_term(crate: ROCrate) -> ContextEntity:
+    """The shared, resolvable 'cell line' DefinedTerm for CellLineSample.sampleType."""
+    return crate.add(ContextEntity(crate, CELL_LINE_TERM_ID, properties={
+        "@type": "DefinedTerm",
+        "name": "cell line",
+        "termCode": ["NCIT:C16403", "IUCLID:108174"],
+        "inDefinedTermSet": {"@id": "http://purl.obolibrary.org/obo/ncit.owl"},
+    }))
+
+
+def _add_leaves(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+    for org in state.list_entities("Organization"):
+        idx[org.entity_id] = crate.add(ContextEntity(
+            crate, _mint_id(org),
+            properties={"@type": "Organization", **_scalar_props(org)}))
+
+    for person in state.list_entities("Person"):
+        node = crate.add(
+            Person(crate, _mint_id(person), properties=_scalar_props(person)))
+        idx[person.entity_id] = node
+        crate.root_dataset.append_to("author", node)
+
+    for chem in state.list_entities("MolecularEntity"):
+        idx[chem.entity_id] = crate.add(ContextEntity(
+            crate, _mint_id(chem),
+            properties={"@type": "MolecularEntity", **_scalar_props(chem)}))
+
+    for dt in state.list_entities("DefinedTerm"):
+        idx[dt.entity_id] = crate.add(ContextEntity(
+            crate, _mint_id(dt),
+            properties={"@type": "DefinedTerm", **_scalar_props(dt)}))
+
+    for pv in state.list_entities("PropertyValue"):
+        idx[pv.entity_id] = crate.add(ContextEntity(
+            crate, _mint_id(pv),
+            properties={"@type": "PropertyValue", **_scalar_props(pv)}))
+
+    for pub in state.list_entities("Publication"):
+        node = crate.add(ContextEntity(
+            crate, _mint_id(pub),
+            properties={"@type": "ScholarlyArticle", **_scalar_props(pub)}))
+        idx[pub.entity_id] = node
+        crate.root_dataset.append_to("citation", node)
+
+    for fe in state.list_entities("File"):
+        idx[fe.entity_id] = crate.add(File(
+            crate, None, dest_path=_file_dest(fe),
+            properties={"@type": "File", **_scalar_props(fe)}))
+
+    for proto in state.list_entities("LabProtocol"):
+        idx[proto.entity_id] = crate.add(ContextEntity(
+            crate, _mint_id(proto),
+            properties={"@type": "LabProtocol", **_scalar_props(proto)}))
+
+    # Samples / CellLineSamples auto-add themselves (AutoAddContextEntity).
+    cell_term: list[Any] = [None]
+    for s in state.list_entities("Sample"):
+        idx[s.entity_id] = Sample(
+            crate, identifier=_mint_id(s), name=str(s.fields.get("name", "")),
+            properties=_scalar_props(s, skip=("name",)) or None)
+
+    for cl in state.list_entities("CellLineSample"):
+        if cell_term[0] is None:
+            cell_term[0] = _cell_line_term(crate)
+        idx[cl.entity_id] = CellLineSample(
+            crate, identifier=_mint_id(cl), name=str(cl.fields.get("name", "")),
+            sample_type=cell_term[0], accession=cl.fields.get("accession"),
+            properties=_scalar_props(cl, skip=("name", "accession")) or None)
+
+
+# ---------------------------------------------------------------------------
+# Structural datasets & processes
+# ---------------------------------------------------------------------------
+
+
+def _add_structural(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+    for inv in state.list_entities("Investigation"):
+        props = {"@type": "Dataset", "additionalType": "Investigation",
+                 **_scalar_props(inv)}
+        props.setdefault("identifier", inv.entity_id)  # ISA MUST: non-empty identifier
+        node = crate.add(DataEntity(crate, _mint_id(inv), properties=props))
+        idx[inv.entity_id] = node
+        crate.root_dataset.append_to("hasPart", node)
+
+    for st in state.list_entities("Study"):
+        props = {"@type": "Dataset", "additionalType": "Study", **_scalar_props(st)}
+        props.setdefault("identifier", st.entity_id)
+        node = crate.add(DataEntity(crate, _mint_id(st), properties=props))
+        idx[st.entity_id] = node
+        crate.root_dataset.append_to("hasPart", node)
+
+    for asy in state.list_entities("Assay"):
+        props = {"@type": "Dataset", "additionalType": "Assay", **_scalar_props(asy)}
+        props.setdefault("identifier", asy.entity_id)
+        node = crate.add(DataEntity(crate, _mint_id(asy), properties=props))
+        idx[asy.entity_id] = node
+        parent = _resolve_one(idx, asy.fields.get("study_id")) or crate.root_dataset
+        parent.append_to("hasPart", node)
+
+
+def _synth_protocol(
+    crate: ROCrate, assay_id: Any, cache: dict[str, Any]) -> ContextEntity:
+    key = str(assay_id) if assay_id else "_default"
+    if key not in cache:
+        cache[key] = crate.add(ContextEntity(
+            crate, f"#protocol_{_slug(key)}",
+            properties={"@type": "LabProtocol", "name": f"Protocol for {key}"}))
+    return cache[key]
+
+
+def _synth_sample(
+    crate: ROCrate, sid: str, name: str, derives_from: Any = None) -> Sample:
+    props: dict[str, Any] = {}
+    if derives_from is not None:
+        props["derivesFrom"] = derives_from
+    ident = sid if sid.startswith("#") else "#" + _slug(sid)
+    return Sample(crate, identifier=ident, name=name, properties=props or None)
+
+
+def _add_processes(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+    proto_cache: dict[str, Any] = {}
+    for proc in state.list_entities("LabProcess"):
+        f = proc.fields
+        ptype = f.get("process_type") or f.get("additionalType") or ""
+        pid = _mint_id(proc)
+        name = f.get("name") or ptype or "Process"
+        protocol = (_resolve_one(idx, f.get("labprotocol"))
+                    or _synth_protocol(crate, f.get("assay_id"), proto_cache))
+        node = _build_process(crate, ptype, pid, name, f, protocol, idx)
+        idx[proc.entity_id] = node
+        assay = _resolve_one(idx, f.get("assay_id"))
+        if assay is not None:
+            assay.append_to("about", node)
+
+
+def _build_process(
+    crate: ROCrate, ptype: str, pid: str, name: str,
+    f: dict[str, Any], protocol: Any, idx: dict[str, Any],
+) -> Any:
+    samples = _resolve_many(idx, f.get("samples"))
+    obj = _resolve_many(idx, f.get("object"))
+    result = _resolve_many(idx, f.get("result"))
+
+    if ptype == "CellCulture":
+        # CellCulture MUST take a cell-line Sample as object; synthesize a
+        # placeholder input Sample if none was referenced/resolved.
+        cell_line = (
+            _resolve_one(idx, f.get("cell_line"))
+            or (samples[0] if samples else None)
+            or (obj[0] if obj else None)
+            or _synth_sample(crate, pid + "_input", f"Input ({name})")
+        )
+        if result:
+            out = result[0]
+        else:
+            label = f"Cultured ({name})"
+            out = _synth_sample(crate, pid + "_cultured", label, cell_line)
+        return LabProcessCellCulture(
+            crate, identifier=pid, name=name, cell_line=cell_line,
+            culture_medium=f.get("culture_medium", "Standard medium"),
+            result=out, labprotocol=protocol)
+
+    if ptype == "Exposure":
+        # ISA forbids a MolecularEntity as a process object (objects MUST be
+        # File/Sample/BioSample — verified by the bundled isa-ro-crate shape), so
+        # the exposed compound is NOT placed in `object`. It is carried at the
+        # Study level (mentions/chemicals) and, in full crates, per-well by the
+        # Exposure's CSVW condition table — matching the paper and the wizard.
+        cells = samples or obj
+        out = result or [_synth_sample(
+            crate, pid + "_exposed", f"{name} (exposed)",
+            cells[0] if cells else None)]
+        return LabProcessExposure(
+            crate, identifier=pid, name=name,
+            duration=f.get("duration", "unknown"),
+            cell_seeding_density=f.get("cell_seeding_density", "NA"),
+            microplate=f.get("microplate", "unknown"),
+            samples=cells, labprotocol=protocol,
+            properties={"output": out})
+
+    if ptype == "EndpointReadout":
+        return LabProcessEndpointReadout(
+            crate, identifier=pid, name=name,
+            samples=(samples or obj or None), labprotocol=protocol,
+            result=result,
+            detection_instrument=f.get("detection_instrument", "unknown"),
+            instrument_manufacturer=f.get("instrument_manufacturer", "unknown"),
+            measured_entity=f.get("measured_entity", "unknown"),
+            technical_replicate=f.get("technical_replicate", "1"),
+            endpoint=f.get("endpoint", "unknown"))
+
+    if ptype == "DataAnalysis":
+        return LabProcessDataAnalysis(
+            crate, identifier=pid, name=name,
+            object=(obj or samples), result=result, labprotocol=protocol,
+            data_processing=f.get("data_processing", ""),
+            software=f.get("software", ""))
+
+    # Generic LabProcess (no domain discriminator).
+    return LabProcess(
+        crate, identifier=pid, name=name, labprotocol=protocol,
+        object=(obj or samples or None) or None,
+        result=(result or None) or None)
+
+
+# ---------------------------------------------------------------------------
+# Ontology annotations (AOP / Key Event / organism / …) via schema:mentions
+# ---------------------------------------------------------------------------
+
+
+def _wire_mention(node: Any, prop: str, value: Any, idx: dict[str, Any]) -> None:
+    """Append AOP/KeyEvent/organism annotations under an alias of schema:mentions.
+
+    Each value may be a reference to an in-crate entity (resolved via the index),
+    an inline ``{"@id": …}`` object, or a bare resolvable IRI (e.g. an AOP-Wiki id).
+    """
+    for item in (value if isinstance(value, list) else [value]):
+        if item is None:
+            continue
+        ent = _resolve_one(idx, item)
+        if ent is not None:
+            node.append_to(prop, ent)
+        elif isinstance(item, dict) and item.get("@id"):
+            node.append_to(prop, item)
+        elif isinstance(item, str) and ("://" in item or item.startswith("#")):
+            node.append_to(prop, {"@id": item})
+
+
+def _wire_mentions(state: CrateState, idx: dict[str, Any]) -> None:
+    for st in state.list_entities("Study"):
+        node = idx.get(st.entity_id)
+        if node is None:
+            continue
+        for field, prop in _STUDY_MENTION_FIELDS.items():
+            if field in st.fields:
+                _wire_mention(node, prop, st.fields[field], idx)
+
+    for asy in state.list_entities("Assay"):
+        node = idx.get(asy.entity_id)
+        if node is None:
+            continue
+        for field, prop in _ASSAY_MENTION_FIELDS.items():
+            if field in asy.fields:
+                _wire_mention(node, prop, asy.fields[field], idx)

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -1,34 +1,33 @@
-"""Tool that assembles a ROCrate directory from CrateState entity data.
+"""Tool that assembles an RO-Crate directory from CrateState entity data.
 
-For now, this is a scaffold that creates the output directory structure and
-writes a minimal ro-crate-metadata.json from state data. Full ROCrate assembly
-via rocrate-py comes later.
+The crate is assembled with `ro-crate-py` (the official RO-Crate SDK): a
+`ROCrate` is created, the ISA-Tox JSON-LD context is attached, and the entity
+graph is built by `builder/tools/_crate_mapping.py` (which maps each CrateState
+entity onto its ISA-Tox domain-model class, resolves cross-entity references, and
+wires the Investigation → Study → Assay → LabProcess graph). `crate.write()` then
+serialises a valid `ro-crate-metadata.json`.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any
 
+from rocrate.rocrate import ROCrate
+
 from builder.state import CrateState
+from builder.tools._crate_mapping import populate_crate
+from profiles.context import ISA_TOX_CONTEXT
 
 logger = logging.getLogger(__name__)
 
-ISA_TOX_CONTEXT = [
-    {
-        "@vocab": "http://schema.org/",
-        "schema": "http://schema.org/",
-    }
-]
-
 
 def build_crate(state: CrateState, output_path: str) -> dict[str, Any]:
-    """Build (or scaffold) an RO-Crate from CrateState.
+    """Build an RO-Crate from CrateState using ro-crate-py.
 
-    Creates the output directory, writes a minimal ro-crate-metadata.json
-    from state data, and returns a result dict.
+    Creates the output directory, assembles a `ROCrate` from the state, and
+    writes `ro-crate-metadata.json` plus any payload.
 
     Args:
         state: The current CrateState to build from.
@@ -42,47 +41,21 @@ def build_crate(state: CrateState, output_path: str) -> dict[str, Any]:
     """
     try:
         if not output_path:
-            return {"success": False, "crate_path": output_path, "error": "Empty output path"}
+            return {
+                "success": False,
+                "crate_path": output_path,
+                "error": "Empty output path",
+            }
 
         output_dir = Path(output_path)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Build minimal ro-crate-metadata.json
-        root_id = "./"
+        crate = ROCrate()
+        crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+        populate_crate(state, crate)
+        crate.write(str(output_dir))
 
-        # Root dataset entry
-        root_dataset: dict[str, Any] = {
-            "@id": root_id,
-            "@type": "Dataset",
-        }
-
-        if state.metadata.title:
-            root_dataset["name"] = state.metadata.title
-        if state.metadata.description:
-            root_dataset["description"] = state.metadata.description
-        if state.metadata.accession:
-            root_dataset["identifier"] = state.metadata.accession
-
-        # Add entities from state as graph nodes
-        graph_entries: list[dict[str, Any]] = [root_dataset]
-        for entity in state.list_entities():
-            entry: dict[str, Any] = {
-                "@id": entity.entity_id,
-                "@type": entity.type,
-            }
-            entry.update(entity.fields)
-            graph_entries.append(entry)
-
-        metadata: dict[str, Any] = {
-            "@context": ISA_TOX_CONTEXT,
-            "@graph": graph_entries,
-        }
-
-        metadata_path = output_dir / "ro-crate-metadata.json"
-        with open(metadata_path, "w") as f:
-            json.dump(metadata, f, indent=2, default=str)
-
-        logger.info("Crate scaffold created at %s", output_path)
+        logger.info("Crate built at %s", output_path)
         return {"success": True, "crate_path": output_path, "error": None}
 
     except OSError as e:

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -52,7 +52,7 @@ def build_crate(state: CrateState, output_path: str) -> dict[str, Any]:
 
         crate = ROCrate()
         crate.metadata.extra_contexts = ISA_TOX_CONTEXT
-        populate_crate(state, crate)
+        populate_crate(state, crate, output_dir)
         crate.write(str(output_dir))
 
         logger.info("Crate built at %s", output_path)

--- a/profiles/docs/isa_tox.md
+++ b/profiles/docs/isa_tox.md
@@ -120,18 +120,20 @@ array, and each referenced profile is declared as a `Profile` contextual entity.
   "@type": "CreativeWork",
   "conformsTo": [
     {"@id": "https://w3id.org/ro/crate/1.1"},
-    {"@id": "https://w3id.org/ro/crate/isa/1.0"},
+    {"@id": "https://github.com/nfdi4plants/isa-ro-crate-profile"},
     {"@id": "https://w3id.org/ro/crate/isa-tox/1.0"}
   ],
   "about": {"@id": "./"}
 }
 ```
 
-The referenced profiles are declared as contextual entities:
+The ISA layer is declared with the IRI the profile actually extends (see
+`profiles/shapes/tox/profile.ttl`, `prof:isProfileOf`); a stable `w3id.org/ro/crate/isa/…`
+permalink is not yet registered. The referenced profiles are declared as contextual entities:
 
 ```json
 {
-  "@id": "https://w3id.org/ro/crate/isa/1.0",
+  "@id": "https://github.com/nfdi4plants/isa-ro-crate-profile",
   "@type": ["CreativeWork", "Profile"],
   "name": "ISA RO-Crate Profile"
 },
@@ -223,9 +225,15 @@ for this step:
 
 Is based on the Bioschemas DRAFT [bioschemas.org/LabProcess](https://bioschemas.org/LabProcess) type
 ([ISA LabProcess](isa.md#labprocess)), narrowed by `additionalType` to represent exposing the cell-based test system to
-the chemical(s). It captures the experimental design: it takes the cultured cell [Sample](isa.md#sample) and the
-[MolecularEntity](#molecularentity---chemical) compound(s) as input, and SHOULD emit a normalised condition table (CSVW)
-as its result in which each row records a single well (cell line, compound, concentration, exposure duration).
+the chemical(s). It captures the experimental design: it takes the cultured cell [Sample](isa.md#sample)
+as its `object`, and emits a normalised condition table (CSVW) as its `result` in which each row records a single
+well (cell line, compound, concentration, exposure duration).
+
+> **Where the compound goes.** The [MolecularEntity](#molecularentity---chemical) compound is **not** a process
+> `object`: the inherited ISA [LabProcess](isa.md#labprocess) shape restricts `schema:object` (and `schema:result`)
+> to `File`/`Sample`/`BioSample`, so a `MolecularEntity` there fails validation. The compound is instead connected
+> **through the condition table** — the table's compound column resolves (CSVW `valueUrl`) to the `MolecularEntity`
+> `@id`, and the compound is also listed at a glance on the [Study](#) via `schema:mentions`.
 
 | Property | Required | Expected Type | Description |
 |----------|----------|---------------|-------------|
@@ -233,9 +241,9 @@ as its result in which each row records a single well (cell line, compound, conc
 |@type|MUST|Text|MUST be '[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)'|
 |additionalType|MUST|Text|MUST be `"Exposure"`. Discriminator identifying this LabProcess as an exposure step.|
 |name|MUST|Text|The name of the process, e.g. "Exposure".|
-|object|MUST|[bioschemas.org/Sample](isa.md#sample), [MolecularEntity](#molecularentity---chemical) or [File](https://schema.org/MediaObject)|The input entities: the cell sample(s) being exposed and the compound(s) they are exposed to. At least one.|
+|object|MUST|[bioschemas.org/Sample](isa.md#sample) or [File](https://schema.org/MediaObject)|The input cell sample(s) being exposed. At least one. (A `MolecularEntity` is **not** allowed here — see note above.)|
 |parameterValue|MUST|[schema.org/PropertyValue](isa.md#propertyvalue) ([Parameter](isa.md#propertyvalue---parameter))|Exposure parameter(s); see expected values below. At least one.|
-|result|SHOULD|[bioschemas.org/Sample](isa.md#sample) or [File](https://schema.org/MediaObject)|The output (exposed) sample(s) and/or the condition table.|
+|result|MUST|[File](https://schema.org/MediaObject) (typed also as `csvw:Table`) or [bioschemas.org/Sample](isa.md#sample)|The CSVW condition table (a `File` that is also a `csvw:Table`) and/or the exposed sample(s). At least one.|
 |executesLabProtocol|SHOULD|[bioschemas.org/LabProtocol](isa.md#labprotocol)|The protocol this step executes.|
 
 **Expected `parameterValue` items.** Each is a Parameter [PropertyValue](isa.md#propertyvalue---parameter)

--- a/profiles/models/tox.py
+++ b/profiles/models/tox.py
@@ -26,6 +26,17 @@ def _pv(crate, name, value, property_id=None, unit=None):
 
 
 class LabProcessExposure(LabProcess):
+    """Exposure step (additionalType "Exposure").
+
+    object  = the cultured cell ``Sample``(s) being exposed.
+    result  = the CSVW condition table (a ``File`` that is also a ``csvw:Table``),
+              recording per well the cell line / compound / concentration /
+              duration. The exposed compound is NOT a process object — the base
+              ISA shape allows only File/Sample/BioSample, so the compound is
+              connected THROUGH the condition table (and shown at a glance on the
+              Study via schema:mentions), never via schema:object.
+    """
+
     def __init__(
         self,
         crate: ROCrate,
@@ -36,12 +47,17 @@ class LabProcessExposure(LabProcess):
         samples: list[Sample],
         labprotocol: LabProtocol,
         name: str = "Exposure",
+        result: list[Sample | File] | Sample | File | None = None,
         units: dict[str, str] | None = None,
         properties: dict | None = None,
         add: bool = True,
     ):
+        # ISA-Tox requires an Exposure to emit a schema:result (the CSVW condition
+        # table), so `result` is a first-class parameter here — symmetric with the
+        # other LabProcess subtypes — rather than only reachable through
+        # `properties`.
         u = units or {}
-        merged_properties = {
+        base_properties: dict = {
             "additionalType": "Exposure",
             "parameter": [
                 _pv(crate, "Exposure Duration", duration,
@@ -52,7 +68,10 @@ class LabProcessExposure(LabProcess):
                     "https://bioregistry.io/NCIT:C43377", u.get("Microplate")),
             ],
             "input": samples,
-        } | (properties or {})
+        }
+        if result is not None:
+            base_properties["output"] = result
+        merged_properties = base_properties | (properties or {})
         super().__init__(
             crate=crate,
             name = name,

--- a/profiles/models/tox.py
+++ b/profiles/models/tox.py
@@ -1,7 +1,7 @@
-from rocrate.model import ContextEntity
+from rocrate.model import ContextEntity, File
 from rocrate.rocrate import ROCrate
-from rocrate_wizard.core.models.isa import (  # ty: ignore[unresolved-import]
-    File,
+
+from profiles.models.isa import (
     LabProcess,
     LabProtocol,
     ParameterValue,

--- a/profiles/shapes/tox/profile.ttl
+++ b/profiles/shapes/tox/profile.ttl
@@ -11,7 +11,10 @@
 
 <https://w3id.org/ro/crate/isa-tox/1.0>
     a prof:Profile ;
-    rdfs:label "ISA-Tox RO-Crate Profile 1.0" ;
+    rdfs:label "ISA-Tox RO-Crate Profile" ;
+    # The /1.0 IRI path is the profile series; this is its precise (pre-release)
+    # version, kept in sync with isa_tox.md's Profile contextual entity.
+    dct:hasVersion "0.1.0-draft.1" ;
     rdfs:comment "Toxicology (in vitro New Approach Methodology) domain extension of the ISA RO-Crate Profile."@en ;
 
     # Extends the bundled ISA RO-Crate profile (token `isa-ro-crate`), which in

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -23,9 +23,10 @@ from pathlib import Path
 from rocrate_validator import models, services
 from rocrate_validator.services import DEFAULT_PROFILES_PATH
 
-# src/rocrate_wizard/core/validator.py -> repo root is four parents up.
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-SHAPES_DIR = REPO_ROOT / "profiles" / "shapes"
+# This file lives at <repo>/profiles/validator.py, so the repo root is two
+# parents up and the SHACL shapes are the sibling ``shapes`` directory.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHAPES_DIR = Path(__file__).resolve().parent / "shapes"
 
 
 def _patch_bundled_isa_ontology() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "ISA-Tox RO-Crate Builder — LLM-assisted creation of profile-con
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "rocrate>=0.9.0",
-    "roc-validator>=0.1.0",
+    "rocrate>=0.15.0",
+    "roc-validator>=0.10.0",
     "requests>=2.31.0",
     "pyyaml>=6.0",
     "openpyxl>=3.1.0",

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -76,7 +76,8 @@ class TestLabProcessSubtypes:
 
     def test_cell_culture(self, tmp_path):
         state = self._state_with_process(
-            "CellCulture", cell_line="cell_1", culture_medium="DMEM", result="sample_out",
+            "CellCulture", cell_line="cell_1", culture_medium="DMEM",
+            result="sample_out",
         )
         state.add_entity(
             _ent("cell_1", "CellLineSample", name="HepG2", accession="CVCL_0027"))
@@ -89,10 +90,10 @@ class TestLabProcessSubtypes:
         assert "#cell_1" in _ids(proc.get("input"))
         assert "#sample_out" in _ids(proc.get("output"))
 
-    def test_exposure_object_is_cells_not_compound(self, tmp_path):
+    def test_exposure_object_is_cells_result_is_condition_table(self, tmp_path):
         # ISA forbids a MolecularEntity as a process object (objects MUST be
-        # File/Sample/BioSample). The exposed compound is therefore NOT in
-        # `object`; it is linked at the Study level instead.
+        # File/Sample/BioSample). The compound is therefore NOT in `object`; the
+        # Exposure's result is the CSVW condition table, which links the compound.
         state = self._state_with_process(
             "Exposure", samples="sample_cult", chemicals="chem_1",
             duration="24h", microplate="96-well",
@@ -102,9 +103,19 @@ class TestLabProcessSubtypes:
         _, by_id = _build(state, tmp_path)
         proc = by_id["#proc_1"]
         assert proc["additionalType"] == "Exposure"
-        obj_ids = _ids(proc.get("input"))
-        assert "#sample_cult" in obj_ids               # the cells (Sample) — allowed
-        assert "#chem_1" not in obj_ids                # MolecularEntity — ISA-forbidden
+
+        obj_ids = _ids(proc.get("input"))           # input → schema:object
+        assert "#sample_cult" in obj_ids            # the cells (Sample) — allowed
+        assert "#chem_1" not in obj_ids             # MolecularEntity — ISA-forbidden
+
+        result_ids = _ids(proc.get("output"))       # output → schema:result (MUST)
+        assert result_ids, "Exposure MUST emit a result (the condition table)"
+        table = by_id[result_ids[0]]
+        # the result is the condition table: a File (ISA-valid result) + csvw:Table
+        tt = table["@type"] if isinstance(table["@type"], list) else [table["@type"]]
+        assert "File" in tt and "csvw:Table" in tt
+        # the compound is connected to the Exposure THROUGH the condition table
+        assert "#chem_1" in _ids(table.get("about"))
 
     def test_endpoint_readout_result_is_file(self, tmp_path):
         state = self._state_with_process(
@@ -204,9 +215,10 @@ class TestIdentifiersAndConformance:
         _, by_id = _build(state, tmp_path)
         descriptor = by_id["ro-crate-metadata.json"]
         conforms = _ids(descriptor.get("conformsTo"))
-        assert "https://w3id.org/ro/crate/isa/1.0" in conforms
         assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
+        # ISA layer is declared with the IRI the shapes actually extend
+        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in conforms
         # each declared profile also exists as a Profile contextual entity
-        prof = by_id["https://w3id.org/ro/crate/isa/1.0"]
+        prof = by_id["https://github.com/nfdi4plants/isa-ro-crate-profile"]
         pt = prof["@type"]
         assert "Profile" in (pt if isinstance(pt, list) else [pt])

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -1,0 +1,212 @@
+"""Tests for the full ISA-Tox domain-model mapping in build_crate.
+
+These pin the contract from profiles/docs/isa_tox.md: Study/Assay as
+Dataset+additionalType linked by hasPart, LabProcess subtypes discriminated by
+additionalType with executesLabProtocol and input/output (→ schema:object/result
+via the context), protocol synthesis, Exposure object carrying the compounds,
+conformsTo gating on validation, and the #-fragment / resolvable-URI id scheme.
+"""
+
+from __future__ import annotations
+
+import json
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.builder import build_crate
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+def _build(state, tmp_path):
+    out = tmp_path / "crate"
+    result = build_crate(state, str(out))
+    assert result["success"] is True, result
+    with open(out / "ro-crate-metadata.json") as f:
+        graph = json.load(f)["@graph"]
+    return graph, {e["@id"]: e for e in graph}
+
+
+def _ids(value):
+    """Normalize a hasPart/about/object value to a list of @id strings."""
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [v.get("@id") if isinstance(v, dict) else v for v in items]
+
+
+class TestStructuralDatasets:
+    def test_study_and_assay_are_datasets_with_additionaltype(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("study_1", "Study", name="My Study"))
+        state.add_entity(_ent("assay_1", "Assay", name="My Assay", study_id="study_1"))
+        _, by_id = _build(state, tmp_path)
+
+        assert by_id["#study_1"]["@type"] == "Dataset"
+        assert by_id["#study_1"]["additionalType"] == "Study"
+        assert by_id["#assay_1"]["@type"] == "Dataset"
+        assert by_id["#assay_1"]["additionalType"] == "Assay"
+
+    def test_haspart_wiring(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        state.add_entity(_ent("assay_1", "Assay", name="A", study_id="study_1"))
+        _, by_id = _build(state, tmp_path)
+
+        # root contains the study; study contains the assay
+        assert "#study_1" in _ids(by_id["./"].get("hasPart"))
+        assert "#assay_1" in _ids(by_id["#study_1"].get("hasPart"))
+
+
+class TestLabProcessSubtypes:
+    def _state_with_process(self, process_type, **proc_fields):
+        state = CrateState()
+        state.add_entity(_ent("assay_1", "Assay", name="A"))
+        state.add_entity(
+            _ent("proc_1", "LabProcess", name=process_type, process_type=process_type,
+                 assay_id="assay_1", **proc_fields)
+        )
+        return state
+
+    def test_cell_culture(self, tmp_path):
+        state = self._state_with_process(
+            "CellCulture", cell_line="cell_1", culture_medium="DMEM", result="sample_out",
+        )
+        state.add_entity(
+            _ent("cell_1", "CellLineSample", name="HepG2", accession="CVCL_0027"))
+        state.add_entity(_ent("sample_out", "Sample", name="cultured"))
+        _, by_id = _build(state, tmp_path)
+        proc = by_id["#proc_1"]
+        assert proc["additionalType"] == "CellCulture"
+        assert proc.get("executesLabProtocol")  # SHOULD, always synthesized
+        # input → schema:object, output → schema:result (via the @context)
+        assert "#cell_1" in _ids(proc.get("input"))
+        assert "#sample_out" in _ids(proc.get("output"))
+
+    def test_exposure_object_is_cells_not_compound(self, tmp_path):
+        # ISA forbids a MolecularEntity as a process object (objects MUST be
+        # File/Sample/BioSample). The exposed compound is therefore NOT in
+        # `object`; it is linked at the Study level instead.
+        state = self._state_with_process(
+            "Exposure", samples="sample_cult", chemicals="chem_1",
+            duration="24h", microplate="96-well",
+        )
+        state.add_entity(_ent("sample_cult", "Sample", name="cultured"))
+        state.add_entity(_ent("chem_1", "MolecularEntity", name="Silychristin A"))
+        _, by_id = _build(state, tmp_path)
+        proc = by_id["#proc_1"]
+        assert proc["additionalType"] == "Exposure"
+        obj_ids = _ids(proc.get("input"))
+        assert "#sample_cult" in obj_ids               # the cells (Sample) — allowed
+        assert "#chem_1" not in obj_ids                # MolecularEntity — ISA-forbidden
+
+    def test_endpoint_readout_result_is_file(self, tmp_path):
+        state = self._state_with_process(
+            "EndpointReadout", samples="sample_x", result="file_raw",
+            endpoint="viability", detection_instrument="plate reader",
+        )
+        state.add_entity(_ent("sample_x", "Sample", name="exposed"))
+        state.add_entity(_ent("file_raw", "File", name="raw.csv",
+                              dest_path="assays/a1/dataset/raw_data/raw.csv"))
+        _, by_id = _build(state, tmp_path)
+        proc = by_id["#proc_1"]
+        assert proc["additionalType"] == "EndpointReadout"
+        assert "assays/a1/dataset/raw_data/raw.csv" in _ids(proc.get("output"))
+
+    def test_data_analysis(self, tmp_path):
+        state = self._state_with_process(
+            "DataAnalysis", object="file_raw", result="file_proc",
+            software="R", data_processing="normalise",
+        )
+        state.add_entity(_ent("file_raw", "File", name="raw.csv", dest_path="raw.csv"))
+        state.add_entity(_ent("file_proc", "File", name="out.csv", dest_path="out.csv"))
+        _, by_id = _build(state, tmp_path)
+        proc = by_id["#proc_1"]
+        assert proc["additionalType"] == "DataAnalysis"
+        assert "raw.csv" in _ids(proc.get("input"))
+        assert "out.csv" in _ids(proc.get("output"))
+
+    def test_process_attached_to_assay_via_about(self, tmp_path):
+        state = self._state_with_process("CellCulture", cell_line="cell_1")
+        state.add_entity(_ent("cell_1", "CellLineSample", name="HepG2"))
+        _, by_id = _build(state, tmp_path)
+        assert "#proc_1" in _ids(by_id["#assay_1"].get("about"))
+
+    def test_protocol_synthesized_when_absent(self, tmp_path):
+        state = self._state_with_process("CellCulture", cell_line="cell_1")
+        state.add_entity(_ent("cell_1", "CellLineSample", name="HepG2"))
+        _, by_id = _build(state, tmp_path)
+        proto_ref = _ids(by_id["#proc_1"].get("executesLabProtocol"))
+        assert proto_ref
+        proto = by_id[proto_ref[0]]
+        assert proto["@type"] == "LabProtocol"
+
+
+class TestOntologyAnnotations:
+    """AOP on the Study, Key Event on the Assay (paper §Methods, via mentions)."""
+
+    def test_study_annotated_with_aop_entity(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("study_1", "Study", name="S", aop="aop_37"))
+        state.add_entity(_ent("aop_37", "DefinedTerm", name="AOP 37"))
+        _, by_id = _build(state, tmp_path)
+        assert "#aop_37" in _ids(by_id["#study_1"].get("aop"))
+
+    def test_study_aop_inline_iri(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("study_1", "Study", name="S",
+                              aop="https://aopwiki.org/aops/37"))
+        _, by_id = _build(state, tmp_path)
+        assert "https://aopwiki.org/aops/37" in _ids(by_id["#study_1"].get("aop"))
+
+    def test_assay_annotated_with_key_event(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("assay_1", "Assay", name="A", key_event="ke_55"))
+        state.add_entity(_ent("ke_55", "DefinedTerm", name="KE 55"))
+        _, by_id = _build(state, tmp_path)
+        assert "#ke_55" in _ids(by_id["#assay_1"].get("keyEvent"))
+
+
+class TestIdentifiersAndConformance:
+    def test_local_ids_are_hash_prefixed(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        _, by_id = _build(state, tmp_path)
+        assert "#study_1" in by_id
+        assert "study_1" not in by_id  # bare id must not be emitted
+
+    def test_person_uses_orcid_uri(self, tmp_path):
+        state = CrateState()
+        state.add_entity(_ent("person_1", "Person", name="Jane Doe",
+                              orcid="0000-0002-1825-0097"))
+        _, by_id = _build(state, tmp_path)
+        assert "https://orcid.org/0000-0002-1825-0097" in by_id
+
+    def test_conformsto_gated_on_validation(self, tmp_path):
+        state = CrateState()
+        # No validation passes recorded → only RO-Crate 1.1 asserted.
+        _, by_id = _build(state, tmp_path)
+        descriptor = by_id["ro-crate-metadata.json"]
+        conforms = _ids(descriptor.get("conformsTo"))
+        assert "https://w3id.org/ro/crate/1.1" in conforms
+        assert "https://w3id.org/ro/crate/isa/1.0" not in conforms
+
+    def test_conformsto_includes_profiles_when_validated(self, tmp_path):
+        state = CrateState()
+        state.validation.isa_passed = True
+        state.validation.tox_passed = True
+        _, by_id = _build(state, tmp_path)
+        descriptor = by_id["ro-crate-metadata.json"]
+        conforms = _ids(descriptor.get("conformsTo"))
+        assert "https://w3id.org/ro/crate/isa/1.0" in conforms
+        assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
+        # each declared profile also exists as a Profile contextual entity
+        prof = by_id["https://w3id.org/ro/crate/isa/1.0"]
+        pt = prof["@type"]
+        assert "Profile" in (pt if isinstance(pt, list) else [pt])

--- a/tests/test_tools_builder.py
+++ b/tests/test_tools_builder.py
@@ -75,3 +75,36 @@ class TestBuildCrate:
         assert result["success"] is False
         assert result["error"] is not None
         assert result["crate_path"] == ""
+
+    def test_uses_rocrate_py_metadata_descriptor(self):
+        """build_crate assembles via ro-crate-py, not a hand-rolled dict.
+
+        ro-crate-py always emits a self-describing RO-Crate Metadata Descriptor
+        entity (@id ro-crate-metadata.json, @type CreativeWork) whose conformsTo
+        names the RO-Crate 1.1 spec and whose `about` points at the root. A
+        hand-rolled graph does not produce this, so its presence proves the
+        library is doing the assembly.
+        """
+        state = CrateState()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = str(Path(tmpdir) / "crate")
+            result = build_crate(state, output_path)
+
+            assert result["success"] is True
+            with open(Path(output_path) / "ro-crate-metadata.json") as f:
+                metadata = json.load(f)
+
+            descriptor = next(
+                e for e in metadata["@graph"]
+                if e.get("@id") == "ro-crate-metadata.json"
+            )
+            assert descriptor.get("@type") == "CreativeWork"
+            assert descriptor.get("about") == {"@id": "./"}
+            conforms = descriptor.get("conformsTo")
+            conforms_ids = (
+                [conforms.get("@id")] if isinstance(conforms, dict)
+                else [c.get("@id") for c in conforms or []]
+            )
+            # ro-crate-py stamps the descriptor with the RO-Crate spec it conforms
+            # to; the exact minor version is pinned explicitly in Step 2.
+            assert any("w3id.org/ro/crate" in cid for cid in conforms_ids)

--- a/tests/test_validator_wiring.py
+++ b/tests/test_validator_wiring.py
@@ -1,0 +1,69 @@
+"""Regression tests for the three-pass validator wiring (profiles/validator.py).
+
+These guard the SHAPES_DIR path (which previously pointed outside the repo, so
+the ISA-Tox pass silently failed to load its custom shapes) and assert that a
+representative crate built by build_crate conforms across all three SHACL passes
+at REQUIRED severity — the real end-to-end check.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.builder import build_crate
+from profiles.validator import SHAPES_DIR, validate_crate
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+def test_shapes_dir_resolves_inside_repo():
+    """The ISA-Tox shapes directory must exist and hold the tox profile."""
+    assert SHAPES_DIR.exists(), f"SHAPES_DIR does not exist: {SHAPES_DIR}"
+    assert (SHAPES_DIR / "tox").is_dir()
+
+
+def _representative_state() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Demo Investigation"
+    state.metadata.description = "A representative ISA-Tox crate"
+    state.metadata.accession = "S-VHPS99"
+    state.add_entity(_ent("study_1", "Study", name="Hepatotoxicity study",
+                          aop="https://aopwiki.org/aops/37"))
+    state.add_entity(_ent("assay_1", "Assay", name="Viability assay",
+                          study_id="study_1",
+                          key_event="https://aopwiki.org/events/55"))
+    state.add_entity(_ent("chem_1", "MolecularEntity", name="Silychristin A"))
+    state.add_entity(_ent("cell_1", "CellLineSample", name="HepG2",
+                          accession="CVCL_0027"))
+    state.add_entity(_ent("cc", "LabProcess", name="Cell Culture",
+                          process_type="CellCulture", assay_id="assay_1",
+                          cell_line="cell_1"))
+    state.add_entity(_ent("exp", "LabProcess", name="Exposure",
+                          process_type="Exposure", assay_id="assay_1",
+                          samples="cell_1", chemicals="chem_1",
+                          duration="24h", microplate="96-well"))
+    return state
+
+
+def test_representative_crate_passes_all_three_required(tmp_path):
+    """A built crate conforms to base RO-Crate 1.1, ISA and ISA-Tox at REQUIRED."""
+    out = tmp_path / "crate"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert build_crate(_representative_state(), str(out))["success"] is True
+        results = validate_crate(out)
+
+    assert len(results) == 3  # base RO-Crate, ISA, ISA-Tox
+    for res in results:
+        assert res.passed_required, (
+            f"{res.profile} has REQUIRED issues: {res.required_issues}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -5695,8 +5695,8 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "roc-validator", specifier = ">=0.1.0" },
-    { name = "rocrate", specifier = ">=0.9.0" },
+    { name = "roc-validator", specifier = ">=0.10.0" },
+    { name = "rocrate", specifier = ">=0.15.0" },
 ]
 provides-extras = ["langchain"]
 


### PR DESCRIPTION
The builder went from a hand-rolled JSON-LD scaffold to a real ro-crate-py assembler producing fully ISA-Tox-conformant crates — validated end-to-end (base RO-Crate 1.1 + ISA + ISA-Tox all green at REQUIRED).

  Core (Steps 1–3):
  - builder/tools/_crate_mapping.py (new, +470) — maps each CrateState entity onto its profiles/models ISA-Tox class, dependency-ordered
  with reference resolution, protocol synthesis, AOP-on-Study / KeyEvent-on-Assay wiring, and spec-correct @ids (#-fragments / resolvable
  URIs / file paths).
  - builder.py rewritten on ROCrate; existing_crate.py reader updated for Dataset+additionalType round-trips; tox.py broken rocrate_wizard
  import fixed; rocrate>=0.15.0 / roc-validator>=0.10.0 pinned.

  Bugs the work surfaced and fixed:
  - Validator was mis-wired — SHAPES_DIR pointed outside the repo (wizard-era path), so the ISA-Tox pass silently never loaded its shapes.
  Fixed; added test_validator_wiring.py so it can't regress.
  - conformsTo forced to 1.1 — ro-crate-py 0.15 defaults the descriptor to 1.2, but the validator only does 1.1. Gated on actual
  validation.

  Audit-driven fixes (your decisions):
  - Exposure↔compound, done right: the compound is ISA-forbidden in object; the Exposure's result is now the condition table — a File also
  typed csvw:Table (a header-only placeholder CSV is written), schema:about the compound, so the compound is connected through the table.
  Full per-row CSVW intake is deferred (wizard intake/condition_table.py).
  - PROFILE_ISA → github.com/nfdi4plants/isa-ro-crate-profile (what the shapes actually extend; the w3id one 404s).
  - Synced isa_tox.md (Exposure object/result rows + compound note + ISA IRI), tox.py (explicit result param + docstring), and profile.ttl
  (version).

  Consistency audit (5 artifacts, multi-agent): confirmed the model/shapes/paper agree and isa_tox.md was the lone outlier on
  Exposure.object — now reconciled. Remaining items are paper-only wording (RO-Crate 1.1 vs 1.2; a few SHOULD-vs-MUST overstatements) —
  reported, not edited, since it's your manuscript.