### PR TITLE
fix(tools): dedupe read_multiple_files + expose file readers in TOOL_SPECS

### DIFF
--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -260,25 +260,6 @@ TOOL_SPECS = [
         },
     },
     {
-        "name": "read_multiple_files",
-        "description": "Read several files at once and return their contents. Use this when you need to inspect a batch of files (e.g. all metadata files in an assay directory) rather than reading them one at a time.",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "paths": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "List of file paths to read",
-                },
-                "lines": {
-                    "type": "integer",
-                    "description": "Max lines per file (default 50)",
-                },
-            },
-            "required": ["paths"],
-        },
-    },
-    {
         "name": "unzip_file",
         "description": "Extract a zip archive to a directory. Returns the extraction path.",
         "parameters": {
@@ -413,6 +394,39 @@ TOOL_SPECS = [
                 },
             },
             "required": ["paths"],
+        },
+    },
+    {
+        "name": "read_file",
+        "description": "Read a supported file in full by extension (txt, csv, json, xlsx, docx, md, pdf) and return its text content. Use read_file_sample instead when you only need a preview of a large file.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to the file to read"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "read_excel",
+        "description": "Read an Excel .xlsx file and return its content as pipe-delimited text.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to the .xlsx file to read"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "read_docx",
+        "description": "Read a Word .docx file and return its text content.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to the .docx file to read"},
+            },
+            "required": ["path"],
         },
     },
     {

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -213,4 +213,20 @@ def test_every_system_prompt_tool_is_in_tool_specs():
     )
 
 
+def test_no_duplicate_tool_names_in_tool_specs():
+    """TOOL_SPECS must not contain two entries with the same name.
+
+    A duplicate (e.g. an upgraded tool spec added without removing the old one)
+    is silently shadowed when specs are collapsed into a name->tool map, so the
+    LLM sees one schema while another spec's description is dead. The build then
+    disagrees with itself (see the read_multiple_files duplicate from the
+    file-readers change).
+    """
+    from collections import Counter
+
+    counts = Counter(spec["name"] for spec in TOOL_SPECS)  # ty: ignore
+    duplicates = {name: n for name, n in counts.items() if n > 1}
+    assert not duplicates, f"Duplicate tool names in TOOL_SPECS: {duplicates}"
+
+
 __all__: list[str] = []


### PR DESCRIPTION
## Problem
The file-readers change (c89ad52) left two `TOOL_SPECS` consistency bugs on `main` (both reproduce on a clean checkout, independent of #87/#99):

1. A **stale duplicate `read_multiple_files`** entry (the pre-mode version) remained alongside the upgraded mode-aware one. Collapsing `TOOL_SPECS` into a name→tool map silently shadows one, so the LLM sees one schema while the other spec's description is dead — `test_each_tool_has_name_and_description` fails.
2. `read_file` / `read_excel` / `read_docx` are registered in `TOOL_REGISTRY` but were never added to `TOOL_SPECS`, so the LLM cannot call them — `test_every_registry_tool_is_in_tool_specs` fails.

## Fix
- Remove the stale duplicate `read_multiple_files` entry.
- Add `read_file` / `read_excel` / `read_docx` specs (each takes a required `path`).
- Add a regression test asserting `TOOL_SPECS` has no duplicate names.

## Verification
- The two previously-red guard tests now pass; full suite green (`uv run pytest`), `ruff check builder/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)