### PR TITLE
fix(mapping): declare profiles on Root Data Entity, descriptor base-only (#91)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -276,18 +276,28 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
     if not crate.root_dataset.get("license"):
         crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
 
-    # conformsTo lives on the metadata descriptor (RO-Crate 1.1 placement,
-    # isa_tox.md §Conformance). The crate declares the ISA + ISA-Tox profiles it
-    # TARGETS unconditionally — the three-layer (RO-Crate → ISA → ISA-Tox)
-    # duck-typing architecture rests on this declaration, and validation should
-    # be able to see the profiles a crate claims (Issue #89, "guidance over
-    # strictness"). Declaration is therefore independent of any prior validation
-    # pass; conformance is reported separately via build_and_validate (#87).
-    conforms: list[dict[str, str]] = [
-        {"@id": ROCRATE_SPEC},
-        {"@id": PROFILE_ISA},
-        {"@id": PROFILE_ISATOX},
-    ]
+    # Conformance placement follows RO-Crate 1.2 (ro-crate-1.2.0.md §Profiles,
+    # isa_tox.md §Conformance): the metadata file descriptor's conformsTo is
+    # reserved for the single base-spec URI, while the profiles the crate targets
+    # are declared on the Root Data Entity (./) — Issue #91.
+    #
+    # The base spec stays pinned to 1.1 (not 1.2) deliberately: roc-validator
+    # 0.10.0 bundles no ro-crate-1.2 base profile, and its base pass hard-requires
+    # the 1.1 URI on the descriptor (profiles/ro-crate/must/1_file-descriptor_
+    # metadata.ttl: `sh:hasValue <https://w3id.org/ro/crate/1.1>`). Declaring 1.2
+    # there fails REQUIRED validation, which build_and_validate (#87) and the
+    # golden fixtures (#97) rely on staying green. ro-crate-py 0.15 still emits a
+    # 1.2 @context; fully unifying the version on 1.2 is deferred until an upstream
+    # validator ships a 1.2 base profile (tracked on #91).
+    crate.metadata["conformsTo"] = {"@id": ROCRATE_SPEC}
+
+    # Profiles the crate TARGETS, declared on ./ unconditionally — the three-layer
+    # (RO-Crate → ISA → ISA-Tox) duck-typing architecture rests on this
+    # declaration and validation should be able to see the profiles a crate claims
+    # (#89, "guidance over strictness"), independent of any prior validation pass;
+    # conformance is reported separately via build_and_validate (#87).
+    for pid in (PROFILE_ISA, PROFILE_ISATOX):
+        crate.root_dataset.append_to("conformsTo", {"@id": pid})
     crate.add(
         ContextEntity(
             crate,
@@ -309,7 +319,6 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
             },
         )
     )
-    crate.metadata["conformsTo"] = conforms
 
 
 def _cell_line_term(crate: ROCrate) -> ContextEntity:

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -220,19 +220,17 @@ class TestIdentifiersAndConformance:
         _, by_id = _build(state, tmp_path)
         assert "https://orcid.org/0000-0002-1825-0097" in by_id
 
-    def test_conformsto_declares_isa_and_tox_unconditionally(self, tmp_path):
-        # Issue #89: a fresh crate (no validation passes recorded) must still
-        # declare the ISA + ISA-Tox profiles it TARGETS — the three-layer
-        # duck-typing architecture rests on the crate advertising the profiles
-        # it aims for ("guidance over strictness"), not gating them on a prior
-        # validation pass (chicken-and-egg).
+    def test_profiles_declared_on_root_data_entity(self, tmp_path):
+        # Issue #91: RO-Crate 1.2 recommends profile declarations on the Root
+        # Data Entity (./), reserving the metadata descriptor's conformsTo for
+        # the single base-spec URI. The ISA + ISA-Tox profiles the crate TARGETS
+        # are therefore declared on ./ — unconditionally, on a fresh state (#89).
         state = CrateState()
         _, by_id = _build(state, tmp_path)
-        descriptor = by_id["ro-crate-metadata.json"]
-        conforms = _ids(descriptor.get("conformsTo"))
-        assert "https://w3id.org/ro/crate/1.1" in conforms
-        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in conforms
-        assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
+
+        root_conforms = _ids(by_id["./"].get("conformsTo"))
+        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in root_conforms
+        assert "https://w3id.org/ro/crate/isa-tox/1.0" in root_conforms
         # both declared profiles also exist as Profile contextual entities
         for pid in (
             "https://github.com/nfdi4plants/isa-ro-crate-profile",
@@ -241,17 +239,12 @@ class TestIdentifiersAndConformance:
             pt = by_id[pid]["@type"]
             assert "Profile" in (pt if isinstance(pt, list) else [pt])
 
-    def test_conformsto_includes_profiles_when_validated(self, tmp_path):
+    def test_descriptor_conformsto_is_base_spec_only(self, tmp_path):
+        # Issue #91: the metadata file descriptor's conformsTo is reserved for
+        # the single base-spec URI (profiles moved to ./). The base spec stays
+        # 1.1 because roc-validator 0.10.0 bundles no 1.2 base profile and its
+        # base pass requires the 1.1 URI on the descriptor (sh:hasValue).
         state = CrateState()
-        state.validation.isa_passed = True
-        state.validation.tox_passed = True
         _, by_id = _build(state, tmp_path)
-        descriptor = by_id["ro-crate-metadata.json"]
-        conforms = _ids(descriptor.get("conformsTo"))
-        assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
-        # ISA layer is declared with the IRI the shapes actually extend
-        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in conforms
-        # each declared profile also exists as a Profile contextual entity
-        prof = by_id["https://github.com/nfdi4plants/isa-ro-crate-profile"]
-        pt = prof["@type"]
-        assert "Profile" in (pt if isinstance(pt, list) else [pt])
+        desc_conforms = _ids(by_id["ro-crate-metadata.json"].get("conformsTo"))
+        assert desc_conforms == ["https://w3id.org/ro/crate/1.1"]


### PR DESCRIPTION
Addresses #91 (scope: option A — see note below). **Stacked on #104 (#89)** — review/merge that first; the base retargets to `main` automatically once #104 lands.

## What this does
Moves the ISA + ISA-Tox profile `conformsTo` from the **metadata file descriptor**
to the **Root Data Entity** (`./`), the RO-Crate 1.2 recommended placement
(`ro-crate-1.2.0.md` §Profiles, `isa_tox.md` §Conformance). The descriptor's
`conformsTo` is now reserved for the single base-spec URI.

## Scope decision: the 1.1→1.2 version flip is deferred (upstream-blocked)
The issue also asks to unify the version on **1.2**. That half is blocked by the
installed validator and is intentionally **not** done here:

| descriptor `conformsTo` | base pass (REQUIRED) |
|---|---|
| `1.2` only | ❌ "descriptor MUST have conformsTo pointing to 1.1" |
| `1.1` only | ✅ |
| `1.1` + `1.2` | ✅ |

roc-validator 0.10.0 bundles **no** `ro-crate-1.2` base profile, and its 1.1 base
profile hard-requires the 1.1 URI on the descriptor
(`profiles/ro-crate/must/1_file-descriptor_metadata.ttl`:
`sh:hasValue <https://w3id.org/ro/crate/1.1>`). Declaring 1.2-only fails REQUIRED
validation — which `build_and_validate` (#87) and the golden fixtures (#97) rely
on staying green. So the base spec stays **1.1**, documented inline, and the
version flip lands the day an upstream validator ships a 1.2 base profile.
(ro-crate-py 0.15 still emits a 1.2 `@context`; that part is library-controlled.)

## Test (TDD)
- `test_profiles_declared_on_root_data_entity`: fresh state → `./` `conformsTo`
  includes both profiles, both `Profile` context entities exist.
- `test_descriptor_conformsto_is_base_spec_only`: descriptor `conformsTo` ==
  `[1.1]` exactly (profiles not duplicated there).

base/isa/tox REQUIRED behaviour is unchanged by the move (verified empirically).
Full suite: 472 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)