### PR TITLE
fix(scanner): actionable feedback for binary files + repair CI (#101)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -182,6 +182,25 @@ def _build_args_schema(name: str, params: dict[str, Any]) -> type[BaseModel] | N
     return create_model(f"{name}_args", **fields, __base__=BaseModel)
 
 
+def _unreadable_file_message(path: str) -> str:
+    """Actionable message for the LLM when read_file_sample can't return text.
+
+    read_file_sample returns a bare ``None`` for files that are missing, too
+    large, or binary (e.g. .xls/.xlsx Office containers, GraphPad .prism/.pzf).
+    A bare ``None`` gives the model nothing to act on, so a weak model re-calls
+    the tool forever and hits the iteration cap (#101). This turns it into a
+    clear "stop, do something else" signal.
+    """
+    name = (path or "").replace("\\", "/").rsplit("/", 1)[-1] or path or "the file"
+    return (
+        f"read_file_sample could not return text for '{name}'. It is missing, too "
+        f"large (>100MB), or binary — e.g. .xls/.xlsx are Office/zip containers and "
+        f".prism/.pzf are GraphPad Prism binaries. Do NOT retry read_file_sample on "
+        f"it. Use the scan preview already in state, try read_excel/read_file for "
+        f"spreadsheets or Office docs, or skip this file and continue drafting entities."
+    )
+
+
 def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
     """Build LangChain BaseTool instances from the engine's tool registry.
 
@@ -226,6 +245,10 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     from builder.tools.scanner import summarize_scan_result
 
                     return summarize_scan_result(result)
+                # read_file_sample returns None for missing/oversized/binary files;
+                # hand the LLM an actionable message so it stops re-calling it (#101).
+                if tool_name == "read_file_sample" and result is None:
+                    return _unreadable_file_message(kwargs.get("path", ""))
                 return result
 
             _run.__name__ = tool_name

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -467,6 +467,20 @@ def _strip_macos_junk(root: Path) -> None:
 _SUMMARY_MAX_LINES = 50
 
 
+def _looks_binary(path: Path) -> bool:
+    """Return True if the file has a NUL byte in its first 8 KiB.
+
+    A reliable heuristic for binary content. Office formats (.xls/.xlsx) and
+    GraphPad files (.prism/.pzf) are binary containers that ``mimetypes`` may
+    mislabel as ``text/csv``; this guard stops them being read as mojibake text.
+    """
+    try:
+        with path.open("rb") as fb:
+            return b"\x00" in fb.read(8192)
+    except OSError:
+        return True
+
+
 def _summarize_csv(path: Path) -> str | None:
     """Return a summary of a CSV/TSV file: columns, row count, sample."""
     try:
@@ -552,15 +566,30 @@ def _summarize_xlsx(path: Path) -> str | None:
     try:
         for sheet_name in wb.sheetnames:
             ws = wb[sheet_name]
+            # read_only worksheets have no `.dimensions`; count by iterating
+            # (capped, so a huge sheet doesn't make the summary slow).
+            header: tuple = ()
             col_count = 0
-            for row in ws.iter_rows(values_only=True):
-                col_count = len(row)
-                break
-            dim = ws.dimensions
-            if dim and dim != "A1":
-                parts.append(f"  {sheet_name}: ~{dim} ({col_count} cols)")
-            else:
-                parts.append(f"  {sheet_name}: unknown rows, {col_count} cols")
+            row_count = 0
+            capped = False
+            for i, row in enumerate(ws.iter_rows(values_only=True)):
+                if i == 0:
+                    header = row
+                    col_count = len(row)
+                row_count = i + 1
+                if i >= 2000:
+                    capped = True
+                    break
+            cols = ", ".join(str(c) for c in header if c is not None)
+            rows_label = f"{row_count}+" if capped else str(row_count)
+            line = f"  {sheet_name}: {rows_label} rows x {col_count} cols"
+            if cols:
+                line += f"; columns: {cols}"
+            parts.append(line)
+    except Exception:
+        # A malformed sheet must not crash (or escape) the summary.
+        if len(parts) == 1:
+            return None
     finally:
         wb.close()
 
@@ -806,9 +835,10 @@ def read_file_sample(
         # Pick the right summarizer based on file type
         summary: str | None = None
 
-        if suffix == ".csv" or suffix == ".tsv" or mime in _TABULAR_MIME_TYPES:
-            summary = _summarize_csv(file_path)
-        elif suffix == ".json":
+        # Dispatch by suffix to the binary-aware summarizers FIRST: office
+        # formats carry a tabular MIME, so the CSV branch below would otherwise
+        # claim them and read their zip/OLE2 header as mojibake "columns".
+        if suffix == ".json":
             summary = _summarize_json(file_path)
         elif suffix == ".xlsx" or suffix == ".xls":
             summary = _summarize_xlsx(file_path)
@@ -816,14 +846,17 @@ def read_file_sample(
             summary = _summarize_pdf(file_path)
         elif suffix == ".docx":
             summary = _summarize_docx(file_path)
+        elif suffix == ".csv" or suffix == ".tsv" or mime in _TABULAR_MIME_TYPES:
+            # A textual MIME (text/csv, ms-excel) can mislabel a binary file —
+            # e.g. GraphPad .prism/.pzf — which _summarize_csv would read as
+            # mojibake "Columns: PK\x03\x04…". Refuse binary content here.
+            if _looks_binary(file_path):
+                return None
+            summary = _summarize_csv(file_path)
         else:
             # Try as plain text first, else binary check
-            try:
-                with file_path.open("rb") as fb:
-                    if b"\x00" in fb.read(8192):
-                        return None  # binary — no summary possible
-            except OSError:
-                return None
+            if _looks_binary(file_path):
+                return None  # binary — no summary possible
             summary = _summarize_text(file_path)
 
         if mode == "overview":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "ipykernel>=7.3.0",
     "nbformat>=5.10.4",
     "ruff>=0.15.18",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.ruff]

--- a/tests/test_binary_file_feedback.py
+++ b/tests/test_binary_file_feedback.py
@@ -1,0 +1,75 @@
+"""Binary files with textual MIME/extension must not loop the agent (#101).
+
+A real dataset zip (GraphPad .prism/.xls/.xlsx) surfaced two bugs:
+- read_file_sample (content mode) returns a bare None for binary files, so the
+  weak model re-calls it forever and hits the iteration cap.
+- read_file_sample (summary mode) routed .xls/.xlsx/.prism (textual MIME) to the
+  CSV summarizer and read the raw zip/OLE2 header as "Columns: PK\\x03\\x04...".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.tools.scanner import read_file_sample
+
+
+def _write_binary(path, name):
+    """Write a file that looks textual by extension but is binary (zip magic + NULs)."""
+    p = path / name
+    p.write_bytes(b"PK\x03\x04\x14\x00\x00\x00\x08\x00" + b"\x00" * 256)
+    return p
+
+
+class TestSummaryBinaryGuard:
+    def test_binary_csv_extension_not_summarized_as_csv(self, tmp_path):
+        """A binary file mislabeled text/csv must not be parsed into garbage columns."""
+        p = _write_binary(tmp_path, "data.csv")
+        result = read_file_sample(str(p), mode="summary")
+        # Either None (refused) — never a CSV summary built from binary bytes.
+        if result is not None:
+            assert "PK\x03\x04" not in result
+            assert "Columns" not in result
+
+    def test_binary_prism_extension_not_garbage(self, tmp_path):
+        p = _write_binary(tmp_path, "plate.prism")
+        result = read_file_sample(str(p), mode="summary")
+        if result is not None:
+            assert "PK\x03\x04" not in result
+
+    def test_real_xlsx_summarized_as_excel_not_csv(self, tmp_path):
+        """A real .xlsx must reach the Excel summarizer, not the CSV one."""
+        openpyxl = pytest.importorskip("openpyxl")
+        f = tmp_path / "book.xlsx"
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["a", "b"])
+        ws.append([1, 2])
+        wb.save(f)
+        result = read_file_sample(str(f), mode="summary")
+        assert result is not None
+        assert "CSV/TSV" not in result
+        assert "Excel" in result or "xlsx" in result.lower()
+
+
+class TestAgentUnreadableMessage:
+    def test_message_helper_is_actionable(self):
+        from builder.agents.agent_loop import _unreadable_file_message
+
+        msg = _unreadable_file_message("/data/raw/sample.xls")
+        assert isinstance(msg, str) and msg
+        assert "sample.xls" in msg
+        low = msg.lower()
+        assert "skip" in low or "do not retry" in low or "don't retry" in low
+
+    def test_agent_tool_returns_message_not_none_for_binary(self, tmp_path):
+        """The LLM-facing read_file_sample tool returns guidance, never bare None."""
+        pytest.importorskip("langchain_core")
+        from builder.agents.agent_loop import _build_langchain_tools
+        from builder.engine import AgentEngine
+
+        p = _write_binary(tmp_path, "blob.prism")
+        tools = {t.name: t for t in _build_langchain_tools(AgentEngine())}
+        out = tools["read_file_sample"].invoke({"path": str(p)})
+        assert isinstance(out, str)
+        assert out  # non-empty actionable message instead of None

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -377,19 +377,24 @@ class TestReadFileSampleMode:
         assert "3 items" in result.lower() or "3 elements" in result.lower()
 
     def test_summary_xlsx(self, tmp_path):
-        """mode='summary' on XLSX returns sheet names."""
-        import zipfile
+        """mode='summary' on a real XLSX returns the Excel format and sheet info.
+
+        Uses a valid workbook written by openpyxl rather than a hand-crafted zip:
+        the old fake passed only because the file was misrouted to the CSV
+        summarizer, which read the uncompressed zip bytes as mojibake text (#101).
+        """
+        import pytest
+        openpyxl = pytest.importorskip("openpyxl")
         f = tmp_path / "book.xlsx"
-        with zipfile.ZipFile(f, "w") as z:
-            z.writestr("xl/workbook.xml",
-                '<?xml version="1.0"?><workbook><sheets><sheet name="Sheet1"/></sheets></workbook>')
-            z.writestr("xl/sharedStrings.xml",
-                '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"></sst>')
-            z.writestr("xl/worksheets/sheet1.xml",
-                '<?xml version="1.0"?><worksheet><dimension ref="A1:B5"/></worksheet>')
-            z.writestr("[Content_Types].xml", "<Types/>")
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Sheet1"
+        ws.append(["colA", "colB"])
+        ws.append([1, 2])
+        wb.save(f)
         result = read_file_sample(str(f), mode="summary")
         assert result is not None
+        assert "Excel" in result
         assert "Sheet1" in result
 
     def test_summary_pdf(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -4246,6 +4246,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -5755,6 +5767,7 @@ dev = [
     { name = "nbformat" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "responses" },
     { name = "ruff" },
     { name = "ty" },
@@ -5790,6 +5803,7 @@ dev = [
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "responses", specifier = ">=0.26.1" },
     { name = "ruff", specifier = ">=0.15.18" },
     { name = "ty", specifier = ">=0.0.51" },


### PR DESCRIPTION
Closes #101.

## Problem
Feeding a real dataset zip (`input/raw/S-VHPS21.zip` — GraphPad `.prism`/`.xls`/`.xlsx`) made the agent loop to the 100-iteration step limit with **0 entities drafted**. `read_file_sample` returned a bare `None` for every binary file, so the weak model re-called it 95× until the cap. `mode="summary"` was no better — it read the zip/OLE2 header as `Columns (4): PK\x03\x04...`.

## Fix
- **LLM-facing `read_file_sample`**: a `None` result becomes an actionable message ("missing/too large/binary — use read_excel/read_file or skip; do not retry") so the agent moves on instead of looping. Internal callers/tests still get `None`.
- **Summary dispatch**: route `.xlsx/.xls/.pdf/.docx/.json` by suffix **before** the CSV/MIME catch (office formats carry a tabular MIME), and add a NUL-byte binary guard to the CSV/text branches so a binary file mislabeled `text/csv` (e.g. `.prism`) is refused instead of read as mojibake.
- **`_summarize_xlsx`**: fix an `AttributeError` (`ws.dimensions` doesn't exist on a `read_only` worksheet) that made it *always* return `None`/crash for real `.xlsx`; it now reports sheets, row/col counts, and column headers.
- Update `test_summary_xlsx` to use a real openpyxl workbook (the old hand-crafted fake only passed via the CSV-garbage misroute).

## CI repair (bundled — it was blocking every PR)
`.github/workflows/ci.yml` runs `pytest --timeout=30`, but `pytest-timeout` was never a dependency, so pytest errored with `unrecognized arguments: --timeout=30` before running a single test. **CI has been red and not actually testing on main and all PRs.** Add `pytest-timeout` to the dev group.

## Verification
- Exact CI commands locally: `uvx ruff check` clean; `pytest --ignore=... --timeout=30 -x` → **430 passed, 0 failed**.
- On the real session files: `.xlsx` now yields a proper Excel summary; `.prism/.xls/.pzf` return `None`+an actionable agent message instead of looping or garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)