### PR TITLE
refactor(engine): replace dir()-based tool registry with explicit ToolRegistry (#26)

### DIFF
--- a/builder/engine.py
+++ b/builder/engine.py
@@ -6,7 +6,6 @@ It coordinates tool calls, validation, HITL checkpoints, and session persistence
 
 from __future__ import annotations
 
-import inspect
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,6 +15,7 @@ from builder.state import CrateState
 
 if TYPE_CHECKING:
     from builder.tools.hitl import HumanInterface
+    from builder.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class AgentEngine:
     session persistence.
     """
 
-    _registry: dict[str, Any] = {}
+    _registry: ToolRegistry | None = None
 
     def __init__(
         self,
@@ -83,29 +83,29 @@ class AgentEngine:
     # ------------------------------------------------------------------
 
     @classmethod
-    def _build_registry(cls) -> dict[str, Any]:
-        """Build the tool registry by importing all tool functions."""
-        if cls._registry:
+    def _build_registry(cls) -> ToolRegistry:
+        """Return the shared ToolRegistry of explicitly registered tools.
+
+        Importing each tool module triggers its bottom-of-file
+        ``TOOL_REGISTRY.register(...)`` calls; imports are idempotent so this
+        is cached after the first call.
+        """
+        if cls._registry is not None:
             return cls._registry
 
-        import builder.tools.management as mgmt
-        import builder.tools.drafters as draft
-        import builder.tools.lookups as lookups
-        import builder.tools.verification as verify
-        import builder.tools.builder as builder_mod
-        import builder.tools.validation as val_mod
-        import builder.tools.mit_assessment as mit
-        import builder.tools.fair_assessment as fair
-        import builder.tools.session as session_mod
+        import builder.tools.builder  # noqa: F401
+        import builder.tools.drafters  # noqa: F401
+        import builder.tools.fair_assessment  # noqa: F401
+        import builder.tools.lookups  # noqa: F401
+        import builder.tools.management  # noqa: F401
+        import builder.tools.mit_assessment  # noqa: F401
+        import builder.tools.session  # noqa: F401
+        import builder.tools.validation  # noqa: F401
+        import builder.tools.verification  # noqa: F401
+        from builder.tools.registry import TOOL_REGISTRY
 
-        registry: dict[str, Any] = {}
-        for module in [mgmt, draft, lookups, verify, builder_mod, val_mod, mit, fair, session_mod]:
-            for name in dir(module):
-                obj = getattr(module, name)
-                if callable(obj) and not name.startswith("_"):
-                    registry[name] = obj
-        cls._registry = registry
-        return registry
+        cls._registry = TOOL_REGISTRY
+        return TOOL_REGISTRY
 
     # ------------------------------------------------------------------
     # Tool execution
@@ -166,16 +166,13 @@ class AgentEngine:
                 )
         else:
             registry = self._build_registry()
-            if tool_name not in registry:
+            spec = registry.get_spec(tool_name)
+            if spec is None:
                 raise ValueError(f"Unknown tool: {tool_name!r}")
-            tool_fn = registry[tool_name]
-
-            sig = inspect.signature(tool_fn)
-            params = list(sig.parameters.keys())
-            if params and params[0] == "state":
-                result = tool_fn(self.state, **kwargs)
+            if spec.takes_state:
+                result = spec.fn(self.state, **kwargs)
             else:
-                result = tool_fn(**kwargs)
+                result = spec.fn(**kwargs)
 
         self.state.iteration_count += 1
         self.state.log_reasoning(
@@ -196,7 +193,8 @@ class AgentEngine:
             Sorted list of all registered tool names.
         """
         registry = self._build_registry()
-        return sorted(set(list(registry.keys()) + ["scan_files", "read_file_sample", "preview_archive"]))
+        extra = ["scan_files", "read_file_sample", "preview_archive"]
+        return sorted(set(registry.list() + extra))
 
     @property
     def is_stuck(self) -> bool:

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -64,3 +64,11 @@ def build_crate(state: CrateState, output_path: str) -> dict[str, Any]:
     except Exception as e:
         logger.error("Unexpected error building crate: %s", e)
         return {"success": False, "crate_path": output_path, "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("build_crate", build_crate, takes_state=True)

--- a/builder/tools/drafters.py
+++ b/builder/tools/drafters.py
@@ -311,3 +311,25 @@ def draft_publication(state: CrateState, doi: str, hints: dict) -> Entity:
     entity.set_fields_from_dict(merged_hints, source="llm")
     state.add_entity(entity)
     return entity
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("draft_investigation", draft_investigation, takes_state=True)
+TOOL_REGISTRY.register("draft_study", draft_study, takes_state=True)
+TOOL_REGISTRY.register("draft_assay", draft_assay, takes_state=True)
+TOOL_REGISTRY.register("draft_process", draft_process, takes_state=True)
+TOOL_REGISTRY.register("draft_protocol", draft_protocol, takes_state=True)
+TOOL_REGISTRY.register("draft_sample", draft_sample, takes_state=True)
+TOOL_REGISTRY.register(
+    "draft_molecular_entity", draft_molecular_entity, takes_state=True
+)
+TOOL_REGISTRY.register(
+    "draft_cell_line_sample", draft_cell_line_sample, takes_state=True
+)
+TOOL_REGISTRY.register("draft_person", draft_person, takes_state=True)
+TOOL_REGISTRY.register("draft_organization", draft_organization, takes_state=True)
+TOOL_REGISTRY.register("draft_publication", draft_publication, takes_state=True)

--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -426,3 +426,13 @@ def _compute_dsm_level(state: CrateState, dsm_data: dict[str, Any] | None) -> in
             max_level = level
 
     return max_level
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register(
+    "assess_fair_maturity", assess_fair_maturity, takes_state=True
+)

--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -230,3 +230,17 @@ def lookup_doi(doi: str) -> dict[str, Any]:
     except Exception as exc:
         logger.exception("Crossref lookup failed for '%s'", doi)
         return _failure(f"Crossref lookup failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("lookup_compound", lookup_compound, takes_state=False)
+TOOL_REGISTRY.register("lookup_cell_line", lookup_cell_line, takes_state=False)
+TOOL_REGISTRY.register("lookup_aop", lookup_aop, takes_state=False)
+TOOL_REGISTRY.register("lookup_bao_term", lookup_bao_term, takes_state=False)
+TOOL_REGISTRY.register("lookup_orcid", lookup_orcid, takes_state=False)
+TOOL_REGISTRY.register("lookup_ror", lookup_ror, takes_state=False)
+TOOL_REGISTRY.register("lookup_doi", lookup_doi, takes_state=False)

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -121,3 +121,15 @@ def bulk_set_fields(
     for field, value in fields.items():
         entity.fields[field] = value
         entity.set_field_status(field, "filled", source)
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("list_entities", list_entities, takes_state=True)
+TOOL_REGISTRY.register("update_entity", update_entity, takes_state=True)
+TOOL_REGISTRY.register("remove_entity", remove_entity, takes_state=True)
+TOOL_REGISTRY.register("set_entity_field", set_entity_field, takes_state=True)
+TOOL_REGISTRY.register("bulk_set_fields", bulk_set_fields, takes_state=True)

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -151,3 +151,11 @@ def assess_mit_coverage(state: CrateState) -> MITReport:
         module_scores=module_scores,
         overall_score=overall_score,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("assess_mit_coverage", assess_mit_coverage, takes_state=True)

--- a/builder/tools/registry.py
+++ b/builder/tools/registry.py
@@ -1,0 +1,76 @@
+"""Explicit tool registry for the ISA-Tox RO-Crate Builder.
+
+Replaces ``dir()``-based auto-discovery (which registered every public
+callable in a tool module — including imported classes and internal helpers)
+with explicit registration. Each tool module imports the shared
+:data:`TOOL_REGISTRY` and registers its public tools at the bottom of the file
+via :meth:`ToolRegistry.register`, declaring ``takes_state`` rather than
+relying on parameter-name introspection.
+"""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """A registered tool.
+
+    Attributes:
+        name: The name the agent uses to call the tool.
+        fn: The tool callable.
+        description: Optional human-readable description.
+        takes_state: Whether the engine must pass ``CrateState`` as the first
+            positional argument when invoking ``fn``.
+    """
+
+    name: str
+    fn: Callable[..., Any]
+    description: str = ""
+    takes_state: bool = False
+
+
+class ToolRegistry:
+    """Maps tool names to :class:`ToolSpec` entries."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolSpec] = {}
+
+    def register(
+        self,
+        name: str,
+        fn: Callable[..., Any],
+        description: str = "",
+        takes_state: bool = False,
+    ) -> None:
+        """Register ``fn`` under ``name`` (overwrites any existing entry)."""
+        self._tools[name] = ToolSpec(
+            name=name, fn=fn, description=description, takes_state=takes_state
+        )
+
+    def get(self, name: str) -> Callable[..., Any]:
+        """Return the callable registered under ``name`` (raises KeyError)."""
+        return self._tools[name].fn
+
+    def get_spec(self, name: str) -> ToolSpec | None:
+        """Return the full :class:`ToolSpec` for ``name``, or None if absent."""
+        return self._tools.get(name)
+
+    def list(self) -> builtins.list[str]:
+        """Return registered tool names, sorted."""
+        return sorted(self._tools)
+
+    def all(self) -> dict[str, ToolSpec]:
+        """Return a copy of the full name → :class:`ToolSpec` mapping."""
+        return dict(self._tools)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._tools
+
+
+# Shared registry populated by each tool module's bottom-of-file registration.
+TOOL_REGISTRY = ToolRegistry()

--- a/builder/tools/session.py
+++ b/builder/tools/session.py
@@ -204,3 +204,15 @@ def save_session(state: CrateState, label: str = "") -> dict:
         "path": str(session_path),
         "error": None,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("get_status", get_status, takes_state=True)
+TOOL_REGISTRY.register("get_hint", get_hint, takes_state=True)
+TOOL_REGISTRY.register("save_session", save_session, takes_state=True)
+TOOL_REGISTRY.register("list_sessions", list_sessions, takes_state=False)
+TOOL_REGISTRY.register("load_session", load_session, takes_state=False)

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -113,3 +113,11 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
         should_issues=should_issues,
         may_issues=may_issues,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("validate", validate, takes_state=True)

--- a/builder/tools/verification.py
+++ b/builder/tools/verification.py
@@ -136,3 +136,14 @@ def verify_all_identifiers(state: CrateState) -> list[dict]:
                 results.append(result)
 
     return results
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("verify_identifier", verify_identifier, takes_state=True)
+TOOL_REGISTRY.register(
+    "verify_all_identifiers", verify_all_identifiers, takes_state=True
+)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,104 @@
+"""Tests for the explicit ToolRegistry replacing dir()-based discovery."""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.engine import AgentEngine
+from builder.tools.registry import ToolRegistry
+
+
+class TestToolRegistry:
+    """Unit tests for the ToolRegistry container."""
+
+    def test_register_and_get_returns_callable(self):
+        reg = ToolRegistry()
+
+        def my_tool() -> str:
+            return "ok"
+
+        reg.register("my_tool", my_tool, description="does a thing")
+        assert reg.get("my_tool") is my_tool
+
+    def test_get_unknown_raises_key_error(self):
+        reg = ToolRegistry()
+        with pytest.raises(KeyError):
+            reg.get("nope")
+
+    def test_list_returns_sorted_names(self):
+        reg = ToolRegistry()
+        reg.register("beta", lambda: None)
+        reg.register("alpha", lambda: None)
+        assert reg.list() == ["alpha", "beta"]
+
+    def test_all_returns_full_specs(self):
+        reg = ToolRegistry()
+
+        def t(state) -> None:  # noqa: ARG001
+            ...
+
+        reg.register("t", t, description="desc", takes_state=True)
+        spec = reg.all()["t"]
+        assert spec.fn is t
+        assert spec.description == "desc"
+        assert spec.takes_state is True
+
+    def test_takes_state_defaults_to_false(self):
+        reg = ToolRegistry()
+        reg.register("t", lambda: None)
+        assert reg.all()["t"].takes_state is False
+
+    def test_contains(self):
+        reg = ToolRegistry()
+        reg.register("t", lambda: None)
+        assert "t" in reg
+        assert "missing" not in reg
+
+
+class TestToolModulesRegister:
+    """Tool modules register their public tools into the engine registry."""
+
+    def test_registry_contains_expected_tools(self):
+        reg = AgentEngine._build_registry()
+        for name in (
+            "draft_investigation",
+            "build_crate",
+            "validate",
+            "assess_mit_coverage",
+            "assess_fair_maturity",
+            "lookup_compound",
+            "save_session",
+            "list_entities",
+            "verify_identifier",
+        ):
+            assert name in reg, f"{name} should be registered"
+
+    def test_state_passing_is_declared_not_introspected(self):
+        specs = AgentEngine._build_registry().all()
+        assert specs["draft_investigation"].takes_state is True
+        assert specs["build_crate"].takes_state is True
+        assert specs["save_session"].takes_state is True
+        assert specs["lookup_compound"].takes_state is False
+        assert specs["list_sessions"].takes_state is False
+
+
+class TestEngineUsesRegistry:
+    """AgentEngine routes tool execution through the explicit registry."""
+
+    def test_run_tool_state_tool_executes_with_state(self):
+        engine = AgentEngine()
+        result = engine.run_tool("draft_investigation", hints={"name": "Inv"})
+        assert result is not None
+
+    def test_run_tool_unknown_raises_value_error(self):
+        engine = AgentEngine()
+        with pytest.raises(ValueError):
+            engine.run_tool("definitely_not_a_tool")
+
+    def test_get_available_tools_excludes_leaked_classes(self):
+        tools = AgentEngine().get_available_tools()
+        assert "draft_investigation" in tools
+        assert "scan_files" in tools
+        # dir()-based discovery used to leak imported classes/typing aliases:
+        for junk in ("CrateState", "Entity", "FAIRReport", "Any"):
+            assert junk not in tools


### PR DESCRIPTION
Closes #26.

Replaces `AgentEngine._build_registry()`'s `dir()` + `callable()` auto-discovery with an explicit `ToolRegistry`.

## Why
`dir(module)` registered **every** public callable — including imported classes (`CrateState`, `Entity`, `FAIRReport`) and typing aliases (`Any`) — as if they were tools, and state-passing was inferred by introspecting whether the first parameter was named `state`. Both are implicit and error-prone.

## Design
- **`builder/tools/registry.py`** — `ToolSpec` dataclass + `ToolRegistry` with `register()` / `get()` / `list()` / `all()` (plus `get_spec()` and `__contains__`), and a shared `TOOL_REGISTRY` singleton.
- **`register(name, fn, description="", takes_state=False)`** — `takes_state` is declared explicitly, replacing signature introspection.
- **Each tool module** registers its public tools at the bottom of the file (import `TOOL_REGISTRY` is cycle-safe — `registry.py` imports only stdlib).
- **`AgentEngine`** — `_build_registry()` returns the populated `TOOL_REGISTRY`; `run_tool` uses `spec.takes_state` (no more `inspect`); `get_available_tools()` lists only real tools.

## Scope notes
- **Scanner tools** (`scan_files`, …) remain special-cased in `run_tool` — they were never part of the `dir()` registry, so this preserves behavior.
- **HITL** (`present_to_human`/`request_input`) stays out of the registry (it wasn't there before; that wiring is #25).
- 34 tools are registered across 9 modules; the previously-leaked classes/aliases are now correctly excluded (covered by a test).

## Acceptance criteria
- [x] `ToolRegistry` with `register()`, `get()`, `list()`, `all()`
- [x] Each tool module explicitly registers its public tools
- [x] `register()` takes `takes_state: bool` instead of introspecting signatures
- [x] `AgentEngine._build_registry()` delegates to `ToolRegistry`
- [x] All existing tests pass without modification
- [x] Easy to extend (add function + one register call)

## Verification
- New `tests/test_tool_registry.py`: 11 tests pass
- Full suite: 263 pass (the 5 `test_agent_loop.py` failures are pre-existing — missing `langchain_*` deps — unrelated)
- `ty` clean; no new `ruff` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)