### PR TITLE
fix(graph): enforce max_iterations via recursion_limit + graceful loop stop (#56)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -12,6 +12,7 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from langchain_core.callbacks import BaseCallbackHandler
+from langgraph.errors import GraphRecursionError
 from langgraph.graph import add_messages
 
 # Import Annotated from typing_extensions so it survives
@@ -186,6 +187,23 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
         langchain_tools.append(tool_fn)
 
     return langchain_tools
+
+
+# ---------------------------------------------------------------------------
+# Iteration safety net
+# ---------------------------------------------------------------------------
+
+
+def _recursion_limit(max_iterations: int) -> int:
+    """Map the documented tool-iteration cap to LangGraph's ``recursion_limit``.
+
+    Each tool iteration is roughly two super-steps (``model`` then ``tools``),
+    so the recursion limit is ``2 * max_iterations``. Floored at 2 so the graph
+    can always complete at least one model→tools→model cycle. Without this,
+    LangGraph applies its silent default of 25 super-steps and a runaway loop
+    raises an uncaught ``GraphRecursionError`` (#56).
+    """
+    return max(2, max_iterations * 2)
 
 
 # ---------------------------------------------------------------------------
@@ -528,8 +546,16 @@ def run_interactive_agent(
     provider_name = provider or _detect_provider()
 
     # Use LangGraph's built-in thread tracking so the agent accumulates
-    # conversation history automatically.
-    thread_config = cast(RunnableConfig, {"configurable": {"thread_id": engine.state.session_id}})
+    # conversation history automatically. The recursion_limit bounds a single
+    # turn's model/tools alternation so a runaway loop stops gracefully instead
+    # of hitting LangGraph's silent default of 25 super-steps (#56).
+    thread_config = cast(
+        RunnableConfig,
+        {
+            "configurable": {"thread_id": engine.state.session_id},
+            "recursion_limit": _recursion_limit(max_iterations),
+        },
+    )
 
     def _extract_reply(state: dict) -> str:
         """Pull the last AIMessage content from the agent state."""
@@ -821,6 +847,21 @@ def run_interactive_agent(
             except Exception:
                 pass
 
+        except GraphRecursionError:
+            # The turn hit the recursion_limit safety net — stop gracefully
+            # instead of surfacing a raw error, and persist the session.
+            root_logger.setLevel(old_root_level)
+            console.print(
+                "[yellow]I reached the step limit for this request[/yellow] and "
+                "stopped to avoid an endless loop. Your session is saved — try a "
+                "smaller or more specific request, or ask me to continue."
+            )
+            try:
+                from builder.tools.session import save_session
+                save_session(engine.state)
+            except Exception:
+                pass
+            console.print()
         except Exception as exc:
             logger.exception("Agent error")
             console.print(f"[red bold]Error:[/red bold] {exc}")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -409,3 +409,23 @@ class TestMainInteractiveFlag:
         args = parse_args(["-I", "-p", "anthropic"])
         assert args.interactive is True
         assert args.provider == "anthropic"
+
+class TestRecursionLimit:
+    """The documented max_iterations cap must map to LangGraph's recursion_limit
+    so a runaway tool loop stops at a controlled bound instead of LangGraph's
+    silent default of 25 super-steps (#56)."""
+
+    def test_doubles_max_iterations(self):
+        """Each tool iteration is ~2 super-steps (model + tools)."""
+        from builder.agents.agent_loop import _recursion_limit
+
+        assert _recursion_limit(50) == 100
+        assert _recursion_limit(25) == 50
+
+    def test_floors_at_two(self):
+        """A non-positive cap still allows the graph to run at least once."""
+        from builder.agents.agent_loop import _recursion_limit
+
+        assert _recursion_limit(0) == 2
+        assert _recursion_limit(1) == 2
+        assert _recursion_limit(-5) == 2


### PR DESCRIPTION
**Stacked on #77** (tool-binding) — review/merge that first; this PR's base is `jh-fix-tool-binding`.

## Problem
`run_interactive_agent(max_iterations=50)` documented an iteration cap but never passed it to the graph. LangGraph therefore used its **silent default of 25 super-steps**; a runaway turn raised an uncaught `GraphRecursionError` that surfaced only as a raw `Error:` with no recovery and no session save. This is the safety net that makes any *future* loop trigger non-fatal.

## Fix
- `_recursion_limit(max_iterations) = max(2, 2 * max_iterations)` (a tool iteration ≈ 2 super-steps: `model` → `tools`), set as `recursion_limit` on the invoke config.
- Catch `GraphRecursionError` in the main loop → controlled "I reached the step limit… session saved" message + `save_session`, instead of crashing the turn.

## Tests
`TestRecursionLimit`: doubling (`50→100`, `25→50`) and floor (`0/1/-5 → 2`). `uv run pytest` → 350 passing; `ty` unchanged (3 pre-existing diagnostics).

## Why it matters here
#77 makes the agent actually call tools again; multi-tool turns (scan → read_multiple_files → several lookups/drafts) can legitimately chain past 25 super-steps. Without this they'd hit the silent cap and abort. Complements #78 (scan-roots) which removes a concrete loop trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)