### PR TITLE
fix(scanner): stop the scan re-loop — binary sampling skip (#51) + compact LLM scan summary

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -157,7 +157,16 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
 
         def _make_tool(tool_name: str, tool_desc: str, tool_params: dict) -> BaseTool:
             def _run(**kwargs: Any) -> Any:
-                return engine.run_tool(tool_name, **kwargs)
+                result = engine.run_tool(tool_name, **kwargs)
+                # scan_files returns the full list[FileClassification] (already
+                # stored in state); hand the LLM a compact summary instead of
+                # the raw blob so it gets a clear success signal and does not
+                # re-scan in a loop.
+                if tool_name == "scan_files" and isinstance(result, list):
+                    from builder.tools.scanner import summarize_scan_result
+
+                    return summarize_scan_result(result)
+                return result
 
             _run.__name__ = tool_name
             _run.__doc__ = tool_desc

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import time
 import zipfile
+from collections import Counter
 from pathlib import Path
 
 from builder.state import ArchivePreview, FileClassification
@@ -498,6 +499,17 @@ def read_file_sample(path: str, lines: int = 20) -> str | None:
     if _detect_mime_type(file_path) == "application/octet-stream":
         return None
 
+    # Content-based binary guard: office formats (xlsx/xls) are zip/OLE2
+    # containers whose MIME type is *not* octet-stream, so the check above
+    # misses them and their raw bytes (PK\x03\x04…) would be read as mojibake.
+    # A NUL byte in the first chunk reliably marks a file as binary.
+    try:
+        with file_path.open("rb") as fb:
+            if b"\x00" in fb.read(8192):
+                return None
+    except OSError:
+        return None
+
     try:
         sample_lines: list[str] = []
         with file_path.open("r", encoding="utf-8", errors="replace") as f:
@@ -513,3 +525,34 @@ def read_file_sample(path: str, lines: int = 20) -> str | None:
     except Exception:
         logger.exception("Error reading file sample: %s", path)
         return None
+
+
+def summarize_scan_result(
+    files: list[FileClassification], sample: int = 15
+) -> str:
+    """Return a compact, LLM-facing summary of a scan result.
+
+    The full inventory is stored in ``CrateState.scanned_files``; the agent
+    only needs a clear success signal plus a small sample — not the raw list of
+    hundreds/thousands of dataclass objects, which floods the context with no
+    obvious success cue and makes the agent re-scan in a loop.
+
+    Args:
+        files: The scanned ``FileClassification`` records.
+        sample: Maximum number of filenames to include in the sample.
+
+    Returns:
+        A short human/LLM-readable summary string.
+    """
+    n = len(files)
+    if n == 0:
+        return "Scan complete: 0 files found."
+
+    by_type = Counter(f.mime_type for f in files)
+    types = ", ".join(f"{mime} ({count})" for mime, count in by_type.most_common(8))
+    shown = ", ".join(f.filename for f in files[:sample])
+    more = f", +{n - sample} more" if n > sample else ""
+    return (
+        f"Scan complete: {n} files found and stored in session state "
+        f"(no need to scan again). Types: {types}. Sample: {shown}{more}."
+    )

--- a/tests/test_scan_loop_fix.py
+++ b/tests/test_scan_loop_fix.py
@@ -1,0 +1,133 @@
+"""Tests for the scan re-loop fix.
+
+Two compounding causes made the agent re-scan forever:
+  #51 — xlsx/xls were text-sampled, so binary zip bytes (PK\\x03\\x04…) landed
+        in first_rows as mojibake.
+  #61 — the scan tool handed the LLM the raw list[FileClassification] (1468
+        objects), a huge blob with no clear success signal.
+
+These tests cover the binary-sampling skip and the compact LLM-facing summary.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from builder.state import FileClassification
+from builder.tools.scanner import (
+    read_file_sample,
+    scan_files,
+    summarize_scan_result,
+)
+
+
+def _make_xlsx(path: Path) -> None:
+    """Write a minimal real .xlsx (a zip; bytes begin with PK\\x03\\x04)."""
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("xl/worksheets/sheet1.xml", "<worksheet/>")
+
+
+class TestBinarySamplingSkip:
+    """#51 — binary office formats must not be text-sampled into first_rows."""
+
+    def test_read_file_sample_returns_none_for_xlsx(self, tmp_path):
+        f = tmp_path / "data.xlsx"
+        _make_xlsx(f)
+        assert read_file_sample(str(f)) is None
+
+    def test_read_file_sample_returns_none_for_nul_bytes(self, tmp_path):
+        f = tmp_path / "weird.csv"
+        f.write_bytes(b"col1,col2\n\x00\x01\x02 binary junk")
+        assert read_file_sample(str(f)) is None
+
+    def test_read_file_sample_still_reads_text_csv(self, tmp_path):
+        f = tmp_path / "ok.csv"
+        f.write_text("a,b\n1,2\n")
+        out = read_file_sample(str(f))
+        assert out is not None
+        assert "a,b" in out
+
+    def test_scan_files_leaves_xlsx_first_rows_none(self, tmp_path):
+        _make_xlsx(tmp_path / "book.xlsx")
+        results = scan_files(str(tmp_path))
+        xlsx = next(r for r in results if r.filename == "book.xlsx")
+        assert xlsx.first_rows is None
+
+
+class TestSummarizeScanResult:
+    """#61 — the LLM-facing summary is compact and signals success."""
+
+    def _files(self, n: int) -> list[FileClassification]:
+        return [
+            FileClassification(
+                path=f"/d/f{i}.csv",
+                filename=f"f{i}.csv",
+                size=10,
+                mime_type="text/csv",
+                first_rows=["a,b", "1,2"],
+            )
+            for i in range(n)
+        ]
+
+    def test_compact_with_success_signal_and_count(self):
+        s = summarize_scan_result(self._files(1468))
+        assert isinstance(s, str)
+        assert "1468" in s
+        assert "state" in s.lower()       # tells the LLM results are stored
+        assert len(s) < 2000              # not the giant raw blob
+        assert "1,2" not in s             # no first_rows content leaked
+
+    def test_bounded_sample_of_filenames(self):
+        s = summarize_scan_result(self._files(1468), sample=15)
+        assert "f0.csv" in s
+        assert "more" in s.lower()        # indicates truncation
+
+    def test_empty_scan(self):
+        s = summarize_scan_result([])
+        assert "0" in s
+
+
+class TestScanToolWrapperReturnsSummary:
+    """#61 — the LangChain wrapper returns the summary, not the raw list."""
+
+    def test_wrapper_summarizes_scan_files(self, monkeypatch):
+        from builder.agents.agent_loop import _build_langchain_tools
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        fake_files = [
+            FileClassification(
+                path=f"/d/f{i}.csv",
+                filename=f"f{i}.csv",
+                size=1,
+                mime_type="text/csv",
+            )
+            for i in range(1468)
+        ]
+        monkeypatch.setattr(
+            engine,
+            "run_tool",
+            lambda name, **kw: fake_files if name == "scan_files" else None,
+        )
+
+        tools = _build_langchain_tools(engine)
+        scan_tool = next(t for t in tools if t.name == "scan_files")
+        result = scan_tool.invoke({"path": "/d"})
+
+        assert isinstance(result, str)
+        assert "1468" in result
+        assert len(result) < 2000
+
+    def test_wrapper_passes_through_non_scan_tools(self, monkeypatch):
+        from builder.agents.agent_loop import _build_langchain_tools
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        monkeypatch.setattr(
+            engine, "run_tool", lambda name, **kw: {"ok": True, "tool": name}
+        )
+        tools = _build_langchain_tools(engine)
+        validate_tool = next(t for t in tools if t.name == "validate")
+        result = validate_tool.invoke({"crate_path": "/x"})
+        assert result == {"ok": True, "tool": "validate"}


### PR DESCRIPTION
Fixes the agent **re-scanning forever**. `scan_files` succeeds (e.g. 1468 files, correctly stored in `state.scanned_files`), but the LLM was handed a huge, mojibake-laden blob with no success signal — so it concluded the scan hadn't worked and retried, endlessly.

Two compounding causes, both fixed here:

## #51 — binary files sampled as text (mojibake in `first_rows`)
`read_file_sample` only skipped `application/octet-stream`, but xlsx/xls are zip/OLE2 containers whose MIME is `…spreadsheetml.sheet` / `application/vnd.ms-excel` — so they slipped through and their raw bytes (`PK\x03\x04…`) were read as text.
**Fix:** add a content-based binary guard — a NUL byte in the first 8 KB marks the file binary, so any binary file is skipped regardless of MIME. Closes #51.

## #61 (scan-tool slice) — raw list returned to the LLM
The LangChain wrapper returned `engine.run_tool()` verbatim, so `scan_files`' raw `list[FileClassification]` (hundreds/thousands of dataclasses) became one giant `ToolMessage`.
**Fix:** add `summarize_scan_result()` and return a compact summary from the wrapper — count + type breakdown + bounded filename sample, with an explicit *"stored in session state (no need to scan again)"* signal. This matches what `scan_files`' own description already promises.

The full inventory still lives in `state.scanned_files`, and `engine.run_tool('scan_files')` **still returns the list** — so the internal contract (and the test relying on it) is unchanged. Only the LLM-facing boundary is summarized.

## Verification
- New `tests/test_scan_loop_fix.py` (9 tests): binary skip for xlsx/NUL-byte files, text CSV still sampled, `summarize_scan_result` compactness/success-signal, wrapper returns summary for `scan_files` and passes other tools through.
- Full suite **330 passed**; `ty` clean; no new `ruff` findings.

## Notes
- Especially helpful for the **DeepSeek-flash** model — a flash-tier model leans hard on a clear success signal, so this removes a major loop trigger.
- **#61 stays open** for the broader work (trimming/summarizing *all* verbose tool outputs across message history); this PR does the highest-impact slice.
- Recommended safety-net follow-up: **#56** (enforce `recursion_limit`) so no future oversized tool output can loop forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)