### PR TITLE
fix(mapping): resolve Study/Assay mention nodes by type-qualified key (#93)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -706,9 +706,21 @@ def _wire_mention(node: Any, prop: str, value: Any, idx: dict[str, Any]) -> None
             node.append_to(prop, {"@id": item})
 
 
+def _node_for(idx: dict[str, Any], entity: Entity) -> Any:
+    """Look up the graph node for ``entity`` by its type-qualified index key.
+
+    ``_idx_add`` always registers the ``{type}:{entity_id}`` key but the bare
+    ``entity_id`` key only when still free, so two entities of different types
+    sharing an ``entity_id`` collide on the bare slot. Resolve via the typed key
+    first (bare only as a defensive fallback) so annotations never land on the
+    wrong node (Issue #93, same class as #57).
+    """
+    return idx.get(f"{entity.type}:{entity.entity_id}") or idx.get(entity.entity_id)
+
+
 def _wire_mentions(state: CrateState, idx: dict[str, Any]) -> None:
     for st in state.list_entities("Study"):
-        node = idx.get(st.entity_id)
+        node = _node_for(idx, st)
         if node is None:
             continue
         for field, prop in _STUDY_MENTION_FIELDS.items():
@@ -716,7 +728,7 @@ def _wire_mentions(state: CrateState, idx: dict[str, Any]) -> None:
                 _wire_mention(node, prop, st.fields[field], idx)
 
     for asy in state.list_entities("Assay"):
-        node = idx.get(asy.entity_id)
+        node = _node_for(idx, asy)
         if node is None:
             continue
         for field, prop in _ASSAY_MENTION_FIELDS.items():

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -204,6 +204,38 @@ class TestOntologyAnnotations:
         _, by_id = _build(state, tmp_path)
         assert "#DefinedTerm_ke_55" in _ids(by_id["#Assay_assay_1"].get("keyEvent"))
 
+    def test_mentions_resolve_by_typed_key_when_study_and_assay_share_id(self, tmp_path):
+        """Issue #93: with a Study and an Assay sharing an entity_id, each must
+        receive its own mention annotations.
+
+        ``_idx_add`` registers the bare ``entity_id`` key only for whichever
+        entity is added first (the Study, since structural datasets add studies
+        before assays). Resolving mentions via the bare key therefore mis-attached
+        the Assay's keyEvent to the Study node. Resolution must use the
+        type-qualified ``{type}:{entity_id}`` key instead.
+        """
+        state = CrateState()
+        state.add_entity(_ent("shared", "Study", name="S", aop="https://aopwiki.org/aops/37"))
+        state.add_entity(
+            _ent(
+                "shared",
+                "Assay",
+                name="A",
+                study_id="shared",
+                key_event="https://aopwiki.org/events/888",
+            )
+        )
+        _, by_id = _build(state, tmp_path)
+
+        study = by_id["#Study_shared"]
+        assay = by_id["#Assay_shared"]
+        # Each annotation lands on its own node…
+        assert "https://aopwiki.org/aops/37" in _ids(study.get("aop"))
+        assert "https://aopwiki.org/events/888" in _ids(assay.get("keyEvent"))
+        # …and not leaked onto the other node via the colliding bare key.
+        assert "https://aopwiki.org/events/888" not in _ids(study.get("keyEvent"))
+        assert "https://aopwiki.org/aops/37" not in _ids(assay.get("aop"))
+
 
 class TestIdentifiersAndConformance:
     def test_local_ids_are_hash_prefixed(self, tmp_path):


### PR DESCRIPTION
Closes #93.

## Problem
`_wire_mentions` (`builder/tools/_crate_mapping.py`) resolved the Study/Assay
node to annotate via the **bare** `idx.get(entity_id)`. But `_idx_add` registers
the type-qualified `{type}:{entity_id}` key **always** and the bare key **only if
still free**. So when two entities of different types share an `entity_id`, the
bare slot holds whichever was added first (structural datasets add Studies before
Assays), and AOP / key-event / organism annotations attached to the **wrong**
node — or were silently dropped. Same class as #57, in a path #57 didn't cover.

## Fix
Resolve the node via the type-qualified key first (`_node_for` helper), with the
bare key only as a defensive fallback — mirroring `_resolve_many`'s typed-key
resolution.

## Test (TDD)
`test_mentions_resolve_by_typed_key_when_study_and_assay_share_id`: a Study and
an Assay sharing `entity_id="shared"` — the Study's `aop` and the Assay's
`keyEvent` each land on their own node and do not leak onto the other. Fails on
the bare-key resolution, passes with the fix.

Full suite: 473 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)