### PR TITLE
feat(scanner): add timing/progress instrumentation

### DIFF
--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import zipfile
 from pathlib import Path
 
@@ -284,6 +285,11 @@ def scan_files(
     except PermissionError:
         logger.warning("Permission denied scanning %s — recursing manually", target)
         all_entries = sorted(_safe_walk(target))
+
+    scan_start = time.monotonic()
+    processed = 0
+    total_candidates = len(all_entries)
+
     for entry in all_entries:
         if not entry.is_file():
             continue
@@ -312,7 +318,22 @@ def scan_files(
                 first_rows=first_rows,
             )
         )
-    logger.info("Scanned %s — found %d files", path, len(results))
+        processed += 1
+        if processed % 100 == 0:
+            elapsed = time.monotonic() - scan_start
+            logger.debug(
+                "Progress: %d/%d files... (%.1fs elapsed)",
+                processed,
+                total_candidates,
+                elapsed,
+            )
+
+    total_elapsed = time.monotonic() - scan_start
+    logger.info(
+        "Scan complete: %d files in %.2fs",
+        len(results),
+        total_elapsed,
+    )
     return results
 
 
@@ -419,15 +440,27 @@ def read_multiple_files(
     """
     results: dict[str, str] = {}
     skipped: list[str] = []
+    total_start = time.monotonic()
 
     for path in paths:
+        file_start = time.monotonic()
         content = read_file_sample(path, lines=lines)
+        file_elapsed = time.monotonic() - file_start
         if content is not None:
             results[path] = content
+            logger.debug("Read %s in %.3fs", path, file_elapsed)
         else:
             skipped.append(path)
+            logger.debug("Skipped %s in %.3fs", path, file_elapsed)
 
+    total_elapsed = time.monotonic() - total_start
     count = len(results)
+    logger.info(
+        "Read %d file(s) from %d path(s) in %.2fs",
+        count,
+        len(paths),
+        total_elapsed,
+    )
     msg = f"Read {count} file(s)"
     if skipped:
         msg += f" ({len(skipped)} skipped: {', '.join(skipped)})"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -381,6 +381,65 @@ class TestReadMultipleFiles:
         assert result["files"][str(b)] == "world"
 
 
+class TestScannerTiming:
+    """Tests for timing/progress instrumentation in scanner functions."""
+
+    def test_scan_files_logs_progress_and_elapsed(self, tmp_path, caplog):
+        """scan_files emits progress every 100 files and total elapsed at end."""
+        import logging
+        caplog.set_level(logging.DEBUG)
+
+        # Create 250 files so we cross the 100-file progress boundary twice
+        for i in range(250):
+            (tmp_path / f"file_{i:03d}.txt").write_text(f"content {i}\n")
+
+        result = scan_files(str(tmp_path))
+
+        assert len(result) == 250
+        # Should have at least "Progress: 100/..." and "Progress: 200/..."
+        progress_messages = [r for r in caplog.records if "Progress" in r.getMessage()]
+        assert len(progress_messages) >= 2, f"Expected >=2 Progress messages, got {len(progress_messages)}: {[r.getMessage() for r in progress_messages]}"
+
+        # Should have a final "Scan complete" summary
+        complete_messages = [r for r in caplog.records if "Scan complete" in r.getMessage()]
+        assert len(complete_messages) == 1
+        assert "in" in complete_messages[0].getMessage()
+
+    def test_scan_files_small_directory_no_progress(self, tmp_path, caplog):
+        """scan_files with fewer than 100 files does NOT emit progress."""
+        import logging
+        caplog.set_level(logging.DEBUG)
+
+        for i in range(3):
+            (tmp_path / f"file_{i}.txt").write_text(f"content {i}\n")
+
+        result = scan_files(str(tmp_path))
+
+        assert len(result) == 3
+        progress_messages = [r for r in caplog.records if "Progress" in r.getMessage()]
+        assert len(progress_messages) == 0, f"Expected no Progress messages for <100 files, got: {[r.getMessage() for r in progress_messages]}"
+
+        # But should still have the final summary
+        complete_messages = [r for r in caplog.records if "Scan complete" in r.getMessage()]
+        assert len(complete_messages) == 1
+
+    def test_read_multiple_files_logs_per_file_timing(self, tmp_path, caplog):
+        """read_multiple_files logs per-file elapsed time at DEBUG."""
+        import logging
+        caplog.set_level(logging.DEBUG)
+
+        a = tmp_path / "a.txt"
+        a.write_text("hello\n")
+        b = tmp_path / "b.txt"
+        b.write_text("world\n")
+
+        result = read_multiple_files([str(a), str(b)], lines=5)
+
+        # Should have at least one "Read" per-file log
+        read_messages = [r for r in caplog.records if "Read" in r.getMessage() and "in" in r.getMessage()]
+        assert len(read_messages) >= 2, f"Expected >=2 'Read ... in' messages, got {len(read_messages)}"
+
+
 class TestApprovedRoots:
     """Tests for the approved-scan-roots guard in scan_files."""
 


### PR DESCRIPTION
Closes #34

## What
- `scan_files`: logs progress every 100 files at DEBUG, total elapsed at INFO
- `read_multiple_files`: logs per-file elapsed time at DEBUG, summary at INFO
- 3 tests verifying progress messages and per-file timing logs

## Testing
- `uv run pytest tests/test_scanner.py -v` -- 32/32 pass
- `uv run pytest --tb=short -q` -- 272/272 pass
- `uv run ty check` -- 0 new type errors