### PR TITLE
feat: in-memory build_and_validate with routable per-entity feedback (#87)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,12 +415,15 @@ a fix to a specific field:
 ```python
 {
   "ok": bool,                                  # no issues at the gate severity
-  "conformance": {"base": bool, "isa": bool, "tox": bool},
+  "conformance": {"base": bool, "isa": bool, "tox": bool},  # only the scoped key(s) when profile != "all"
   "issues": [
     {"entity_id", "property", "message", "fix", "severity", "profile"}, ...
   ],
 }
 ```
+
+`conformance` is keyed to the passes actually run: all three layers for
+`profile="all"`, or just the scoped layer when a single `profile` is given.
 
 `severity` (`required`|`recommended`|`optional`) is the gate that decides which
 SHACL checks run — `required` (the default) is fastest. `profile`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ The ISA-Tox RO-Crate Builder is a **toolbox-based agent system** that assists re
                          Agent Loop
    LLM Agent ◄─────────────────────────────────────
       │          Tools: draft_entity, update_entity, remove_entity,
-      │          lookup_*, verify_identifier, build_crate, validate,
-      │          assess_mit, assess_fair, present_to_human,
-      │          save_session, get_status
+      │          lookup_*, verify_identifier, build_and_validate,
+      │          export_crate, validate, assess_mit, assess_fair,
+      │          present_to_human, save_session, get_status
       ▼
    ┌──────────────────────┐
    │    CrateState         │── persists between sessions
@@ -239,7 +239,15 @@ Can produce partial crates at any point.
 Runs three-pass SHACL validation via `profiles/validator.py`, which wraps
 [`rocrate_validator`](https://github.com/ResearchObject/rocrate-validator).
 Returns issues by severity: REQUIRED (blocking), SHOULD (recommended), MAY
-(informational).
+(informational). Two entry points:
+- `validate_crate(crate_dir)` validates a crate **on disk** and returns
+  prose `ValidationResult`s (used by the `validate(crate_path)` tool).
+- `validate_crate_dict(metadata_doc, severity, profile)` validates an
+  **in-memory** metadata document (the dict from `crate.metadata.generate()`)
+  via `services.validate_metadata_as_dict`, returning `DictValidationResult`s
+  whose `RoutableIssue`s carry the focus-node `entity_id`, failing `property`
+  IRI, `check_id`, `severity`, and `profile`. This backs `build_and_validate`
+  and is the no-disk fast path.
 
 #### MIT & FAIR Assessors (`builder/tools/mit_assessment.py`, `builder/tools/fair_assessment.py`)
 Score against `mit/invitro_tox.yaml` and `fair/indicators.yaml`. Both produce
@@ -390,9 +398,42 @@ verify_all_identifiers() → [VerificationResult]
 
 ### Crate Assembly & Validation Tools
 ```
-build_crate(output_path: str) → CrateBuildResult
+build_and_validate(severity="required", profile="all") → {ok, conformance, issues}
+export_crate(output_path: str) → CrateBuildResult
+build_crate(output_path: str) → CrateBuildResult     # back-compat alias of export_crate
 validate(crate_path: str) → ValidationReport
 ```
+
+`build_and_validate` is the agent's primary build/fix loop: it assembles the
+crate from `CrateState` **in memory** and validates the generated JSON-LD
+document directly via `rocrate_validator.services.validate_metadata_as_dict` —
+**no crate is written to disk and nothing is re-read** (the old
+`build_crate`→`validate` round-trip touched disk on every ReAct iteration). It
+returns issues keyed to the entity/property that failed so the agent can route
+a fix to a specific field:
+
+```python
+{
+  "ok": bool,                                  # no issues at the gate severity
+  "conformance": {"base": bool, "isa": bool, "tox": bool},
+  "issues": [
+    {"entity_id", "property", "message", "fix", "severity", "profile"}, ...
+  ],
+}
+```
+
+`severity` (`required`|`recommended`|`optional`) is the gate that decides which
+SHACL checks run — `required` (the default) is fastest. `profile`
+(`all`|`base`|`isa`|`tox`) scopes the passes; since the tox pass dominates
+wall-clock, the inner loop can validate a single profile at REQUIRED severity
+and run the full 3-pass sweep only as a gate. The three passes mirror
+`profiles/validator.validate_crate`, fed the metadata dict instead of a path.
+
+`export_crate` is the **only** tool that touches disk — call it once the crate
+is conformant to materialise the on-disk RO-Crate directory (payload included).
+`build_crate` remains as a back-compat alias. The in-memory assembly path
+(`assemble_crate(..., materialize_payload=False)`) skips writing the Exposure
+condition-table placeholder CSV so validation stays a zero-disk operation.
 
 ### Assessment Tools
 ```

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Once in the agent loop, you can type requests like:
 > *"Build the crate and validate it"*
 > *"Assess MIT coverage"*
 
+While iterating, the agent checks conformance with `build_and_validate`, which
+assembles and validates the crate **in memory** (no files written) and returns
+issues keyed to the entity and property that failed. Only when the crate is
+conformant does it call `export_crate` to write the RO-Crate directory to disk.
+
 ### Batch / info mode
 
 ```bash

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -31,8 +31,10 @@ You have access to the following tools:
 - lookup_doi: Look up a publication in Crossref
 - verify_identifier: Verify an identifier resolves at its source
 - verify_all_identifiers: Verify all identifiers in the state
-- build_crate: Assemble the RO-Crate (returns a crate_path)
-- validate: Run three-pass validation (pass the crate_path returned by build_crate)
+- build_and_validate: Build + validate in memory in one step (fast loop); returns routable issues keyed to entity/property
+- export_crate: Write the finished RO-Crate to disk (returns a crate_path)
+- build_crate: Alias of export_crate (writes the crate to disk)
+- validate: Run three-pass validation on a crate already written to disk
 - assess_mit_coverage: Score MIT coverage
 - assess_fair_maturity: Score FAIR maturity
 - save_session: Save the session
@@ -43,9 +45,9 @@ You have access to the following tools:
 
 You have a toolbox — use it in whatever order makes sense for the user. But keep this priority in mind:
 
-**Goal: get to a crate that passes `validate` as early as possible.** Users want to see progress. A crate that validates at the BASE level is more useful than one with rich domain metadata that doesn't validate at all.
+**Goal: get to a crate that passes `build_and_validate` as early as possible.** Users want to see progress. A crate that validates at the BASE level is more useful than one with rich domain metadata that doesn't validate at all.
 
-### Validation Hierarchy (check with `validate`)
+### Validation Hierarchy (check with `build_and_validate`)
 
 The three validation passes stack like a pyramid:
 
@@ -59,7 +61,7 @@ The three validation passes stack like a pyramid:
    └──────────────┘
 ```
 
-**TOX cannot pass if ISA fails. ISA cannot pass if BASE fails.** Every `validate` call runs all three; the report shows you which layer is blocking. Fix bottom-up: tackle BASE REQUIRED issues first, then ISA, then TOX.
+**TOX cannot pass if ISA fails. ISA cannot pass if BASE fails.** Every `build_and_validate` call runs all three layers (unless you scope to one); the conformance map and each issue's profile field show which layer is blocking, and every issue names the entity id and property to fix. Fix bottom-up: tackle BASE REQUIRED issues first, then ISA, then TOX. No need to `export_crate` to check — `build_and_validate` writes nothing.
 
 ### What a Minimal "BASE-passing" Crate Looks Like
 - At least one Investigation entity
@@ -72,7 +74,7 @@ The three validation passes stack like a pyramid:
 - Then the TOX domain layer: MolecularEntity lookups, Cellosaurus queries, AOP refs, BAO terms
 - Then MIT/FAIR scores as improvement suggestions (recommendations, not gates)
 
-The key insight: **draft a minimal Investigation → Study → Assay → run `validate` → fix → enrich → repeat.** Every iteration makes the crate more complete, and validation tells you exactly what to fix next.
+The key insight: **draft a minimal Investigation, Study, Assay, run `build_and_validate`, fix the named entity and property, enrich, repeat.** Every iteration makes the crate more complete, and validation tells you exactly which entity and property to fix next. Call `export_crate` only when you are ready to write the finished crate to disk.
 
 ## Rules
 1. NEVER fabricate identifiers. Every identifier must be verified against its source.

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -203,8 +203,42 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "build_and_validate",
+        "description": "Build the crate from the current state in memory and validate it in one step (no files written). This is the fast build/fix loop: use it on every iteration. Returns {ok, conformance:{base,isa,tox}, issues:[{entity_id, property, message, fix, severity, profile}]} — each issue is keyed to the entity and property that failed, so route your fix there. Fix REQUIRED issues bottom-up: base, then isa, then tox.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "severity": {
+                    "type": "string",
+                    "enum": ["required", "recommended", "optional"],
+                    "description": "Gate severity. 'required' (default) is fastest and surfaces only blocking issues; lower it to also see recommendations.",
+                },
+                "profile": {
+                    "type": "string",
+                    "enum": ["all", "base", "isa", "tox"],
+                    "description": "Which layer(s) to check. 'all' (default) runs base+isa+tox; scope to one layer to go faster while iterating.",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "export_crate",
+        "description": "Write the finished RO-Crate to disk (the only step that touches disk). Use build_and_validate while iterating; call export_crate once the crate is conformant. Returns crate_path. When output_path is omitted, defaults to sessions/<session_id>/working_crate/",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "output_path": {
+                    "type": "string",
+                    "description": "Where to write the crate directory (optional, defaults to sessions/<session_id>/working_crate/)",
+                }
+            },
+            "required": [],
+        },
+    },
+    {
         "name": "build_crate",
-        "description": "Assemble the RO-Crate directory. Returns crate_path which you must pass to validate(). When output_path is omitted, defaults to sessions/<session_id>/working_crate/",
+        "description": "Alias of export_crate: assemble and write the RO-Crate directory to disk. Returns crate_path. When output_path is omitted, defaults to sessions/<session_id>/working_crate/",
         "parameters": {
             "type": "object",
             "properties": {
@@ -218,13 +252,13 @@ TOOL_SPECS = [
     },
     {
         "name": "validate",
-        "description": "Run three-pass SHACL validation on a crate directory. Pass the crate_path returned by build_crate.",
+        "description": "Run three-pass SHACL validation on a crate directory already written to disk. Prefer build_and_validate for the in-loop check; use this only to validate an existing crate_path from export_crate.",
         "parameters": {
             "type": "object",
             "properties": {
                 "crate_path": {
                     "type": "string",
-                    "description": "Path to the crate directory to validate (use the crate_path returned by build_crate)",
+                    "description": "Path to the crate directory to validate (use the crate_path returned by export_crate)",
                 }
             },
             "required": ["crate_path"],

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -204,7 +204,7 @@ TOOL_SPECS = [
     },
     {
         "name": "build_and_validate",
-        "description": "Build the crate from the current state in memory and validate it in one step (no files written). This is the fast build/fix loop: use it on every iteration. Returns {ok, conformance:{base,isa,tox}, issues:[{entity_id, property, message, fix, severity, profile}]} — each issue is keyed to the entity and property that failed, so route your fix there. Fix REQUIRED issues bottom-up: base, then isa, then tox.",
+        "description": "Build the crate from the current state in memory and validate it in one step (no files written). This is the fast build/fix loop: use it on every iteration. Returns {ok, conformance, issues:[{entity_id, property, message, fix, severity, profile}]} — each issue is keyed to the entity and property that failed, so route your fix there. conformance maps each layer that ran to its REQUIRED pass/fail: {base,isa,tox} for profile='all', or just the scoped layer when you pass a single profile. Fix REQUIRED issues bottom-up: base, then isa, then tox.",
         "parameters": {
             "type": "object",
             "properties": {

--- a/builder/tools/__init__.py
+++ b/builder/tools/__init__.py
@@ -21,7 +21,7 @@ Tool categories:
 
 from __future__ import annotations
 
-from builder.tools.builder import build_crate
+from builder.tools.builder import build_crate, export_crate
 from builder.tools.drafters import (
     draft_assay,
     draft_cell_line_sample,
@@ -68,12 +68,13 @@ from builder.tools.session import (
     load_session,
     save_session,
 )
-from builder.tools.validation import validate
+from builder.tools.validation import build_and_validate, validate
 from builder.tools.verification import verify_all_identifiers, verify_identifier
 
 __all__ = [
     "assess_fair_maturity",
     "assess_mit_coverage",
+    "build_and_validate",
     "build_crate",
     "bulk_set_fields",
     "draft_assay",
@@ -85,6 +86,7 @@ __all__ = [
     "draft_process",
     "draft_publication",
     "draft_study",
+    "export_crate",
     "extract_pdf_text",
     "get_hint",
     "get_status",

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -107,17 +107,28 @@ _STRUCT_FIELDS = frozenset(
 )
 
 
-def populate_crate(state: CrateState, crate: ROCrate, output_dir: Path) -> None:
+def populate_crate(
+    state: CrateState,
+    crate: ROCrate,
+    output_dir: Path | None = None,
+    *,
+    materialize_payload: bool = True,
+) -> None:
     """Populate `crate` from `state` using the ISA-Tox domain model.
 
     output_dir is the crate root being written; the Exposure condition table is
     materialised there as a (placeholder) CSV so it is a valid in-payload File.
+
+    When ``materialize_payload`` is False (the in-memory build_and_validate path,
+    #87) no payload file is written to disk — the condition-table File node is
+    still added to the graph so the metadata document validates, but its CSV is
+    not created. This keeps validation a zero-disk operation.
     """
     idx: dict[str, Any] = {}
     _populate_root_and_conformance(state, crate)
     _add_leaves(state, crate, idx)
     _add_structural(state, crate, idx)
-    _add_processes(state, crate, idx, output_dir)
+    _add_processes(state, crate, idx, output_dir, materialize_payload=materialize_payload)
     _wire_mentions(state, idx)
 
 
@@ -497,7 +508,13 @@ _CONDITION_TABLE_HEADER = "cell_line,compound,concentration,unit,duration\n"
 
 
 def _synth_condition_table(
-    crate: ROCrate, output_dir: Path, exp_pid: str, cells: list[Any], chems: list[Any]
+    crate: ROCrate,
+    output_dir: Path | None,
+    exp_pid: str,
+    cells: list[Any],
+    chems: list[Any],
+    *,
+    materialize_payload: bool = True,
 ) -> File:
     """The Exposure's result: the CSVW condition table (the per-well design table).
 
@@ -511,10 +528,14 @@ def _synth_condition_table(
     its result (a MolecularEntity cannot be a process object under the ISA shape).
     """
     rel = f"data/{_slug(exp_pid)}_condition_table.csv"
-    dest = output_dir / rel
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    if not dest.exists():
-        dest.write_text(_CONDITION_TABLE_HEADER, encoding="utf-8")
+    # Only touch disk when materialising payload for an on-disk export. The
+    # in-memory validate path (#87) skips the write; the File node below still
+    # carries dest_path=rel so the metadata graph is complete for validation.
+    if materialize_payload and output_dir is not None:
+        dest = output_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if not dest.exists():
+            dest.write_text(_CONDITION_TABLE_HEADER, encoding="utf-8")
     table = crate.add(
         File(
             crate,
@@ -529,7 +550,12 @@ def _synth_condition_table(
 
 
 def _add_processes(
-    state: CrateState, crate: ROCrate, idx: dict[str, Any], output_dir: Path
+    state: CrateState,
+    crate: ROCrate,
+    idx: dict[str, Any],
+    output_dir: Path | None,
+    *,
+    materialize_payload: bool = True,
 ) -> None:
     proto_cache: dict[str, Any] = {}
     for proc in state.list_entities("LabProcess"):
@@ -540,7 +566,10 @@ def _add_processes(
         protocol = _resolve_one(idx, f.get("labprotocol")) or _synth_protocol(
             crate, f.get("assay_id"), proto_cache
         )
-        node = _build_process(crate, ptype, pid, name, f, protocol, idx, output_dir)
+        node = _build_process(
+            crate, ptype, pid, name, f, protocol, idx, output_dir,
+            materialize_payload=materialize_payload,
+        )
         _idx_add(idx, proc, node)
         assay = _resolve_one(idx, f.get("assay_id"))
         if assay is not None:
@@ -555,7 +584,9 @@ def _build_process(
     f: dict[str, Any],
     protocol: Any,
     idx: dict[str, Any],
-    output_dir: Path,
+    output_dir: Path | None,
+    *,
+    materialize_payload: bool = True,
 ) -> Any:
     samples = _resolve_many(idx, f.get("samples"))
     obj = _resolve_many(idx, f.get("object"))
@@ -596,7 +627,12 @@ def _build_process(
         # intake/condition_table.py.
         cells = samples or obj
         chems = _resolve_many(idx, f.get("chemicals"))
-        out = result or [_synth_condition_table(crate, output_dir, pid, cells, chems)]
+        out = result or [
+            _synth_condition_table(
+                crate, output_dir, pid, cells, chems,
+                materialize_payload=materialize_payload,
+            )
+        ]
         return LabProcessExposure(
             crate,
             identifier=pid,

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -33,11 +33,43 @@ def _default_crate_path(state: CrateState) -> str:
     return str(Path("sessions") / session_id / "working_crate")
 
 
-def build_crate(state: CrateState, output_path: str | None = None) -> dict[str, Any]:
-    """Build an RO-Crate from CrateState using ro-crate-py.
+def assemble_crate(
+    state: CrateState,
+    output_dir: Path | None = None,
+    *,
+    materialize_payload: bool = True,
+) -> ROCrate:
+    """Assemble an in-memory `ROCrate` from CrateState — no disk write.
 
-    Creates the output directory, assembles a `ROCrate` from the state, and
-    writes `ro-crate-metadata.json` plus any payload.
+    This is the shared assembly step behind both :func:`export_crate` (which
+    then writes the crate to disk) and ``build_and_validate`` (which generates
+    the metadata document and validates it in memory). Splitting it out keeps
+    disk writes confined to :func:`export_crate`.
+
+    Args:
+        state: The CrateState to build from.
+        output_dir: Crate root, used only when payload is materialised. ``None``
+            for the pure in-memory path.
+        materialize_payload: When False, no payload file is written (see
+            :func:`builder.tools._crate_mapping.populate_crate`).
+
+    Returns:
+        A populated :class:`ROCrate`. Nothing is written unless the caller
+        invokes ``crate.write()``.
+    """
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, output_dir, materialize_payload=materialize_payload)
+    return crate
+
+
+def export_crate(state: CrateState, output_path: str | None = None) -> dict[str, Any]:
+    """Assemble an RO-Crate from CrateState and write it to disk (ro-crate-py).
+
+    This is the only step that touches disk: it creates the output directory,
+    assembles a `ROCrate` from the state, and writes `ro-crate-metadata.json`
+    plus any payload. For a fast, zero-disk conformance check during the agent
+    loop, use ``build_and_validate`` instead.
 
     Args:
         state: The current CrateState to build from.
@@ -58,12 +90,10 @@ def build_crate(state: CrateState, output_path: str | None = None) -> dict[str, 
         output_dir = Path(output_path)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        crate = ROCrate()
-        crate.metadata.extra_contexts = ISA_TOX_CONTEXT
-        populate_crate(state, crate, output_dir)
+        crate = assemble_crate(state, output_dir, materialize_payload=True)
         crate.write(str(output_dir))
 
-        logger.info("Crate built at %s", output_path)
+        logger.info("Crate exported to %s", output_path)
         return {"success": True, "crate_path": output_path, "error": None}
 
     except OSError as e:
@@ -74,9 +104,15 @@ def build_crate(state: CrateState, output_path: str | None = None) -> dict[str, 
         return {"success": False, "crate_path": output_path, "error": str(e)}
 
 
+def build_crate(state: CrateState, output_path: str | None = None) -> dict[str, Any]:
+    """Back-compat alias for :func:`export_crate` (the on-disk writer)."""
+    return export_crate(state, output_path)
+
+
 # ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
+TOOL_REGISTRY.register("export_crate", export_crate, takes_state=True)
 TOOL_REGISTRY.register("build_crate", build_crate, takes_state=True)

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -258,6 +258,7 @@ _TOOL_ICONS: dict[str, str] = {
     "read_multiple_files": "\U0001f4c2", "preview_archive": "\U0001f4c2",
     "extract_pdf_text": "\U0001f4c4", "extract_pdf_tables": "\U0001f4c4",
     "verify_identifier": "\u2705", "verify_all_identifiers": "\u2705",
+    "build_and_validate": "\u2714\ufe0f", "export_crate": "\U0001f3ed",
     "build_crate": "\U0001f3ed", "validate": "\u2714\ufe0f",
     "assess_mit_coverage": "\U0001f52e", "assess_fair_maturity": "\U0001f52e",
     "save_session": "\U0001f4be", "load_session": "\U0001f4c1",

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -2,14 +2,22 @@
 
 Translates the list[ValidationResult] into a single ValidationReport dataclass
 with per-pass pass/fail and categorized issues.
+
+Also exposes ``build_and_validate`` (#87): an in-memory build + validate that
+returns routable, per-entity feedback without any disk round-trip — the fast
+path for the agent's build/fix loop.
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from builder.state import CrateState, ValidationReport
+
+if TYPE_CHECKING:
+    from profiles.validator import RoutableIssue
 
 logger = logging.getLogger(__name__)
 
@@ -115,8 +123,109 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
 
 
 # ---------------------------------------------------------------------------
+# In-memory build + validate with routable feedback (#87)
+# ---------------------------------------------------------------------------
+
+# Per-property fix templates keyed by the property's local name. Synthesized
+# locally (roc-validator does not provide fixes); richer guidance lands with #88.
+_FIX_TEMPLATES: dict[str, str] = {
+    "name": "Add a `name` to `{entity}`.",
+    "description": "Add a `description` to `{entity}`.",
+    "identifier": "Add an `identifier` to `{entity}`.",
+    "conformsTo": "Add `conformsTo` to `{entity}` referencing the RO-Crate 1.1 spec.",
+    "license": "Add a `license` to `{entity}`.",
+    "author": "Add an `author` to `{entity}`.",
+    "datePublished": "Add a `datePublished` to `{entity}`.",
+}
+
+
+def _local_name(iri: str | None) -> str:
+    """Return the local part of a property IRI (after the last / or #)."""
+    if not iri:
+        return ""
+    return iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+
+
+def _synthesize_fix(issue: RoutableIssue) -> str:
+    """Build a short, actionable fix hint for a routable issue."""
+    entity = issue.entity_id or "the affected entity"
+    prop = _local_name(issue.property)
+    if prop in _FIX_TEMPLATES:
+        return _FIX_TEMPLATES[prop].format(entity=entity)
+    if prop:
+        suffix = f" (check {issue.check_id})" if issue.check_id else ""
+        return f"Set `{prop}` on `{entity}`{suffix}."
+    if issue.check_id:
+        return f"Resolve check `{issue.check_id}` on `{entity}`."
+    return f"Fix `{entity}`: {issue.message}"
+
+
+def build_and_validate(
+    state: CrateState,
+    severity: str = "required",
+    profile: str = "all",
+) -> dict[str, Any]:
+    """Build the crate from CrateState in memory and validate it — no disk write.
+
+    This is the agent's fast build/fix loop: it assembles the crate with
+    ro-crate-py, generates the JSON-LD metadata document, and validates that
+    document directly (no crate is written to disk, nothing is re-read). Issues
+    come back keyed to the entity/property that failed so the agent can route a
+    fix to a specific field rather than parsing prose.
+
+    Args:
+        state: The current CrateState to build and validate.
+        severity: Gate severity ("required" | "recommended" | "optional"). The
+            default "required" runs only REQUIRED-severity checks (fastest);
+            lower it to also surface recommendations.
+        profile: "all" runs the base -> isa -> tox passes; "base"/"isa"/"tox"
+            scopes to a single pass (the tox pass dominates wall-clock).
+
+    Returns:
+        ``{"ok": bool, "conformance": {layer: bool}, "issues": [issue, ...]}``
+        where each issue is ``{entity_id, property, message, fix, severity,
+        profile}``. ``conformance`` reports REQUIRED-level pass/fail per layer
+        validated; ``ok`` is True when there are no issues at the gate severity.
+    """
+    # Imported lazily (not at module top) so validate()'s ImportError handling
+    # stays intact. profiles.validator installs the roc-validator bootstrap shim
+    # + bundled-ISA-ontology patch on import; importing validate_crate_dict here
+    # runs that shim before any rocrate_validator import is triggered. assemble_crate
+    # pulls in ro-crate-py only (no rocrate_validator), so its order is immaterial.
+    from builder.tools.builder import assemble_crate
+    from profiles.validator import validate_crate_dict
+
+    try:
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+        metadata_doc = crate.metadata.generate()
+        results = validate_crate_dict(metadata_doc, severity=severity, profile=profile)
+    except Exception as e:  # noqa: BLE001 — surface as a tool error, never crash the loop
+        logger.error("build_and_validate failed: %s", e)
+        return {"ok": False, "conformance": {}, "issues": [], "error": str(e)}
+
+    conformance = {r.profile: r.passed_required for r in results}
+    issues: list[dict[str, Any]] = []
+    for result in results:
+        for issue in result.issues:
+            issues.append(
+                {
+                    "entity_id": issue.entity_id,
+                    "property": issue.property,
+                    "message": issue.message,
+                    "fix": _synthesize_fix(issue),
+                    "severity": issue.severity,
+                    "profile": issue.profile,
+                }
+            )
+
+    ok = not any(result.issues for result in results)
+    return {"ok": ok, "conformance": conformance, "issues": issues}
+
+
+# ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
 TOOL_REGISTRY.register("validate", validate, takes_state=True)
+TOOL_REGISTRY.register("build_and_validate", build_and_validate, takes_state=True)

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -187,6 +187,13 @@ def build_and_validate(
         profile}``. ``conformance`` reports REQUIRED-level pass/fail per layer
         validated; ``ok`` is True when there are no issues at the gate severity.
     """
+    # Weak models (e.g. DeepSeek-flash) emit explicit nulls for optional tool
+    # args instead of omitting them, so the function defaults never apply and a
+    # bare None would otherwise raise "Unknown profile None". Treat None as "use
+    # the default"; genuine typos (a non-None unknown string) still fail loudly.
+    severity = "required" if severity is None else severity
+    profile = "all" if profile is None else profile
+
     # Imported lazily (not at module top) so validate()'s ImportError handling
     # stays intact. profiles.validator installs the roc-validator bootstrap shim
     # + bundled-ISA-ontology patch on import; importing validate_crate_dict here

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -127,6 +127,137 @@ class ValidationResult:
     passed_required: bool = True  # no REQUIRED-severity issues
 
 
+# ---------------------------------------------------------------------------
+# In-memory (no-disk) validation — routable per-entity feedback (#87)
+# ---------------------------------------------------------------------------
+
+# Layer key -> (profile_identifier, extra ValidationSettings kwargs). Mirrors the
+# three passes in validate_crate(); the only difference is the document is fed as
+# a dict via services.validate_metadata_as_dict instead of read from disk.
+_PROFILE_PASSES: dict[str, tuple[str, dict]] = {
+    "base": ("ro-crate-1.1", {}),
+    "isa": ("isa-ro-crate", {"disable_inherited_profiles_issue_reporting": True}),
+    "tox": (
+        "tox-ro-crate",
+        {
+            "profiles_path": DEFAULT_PROFILES_PATH,
+            "extra_profiles_path": SHAPES_DIR,
+            "disable_inherited_profiles_issue_reporting": True,
+        },
+    ),
+}
+
+# Severity name <-> roc-validator Severity enum.
+_SEVERITY_BY_NAME = {
+    "required": models.Severity.REQUIRED,
+    "recommended": models.Severity.RECOMMENDED,
+    "optional": models.Severity.OPTIONAL,
+}
+_SEVERITY_NAME = {v: k for k, v in _SEVERITY_BY_NAME.items()}
+
+
+@dataclass
+class RoutableIssue:
+    """A SHACL issue keyed to the entity/property that failed.
+
+    Unlike the prose strings in :class:`ValidationResult`, these fields let the
+    agent route a fix to a specific graph node and property.
+    """
+
+    entity_id: str | None  # focus-node @id (crate-relative, e.g. "./", "#id")
+    property: str | None  # failing property IRI (e.g. http://schema.org/name)
+    property_value: str | None  # the offending value, when reported
+    message: str  # human-readable SHACL message
+    severity: str  # "required" | "recommended" | "optional"
+    check_id: str | None  # check.identifier, e.g. "ro-crate-1.1_8.1"
+    profile: str  # "base" | "isa" | "tox"
+
+
+@dataclass
+class DictValidationResult:
+    """Result of one in-memory validation pass over a metadata document."""
+
+    profile: str  # "base" | "isa" | "tox"
+    passed: bool  # no issues at the gate severity
+    passed_required: bool  # no REQUIRED-severity issues
+    issues: list[RoutableIssue] = field(default_factory=list)
+
+
+def _routable_issue(issue, profile: str) -> RoutableIssue:
+    """Adapt a roc-validator CheckIssue to a :class:`RoutableIssue`."""
+
+    def _opt_str(value) -> str | None:
+        return str(value) if value is not None else None
+
+    return RoutableIssue(
+        entity_id=_opt_str(getattr(issue, "violatingEntity", None)),
+        property=_opt_str(getattr(issue, "violatingProperty", None)),
+        property_value=_opt_str(getattr(issue, "violatingPropertyValue", None)),
+        message=issue.message or str(issue),
+        severity=_SEVERITY_NAME.get(issue.severity, issue.severity.name.lower()),
+        check_id=getattr(getattr(issue, "check", None), "identifier", None),
+        profile=profile,
+    )
+
+
+def validate_crate_dict(
+    metadata_doc: dict,
+    *,
+    severity: str = "required",
+    profile: str = "all",
+) -> list[DictValidationResult]:
+    """Validate an in-memory RO-Crate metadata document — no disk round-trip.
+
+    ``metadata_doc`` is the ``{"@context", "@graph"}`` dict returned by
+    ``crate.metadata.generate()`` (ro-crate-py >=0.15 returns a dict, not JSON).
+    It is validated directly via ``services.validate_metadata_as_dict``; nothing
+    is written or read from disk.
+
+    Args:
+        metadata_doc: The RO-Crate metadata document as a dict.
+        severity: Gate severity ("required" | "recommended" | "optional"). At
+            "required" only REQUIRED-severity checks run (fastest, the inner-loop
+            default); lower the gate to also surface recommendations.
+        profile: "all" runs the base -> isa -> tox passes; "base"/"isa"/"tox"
+            runs a single pass (the tox pass dominates wall-clock, so scoping the
+            inner loop is the main speed lever).
+
+    Returns:
+        One :class:`DictValidationResult` per pass run, in dependency order.
+    """
+    gate = _SEVERITY_BY_NAME.get(severity, models.Severity.REQUIRED)
+    if profile == "all":
+        passes = ["base", "isa", "tox"]
+    elif profile in _PROFILE_PASSES:
+        passes = [profile]
+    else:
+        raise ValueError(
+            f"Unknown profile {profile!r}; expected one of 'all', 'base', 'isa', 'tox'."
+        )
+
+    results: list[DictValidationResult] = []
+    for key in passes:
+        profile_identifier, extra = _PROFILE_PASSES[key]
+        # rocrate_uri is required even on the dict path; its value is ignored when
+        # the document is supplied as a dict (base IRI resolves to "./").
+        settings = services.ValidationSettings(
+            rocrate_uri=".",  # ty: ignore[unknown-argument]
+            profile_identifier=profile_identifier,
+            requirement_severity=gate,
+            **extra,
+        )
+        result = services.validate_metadata_as_dict(metadata_doc, settings)
+        results.append(
+            DictValidationResult(
+                profile=key,
+                passed=not result.has_issues(),
+                passed_required=not result.has_issues(min_severity=models.Severity.REQUIRED),
+                issues=[_routable_issue(i, key) for i in result.get_issues()],
+            )
+        )
+    return results
+
+
 def validate_crate(crate_dir: Path) -> list[ValidationResult]:
     """Run all three validation passes against crate_dir.
 

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -225,7 +225,14 @@ def validate_crate_dict(
     Returns:
         One :class:`DictValidationResult` per pass run, in dependency order.
     """
-    gate = _SEVERITY_BY_NAME.get(severity, models.Severity.REQUIRED)
+    if severity not in _SEVERITY_BY_NAME:
+        # Fail loudly rather than silently falling back to the strictest gate,
+        # which would under-report recommended/optional issues as a false pass.
+        raise ValueError(
+            f"Unknown severity {severity!r}; expected one of "
+            f"{sorted(_SEVERITY_BY_NAME)}."
+        )
+    gate = _SEVERITY_BY_NAME[severity]
     if profile == "all":
         passes = ["base", "isa", "tox"]
     elif profile in _PROFILE_PASSES:

--- a/tests/test_crate_mapping_no_payload.py
+++ b/tests/test_crate_mapping_no_payload.py
@@ -1,0 +1,67 @@
+"""Tests for the in-memory (no-payload) assembly path in _crate_mapping (Issue #87).
+
+``populate_crate`` materialises exactly one payload artefact on disk: the CSVW
+condition table for an ``Exposure`` LabProcess (``_synth_condition_table``). The
+in-memory ``build_and_validate`` path must assemble the *graph* without writing
+that file, so the validator can run on the metadata dict with zero disk writes.
+"""
+
+from __future__ import annotations
+
+from rocrate.rocrate import ROCrate
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools._crate_mapping import populate_crate
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _exposure_state() -> CrateState:
+    """A state with a single Exposure LabProcess (triggers condition-table synth)."""
+    state = CrateState()
+    state.metadata.title = "Exposure crate"
+    state.add_entity(
+        Entity(
+            entity_id="proc_exp",
+            type="LabProcess",
+            fields={"process_type": "Exposure", "name": "Exposure step"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    return state
+
+
+def _assemble(state, output_dir, *, materialize_payload):
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, output_dir, materialize_payload=materialize_payload)
+    return crate
+
+
+def _condition_table_nodes(crate: ROCrate) -> list[dict]:
+    graph = crate.metadata.generate()["@graph"]
+    return [e for e in graph if str(e.get("@id", "")).endswith("condition_table.csv")]
+
+
+def test_no_payload_writes_nothing(tmp_path):
+    """With materialize_payload=False the Exposure condition table is NOT written."""
+    crate = _assemble(_exposure_state(), tmp_path, materialize_payload=False)
+    # No CSV (or any file) materialised on disk.
+    assert list(tmp_path.iterdir()) == []
+    # But the condition-table File node still exists in the graph so the
+    # metadata document is structurally complete for validation.
+    assert _condition_table_nodes(crate), "condition table node must be in the graph"
+
+
+def test_no_payload_with_none_output_dir(tmp_path, monkeypatch):
+    """materialize_payload=False works even when output_dir is None (pure memory)."""
+    monkeypatch.chdir(tmp_path)
+    crate = _assemble(_exposure_state(), None, materialize_payload=False)
+    assert list(tmp_path.iterdir()) == []
+    assert _condition_table_nodes(crate)
+
+
+def test_default_materializes_payload(tmp_path):
+    """Default (materialize_payload=True) still writes the condition-table CSV."""
+    _assemble(_exposure_state(), tmp_path, materialize_payload=True)
+    csvs = list(tmp_path.rglob("*condition_table.csv"))
+    assert csvs, "condition table CSV must be written to disk by default"

--- a/tests/test_tools_build_and_validate.py
+++ b/tests/test_tools_build_and_validate.py
@@ -1,0 +1,103 @@
+"""Tests for build_and_validate — in-memory build + routable validation (Issue #87).
+
+build_and_validate assembles the crate from CrateState in memory and validates
+the generated JSON-LD document directly (no disk round-trip), returning issues
+keyed to the entity/property that failed so the agent can route a fix.
+"""
+
+from __future__ import annotations
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.validation import build_and_validate
+
+
+def _exposure_state() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Exposure crate"
+    state.add_entity(
+        Entity(
+            entity_id="proc_exp",
+            type="LabProcess",
+            fields={"process_type": "Exposure", "name": "Exposure step"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    return state
+
+
+class TestBuildAndValidateShape:
+    def test_returns_routable_shape(self):
+        report = build_and_validate(CrateState())
+        assert set(report.keys()) == {"ok", "conformance", "issues"}
+        assert isinstance(report["ok"], bool)
+        assert isinstance(report["conformance"], dict)
+        assert set(report["conformance"]) == {"base", "isa", "tox"}
+        assert all(isinstance(v, bool) for v in report["conformance"].values())
+        assert isinstance(report["issues"], list)
+
+    def test_issue_entries_have_routable_keys(self):
+        report = build_and_validate(CrateState())
+        assert report["issues"], "minimal crate should surface at least one issue"
+        for issue in report["issues"]:
+            assert set(issue.keys()) == {
+                "entity_id",
+                "property",
+                "message",
+                "fix",
+                "severity",
+                "profile",
+            }
+
+
+class TestBuildAndValidateRouting:
+    def test_surfaces_root_identifier_violation(self):
+        """A minimal crate misses schema:identifier on the root (ISA REQUIRED)."""
+        report = build_and_validate(CrateState())
+        matches = [
+            i
+            for i in report["issues"]
+            if i["entity_id"] == "./"
+            and i["property"]
+            and i["property"].endswith("identifier")
+        ]
+        assert matches, report["issues"]
+        issue = matches[0]
+        assert issue["profile"] == "isa"
+        assert issue["severity"] == "required"
+        assert issue["fix"], "a synthesized fix hint must be present"
+
+    def test_conformance_base_passes_isa_fails_for_minimal(self):
+        report = build_and_validate(CrateState())
+        assert report["conformance"]["base"] is True
+        assert report["conformance"]["isa"] is False
+        assert report["ok"] is False
+
+
+class TestBuildAndValidateNoDisk:
+    def test_writes_no_files_for_minimal(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        build_and_validate(CrateState())
+        assert list(tmp_path.iterdir()) == []
+
+    def test_writes_no_files_with_exposure(self, tmp_path, monkeypatch):
+        """The only disk-writing build path (Exposure condition table) stays in memory."""
+        monkeypatch.chdir(tmp_path)
+        build_and_validate(_exposure_state())
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestBuildAndValidateScoping:
+    def test_profile_scope_runs_single_pass(self):
+        report = build_and_validate(CrateState(), profile="base")
+        assert set(report["conformance"]) == {"base"}
+        assert all(i["profile"] == "base" for i in report["issues"])
+
+    def test_profile_scope_base_is_ok(self):
+        """Base scope on a minimal crate is conformant -> ok True, no issues."""
+        report = build_and_validate(CrateState(), profile="base")
+        assert report["ok"] is True
+        assert report["issues"] == []
+
+    def test_required_severity_only_required_issues(self):
+        report = build_and_validate(CrateState(), severity="required")
+        assert all(i["severity"] == "required" for i in report["issues"])

--- a/tests/test_tools_build_and_validate.py
+++ b/tests/test_tools_build_and_validate.py
@@ -101,3 +101,22 @@ class TestBuildAndValidateScoping:
     def test_required_severity_only_required_issues(self):
         report = build_and_validate(CrateState(), severity="required")
         assert all(i["severity"] == "required" for i in report["issues"])
+
+    def test_invalid_severity_surfaced_as_error(self):
+        """A bad severity is surfaced as a tool error, not a silent false pass."""
+        report = build_and_validate(CrateState(), severity="bogus")
+        assert report["ok"] is False
+        assert "error" in report
+
+    def test_none_args_fall_back_to_defaults(self):
+        """Weak models pass null for optional args explicitly; treat None as default.
+
+        DeepSeek-flash calls build_and_validate(severity=None, profile=None) rather
+        than omitting them, so None must behave like the defaults (all/required) and
+        NOT raise 'Unknown profile None'.
+        """
+        explicit_none = build_and_validate(CrateState(), severity=None, profile=None)
+        defaults = build_and_validate(CrateState())
+        assert "error" not in explicit_none
+        assert explicit_none["conformance"] == defaults["conformance"]
+        assert set(explicit_none["conformance"]) == {"base", "isa", "tox"}

--- a/tests/test_tools_builder.py
+++ b/tests/test_tools_builder.py
@@ -7,7 +7,45 @@ import tempfile
 from pathlib import Path
 
 from builder.state import CrateState
-from builder.tools.builder import build_crate
+from builder.tools.builder import build_crate, export_crate
+
+
+class TestExportCrate:
+    """export_crate is the explicit disk-writer (the only step that touches disk)."""
+
+    def test_export_crate_writes_to_disk(self):
+        state = CrateState()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = str(Path(tmpdir) / "crate")
+            result = export_crate(state, output_path)
+
+            assert result["success"] is True
+            assert result["crate_path"] == output_path
+            metadata_path = Path(output_path) / "ro-crate-metadata.json"
+            assert metadata_path.exists()
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+            assert "@context" in metadata
+            assert "@graph" in metadata
+
+    def test_build_crate_is_export_crate_alias(self):
+        """build_crate stays as a back-compat alias for export_crate."""
+        state = CrateState()
+        state.metadata.title = "Alias check"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            via_build = build_crate(state, str(Path(tmpdir) / "a"))
+            via_export = export_crate(state, str(Path(tmpdir) / "b"))
+
+            assert via_build["success"] is via_export["success"] is True
+            graph_a = json.loads(
+                (Path(via_build["crate_path"]) / "ro-crate-metadata.json").read_text()
+            )["@graph"]
+            graph_b = json.loads(
+                (Path(via_export["crate_path"]) / "ro-crate-metadata.json").read_text()
+            )["@graph"]
+            roots_a = [e for e in graph_a if e.get("@type") == "Dataset"][0]
+            roots_b = [e for e in graph_b if e.get("@type") == "Dataset"][0]
+            assert roots_a.get("name") == roots_b.get("name") == "Alias check"
 
 
 class TestBuildCrate:

--- a/tests/test_validate_dict.py
+++ b/tests/test_validate_dict.py
@@ -1,0 +1,87 @@
+"""Tests for profiles.validator.validate_crate_dict — in-memory SHACL validation.
+
+These pin the in-memory (no-disk) validation path introduced for Issue #87: a
+JSON-LD metadata document (the dict returned by ``crate.metadata.generate()``)
+is validated directly via ``rocrate_validator.services.validate_metadata_as_dict``,
+returning per-pass results whose issues carry routable focus-node / property
+information instead of opaque prose.
+"""
+
+from __future__ import annotations
+
+from rocrate.rocrate import ROCrate
+
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _minimal_doc() -> dict:
+    """A minimal RO-Crate metadata document with no ISA identifier on the root.
+
+    ro-crate-py always emits a base-valid root (name/description default via the
+    library), but a bare crate has no ``schema:identifier`` on the Root Data
+    Entity, which the ISA profile requires (isa-ro-crate_3.2) — a reliable,
+    routable REQUIRED violation to assert against.
+    """
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    crate.root_dataset["name"] = "Test"
+    crate.root_dataset["description"] = "Test crate"
+    # Base RO-Crate requires a license on the root (ro-crate-1.1_8.3); populate_crate
+    # supplies this same placeholder, so a base-valid doc mirrors the real path.
+    crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+    # The metadata descriptor MUST conformsTo the versioned spec (ro-crate-1.1_5.3);
+    # populate_crate sets this explicitly rather than relying on the library default.
+    crate.metadata["conformsTo"] = {"@id": "https://w3id.org/ro/crate/1.1"}
+    return crate.metadata.generate()
+
+
+class TestValidateCrateDict:
+    def test_returns_one_result_per_pass(self):
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(_minimal_doc())
+        # default profile="all" -> base, isa, tox
+        assert [r.profile for r in results] == ["base", "isa", "tox"]
+
+    def test_profile_scope_runs_single_pass(self):
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(_minimal_doc(), profile="base")
+        assert len(results) == 1
+        assert results[0].profile == "base"
+
+    def test_issues_are_routable(self):
+        """Each issue exposes the focus-node id and failing property IRI."""
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(_minimal_doc())
+        isa = next(r for r in results if r.profile == "isa")
+        assert isa.passed_required is False
+        # The root (./) is missing schema:identifier — a routable REQUIRED issue.
+        ident_issues = [
+            i
+            for i in isa.issues
+            if i.property and i.property.endswith("identifier") and i.entity_id == "./"
+        ]
+        assert ident_issues, [
+            (i.entity_id, i.property, i.check_id) for i in isa.issues
+        ]
+        issue = ident_issues[0]
+        assert issue.severity == "required"
+        assert issue.profile == "isa"
+        assert issue.check_id  # e.g. isa-ro-crate_3.2
+
+    def test_base_passes_for_minimal_doc(self):
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(_minimal_doc())
+        base = next(r for r in results if r.profile == "base")
+        assert base.passed_required is True
+
+    def test_writes_no_files(self, tmp_path, monkeypatch):
+        """Validation must not touch disk — cwd stays empty."""
+        from profiles.validator import validate_crate_dict
+
+        monkeypatch.chdir(tmp_path)
+        validate_crate_dict(_minimal_doc())
+        assert list(tmp_path.iterdir()) == []

--- a/tests/test_validate_dict.py
+++ b/tests/test_validate_dict.py
@@ -85,3 +85,20 @@ class TestValidateCrateDict:
         monkeypatch.chdir(tmp_path)
         validate_crate_dict(_minimal_doc())
         assert list(tmp_path.iterdir()) == []
+
+    def test_invalid_severity_raises(self):
+        """An unknown severity must fail loudly, not silently pick the strictest gate."""
+        import pytest
+
+        from profiles.validator import validate_crate_dict
+
+        with pytest.raises(ValueError):
+            validate_crate_dict(_minimal_doc(), severity="bogus")
+
+    def test_invalid_profile_raises(self):
+        import pytest
+
+        from profiles.validator import validate_crate_dict
+
+        with pytest.raises(ValueError):
+            validate_crate_dict(_minimal_doc(), profile="bogus")


### PR DESCRIPTION
Closes #87.

## What
Adds `build_and_validate(state, severity="required", profile="all")` — the agent's fast build/fix loop. It assembles the crate from `CrateState` **in memory** and validates the generated JSON-LD document via `roc-validator`'s `validate_metadata_as_dict`. No crate is written to disk and nothing is re-read (the old `build_crate`→`validate` path did a disk round-trip every ReAct iteration).

Issues come back keyed to the entity/property that failed so the agent can route a fix to a specific field:

```
{ok, conformance:{base,isa,tox}, issues:[{entity_id, property, message, fix, severity, profile}]}
```

## How
- `profiles/validator.py`: `validate_crate_dict()` runs the same 3 passes as `validate_crate()` but feeds a dict; `RoutableIssue`/`DictValidationResult` expose `violatingEntity`/`violatingProperty`/`check.identifier`/`severity`/`profile`.
- `_crate_mapping.populate_crate` gains `materialize_payload` so the in-memory path never writes the Exposure condition-table placeholder CSV (the one disk write in `populate_crate`).
- `builder.py`: extract `assemble_crate()`; `export_crate()` is now the explicit disk writer (the only step that touches disk); `build_crate()` stays as a back-compat alias.
- Severity + profile scoping: the tox SHACL pass dominates wall-clock, so the inner loop can scope to one profile at REQUIRED severity and run the full sweep only as a gate.
- Repoint the agent (`tools_spec`, `system_prompt`, `__init__`) at `build_and_validate`/`export_crate`; keep `validate(crate_path)` as a back-compat wrapper.

## Hardening (found by a live run + adversarial review)
- **None args fall back to defaults.** Weak models (DeepSeek-flash) emit explicit nulls for optional tool args, so `build_and_validate(profile=None)` raised "Unknown profile None" on the happy path. None now means "use the default"; genuine typos still fail loudly.
- **Unknown severity raises** instead of silently selecting the strictest gate (which under-reported recommended/optional issues as a false `ok=True`).
- Docs note `conformance` is keyed to the passes actually run.
- Dashboard icons for the new tools.

## Verification
- TDD: 19 new tests (routable shape, root-identifier routing, zero-disk incl. Exposure crates, severity/profile scoping, None-args, export_crate disk write). Full suite green (`uv run pytest`), `ruff` clean.
- Bench (best-of-5, 25-file crate): old disk round-trip 3-pass **4555 ms** → in-memory 3-pass **3582 ms**; `profile="base"` **317 ms**; **0 files written**.
- Verified live in the agent app: `build_and_validate` returns the routable shape and the agent acted on it; `build a base conformant crate only` now returns `{"ok": true, "conformance": {"base": true}}` with no error.

## Notes / out of scope
- The full 3-pass is still ~3.6 s because the tox SHACL pass (~2.9 s) is `roc-validator` 0.10.0's per-check graph-recomposition cost — identical in-memory or on-disk. Speeding up the SHACL engine is #63 (reframed: it's not disk re-parsing, so an lru_cache over shapes won't help; needs a persistent warmed context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)