### PR TITLE
fix(graph): bind tools to the model so the agent can actually call them (#37 regression)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -416,8 +416,10 @@ def _build_agent_graph(
     model invocation.
 
     Args:
-        llm: A LangChain chat model (with tools already bound).
-        tools: List of LangChain BaseTool instances for the ToolNode.
+        llm: A LangChain chat model. The tools are bound to it internally
+            (via ``llm.bind_tools``) so the model can emit tool calls.
+        tools: List of LangChain BaseTool instances — bound to the model
+            for advertising and used by the ToolNode for execution.
         engine: Optional engine; when it has an active profiler, the
             ``"model"`` and ``"tools"`` nodes are wrapped with timing
             instrumentation that writes to ``profile.ndjson``.
@@ -436,13 +438,21 @@ def _build_agent_graph(
         (lambda: engine.state.iteration_count) if engine is not None else None
     )
 
+    # Bind the tool schemas to the model so it can actually emit tool_calls.
+    # Without this, the model is never told the tools exist: should_continue
+    # always routes to END, the ToolNode is unreachable, and the agent
+    # silently degrades to a text-only chatbot that narrates "let me scan..."
+    # but never executes a tool. (create_agent() bound tools internally;
+    # the explicit-graph migration dropped this and broke tool-calling.)
+    model = llm.bind_tools(tools) if tools else llm
+
     def call_model(state: dict[str, Any]) -> dict[str, Any]:
-        """Model node: prepend system prompt and invoke the LLM."""
+        """Model node: prepend system prompt and invoke the tool-bound LLM."""
         messages = state.get("messages", [])
         # Prepend system prompt on every invocation
         system_msg = SystemMessage(content=SYSTEM_PROMPT)
         model_messages = [system_msg, *messages]
-        response = llm.invoke(model_messages)
+        response = model.invoke(model_messages)
         # Return only the new response; the add_messages reducer appends it
         return {"messages": [response]}
 

--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -67,6 +67,45 @@ class TestBuildAgentGraph:
         assert "model" in node_names, f"Expected 'model' node, got {node_names}"
         assert "tools" in node_names, f"Expected 'tools' node, got {node_names}"
 
+    def test_tools_are_bound_to_model(self):
+        """The model MUST be given the tool schemas via bind_tools.
+
+        Regression guard for the #71 StateGraph migration: call_model invoked
+        a RAW, unbound llm, so with a real provider the model was never told
+        the tools exist, could never emit tool_calls, should_continue always
+        routed to END, and the agent silently degraded to a text-only chatbot
+        that narrates 'let me scan...' forever but never executes a tool.
+        """
+        from unittest.mock import MagicMock
+
+        from langchain_core.messages import AIMessage, HumanMessage
+        from langchain_core.tools import tool as langchain_tool
+
+        from builder.agents.agent_loop import _build_agent_graph
+
+        @langchain_tool
+        def dummy_tool(query: str) -> str:
+            """A dummy tool for testing."""
+            return f"result: {query}"
+
+        bound = MagicMock()
+        bound.invoke.return_value = AIMessage(content="ok")
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = bound
+
+        app = _build_agent_graph(mock_llm, [dummy_tool])
+        app.invoke(
+            {"messages": [HumanMessage(content="hi")]},
+            {"configurable": {"thread_id": "bind-test-001"}},
+        )
+
+        # The tools must have been bound to the model...
+        mock_llm.bind_tools.assert_called_once()
+        bound_tools = mock_llm.bind_tools.call_args.args[0]
+        assert dummy_tool in bound_tools
+        # ...and the BOUND model (not the raw llm) must be the one invoked.
+        bound.invoke.assert_called()
+
     def test_should_continue_routes_to_tools_when_tool_calls_present(self):
         """should_continue returns 'tools' when last message has tool_calls."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
## The bug

The explicit-StateGraph migration (#71 / #37) replaced `create_agent()` with a hand-built graph whose `call_model` invokes a **raw, unbound** `llm`:

```python
response = llm.invoke(model_messages)   # tools never advertised
```

`tools` were passed only to `ToolNode` (execution), never to the model. So with a real provider the model is never told the tools exist → it can't emit `tool_calls` → `should_continue` always routes to `END` → the `ToolNode` is unreachable → **the agent silently degrades to a text-only chatbot** that narrates *"let me scan…"* across turns but never executes a tool. `create_agent()` used to bind tools internally; the rewrite dropped it.

This is the true root cause of the repeated "agent loops promising to scan but `0 entities`/`0 files` forever" reports — the scan never runs.

### Why every test stayed green
The graph tests fake `tool_calls` on a mock and even pre-wired `mock_llm.bind_tools.return_value` — but never asserted `bind_tools` was *called*. So the regression was invisible.

## The fix
- Bind tools in `_build_agent_graph`: `model = llm.bind_tools(tools) if tools else llm`, and invoke the bound model.
- Corrected the docstring (it falsely claimed the caller passes a pre-bound model).
- Added `test_tools_are_bound_to_model` asserting `bind_tools` is called with the tools and the bound model is the one invoked.

## Verification
- `uv run pytest` → 348 passing; `ty` clean (3 pre-existing diagnostics unrelated to this change).
- ⚠️ Needs a real-LLM run to confirm end-to-end tool execution (cannot exercise a live provider in CI).

## Follow-ups (separate PRs)
- #56 — enforce `recursion_limit` so a runaway loop stops gracefully (safety net).
- Tool-surface drift: the registry exposes 34 tools but `TOOL_SPECS` advertises only 30 — `present_to_human`/`request_input` and others are still invisible to the LLM even after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)