### PR TITLE
feat(graph): migrate create_agent to explicit StateGraph

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -8,9 +8,17 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from langchain_core.callbacks import BaseCallbackHandler
+from langgraph.graph import add_messages
+
+# Import Annotated from typing_extensions so it survives
+# from __future__ import annotations at module level.
+try:
+    from typing import Annotated as _Annotated
+except ImportError:
+    from typing_extensions import Annotated as _Annotated
 
 from builder.agents.system_prompt import SYSTEM_PROMPT
 from builder.agents.tools_spec import TOOL_SPECS
@@ -23,6 +31,19 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Agent graph state (TypedDict with add_messages reducer)
+# ---------------------------------------------------------------------------
+
+from typing import TypedDict
+from langchain_core.messages import BaseMessage
+
+
+class AgentState(TypedDict):
+    """State for the agent LangGraph — messages with automatic concatenation."""
+    messages: _Annotated[Sequence[BaseMessage], add_messages]  # type: ignore[valid-type]
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +290,80 @@ def _build_chat_model(
 
     raise RuntimeError(f"Unknown provider: {provider!r}. Use openai or anthropic.")
 # ---------------------------------------------------------------------------
+# Explicit StateGraph construction (replaces create_agent)
+# ---------------------------------------------------------------------------
+
+
+def should_continue(state: dict[str, Any]) -> str:
+    """Route to ``"tools"`` if the last AIMessage has tool_calls, else ``END``.
+
+    This is the conditional edge function for the LangGraph agent graph.
+    """
+    from langgraph.graph import END
+
+    messages = state.get("messages", [])
+    if not messages:
+        return END
+    last_message = messages[-1]
+    # LangGraph AIMessage stores tool_calls as an attribute
+    tool_calls = getattr(last_message, "tool_calls", None)
+    if tool_calls and len(tool_calls) > 0:
+        return "tools"
+    return END
+
+
+def _build_agent_graph(
+    llm: Any,
+    tools: list[Any],
+) -> Any:
+    """Build a compiled StateGraph replacing ``create_agent()``.
+
+    Creates an explicit graph with ``"model"`` and ``"tools"`` nodes,
+    with a conditional edge routing tool calls back to the model and
+    final answers to END. The system prompt is prepended on every
+    model invocation.
+
+    Args:
+        llm: A LangChain chat model (with tools already bound).
+        tools: List of LangChain BaseTool instances for the ToolNode.
+
+    Returns:
+        A compiled ``CompiledStateGraph`` ready for ``.invoke()``.
+    """
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.graph import START, StateGraph
+    from langgraph.prebuilt import ToolNode
+
+    from langchain_core.messages import SystemMessage
+
+    def call_model(state: dict[str, Any]) -> dict[str, Any]:
+        """Model node: prepend system prompt and invoke the LLM."""
+        messages = state.get("messages", [])
+        # Prepend system prompt on every invocation
+        system_msg = SystemMessage(content=SYSTEM_PROMPT)
+        model_messages = [system_msg, *messages]
+        response = llm.invoke(model_messages)
+        # Return only the new response; the add_messages reducer appends it
+        return {"messages": [response]}
+
+    tool_node = ToolNode(tools)
+
+    # Use a typed state with add_messages reducer so ToolNode and model
+    # both append to the message list rather than replacing it.
+    graph: Any = StateGraph(AgentState)
+    graph.add_node("model", call_model)
+    graph.add_node("tools", tool_node)
+
+    # should_continue returns "tools" or END (the string "__end__").
+    # Without a path_map, the return value is used as the destination node name.
+    graph.add_conditional_edges("model", should_continue)
+    graph.add_edge("tools", "model")
+    graph.add_edge(START, "model")
+
+    return graph.compile(checkpointer=MemorySaver())
+
+
+# ---------------------------------------------------------------------------
 # Agent execution
 # ---------------------------------------------------------------------------
 
@@ -296,23 +391,15 @@ def run_interactive_agent(
         max_iterations: Maximum tool-calling iterations before forcing
             a final response.
     """
-    from langchain.agents import create_agent
     from langchain_core.messages import AIMessage, HumanMessage
     from langchain_core.runnables import RunnableConfig
-    from langgraph.checkpoint.memory import MemorySaver
 
     tools = _build_langchain_tools(engine)
     llm = _build_chat_model(provider=provider, model=model, base_url=base_url)
 
-    # Use the new LangChain 1.3+ create_agent graph API
-    # The system prompt is passed as the system_prompt kwarg;
-    # conversational memory is handled by the checkpointer.
-    app = create_agent(
-        llm,
-        tools,
-        system_prompt=SYSTEM_PROMPT,
-        checkpointer=MemorySaver(),
-    )
+    # Build the explicit StateGraph instead of using create_agent()
+    # The system prompt is prepended by the model node on every invocation.
+    app = _build_agent_graph(llm, tools)
 
     from rich.console import Console
     from rich.panel import Panel

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -1,0 +1,169 @@
+"""Tests for the explicit StateGraph construction in agent_loop.
+
+These tests verify that _build_agent_graph() produces a compiled graph
+with the expected node structure, routing behavior, and message flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class TestBuildAgentGraph:
+    """Tests for the _build_agent_graph function."""
+
+    def test_import_and_callable(self):
+        """_build_agent_graph is importable and callable."""
+        from builder.agents.agent_loop import _build_agent_graph
+
+        # Must be instantiated with llm and tools
+        assert callable(_build_agent_graph)
+
+    def test_returns_compiled_graph(self):
+        """_build_agent_graph returns a compiled StateGraph."""
+        from unittest.mock import MagicMock
+
+        from langchain_core.tools import tool as langchain_tool
+
+        from builder.agents.agent_loop import _build_agent_graph
+
+        @langchain_tool
+        def dummy_tool(query: str) -> str:
+            """A dummy tool for testing."""
+            return f"result: {query}"
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+
+        app = _build_agent_graph(mock_llm, [dummy_tool])
+
+        # Should have expected attributes of a compiled graph
+        assert hasattr(app, "invoke")
+        assert hasattr(app, "get_graph")
+
+    def test_compiled_graph_has_expected_nodes(self):
+        """The compiled graph contains the expected node names."""
+        from unittest.mock import MagicMock
+
+        from langchain_core.tools import tool as langchain_tool
+
+        from builder.agents.agent_loop import _build_agent_graph
+
+        @langchain_tool
+        def dummy_tool(query: str) -> str:
+            """A dummy tool for testing."""
+            return f"result: {query}"
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+
+        app = _build_agent_graph(mock_llm, [dummy_tool])
+
+        graph = app.get_graph()
+        # In compiled graphs, nodes is a list of node names (strings)
+        node_names = list(graph.nodes)
+        assert "model" in node_names, f"Expected 'model' node, got {node_names}"
+        assert "tools" in node_names, f"Expected 'tools' node, got {node_names}"
+
+    def test_should_continue_routes_to_tools_when_tool_calls_present(self):
+        """should_continue returns 'tools' when last message has tool_calls."""
+        from unittest.mock import MagicMock
+
+        from langchain_core.messages import AIMessage
+
+        from builder.agents.agent_loop import should_continue
+
+        # Create an AI message with tool_calls
+        ai_msg = AIMessage(
+            content="I'll look that up",
+            tool_calls=[
+                {
+                    "name": "dummy_tool",
+                    "args": {"query": "test"},
+                    "id": "call_123",
+                    "type": "tool_call",
+                }
+            ],
+        )
+        state = {"messages": [ai_msg]}
+
+        result = should_continue(state)
+        assert result == "tools"
+
+    def test_should_continue_routes_to_end_when_no_tool_calls(self):
+        """should_continue returns END when last message has no tool_calls."""
+        from langgraph.graph import END
+
+        from builder.agents.agent_loop import should_continue
+
+        from langchain_core.messages import AIMessage
+
+        ai_msg = AIMessage(content="Here is the answer.")
+        state = {"messages": [ai_msg]}
+
+        result = should_continue(state)
+        assert result == END
+
+    def test_should_continue_routes_to_end_when_empty_tool_calls(self):
+        """should_continue returns END when tool_calls is empty list."""
+        from langgraph.graph import END
+
+        from builder.agents.agent_loop import should_continue
+
+        from langchain_core.messages import AIMessage
+
+        ai_msg = AIMessage(content="Done.", tool_calls=[])
+        state = {"messages": [ai_msg]}
+
+        result = should_continue(state)
+        assert result == END
+
+    def test_model_node_calls_llm_and_returns_messages(self):
+        """The model node calls the LLM and returns updated messages."""
+        from unittest.mock import MagicMock
+
+        from langchain_core.messages import AIMessage, HumanMessage
+        from langchain_core.tools import tool as langchain_tool
+
+        from builder.agents.agent_loop import _build_agent_graph
+
+        @langchain_tool
+        def dummy_tool(query: str) -> str:
+            """A dummy tool for testing."""
+            return f"result: {query}"
+
+        # Mock LLM that returns a simple answer
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.invoke.return_value = AIMessage(content="Hello! I am the agent.")
+
+        app = _build_agent_graph(mock_llm, [dummy_tool])
+
+        # Need thread_id for MemorySaver checkpointing
+        config = {"configurable": {"thread_id": "test-thread-001"}}
+        result = app.invoke(
+            {"messages": [HumanMessage(content="Hi")]},
+            config,
+        )
+
+        assert "messages" in result
+        messages = result["messages"]
+        # Should have at least the human message and the AI response
+        assert len(messages) >= 2
+        # The last message should be from the AI (no tool calls)
+        last_msg = messages[-1]
+        assert last_msg.content == "Hello! I am the agent."
+
+
+class TestRunInteractiveAgentPreservesBehavior:
+    """Tests that run_interactive_agent still works via the new graph."""
+
+    def test_run_interactive_agent_imports_and_calls_create_agent(self, monkeypatch):
+        """run_interactive_agent still imports successfully and calls the new _build_agent_graph."""
+        import builder.agents.agent_loop as loop_mod
+
+        # The _build_agent_graph function should be defined
+        assert hasattr(loop_mod, "_build_agent_graph")
+        assert callable(loop_mod._build_agent_graph)


### PR DESCRIPTION
Closes #37

## What
Replace `create_agent(llm, tools, system_prompt=..., checkpointer=MemorySaver())` with explicit `StateGraph` construction in `_build_agent_graph()`.

### Graph topology
- `__start__` → `model` → conditional edge → `tools` or `__end__`
- `tools` → `model` (ReAct loop)
- Conditional routing: `should_continue()` checks if last AI message has `tool_calls`

### Key design decisions
- `AgentState` TypedDict with `add_messages` reducer (enables append, not replace)
- System prompt prepended on every `model` node invocation
- No `path_map` — router returns node name strings directly
- Preserves `MemorySaver` checkpointer, Rich spinner, REPL loop, greeting/resume/goodbye

### TDD
Tests written first in `tests/test_agent_graph.py` (8 tests):
- Router behavior (3 tests): tools, END, empty tool_calls
- Graph compilation (2 tests): returns callable, has expected nodes
- Model invocation (1 test): mock LLM, verifies message flow
- Behavioral compatibility (2 tests): import + function exists

## Blocking
#37 done → #38, #39, #40 are now unblocked.

## Testing
- `uv run pytest --tb=short -q` — 298/298 pass
- `uv run ty check` — 1 new type error (StateGraph TypedDict bound; runtime passes)