### PR TITLE
feat(lookups): shared resilient HTTP helper — retry/backoff + 404-vs-transient (#49)

### DIFF
--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -15,6 +15,7 @@ import logging
 import time
 from typing import Any
 
+from lookups._http import TransientLookupError
 from lookups.aopwiki import lookup_aop as lookup_aop_wiki
 from lookups.bao import lookup_bao_term as lookup_bao_term_ols
 from lookups.cellosaurus import lookup_cellosaurus
@@ -76,6 +77,8 @@ def lookup_compound(name: str) -> dict[str, Any]:
                 return _success(result)
 
         return _failure(f"Compound '{name}' not found in PubChem")
+    except TransientLookupError as exc:
+        return _failure(f"PubChem temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("PubChem lookup failed for '%s'", name)
         return _failure(f"PubChem lookup failed: {exc}")
@@ -101,6 +104,8 @@ def lookup_cell_line(accession: str) -> dict[str, Any]:
         if result and result.get("name"):
             return _success(result)
         return _failure(f"Cell line '{accession}' not found in Cellosaurus")
+    except TransientLookupError as exc:
+        return _failure(f"Cellosaurus temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("Cellosaurus lookup failed for '%s'", accession)
         return _failure(f"Cellosaurus lookup failed: {exc}")
@@ -125,6 +130,8 @@ def lookup_aop(aop_id: str) -> dict[str, Any]:
         if result and result.get("aop"):
             return _success(result)
         return _failure(f"AOP '{aop_id}' not found in AOP-Wiki")
+    except TransientLookupError as exc:
+        return _failure(f"AOP-Wiki temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("AOP-Wiki lookup failed for '%s'", aop_id)
         return _failure(f"AOP-Wiki lookup failed: {exc}")
@@ -149,6 +156,8 @@ def lookup_bao_term(query: str) -> dict[str, Any]:
         if result and result.get("@id"):
             return _success(result)
         return _failure(f"No BAO term found for '{query}'")
+    except TransientLookupError as exc:
+        return _failure(f"BAO/OLS temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("BAO/OLS lookup failed for '%s'", query)
         return _failure(f"BAO/OLS lookup failed: {exc}")
@@ -178,6 +187,8 @@ def lookup_orcid(orcid_id: str) -> dict[str, Any]:
         if result and result.get("@id"):
             return _success(result)
         return _failure(f"ORCID lookup failed for '{orcid_id}'")
+    except TransientLookupError as exc:
+        return _failure(f"ORCID temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("ORCID lookup failed for '%s'", orcid_id)
         return _failure(f"ORCID lookup failed: {exc}")
@@ -202,6 +213,8 @@ def lookup_ror(name: str) -> dict[str, Any]:
         if result and result.get("@id"):
             return _success(result)
         return _failure(f"No ROR organization found for '{name}'")
+    except TransientLookupError as exc:
+        return _failure(f"ROR temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("ROR lookup failed for '%s'", name)
         return _failure(f"ROR lookup failed: {exc}")
@@ -227,6 +240,8 @@ def lookup_doi(doi: str) -> dict[str, Any]:
         if result and result.get("name"):
             return _success(result)
         return _failure(f"DOI '{doi}' not found in Crossref")
+    except TransientLookupError as exc:
+        return _failure(f"Crossref temporarily unavailable (transient): {exc}")
     except Exception as exc:
         logger.exception("Crossref lookup failed for '%s'", doi)
         return _failure(f"Crossref lookup failed: {exc}")

--- a/lookups/_http.py
+++ b/lookups/_http.py
@@ -1,0 +1,131 @@
+"""Shared resilient HTTP helper for the lookup clients.
+
+All lookup clients hit third-party APIs (PubChem, Cellosaurus, AOP-Wiki,
+OLS/BAO, ORCID, ROR, Crossref). A single dropped packet, read timeout, or a
+429/503 throttle used to turn into a hard "not found" for the rest of the run
+— and because the clients are ``lru_cache``d, that failure was negatively
+cached too.
+
+This helper centralizes a :class:`requests.Session` with automatic retry +
+exponential backoff (honoring ``Retry-After``) and a clear three-way outcome:
+
+* **success** — HTTP 200 with a valid JSON body → the parsed object.
+* **definitive not-found** — HTTP 404 (or other non-retryable 4xx) →
+  :data:`NOT_FOUND` (a sentinel). Callers map this to their empty result.
+* **transient failure** — timeout, connection error, or 429/5xx that persists
+  after retries, or a malformed 200 body → :class:`TransientLookupError`.
+
+Because a transient failure *raises*, ``lru_cache`` never stores it, so a
+later call in the same session re-hits the network instead of returning a
+stale failure.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+DEFAULT_TIMEOUT = 10
+_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+class TransientLookupError(Exception):
+    """A lookup failed transiently (timeout / connection / 429 / 5xx).
+
+    Distinct from a definitive not-found so callers can keep the user's value
+    and retry later instead of treating it as "not found".
+    """
+
+
+class _NotFound:
+    """Sentinel type for a definitive not-found response."""
+
+    _instance: _NotFound | None = None
+
+    def __new__(cls) -> _NotFound:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return "NOT_FOUND"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+NOT_FOUND = _NotFound()
+
+_session: requests.Session | None = None
+
+
+def _build_session() -> requests.Session:
+    """Build a Session whose adapters retry transient failures with backoff."""
+    retry = Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=tuple(_TRANSIENT_STATUS),
+        allowed_methods=frozenset({"GET", "POST"}),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def get_session() -> requests.Session:
+    """Return the shared, lazily-built, retry-enabled Session."""
+    global _session
+    if _session is None:
+        _session = _build_session()
+    return _session
+
+
+def http_get_json(
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Any:
+    """GET ``url`` and return parsed JSON, ``NOT_FOUND``, or raise transiently.
+
+    Args:
+        url: The URL to GET.
+        params: Optional query parameters.
+        headers: Optional request headers.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The parsed JSON object on HTTP 200, or :data:`NOT_FOUND` on a
+        definitive 4xx (404 and other non-retryable client errors).
+
+    Raises:
+        TransientLookupError: on timeout, connection error, a 429/5xx that
+            survived retries, or a 200 with a malformed JSON body.
+    """
+    try:
+        resp = get_session().get(
+            url, params=params, headers=headers, timeout=timeout
+        )
+    except requests.RequestException as exc:
+        raise TransientLookupError(f"request error for {url}: {exc}") from exc
+
+    code = resp.status_code
+    if code == 200:
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise TransientLookupError(
+                f"invalid JSON body from {url}: {exc}"
+            ) from exc
+    if code in _TRANSIENT_STATUS:
+        raise TransientLookupError(f"HTTP {code} from {url} after retries")
+    # 404 and any other non-retryable client/redirect status → definitive.
+    return NOT_FOUND

--- a/lookups/aopwiki.py
+++ b/lookups/aopwiki.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import functools
 import time
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://aopwiki.org"
 
@@ -42,10 +42,9 @@ def _event_details(event_id: str) -> dict:
     """
     try:
         time.sleep(0.1)
-        r = requests.get(f"{_event_url(event_id)}.json", timeout=10)
-        if r.status_code != 200:
+        d = http_get_json(f"{_event_url(event_id)}.json")
+        if d is NOT_FOUND:
             return {}
-        d = r.json()
         out: dict = {}
         if d.get("short_name"):
             out["short_name"] = d["short_name"]
@@ -78,10 +77,9 @@ def lookup_aop(aop_id: str) -> dict:
     aop_url = f"{_BASE}/aops/{aop_id}"
     try:
         time.sleep(0.1)
-        r = requests.get(f"{aop_url}.json", timeout=15)
-        if r.status_code != 200:
+        data = http_get_json(f"{aop_url}.json", timeout=15)
+        if data is NOT_FOUND:
             return {}
-        data = r.json()
         # AOP-Wiki JSON may nest the payload under an "aop" key.
         if isinstance(data, dict) and "aop" in data:
             data = data["aop"]
@@ -159,5 +157,7 @@ def lookup_aop(aop_id: str) -> dict:
             aop["has_key_event_relationship"] = kers
 
         return {"aop": aop, "events": events, "relationships": relationships}
+    except TransientLookupError:
+        raise
     except Exception:
         return {}

--- a/lookups/bao.py
+++ b/lookups/bao.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import functools
 import time
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://www.ebi.ac.uk/ols4/api/search"
 
@@ -25,21 +25,21 @@ def lookup_bao_term(query: str) -> dict:
 
     Returns:
         dict with keys: @id (BAO IRI), @type ("DefinedTerm"), name.
-        Returns {} if no match or on API failure.
+        Returns {} if no match. Raises TransientLookupError on a transient API
+        failure (timeout / connection / 429 / 5xx).
     """
     if not query:
         return {}
     try:
         time.sleep(0.1)
-        r = requests.get(
+        data = http_get_json(
             _BASE,
             params={"q": query, "ontology": "bao", "rows": 1},
-            timeout=10,
         )
-        if r.status_code != 200:
+        if data is NOT_FOUND:
             return {}
 
-        docs = r.json().get("response", {}).get("docs", [])
+        docs = data.get("response", {}).get("docs", [])
         if not docs:
             return {}
 
@@ -56,5 +56,7 @@ def lookup_bao_term(query: str) -> dict:
             "name": label,
             "termCode": top.get("short_form", ""),
         }
+    except TransientLookupError:
+        raise
     except Exception:
         return {}

--- a/lookups/cellosaurus.py
+++ b/lookups/cellosaurus.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import functools
 import time
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://api.cellosaurus.org/cell-line"
 
@@ -45,11 +45,9 @@ def lookup_cellosaurus(accession: str) -> dict:
     """
     try:
         time.sleep(0.1)
-        r = requests.get(f"{_BASE}/{accession}?format=json", timeout=10)
-        if r.status_code != 200:
+        data = http_get_json(f"{_BASE}/{accession}?format=json")
+        if data is NOT_FOUND:
             return {}
-
-        data = r.json()
         # API wraps result: {"Cellosaurus": {"cell-line-list": [...]}}
         if "Cellosaurus" in data:
             cell_lines = data["Cellosaurus"].get("cell-line-list", [])
@@ -119,5 +117,7 @@ def lookup_cellosaurus(accession: str) -> dict:
 
         return result
 
+    except TransientLookupError:
+        raise
     except Exception:
         return {}

--- a/lookups/crossref.py
+++ b/lookups/crossref.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import functools
 import time
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://api.crossref.org/works"
 _HEADERS = {"User-Agent": "rocrate-wizard/0.1 (mailto:support@example.com)"}
@@ -26,7 +26,8 @@ def lookup_doi(doi: str) -> dict:
     Returns:
         dict with keys: @id, @type ("ScholarlyArticle"), name, author (list),
         datePublished, url, identifier.
-        Returns {} on failure.
+        Returns {} when the DOI is not found. Raises TransientLookupError on a
+        transient API failure (timeout / connection / 429 / 5xx).
     """
     doi = doi.strip()
     # Strip URL prefix if present
@@ -38,11 +39,11 @@ def lookup_doi(doi: str) -> dict:
     doi_url = f"https://doi.org/{doi}"
     try:
         time.sleep(0.1)
-        r = requests.get(f"{_BASE}/{doi}", headers=_HEADERS, timeout=10)
-        if r.status_code != 200:
+        data = http_get_json(f"{_BASE}/{doi}", headers=_HEADERS)
+        if data is NOT_FOUND:
             return {}
 
-        work = r.json().get("message", {})
+        work = data.get("message", {})
 
         # Title
         titles = work.get("title", [])
@@ -81,5 +82,7 @@ def lookup_doi(doi: str) -> dict:
             "datePublished": year,
             "url": url,
         }
+    except TransientLookupError:
+        raise
     except Exception:
         return {}

--- a/lookups/orcid.py
+++ b/lookups/orcid.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import functools
 import time
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://pub.orcid.org/v3.0"
 _HEADERS = {"Accept": "application/json"}
@@ -27,21 +27,17 @@ def lookup_orcid(orcid_id: str) -> dict:
         dict with keys: @id, @type, identifier, name, givenName, familyName,
         affiliation_name (str), affiliation_ror (str, may be ""). The caller
         is responsible for creating an Organization entity from these fields.
-        On API failure returns a minimal dict with just @id and identifier.
+        Returns {} when the iD is not found. Raises TransientLookupError on a
+        transient API failure (timeout / connection / 429 / 5xx) so a momentary
+        outage is never mistaken for a resolved (or unresolvable) record.
     """
     orcid_url = f"https://orcid.org/{orcid_id}"
-    fallback = {
-        "@id": orcid_url,
-        "@type": "Person",
-        "identifier": orcid_url,
-    }
     try:
         time.sleep(0.1)
-        r = requests.get(f"{_BASE}/{orcid_id}/record", headers=_HEADERS, timeout=10)
-        if r.status_code != 200:
-            return fallback
+        data = http_get_json(f"{_BASE}/{orcid_id}/record", headers=_HEADERS)
+        if data is NOT_FOUND:
+            return {}
 
-        data = r.json()
         person = data.get("person", {})
         name_block = person.get("name") or {}
         given = (name_block.get("given-names") or {}).get("value", "")
@@ -78,5 +74,7 @@ def lookup_orcid(orcid_id: str) -> dict:
             "affiliation_name": affiliation_name,
             "affiliation_ror": affiliation_ror,
         }
+    except TransientLookupError:
+        raise
     except Exception:
-        return fallback
+        return {}

--- a/lookups/pubchem.py
+++ b/lookups/pubchem.py
@@ -13,7 +13,7 @@ import re
 import time
 from urllib.parse import quote
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name"
 _CAS_PATTERN = re.compile(r"^\d{2,7}-\d{2}-\d$")
@@ -24,15 +24,17 @@ def lookup_pubchem(name: str) -> dict:
     """Fetch chemical identifiers from PubChem by compound name.
 
     Returns a dict with keys: cas, smiles, inchikey, inchi, formula, mass,
-    iupac_name, pubchem_cid. Returns an empty dict if the compound is not found
-    or the request fails.
+    iupac_name, pubchem_cid. Returns an empty dict if the compound is not
+    found. Raises TransientLookupError if the compound request fails
+    transiently (timeout / connection / 429 / 5xx); the synonyms request is
+    best-effort and never fatal.
     """
     try:
-        r = requests.get(f"{_BASE}/{quote(name)}/JSON", timeout=10)
-        if r.status_code != 200:
+        compound_data = http_get_json(f"{_BASE}/{quote(name)}/JSON")
+        if compound_data is NOT_FOUND:
             return {}
 
-        compound = r.json()["PC_Compounds"][0]
+        compound = compound_data["PC_Compounds"][0]
         cid = str(compound["id"]["id"]["cid"])
 
         props: dict = {}
@@ -59,20 +61,23 @@ def lookup_pubchem(name: str) -> dict:
                 else:
                     props.setdefault("iupac_name", val.get("sval", ""))
 
-        # CAS numbers appear in the synonyms list
+        # CAS numbers appear in the synonyms list. This is best-effort
+        # enrichment: a transient/absent synonyms response must not lose the
+        # compound we already resolved.
         time.sleep(0.2)  # stay under rate limit
-        sr = requests.get(
-            f"{_BASE}/{quote(name)}/synonyms/JSON", timeout=10
-        )
         cas = ""
-        if sr.status_code == 200:
-            synonyms = (
-                sr.json()
-                .get("InformationList", {})
-                .get("Information", [{}])[0]
-                .get("Synonym", [])
-            )
-            cas = next((s for s in synonyms if _CAS_PATTERN.match(s)), "")
+        try:
+            syn_data = http_get_json(f"{_BASE}/{quote(name)}/synonyms/JSON")
+            if syn_data is not NOT_FOUND:
+                synonyms = (
+                    syn_data
+                    .get("InformationList", {})
+                    .get("Information", [{}])[0]
+                    .get("Synonym", [])
+                )
+                cas = next((s for s in synonyms if _CAS_PATTERN.match(s)), "")
+        except TransientLookupError:
+            pass  # synonyms are optional; keep the compound result
 
         return {
             "cas": cas,
@@ -85,5 +90,7 @@ def lookup_pubchem(name: str) -> dict:
             "pubchem_cid": cid,
         }
 
+    except TransientLookupError:
+        raise
     except Exception:
         return {}

--- a/lookups/ror.py
+++ b/lookups/ror.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import functools
 import time
 
-import requests
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://api.ror.org/organizations"
 
@@ -23,17 +23,18 @@ def search_ror(name: str) -> dict:
 
     Returns:
         dict with keys: @id (ROR URL), @type, name, url.
-        Returns {} on failure or no match.
+        Returns {} on no match. Raises TransientLookupError on a transient API
+        failure (timeout / connection / 429 / 5xx).
     """
     if not name:
         return {}
     try:
         time.sleep(0.1)
-        r = requests.get(_BASE, params={"query": name}, timeout=10)
-        if r.status_code != 200:
+        data = http_get_json(_BASE, params={"query": name})
+        if data is NOT_FOUND:
             return {}
 
-        items = r.json().get("items", [])
+        items = data.get("items", [])
         if not items:
             return {}
 
@@ -57,5 +58,7 @@ def search_ror(name: str) -> dict:
             "url": url,
             "identifier": ror_id,
         }
+    except TransientLookupError:
+        raise
     except Exception:
         return {}

--- a/tests/test_http_resilience.py
+++ b/tests/test_http_resilience.py
@@ -1,0 +1,159 @@
+"""Tests for the shared resilient HTTP helper and lookup transient handling (#49)."""
+
+from __future__ import annotations
+
+import pytest
+import responses
+from requests.exceptions import ConnectionError as ReqConnectionError
+from requests.exceptions import Timeout
+
+from lookups._http import (
+    NOT_FOUND,
+    TransientLookupError,
+    get_session,
+    http_get_json,
+)
+
+
+class TestHttpGetJson:
+    """http_get_json maps HTTP outcomes to data / NOT_FOUND / transient error."""
+
+    @responses.activate
+    def test_200_returns_parsed_json(self):
+        responses.add(responses.GET, "https://api.test/x", json={"a": 1}, status=200)
+        assert http_get_json("https://api.test/x") == {"a": 1}
+
+    @responses.activate
+    def test_404_returns_not_found(self):
+        responses.add(responses.GET, "https://api.test/x", status=404)
+        assert http_get_json("https://api.test/x") is NOT_FOUND
+
+    @responses.activate
+    def test_other_4xx_returns_not_found(self):
+        responses.add(responses.GET, "https://api.test/x", status=400)
+        assert http_get_json("https://api.test/x") is NOT_FOUND
+
+    @responses.activate
+    def test_503_raises_transient(self):
+        responses.add(responses.GET, "https://api.test/x", status=503)
+        with pytest.raises(TransientLookupError):
+            http_get_json("https://api.test/x")
+
+    @responses.activate
+    def test_429_raises_transient(self):
+        responses.add(responses.GET, "https://api.test/x", status=429)
+        with pytest.raises(TransientLookupError):
+            http_get_json("https://api.test/x")
+
+    @responses.activate
+    def test_timeout_raises_transient(self):
+        responses.add(responses.GET, "https://api.test/x", body=Timeout("timed out"))
+        with pytest.raises(TransientLookupError):
+            http_get_json("https://api.test/x")
+
+    @responses.activate
+    def test_connection_error_raises_transient(self):
+        responses.add(
+            responses.GET, "https://api.test/x", body=ReqConnectionError("reset")
+        )
+        with pytest.raises(TransientLookupError):
+            http_get_json("https://api.test/x")
+
+    @responses.activate
+    def test_malformed_json_raises_transient(self):
+        responses.add(
+            responses.GET,
+            "https://api.test/x",
+            body="not json",
+            status=200,
+            content_type="application/json",
+        )
+        with pytest.raises(TransientLookupError):
+            http_get_json("https://api.test/x")
+
+    @responses.activate
+    def test_passes_params_and_headers(self):
+        responses.add(
+            responses.GET, "https://api.test/x", json={"ok": True}, status=200
+        )
+        http_get_json(
+            "https://api.test/x",
+            params={"q": "v"},
+            headers={"Accept": "application/json"},
+        )
+        assert "q=v" in responses.calls[0].request.url
+
+
+class TestSessionRetryConfig:
+    """The shared Session retries transient statuses with backoff + Retry-After."""
+
+    def test_retry_configuration(self):
+        adapter = get_session().get_adapter("https://example.org")
+        retry = adapter.max_retries
+        assert retry.total == 3
+        assert retry.backoff_factor == 0.5
+        assert {429, 500, 502, 503, 504}.issubset(set(retry.status_forcelist))
+        assert retry.respect_retry_after_header is True
+
+    def test_session_is_shared(self):
+        assert get_session() is get_session()
+
+
+class TestNoNegativeCaching:
+    """A transient failure must not be cached (lru_cache skips raised errors)."""
+
+    def test_transient_then_success_rehits(self, monkeypatch):
+        from lookups import crossref
+
+        crossref.lookup_doi.cache_clear()
+        calls = {"n": 0}
+
+        def fake_get_json(url, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise TransientLookupError("simulated outage")
+            return {"message": {"title": ["A Title"], "type": "journal-article"}}
+
+        # crossref imported http_get_json into its own namespace.
+        monkeypatch.setattr(crossref, "http_get_json", fake_get_json)
+
+        doi = "10.1/transient-x"
+        with pytest.raises(TransientLookupError):
+            crossref.lookup_doi(doi)
+
+        # Same arg again: must re-invoke (not return a cached failure).
+        result = crossref.lookup_doi(doi)
+        assert result.get("name") == "A Title"
+        assert calls["n"] == 2
+
+
+class TestFacadeTransientMapping:
+    """The facade maps transient errors to a distinct _failure error string."""
+
+    @responses.activate
+    def test_transient_maps_to_distinct_failure(self):
+        from builder.tools import lookups as facade
+        from lookups import crossref
+
+        crossref.lookup_doi.cache_clear()
+        facade.lookup_doi.cache_clear()
+        doi = "10.2/transient-y"
+        responses.add(responses.GET, f"{crossref._BASE}/{doi}", status=503)
+
+        result = facade.lookup_doi(doi)
+        assert result["found"] is False
+        assert "transient" in result["error"].lower()
+
+    @responses.activate
+    def test_not_found_is_not_labelled_transient(self):
+        from builder.tools import lookups as facade
+        from lookups import crossref
+
+        crossref.lookup_doi.cache_clear()
+        facade.lookup_doi.cache_clear()
+        doi = "10.3/missing-z"
+        responses.add(responses.GET, f"{crossref._BASE}/{doi}", status=404)
+
+        result = facade.lookup_doi(doi)
+        assert result["found"] is False
+        assert "transient" not in (result["error"] or "").lower()

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -16,6 +16,7 @@ import pytest
 import responses
 from requests.exceptions import ConnectionError, Timeout
 
+from lookups._http import TransientLookupError
 from lookups.aopwiki import lookup_aop
 from lookups.bao import lookup_bao_term
 from lookups.cellosaurus import lookup_cellosaurus
@@ -103,8 +104,8 @@ class TestPubChemContract:
             body=Timeout("Connection timed out"),
         )
 
-        result = lookup_pubchem("taxifolin")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            lookup_pubchem("taxifolin")
 
     @responses.activate
     def test_malformed_json_returns_empty(self):
@@ -117,8 +118,8 @@ class TestPubChemContract:
             content_type="application/json",
         )
 
-        result = lookup_pubchem("taxifolin")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            lookup_pubchem("taxifolin")
 
     @responses.activate
     def test_missing_synonyms_still_returns_compound(self):
@@ -200,8 +201,8 @@ class TestCellosaurusContract:
             body=Timeout("timed out"),
         )
 
-        result = lookup_cellosaurus("CVCL_0027")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            lookup_cellosaurus("CVCL_0027")
 
     @responses.activate
     def test_minimal_response_no_optional_fields(self):
@@ -305,8 +306,8 @@ class TestAOPWikiContract:
             body=ConnectionError("Connection refused"),
         )
 
-        result = lookup_aop("610")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            lookup_aop("610")
 
     @responses.activate
     def test_empty_events_still_returns_aop(self):
@@ -389,8 +390,8 @@ class TestBAOContract:
             body=Timeout("timed out"),
         )
 
-        result = lookup_bao_term("cell viability")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            lookup_bao_term("cell viability")
 
     @responses.activate
     def test_missing_iri_returns_empty(self):
@@ -445,9 +446,7 @@ class TestORCIDContract:
         )
 
         result = lookup_orcid("0000-0000-0000-0000")
-        assert result["@id"] == "https://orcid.org/0000-0000-0000-0000"
-        assert result["@type"] == "Person"
-        assert "givenName" not in result
+        assert result == {}
 
     @responses.activate
     def test_timeout_returns_fallback(self):
@@ -458,9 +457,8 @@ class TestORCIDContract:
             body=Timeout("timed out"),
         )
 
-        result = lookup_orcid("0000-0001-6004-8653")
-        assert result["@id"] == "https://orcid.org/0000-0001-6004-8653"
-        assert result["@type"] == "Person"
+        with pytest.raises(TransientLookupError):
+            lookup_orcid("0000-0001-6004-8653")
 
     @responses.activate
     def test_no_affiliation(self):
@@ -540,8 +538,8 @@ class TestRORContract:
             body=Timeout("timed out"),
         )
 
-        result = search_ror("Maastricht University")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            search_ror("Maastricht University")
 
     @responses.activate
     def test_server_error_returns_empty(self):
@@ -552,8 +550,8 @@ class TestRORContract:
             status=500,
         )
 
-        result = search_ror("Maastricht University")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            search_ror("Maastricht University")
 
 
 # ===========================================================================
@@ -620,8 +618,8 @@ class TestCrossrefContract:
             body=Timeout("timed out"),
         )
 
-        result = lookup_doi("10.1016/j.tox.2021.152898")
-        assert result == {}
+        with pytest.raises(TransientLookupError):
+            lookup_doi("10.1016/j.tox.2021.152898")
 
     @responses.activate
     def test_empty_title_and_authors(self):


### PR DESCRIPTION
Closes #49. The root-cause fix for the biggest reliability risk: external lookups.

## Problem
Every lookup client did a single bare `requests.get(timeout=10)` inside `except Exception → {}`, and was `lru_cache`d. So a dropped packet / read timeout / 429 / 503 became a hard "not found" for the rest of the run — and the empty failure was **negatively cached**, so retries returned the stale failure without re-hitting the network. None of them distinguished a real 404 from an outage.

## Fix
**New `lookups/_http.py`** — a shared `requests.Session` with a urllib3 `Retry` (`total=3`, `backoff_factor=0.5`, `status_forcelist={429,500,502,503,504}`, `respect_retry_after_header=True`) and `http_get_json()` with a clear three-way outcome:
- **200 + valid JSON** → parsed object
- **404 / other 4xx** → `NOT_FOUND` sentinel
- **timeout / connection / 429 / 5xx-after-retries / malformed-200** → raise `TransientLookupError`

**All 7 HTTP clients** (pubchem, cellosaurus, aopwiki, bao, orcid, ror, crossref) now use it:
- `NOT_FOUND` → `{}` (definitive not-found, still cacheable)
- transient → **propagated** — `lru_cache` never stores a raised error, so a later call re-hits the network (no more sticky failures)
- **ORCID** no longer returns a fallback dict on failure (that masked an outage as a *resolved* record — the false-positive from the #48 analysis); pubchem's synonyms request stays best-effort.

**Facade** (`builder/tools/lookups.py`) maps `TransientLookupError` → a distinct `_failure("… temporarily unavailable (transient) …")` string — the signal the **#48** `verify_identifier` fix will consume so a flaky network never deletes a user's valid identifier.

## Acceptance criteria
- [x] Shared Session + Retry helper used by all clients
- [x] 404 → not-found sentinel; 429/5xx/timeout → `TransientLookupError` after retries honoring `Retry-After`
- [x] Facade maps transient → distinct `_failure` error string
- [x] Only successful results memoized; transient failures aren't sticky
- [x] Tests cover retry config, 404-vs-transient, no-negative-caching, facade mapping

## Verification
- New `tests/test_http_resilience.py` (14 tests) + updated lookup contract tests (timeout/malformed/server-error/fallback now assert the transient-vs-not-found distinction)
- Full suite **344 passed**; `ty` clean; no new `ruff` findings (client files carry only pre-existing E501s)

## Note
This unblocks **#48** (verify_identifier data-loss) — the next item — which consumes the `transient` signal to keep the user's value instead of clearing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)