### PR TITLE
fix(mapping): declare ISA + ISA-Tox profiles in conformsTo unconditionally (#89)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -277,33 +277,38 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
         crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
 
     # conformsTo lives on the metadata descriptor (RO-Crate 1.1 placement,
-    # isa_tox.md §Conformance) and asserts only layers the crate satisfies.
-    conforms: list[dict[str, str]] = [{"@id": ROCRATE_SPEC}]
-    if state.validation.isa_passed:
-        conforms.append({"@id": PROFILE_ISA})
-        crate.add(
-            ContextEntity(
-                crate,
-                PROFILE_ISA,
-                properties={
-                    "@type": ["CreativeWork", "Profile"],
-                    "name": "ISA RO-Crate Profile",
-                },
-            )
+    # isa_tox.md §Conformance). The crate declares the ISA + ISA-Tox profiles it
+    # TARGETS unconditionally — the three-layer (RO-Crate → ISA → ISA-Tox)
+    # duck-typing architecture rests on this declaration, and validation should
+    # be able to see the profiles a crate claims (Issue #89, "guidance over
+    # strictness"). Declaration is therefore independent of any prior validation
+    # pass; conformance is reported separately via build_and_validate (#87).
+    conforms: list[dict[str, str]] = [
+        {"@id": ROCRATE_SPEC},
+        {"@id": PROFILE_ISA},
+        {"@id": PROFILE_ISATOX},
+    ]
+    crate.add(
+        ContextEntity(
+            crate,
+            PROFILE_ISA,
+            properties={
+                "@type": ["CreativeWork", "Profile"],
+                "name": "ISA RO-Crate Profile",
+            },
         )
-    if state.validation.tox_passed:
-        conforms.append({"@id": PROFILE_ISATOX})
-        crate.add(
-            ContextEntity(
-                crate,
-                PROFILE_ISATOX,
-                properties={
-                    "@type": ["CreativeWork", "Profile"],
-                    "name": "ISA-Tox RO-Crate Profile",
-                    "version": "0.1.0-draft.1",
-                },
-            )
+    )
+    crate.add(
+        ContextEntity(
+            crate,
+            PROFILE_ISATOX,
+            properties={
+                "@type": ["CreativeWork", "Profile"],
+                "name": "ISA-Tox RO-Crate Profile",
+                "version": "0.1.0-draft.1",
+            },
         )
+    )
     crate.metadata["conformsTo"] = conforms
 
 

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -220,14 +220,26 @@ class TestIdentifiersAndConformance:
         _, by_id = _build(state, tmp_path)
         assert "https://orcid.org/0000-0002-1825-0097" in by_id
 
-    def test_conformsto_gated_on_validation(self, tmp_path):
+    def test_conformsto_declares_isa_and_tox_unconditionally(self, tmp_path):
+        # Issue #89: a fresh crate (no validation passes recorded) must still
+        # declare the ISA + ISA-Tox profiles it TARGETS — the three-layer
+        # duck-typing architecture rests on the crate advertising the profiles
+        # it aims for ("guidance over strictness"), not gating them on a prior
+        # validation pass (chicken-and-egg).
         state = CrateState()
-        # No validation passes recorded → only RO-Crate 1.1 asserted.
         _, by_id = _build(state, tmp_path)
         descriptor = by_id["ro-crate-metadata.json"]
         conforms = _ids(descriptor.get("conformsTo"))
         assert "https://w3id.org/ro/crate/1.1" in conforms
-        assert "https://w3id.org/ro/crate/isa/1.0" not in conforms
+        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in conforms
+        assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
+        # both declared profiles also exist as Profile contextual entities
+        for pid in (
+            "https://github.com/nfdi4plants/isa-ro-crate-profile",
+            "https://w3id.org/ro/crate/isa-tox/1.0",
+        ):
+            pt = by_id[pid]["@type"]
+            assert "Profile" in (pt if isinstance(pt, list) else [pt])
 
     def test_conformsto_includes_profiles_when_validated(self, tmp_path):
         state = CrateState()


### PR DESCRIPTION
Closes #89.

## Problem
Root `conformsTo` only declared `https://w3id.org/ro/crate/1.1`. The ISA +
ISA-Tox profile PIDs (and their `Profile` context entities) were added **only if**
`state.validation.isa_passed` / `tox_passed` — both `False` on a fresh state. So a
freshly built crate never advertised that it is ISA-structured or tox-profiled,
and there was a chicken-and-egg: validation should be able to see the profiles a
crate claims. The entire three-layer (RO-Crate → ISA → ISA-Tox) duck-typing
architecture rests on this declaration.

## Fix
In `_populate_root_and_conformance`, declare the `PROFILE_ISA` / `PROFILE_ISATOX`
`conformsTo` entries and their `Profile` context entities **unconditionally** —
the profiles the crate *targets* ("guidance over strictness", per RO-Crate 1.2
conformance and the paper's profile design). Actual per-layer pass/fail is
reported separately by `build_and_validate` (#87), not by the presence of the
`conformsTo` claim.

## Test (TDD)
Replaces `test_conformsto_gated_on_validation` (which pinned the removed gating)
with `test_conformsto_declares_isa_and_tox_unconditionally`: a fresh state (all
`validation.*` `False`) builds a crate whose `conformsTo` includes base + ISA +
ISA-Tox, and both `Profile` context entities exist in the graph.

Full suite: 472 passed.

## Note
#91 (unify RO-Crate version to 1.2 + move profile `conformsTo` to the Root Data
Entity) builds on this and is stacked on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)