### PR TITLE
fix(verify): stop verify_identifier deleting valid IDs on transient failures (#48)

### DIFF
--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -35,9 +35,14 @@ def _success(data: dict) -> dict[str, Any]:
     return {"found": True, "data": data, "error": None}
 
 
-def _failure(error: str) -> dict[str, Any]:
-    """Wrap a failure into the standard result format."""
-    return {"found": False, "data": {}, "error": error}
+def _failure(error: str, transient: bool = False) -> dict[str, Any]:
+    """Wrap a failure into the standard result format.
+
+    ``transient=True`` marks a temporary outage (timeout / 429 / 5xx) as
+    distinct from a definitive not-found, so callers (e.g. verify_identifier)
+    can keep the user's value and retry rather than treat it as unresolved.
+    """
+    return {"found": False, "data": {}, "error": error, "transient": transient}
 
 
 @functools.lru_cache(maxsize=256)
@@ -78,7 +83,7 @@ def lookup_compound(name: str) -> dict[str, Any]:
 
         return _failure(f"Compound '{name}' not found in PubChem")
     except TransientLookupError as exc:
-        return _failure(f"PubChem temporarily unavailable (transient): {exc}")
+        return _failure(f"PubChem unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("PubChem lookup failed for '%s'", name)
         return _failure(f"PubChem lookup failed: {exc}")
@@ -105,7 +110,7 @@ def lookup_cell_line(accession: str) -> dict[str, Any]:
             return _success(result)
         return _failure(f"Cell line '{accession}' not found in Cellosaurus")
     except TransientLookupError as exc:
-        return _failure(f"Cellosaurus temporarily unavailable (transient): {exc}")
+        return _failure(f"Cellosaurus unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("Cellosaurus lookup failed for '%s'", accession)
         return _failure(f"Cellosaurus lookup failed: {exc}")
@@ -131,7 +136,7 @@ def lookup_aop(aop_id: str) -> dict[str, Any]:
             return _success(result)
         return _failure(f"AOP '{aop_id}' not found in AOP-Wiki")
     except TransientLookupError as exc:
-        return _failure(f"AOP-Wiki temporarily unavailable (transient): {exc}")
+        return _failure(f"AOP-Wiki unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("AOP-Wiki lookup failed for '%s'", aop_id)
         return _failure(f"AOP-Wiki lookup failed: {exc}")
@@ -157,7 +162,7 @@ def lookup_bao_term(query: str) -> dict[str, Any]:
             return _success(result)
         return _failure(f"No BAO term found for '{query}'")
     except TransientLookupError as exc:
-        return _failure(f"BAO/OLS temporarily unavailable (transient): {exc}")
+        return _failure(f"BAO/OLS unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("BAO/OLS lookup failed for '%s'", query)
         return _failure(f"BAO/OLS lookup failed: {exc}")
@@ -188,7 +193,7 @@ def lookup_orcid(orcid_id: str) -> dict[str, Any]:
             return _success(result)
         return _failure(f"ORCID lookup failed for '{orcid_id}'")
     except TransientLookupError as exc:
-        return _failure(f"ORCID temporarily unavailable (transient): {exc}")
+        return _failure(f"ORCID unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("ORCID lookup failed for '%s'", orcid_id)
         return _failure(f"ORCID lookup failed: {exc}")
@@ -214,7 +219,7 @@ def lookup_ror(name: str) -> dict[str, Any]:
             return _success(result)
         return _failure(f"No ROR organization found for '{name}'")
     except TransientLookupError as exc:
-        return _failure(f"ROR temporarily unavailable (transient): {exc}")
+        return _failure(f"ROR unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("ROR lookup failed for '%s'", name)
         return _failure(f"ROR lookup failed: {exc}")
@@ -241,7 +246,7 @@ def lookup_doi(doi: str) -> dict[str, Any]:
             return _success(result)
         return _failure(f"DOI '{doi}' not found in Crossref")
     except TransientLookupError as exc:
-        return _failure(f"Crossref temporarily unavailable (transient): {exc}")
+        return _failure(f"Crossref unavailable (transient): {exc}", transient=True)
     except Exception as exc:
         logger.exception("Crossref lookup failed for '%s'", doi)
         return _failure(f"Crossref lookup failed: {exc}")

--- a/builder/tools/verification.py
+++ b/builder/tools/verification.py
@@ -88,6 +88,22 @@ def verify_identifier(state: CrateState, entity_id: str, field: str) -> dict:
             "suggested_fix": None,
         }
 
+    # Transient lookup failure (timeout / 429 / 5xx): the source could not be
+    # reached, which is NOT evidence the identifier is wrong. Keep the user's
+    # value intact (status stays "filled") instead of destroying it.
+    if result.get("transient"):
+        return {
+            "verified": False,
+            "entity_id": entity_id,
+            "field": field,
+            "message": (
+                f"{field} for {entity.type} could not be verified right now — "
+                f"{lookup_name or 'the source'} is temporarily unavailable; "
+                "value kept."
+            ),
+            "suggested_fix": "Retry verification later.",
+        }
+
     entity.fields.pop(field, None)
     entity.set_field_status(field, "missing", "lookup")
     return {

--- a/tests/test_tools_verification.py
+++ b/tests/test_tools_verification.py
@@ -91,6 +91,65 @@ class TestVerifyIdentifier:
         assert completion2 is not None
         assert completion2.status == "missing"
 
+    def test_transient_failure_keeps_value(self, minimal_state, monkeypatch):
+        """A transient lookup failure must NOT delete the user's value."""
+        state = minimal_state
+        chem = Entity(
+            entity_id="chem_001",
+            type="MolecularEntity",
+            fields={"identifier": "50-00-0"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        chem.set_field_status("identifier", "filled", "llm")
+        state.add_entity(chem)
+
+        monkeypatch.setattr(
+            "builder.tools.verification.lookup_compound",
+            lambda query: {
+                "found": False,
+                "data": {},
+                "error": "PubChem temporarily unavailable (transient): timeout",
+                "transient": True,
+            },
+        )
+
+        result = verify_identifier(state, "chem_001", "identifier")
+
+        assert result["verified"] is False
+        # Value is preserved (NOT cleared) on a transient failure.
+        assert chem.fields["identifier"] == "50-00-0"
+        status = chem.get_field_status("identifier")
+        assert status is not None
+        assert status.status != "missing"
+
+    def test_transient_orcid_not_verified_and_kept(self, minimal_state, monkeypatch):
+        """A transient ORCID error is neither verified nor cleared (no false +)."""
+        state = minimal_state
+        person = Entity(
+            entity_id="p_001",
+            type="Person",
+            fields={"identifier": "0000-0001-6004-8653"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        person.set_field_status("identifier", "filled", "llm")
+        state.add_entity(person)
+
+        monkeypatch.setattr(
+            "builder.tools.verification.lookup_orcid",
+            lambda query: {
+                "found": False,
+                "data": {},
+                "error": "ORCID temporarily unavailable (transient): timeout",
+                "transient": True,
+            },
+        )
+
+        result = verify_identifier(state, "p_001", "identifier")
+
+        assert result["verified"] is False
+        assert person.fields["identifier"] == "0000-0001-6004-8653"
+        assert person.get_field_status("identifier").status != "missing"
+
 
 class TestVerifyAllIdentifiers:
     """Tests for the verify_all_identifiers function."""


### PR DESCRIPTION
Closes #48. Completes the lookup-resilience chain (#49 → #48).

## Problem
`verify_identifier` treated **every** non-success as "unverified" and unconditionally `pop`ped the field value, marking it `missing`. With the old clients that returned `{}` on timeouts/429/5xx, a momentary network blip **silently destroyed a user's correct CAS/DOI/ORCID/accession** — and `verify_all_identifiers` amplified it across every filled identifier in one pass.

## Fix
Now that the facade distinguishes transient failures (#49), thread that signal through:
- **`_failure()`** gains a `transient` flag; the 7 transient catches set `transient=True`.
- **`verify_identifier`**: on a transient result, **keep the value** (status stays `filled`) and return `verified=False` with a *"temporarily unavailable; value kept — retry later"* message. A **definitive not-found still clears** (with the existing explicit "value cleared" message — not silent).

Also closes the **ORCID false-positive**: a transient ORCID error is no longer mistaken for a resolved record (it raises → facade marks transient → kept, not verified).

> Note on status: `CompletionStatus` is `missing|filled|verified` (no `unverified`), so a kept-but-unverified value stays `filled` (value present) rather than `missing` (cleared) — that's the meaningful 3-way distinction within the existing type.

## Acceptance criteria
- [x] Transient failure leaves the identifier value intact
- [x] Status on transient is not `missing` (stays `filled`); message says it couldn't be verified now
- [x] Genuine not-found clears only with explicit signalling (unchanged)
- [x] Transient ORCID error is not classified as verified
- [x] Failing tests added first (TDD)

## Verification
- New tests: transient keeps CAS value + status not missing; transient ORCID kept & not verified; existing definitive-not-found-clears test unchanged.
- Full suite **347 passed**; `ty` clean; no new `ruff` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)