### PR TITLE
feat(hitl): extract HumanInterface protocol with injectable adapter (#25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,16 @@ Automatically at: after file scanning, after each entity draft, after HITL check
 3. Agent incorporates feedback and continues
 4. All feedback logged in entity `_provenance`
 
+### Interface Adapter
+HITL requests go through a `HumanInterface` protocol (`builder/tools/hitl.py`)
+injected into the engine via `AgentEngine(human_interface=...)`. It defines
+`present(context, options) → HumanResponse` and `request_input(prompt,
+field_type) → InputResponse`. The default `SimulatedHumanInterface`
+auto-approves and skips input for headless/batch runs; a frontend (Streamlit,
+FastAPI, CLI) supplies its own adapter without monkeypatching the tool
+functions. The module-level `present_to_human` / `request_input` functions
+remain as thin wrappers over a shared default simulator.
+
 ## 9. Input & Output Formats
 
 ### Input Formats

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -10,9 +10,12 @@ import inspect
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from builder.state import CrateState
+
+if TYPE_CHECKING:
+    from builder.tools.hitl import HumanInterface
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +30,24 @@ class AgentEngine:
 
     _registry: dict[str, Any] = {}
 
-    def __init__(self, state: CrateState | None = None):
-        """Initialize the engine with an optional existing state."""
+    def __init__(
+        self,
+        state: CrateState | None = None,
+        human_interface: HumanInterface | None = None,
+    ):
+        """Initialize the engine with optional state and HITL interface.
+
+        Args:
+            state: Existing CrateState to resume, or None for a fresh state.
+            human_interface: Adapter for human-in-the-loop interaction;
+                defaults to a non-interactive ``SimulatedHumanInterface``.
+        """
         self.state = state or CrateState()
+        if human_interface is None:
+            from builder.tools.hitl import SimulatedHumanInterface
+
+            human_interface = SimulatedHumanInterface()
+        self.human_interface = human_interface
         self._running = False
 
     # ------------------------------------------------------------------
@@ -116,7 +134,15 @@ class AgentEngine:
         except ImportError:
             pass
 
-        if tool_name in scanner_tools:
+        if tool_name == "present_to_human":
+            result = self.human_interface.present(
+                kwargs.get("context", ""), kwargs.get("options")
+            )
+        elif tool_name == "request_input":
+            result = self.human_interface.request_input(
+                kwargs.get("prompt", ""), kwargs.get("field_type", "text")
+            )
+        elif tool_name in scanner_tools:
             tool_fn = scanner_tools[tool_name]
             # Inject approved roots for scan_files
             tool_kwargs = dict(kwargs)

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -1,64 +1,121 @@
 """Human-in-the-Loop interaction tools for the ISA-Tox RO-Crate Builder.
 
-Provides primitives for presenting content to the user and incorporating
-their feedback into the CrateState workflow.
+Provides a :class:`HumanInterface` protocol so frontends (Streamlit, FastAPI,
+…) can be injected into :class:`~builder.engine.AgentEngine` without
+monkeypatching. The default :class:`SimulatedHumanInterface` reproduces the
+previous non-interactive stub behaviour (auto-approve, skip-input). The
+module-level :func:`present_to_human` / :func:`request_input` functions remain
+as thin wrappers over a shared default simulator for backward compatibility.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+
+class HumanResponse(TypedDict):
+    """Response from presenting content to a human for review.
+
+    Attributes:
+        action: One of "approved", "edited", "rejected", "skipped".
+        comments: Free-text comments from the user, or None.
+        edits: Dict of field edits (when action == "edited"), or None.
+    """
+
+    action: Literal["approved", "edited", "rejected", "skipped"]
+    comments: str | None
+    edits: dict | None
+
+
+class InputResponse(TypedDict):
+    """Response from requesting a specific input value from a human.
+
+    Attributes:
+        value: The user's input, or None if skipped.
+        skipped: True if the user chose to skip.
+    """
+
+    value: Any | None
+    skipped: bool
+
+
+@runtime_checkable
+class HumanInterface(Protocol):
+    """Dependency-injection point for human-in-the-loop interaction.
+
+    Implementations adapt the agent's HITL requests to a concrete frontend
+    (CLI prompt, Streamlit widget, FastAPI round-trip, test double, …).
+    """
+
+    def present(
+        self, context: str, options: list[str] | None = None
+    ) -> HumanResponse:
+        """Present content to the human and return their decision."""
+        ...
+
+    def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
+        """Request a specific input value from the human."""
+        ...
+
+
+class SimulatedHumanInterface:
+    """Default non-interactive interface: auto-approves and skips input.
+
+    Reproduces the previous stub behaviour so headless/batch runs proceed
+    without blocking on a real user.
+    """
+
+    def present(
+        self, context: str, options: list[str] | None = None
+    ) -> HumanResponse:
+        """Log the presentation and return a simulated-approved response."""
+        logger.info("HITL presentation: %s", context)
+        if options:
+            logger.info("HITL options: %s", options)
+        return {"action": "approved", "comments": None, "edits": None}
+
+    def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
+        """Log the request and return a skip response."""
+        logger.info("HITL input request: %s (type=%s)", prompt, field_type)
+        return {"value": None, "skipped": True}
+
+
+# Shared default simulator backing the module-level convenience functions.
+_default_interface: HumanInterface = SimulatedHumanInterface()
 
 
 def present_to_human(
     context: str,
     options: list[str] | None = None,
-) -> dict[str, Any]:
-    """Present content to the human user and get a response.
+) -> HumanResponse:
+    """Present content to the human via the default simulated interface.
 
-    In the default (non-interactive) mode, this logs the presentation
-    and returns a simulated-approved response. In production, this would
-    be overridden by a UI callback.
-
-    Args:
-        context: Human-readable description of what's being presented.
-        options: Optional list of response buttons (e.g. ["Approve", "Edit", "Reject"]).
-
-    Returns:
-        A dict with keys:
-            action: One of "approved", "edited", "rejected", "skipped".
-            comments: Free-text comments from the user.
-            edits: Dict of field edits (only present if action == "edited").
+    Backward-compatible wrapper; new code should inject a
+    :class:`HumanInterface` into :class:`~builder.engine.AgentEngine` instead.
     """
-    logger.info("HITL presentation: %s", context)
-    if options:
-        logger.info("HITL options: %s", options)
-
-    # Simulate approval — in production this would block waiting for user input
-    return {"type": "approve"}
+    return _default_interface.present(context, options)
 
 
 def request_input(
     prompt: str,
     field_type: str = "text",
-) -> dict[str, Any]:
-    """Request a specific input from the user.
+) -> InputResponse:
+    """Request input from the human via the default simulated interface.
 
-    In the default mode, logs the request and returns a skip response.
-
-    Args:
-        prompt: The question or prompt to present to the user.
-        field_type: Type of input expected ("text", "identifier", "select").
-
-    Returns:
-        A dict with keys:
-            value: The user's input, or None if skipped.
-            skipped: True if the user chose to skip.
+    Backward-compatible wrapper; new code should inject a
+    :class:`HumanInterface` into :class:`~builder.engine.AgentEngine` instead.
     """
-    logger.info("HITL input request: %s (type=%s)", prompt, field_type)
-    return {"value": None, "skipped": True}
+    return _default_interface.request_input(prompt, field_type)
 
 
-__all__ = ["present_to_human", "request_input"]
+__all__ = [
+    "HumanInterface",
+    "HumanResponse",
+    "InputResponse",
+    "SimulatedHumanInterface",
+    "present_to_human",
+    "request_input",
+]

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -1,0 +1,102 @@
+"""Tests for the HITL HumanInterface protocol and engine injection."""
+
+from __future__ import annotations
+
+from builder.engine import AgentEngine
+from builder.tools.hitl import (
+    HumanInterface,
+    InputResponse,
+    SimulatedHumanInterface,
+    present_to_human,
+    request_input,
+)
+
+
+class MockHumanInterface:
+    """Test double returning controlled responses and recording calls."""
+
+    def __init__(self) -> None:
+        self.present_calls: list[tuple[str, list[str] | None]] = []
+        self.input_calls: list[tuple[str, str]] = []
+
+    def present(self, context, options=None):
+        self.present_calls.append((context, options))
+        return {"action": "edited", "comments": "fix it", "edits": {"name": "X"}}
+
+    def request_input(self, prompt, field_type="text"):
+        self.input_calls.append((prompt, field_type))
+        return {"value": "42", "skipped": False}
+
+
+class TestSimulatedHumanInterface:
+    """The default simulator implements the protocol and auto-approves."""
+
+    def test_satisfies_human_interface_protocol(self):
+        assert isinstance(SimulatedHumanInterface(), HumanInterface)
+
+    def test_present_returns_approved_human_response(self):
+        resp = SimulatedHumanInterface().present("Review investigation")
+        assert resp == {"action": "approved", "comments": None, "edits": None}
+
+    def test_request_input_returns_skipped_input_response(self):
+        resp = SimulatedHumanInterface().request_input("DOI?", "identifier")
+        assert resp == {"value": None, "skipped": True}
+
+
+class TestBackwardCompatibleFunctions:
+    """The module-level functions still work via the default simulator."""
+
+    def test_present_to_human_delegates_to_default_simulator(self):
+        assert present_to_human("ctx", ["Approve"]) == {
+            "action": "approved",
+            "comments": None,
+            "edits": None,
+        }
+
+    def test_request_input_delegates_to_default_simulator(self):
+        resp: InputResponse = request_input("Name?")
+        assert resp == {"value": None, "skipped": True}
+
+
+class TestEngineHumanInterfaceInjection:
+    """AgentEngine routes HITL tool calls through the injected interface."""
+
+    def test_defaults_to_simulated_interface(self):
+        engine = AgentEngine()
+        assert isinstance(engine.human_interface, SimulatedHumanInterface)
+
+    def test_accepts_injected_interface(self):
+        mock = MockHumanInterface()
+        engine = AgentEngine(human_interface=mock)
+        assert engine.human_interface is mock
+
+    def test_run_tool_present_uses_injected_interface(self):
+        mock = MockHumanInterface()
+        engine = AgentEngine(human_interface=mock)
+
+        result = engine.run_tool(
+            "present_to_human", context="Review", options=["Approve", "Edit"]
+        )
+
+        assert result == {
+            "action": "edited",
+            "comments": "fix it",
+            "edits": {"name": "X"},
+        }
+        assert mock.present_calls == [("Review", ["Approve", "Edit"])]
+
+    def test_run_tool_request_input_uses_injected_interface(self):
+        mock = MockHumanInterface()
+        engine = AgentEngine(human_interface=mock)
+
+        result = engine.run_tool(
+            "request_input", prompt="Enter DOI", field_type="identifier"
+        )
+
+        assert result == {"value": "42", "skipped": False}
+        assert mock.input_calls == [("Enter DOI", "identifier")]
+
+    def test_run_tool_present_defaults_to_simulated_when_not_injected(self):
+        engine = AgentEngine()
+        result = engine.run_tool("present_to_human", context="Review")
+        assert result == {"action": "approved", "comments": None, "edits": None}


### PR DESCRIPTION
Closes #25.

Replaces the hardcoded HITL stubs with an injectable `HumanInterface`, so a Streamlit/FastAPI/test frontend can be supplied to `AgentEngine` without monkeypatching `builder/tools/hitl.py`.

## Design
- **`HumanInterface`** — a `@runtime_checkable` Protocol with `present(context, options) → HumanResponse` and `request_input(prompt, field_type) → InputResponse`.
- **TypedDicts** — `HumanResponse` `{action, comments, edits}` and `InputResponse` `{value, skipped}` (the shapes the previous docstrings already documented).
- **`SimulatedHumanInterface`** — the default; reproduces the old stub behaviour (auto-approve / skip-input) in the documented response shape.
- **Backward compatibility** — module-level `present_to_human` / `request_input` remain as thin wrappers over a shared default simulator, so existing imports/exports are unaffected.
- **`AgentEngine`** — `__init__` gains an optional `human_interface` (defaults to `SimulatedHumanInterface`); `run_tool` routes `present_to_human` / `request_input` through it. (These weren't in the tool registry before, so the routing is purely additive.)

## Acceptance criteria
- [x] `HumanInterface` protocol with `present()` and `request_input()`
- [x] `SimulatedHumanInterface` implements it (behavior unchanged for headless runs)
- [x] `AgentEngine.__init__` accepts optional `human_interface`
- [x] Engine uses the injected interface when calling HITL tools
- [x] Existing tests pass without modification
- [x] New test: engine with `MockHumanInterface` returns controlled responses
- [x] New test: engine without explicit interface defaults to `SimulatedHumanInterface`

## Verification
- New `tests/test_tools_hitl.py`: 10 tests pass
- Full suite: 262 pass (the 5 `test_agent_loop.py` failures are pre-existing — missing `langchain_*` deps — unrelated)
- `ty` clean; no new `ruff` findings
- AGENTS.md §8 documents the adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)