### PR TITLE
fix(engine): scan-roots guard — no empty-overwrite, approve extraction dir, lock guard

### DIFF
--- a/builder/engine.py
+++ b/builder/engine.py
@@ -21,6 +21,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _directory_to_approve(scanned_path: str) -> str:
+    """Return the directory to add to ``approved_scan_roots`` for *scanned_path*.
+
+    The approved root must be a *directory*: the guard treats roots as
+    directory prefixes, and nothing can be a sub-path of a file, so approving
+    a file path is useless and denies every follow-up scan. The chosen
+    directory is the one whose contents are actually inventoried:
+
+    - a directory  -> the directory itself;
+    - an archive   -> its extraction directory (``<stem>_extracted``), **not**
+      the archive's parent — approving the parent would expose unrelated
+      sibling files, weakening the D9 approved-roots guard rail;
+    - any other file -> its parent directory.
+    """
+    from builder.tools.scanner import _is_archive
+
+    p = Path(scanned_path).resolve()
+    if p.is_dir():
+        return str(p)
+    if _is_archive(p):
+        # Mirror unzip_file's extraction layout: <parent>/<stem>_extracted
+        return str(p.parent / f"{p.stem}_extracted")
+    return str(p.parent)
+
+
 class AgentEngine:
     """Orchestrator for the LLM agent toolbox loop.
 
@@ -64,8 +89,10 @@ class AgentEngine:
             scanned = scan_files(input_path)
             self.state.scanned_files = scanned
             self.state.metadata.input_path = input_path
-            resolved = Path(input_path).resolve()
-            self.state.approved_scan_roots.add(str(resolved))
+            # Approve the directory whose contents we inventoried (the
+            # extraction dir for an archive), not the raw input path — see
+            # _directory_to_approve. Locks the guard even on an empty scan.
+            self.state.approved_scan_roots.add(_directory_to_approve(input_path))
 
         if not self.state.session_id:
             self.state.session_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
@@ -165,14 +192,28 @@ class AgentEngine:
             # Auto-store scan results in state, and register the scanned
             # path as an approved root if none were set yet.
             if tool_name == "scan_files" and isinstance(result, list):
-                self.state.scanned_files = result
+                # Lock the guard to the scanned area on the first scan, even if
+                # it returned nothing — otherwise approved_scan_roots stays
+                # empty, run_tool keeps passing approved_roots=None, and the
+                # guard is effectively disabled (any path becomes scannable).
                 if not self.state.approved_scan_roots:
-                    resolved = Path(kwargs.get("path", "")).resolve()
-                    self.state.approved_scan_roots.add(str(resolved))
-                self.state.log_reasoning(
-                    "store_scan_results", "scan_files",
-                    f"Stored {len(result)} files in state",
-                )
+                    self.state.approved_scan_roots.add(
+                        _directory_to_approve(kwargs.get("path", ""))
+                    )
+                if result:
+                    self.state.scanned_files = result
+                    self.state.log_reasoning(
+                        "store_scan_results", "scan_files",
+                        f"Stored {len(result)} files in state",
+                    )
+                else:
+                    # Empty = denied root or empty/failed scan. Do NOT clobber
+                    # an existing inventory with zero — that tricked the agent
+                    # into endless re-scanning.
+                    self.state.log_reasoning(
+                        "scan_no_results", "scan_files",
+                        "Scan returned no files; keeping existing inventory",
+                    )
         else:
             registry = self._build_registry()
             spec = registry.get_spec(tool_name)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -143,3 +143,133 @@ class TestAgentEngine:
 
         assert result is None
         assert engine.state.scanned_files == ["existing"]
+
+
+def _make_zip(tmp_path, name="study.zip", with_sibling=False):
+    """Helper: build a small zip under tmp_path; return its Path."""
+    import zipfile
+
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    (src / "x.txt").write_text("hello world")
+    (src / "y.csv").write_text("a,b\n1,2\n")
+    if with_sibling:
+        (tmp_path / "secret.txt").write_text("do not read me")
+    zpath = tmp_path / name
+    with zipfile.ZipFile(zpath, "w") as zf:
+        zf.write(src / "x.txt", "x.txt")
+        zf.write(src / "y.csv", "y.csv")
+    return zpath
+
+
+class TestScanApprovedRoots:
+    """The approved-roots guard must (a) not be wiped by an empty scan,
+    (b) allow follow-up scans of extracted contents, and (c) NOT over-broaden
+    to expose unrelated sibling files (D9)."""
+
+    def test_empty_scan_result_does_not_overwrite_state(self, monkeypatch):
+        """A denied/empty scan must NOT wipe a populated inventory with zero."""
+        engine = AgentEngine()
+        engine.state.scanned_files = ["existing1", "existing2"]
+
+        monkeypatch.setattr(
+            "builder.tools.scanner.scan_files", lambda **kw: []
+        )
+
+        result = engine.run_tool("scan_files", path="/tmp/denied")
+
+        assert result == []
+        assert engine.state.scanned_files == ["existing1", "existing2"]
+
+    def test_directory_scan_approves_that_directory(self, tmp_path):
+        """Scanning a directory approves that directory; a subdir is allowed."""
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "a.txt").write_text("a")
+        sub = d / "sub"
+        sub.mkdir()
+        (sub / "c.txt").write_text("c")
+
+        engine = AgentEngine()
+        engine.run_tool("scan_files", path=str(d))
+        assert str(d.resolve()) in engine.state.approved_scan_roots
+
+        r = engine.run_tool("scan_files", path=str(sub))
+        assert len(r) == 1  # subdir of an approved root is allowed
+
+    def test_zip_scan_approves_extracted_dir_not_parent(self, tmp_path):
+        """A zip approves its extraction dir, NOT the archive's parent — so a
+        sibling file next to the zip stays out of reach (security)."""
+        zpath = _make_zip(tmp_path, with_sibling=True)
+
+        engine = AgentEngine()
+        engine.run_tool("scan_files", path=str(zpath))
+
+        extracted = str((tmp_path / "study_extracted").resolve())
+        assert extracted in engine.state.approved_scan_roots
+        assert str(tmp_path.resolve()) not in engine.state.approved_scan_roots
+
+        # Scanning the parent (which holds secret.txt) must be DENIED.
+        r = engine.run_tool("scan_files", path=str(tmp_path))
+        assert r == []
+        # ...and must not have clobbered the real inventory.
+        assert len(engine.state.scanned_files) >= 2
+
+    def test_followup_scan_of_extracted_dir_is_not_denied(self, tmp_path):
+        """run_tool path: scan a zip, then scan its extracted dir — allowed."""
+        zpath = _make_zip(tmp_path, name="d.zip")
+
+        engine = AgentEngine()
+        r1 = engine.run_tool("scan_files", path=str(zpath))
+        assert len(r1) >= 2
+
+        extracted = zpath.parent / "d_extracted"
+        r2 = engine.run_tool("scan_files", path=str(extracted))
+        assert len(r2) >= 2, "follow-up scan of extracted dir was denied"
+        assert len(engine.state.scanned_files) >= 2
+
+    def test_initialize_zip_then_scan_extracted_not_denied(self, tmp_path):
+        """Production CLI path: initialize('archive.zip') then scan extracted."""
+        zpath = _make_zip(tmp_path, name="study.zip")
+
+        engine = AgentEngine()
+        engine.initialize(str(zpath))
+        assert len(engine.state.scanned_files) >= 2
+
+        extracted = tmp_path / "study_extracted"
+        r = engine.run_tool("scan_files", path=str(extracted))
+        assert len(r) >= 2, "extracted dir denied on the initialize() entry path"
+
+    def test_empty_first_scan_locks_guard(self, tmp_path):
+        """An empty first scan must still lock the guard, not leave it open."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        engine = AgentEngine()
+        r1 = engine.run_tool("scan_files", path=str(empty))
+        assert r1 == []
+        assert engine.state.approved_scan_roots, "guard left wide open after empty scan"
+
+        # An unrelated path must now be denied (guard is active).
+        other = tmp_path / "other"
+        other.mkdir()
+        (other / "f.txt").write_text("x")
+        r2 = engine.run_tool("scan_files", path=str(other))
+        assert r2 == []
+
+    def test_unrelated_dir_scan_denied_after_first(self, tmp_path):
+        """The agent cannot wander into an unrelated directory unprompted."""
+        d1 = tmp_path / "d1"
+        d1.mkdir()
+        (d1 / "a.txt").write_text("a")
+        d2 = tmp_path / "d2"
+        d2.mkdir()
+        (d2 / "b.txt").write_text("b")
+
+        engine = AgentEngine()
+        r1 = engine.run_tool("scan_files", path=str(d1))
+        assert len(r1) == 1
+
+        r2 = engine.run_tool("scan_files", path=str(d2))
+        assert r2 == []  # d2 is not under the approved root (d1)
+        assert len(engine.state.scanned_files) == 1  # inventory preserved


### PR DESCRIPTION
Fixes three related scan/guard defects surfaced by an adversarial audit of the earlier scan-loop work. These become reachable once tool-calling works again (see #77).

## Defects
1. **Empty scan overwrote good state.** `run_tool` did `scanned_files = result` unconditionally; a denied/empty scan returns `[]`, wiping a populated inventory → status flips to `files 0` → agent re-scans forever.
2. **Approved root was the scanned path itself.** For a zip that's the *file* path; nothing can be a sub-path of a file, so every follow-up scan of the extracted contents (which `unzip_file` explicitly tells the agent to scan) was denied → `[]` → (1).
3. **Empty first scan disabled the guard.** The root was only added on a non-empty result, so an empty first scan left `approved_scan_roots` empty → `run_tool` keeps passing `approved_roots=None` → guard off → arbitrary paths scannable (reproduced scanning `/etc`).

## Fix
A shared `_directory_to_approve()` used by **both** `initialize()` (the CLI `--input` entry path — previously unpatched) and `run_tool()`:
- approve the directory whose contents we inventory: the dir itself, or an archive's `<stem>_extracted` dir — **not** the archive's parent (which would expose unrelated sibling files, weakening D9);
- lock the guard on the first scan even when it returns nothing;
- never clobber a populated inventory with an empty result.

## Tests (`TestScanApprovedRoots`)
- empty result does not overwrite inventory;
- zip approves the extraction dir and **not** the parent, and a sibling file stays denied (security);
- follow-up scan of the extracted dir is allowed (both `run_tool` and `initialize()` entry paths);
- empty first scan still locks the guard (unrelated path then denied);
- an unrelated directory is denied after the first scan.

`uv run pytest` → 354 passing; `ty` clean.

## Relationship to prior work
Supersedes the symptom-level diagnosis in #74 (which fixed mojibake + the LLM blob but not this root-cause path). Pairs with #77 (tool-binding) and the follow-up #56 (recursion-limit safety net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)