### PR TITLE
fix(test): green default suite — declare langgraph/langchain, unround profiler durations (#50)

### DIFF
--- a/builder/tools/profiler.py
+++ b/builder/tools/profiler.py
@@ -115,7 +115,10 @@ class ProfilingLogger:
         if tool is not None:
             record["tool"] = tool
         if duration_ms is not None:
-            record["duration_ms"] = round(duration_ms, 1)
+            # Store the unrounded duration so sub-millisecond tool/node timings
+            # survive (rounding to 1 decimal collapsed fast calls to 0.0).
+            # Consumers round at display/analysis time (see docs/profiling.md).
+            record["duration_ms"] = duration_ms
         if iteration is not None:
             record["iteration"] = iteration
         if args is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ langchain = [
     "langchain>=0.3.0",
     "langchain-openai>=0.3.0",
     "langchain-anthropic>=0.3.0",
+    "langgraph>=0.2.0",
 ]
 
 [dependency-groups]
@@ -30,6 +31,12 @@ dev = [
     "responses>=0.25.0",
     "ipykernel>=7.3.0",
     "nbformat>=5.10.4",
+    # Agent stack — required so the default `uv run` (and `uv run pytest`) can
+    # import builder.agents.agent_loop (LangChain providers + LangGraph graph).
+    "langchain>=0.3.0",
+    "langchain-openai>=0.3.0",
+    "langchain-anthropic>=0.3.0",
+    "langgraph>=0.2.0",
 ]
 
 [tool.ruff.lint]

--- a/uv.lock
+++ b/uv.lock
@@ -5687,6 +5687,7 @@ langchain = [
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },
+    { name = "langgraph" },
 ]
 
 [package.dev-dependencies]
@@ -5694,6 +5695,10 @@ dev = [
     { name = "hindsight-all" },
     { name = "hindsight-cline" },
     { name = "ipykernel" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
     { name = "nbformat" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -5706,6 +5711,7 @@ requires-dist = [
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.0" },
     { name = "langchain-anthropic", marker = "extra == 'langchain'", specifier = ">=0.3.0" },
     { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=0.3.0" },
+    { name = "langgraph", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
@@ -5720,6 +5726,10 @@ dev = [
     { name = "hindsight-all", specifier = ">=0.8.3" },
     { name = "hindsight-cline", specifier = ">=0.2.0" },
     { name = "ipykernel", specifier = ">=7.3.0" },
+    { name = "langchain", specifier = ">=0.3.0" },
+    { name = "langchain-anthropic", specifier = ">=0.3.0" },
+    { name = "langchain-openai", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=0.2.0" },
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },


### PR DESCRIPTION
Closes #50.

`uv run pytest` — and `uv run python -m main --interactive` — failed out of the box. Two root causes:

## 1. Undeclared agent stack (broke the app + 13 tests)
#37 made `langgraph` a **hard top-level import** of `builder.agents.agent_loop`, but `langgraph` was **not declared anywhere**, and the langchain providers lived only in the optional `langchain` extra — not the dev group. So importing `agent_loop` raised `ModuleNotFoundError: No module named 'langgraph'`, breaking:
- the app entrypoint (`python -m main --interactive`),
- `tests/test_agent_graph.py` (8 tests, collection error),
- `tests/test_agent_loop.py::TestBuildChatModel` (5 tests).

**Fix:** add the agent stack (`langchain`, `langchain-openai`, `langchain-anthropic`, `langgraph`) to the **dev dependency-group** (so `uv run` has it by default), and add the missing **`langgraph` to the `langchain` extra** so `pip install vitro-crate[langchain]` is complete at runtime.

## 2. Profiler rounded sub-ms durations to 0.0
`ProfilingLogger` rounded `duration_ms` to 1 decimal, so fast tools recorded `0.0` and `test_run_tool_writes_profile_entry` failed (`assert 0.0 > 0`) — deterministically on fast machines. **Fix:** store the unrounded duration; consumers round at display/analysis time.

## Acceptance criteria
- [x] `uv run pytest` passes from a clean `uv sync` — **313 passed**, no ImportErrors
- [x] langchain provider tests execute (not skipped)
- [x] Profiler records unrounded duration; rounding deferred to display
- [x] `test_run_tool_writes_profile_entry` passes repeatedly — **6/6**
- [x] `ty` clean; `ruff` clean

## Note (DeepSeek)
The agent runs on **DeepSeek-flash** (OpenAI-API-compatible), which uses the `langchain-openai` path with a custom `base_url`. `langchain-anthropic` is included only because `test_anthropic_provider` exercises that branch — it can be dropped later if you commit to DeepSeek-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)