### PR TITLE
fix(management): preserve referential integrity on entity removal (#92)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,9 +375,17 @@ draft_publication(doi: str, hints: dict) → Entity
 ### Entity Management Tools
 ```
 update_entity(entity_id: str, patch: dict) → Entity
-remove_entity(entity_id: str) → bool
+remove_entity(entity_id: str, cascade: bool = False) → bool
 list_entities(entity_type: str | None) → [Entity]
 ```
+`remove_entity` preserves referential integrity: the builder rebuilds the crate
+from state each iteration, so a reference left dangling in state surfaces as a
+dangling `{"@id": ...}` in the built graph. It first scans every entity's
+reference fields (`_REF_FIELDS`); if the target is still referenced it refuses
+with an actionable error naming the referrers, unless `cascade=True` clears those
+references first. `entity_id` is the stable key — "renaming" changes the `name`
+field, never the `entity_id`, so referrers (which point at `entity_id`) are never
+orphaned.
 
 ### Lookup Tools
 ```

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -112,10 +112,16 @@ TOOL_SPECS = [
     },
     {
         "name": "remove_entity",
-        "description": "Remove an entity by id",
+        "description": "Remove an entity by id. Refuses (with an error naming the referrers) if other entities still reference it, so no dangling reference is left behind. Pass cascade=true to clear those references and remove anyway.",
         "parameters": {
             "type": "object",
-            "properties": {"entity_id": {"type": "string"}},
+            "properties": {
+                "entity_id": {"type": "string"},
+                "cascade": {
+                    "type": "boolean",
+                    "description": "When true, clear references to this entity from all referrers instead of refusing. Default false.",
+                },
+            },
             "required": ["entity_id"],
         },
     },

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -13,6 +13,7 @@ from builder.state import (
     CrateState,
     Entity,
 )
+from builder.tools._crate_mapping import _REF_FIELDS
 
 
 def update_entity(state: CrateState, entity_id: str, patch: dict) -> Entity:
@@ -43,16 +44,92 @@ def update_entity(state: CrateState, entity_id: str, patch: dict) -> Entity:
     return entity
 
 
-def remove_entity(state: CrateState, entity_id: str) -> bool:
-    """Remove an entity by id.
+def _ref_key(value: Any) -> str | None:
+    """The bare entity_id a single reference value points at (``#`` stripped)."""
+    key = value.get("@id") if isinstance(value, dict) else value
+    return key.lstrip("#") if isinstance(key, str) else None
+
+
+def find_referrers(state: CrateState, entity_id: str) -> list[tuple[Entity, str]]:
+    """Find every entity that references ``entity_id`` through a reference field.
+
+    Scans each entity's reference-bearing fields (``_REF_FIELDS`` — the same set
+    the crate mapping resolves) for a pointer to ``entity_id``, handling scalar
+    values, ``{"@id": ...}`` objects, and lists thereof.
+
+    Args:
+        state: The crate state to scan.
+        entity_id: The entity_id to find referrers of.
+
+    Returns:
+        ``(referrer_entity, field_name)`` tuples — one per field that points at
+        ``entity_id``. The entity itself is never reported as its own referrer.
+    """
+    referrers: list[tuple[Entity, str]] = []
+    for ent in state.list_entities():
+        if ent.entity_id == entity_id:
+            continue
+        for field in _REF_FIELDS:
+            value = ent.fields.get(field)
+            if value is None:
+                continue
+            items = value if isinstance(value, list) else [value]
+            if any(_ref_key(item) == entity_id for item in items):
+                referrers.append((ent, field))
+    return referrers
+
+
+def _drop_reference(fields: dict[str, Any], field: str, entity_id: str) -> None:
+    """Remove every pointer to ``entity_id`` from ``fields[field]`` in place."""
+    value = fields.get(field)
+    if isinstance(value, list):
+        pruned = [item for item in value if _ref_key(item) != entity_id]
+        if pruned:
+            fields[field] = pruned
+        else:
+            del fields[field]
+    elif _ref_key(value) == entity_id:
+        del fields[field]
+
+
+def remove_entity(state: CrateState, entity_id: str, cascade: bool = False) -> bool:
+    """Remove an entity by id, preserving referential integrity.
+
+    The builder rebuilds the crate from state on every iteration, so a dangling
+    reference left in state surfaces as a dangling ``{"@id": ...}`` in the built
+    ``ro-crate-metadata.json``. To prevent that, removal first finds every
+    referrer:
+
+    - ``cascade=False`` (default): if any entity still references the target,
+      refuse with an actionable ``ValueError`` naming the referrers (and the
+      ``cascade=True`` escape hatch). The target is left in place.
+    - ``cascade=True``: clear the target's id out of every referrer's field
+      first, then remove it — no dangling references survive.
 
     Args:
         state: The crate state to operate on.
         entity_id: The ID of the entity to remove.
+        cascade: When True, clear referrers instead of refusing.
 
     Returns:
         True if the entity was found and removed, False otherwise.
+
+    Raises:
+        ValueError: If the entity is still referenced and ``cascade`` is False.
     """
+    referrers = find_referrers(state, entity_id)
+    if referrers and not cascade:
+        named = ", ".join(
+            sorted({f"{ent.entity_id} (via {field})" for ent, field in referrers})
+        )
+        raise ValueError(
+            f"Cannot remove '{entity_id}': still referenced by {named}. "
+            f"Repoint or remove those references first, or pass cascade=True to "
+            f"clear them."
+        )
+    if cascade:
+        for ent, field in referrers:
+            _drop_reference(ent.fields, field, entity_id)
     return state.remove_entity(entity_id)
 
 

--- a/tests/test_tools_management.py
+++ b/tests/test_tools_management.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.builder import build_crate
 from builder.tools.management import (
     bulk_set_fields,
+    find_referrers,
     list_entities,
     remove_entity,
     set_entity_field,
     update_entity,
 )
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
 
 
 class TestUpdateEntity:
@@ -67,6 +81,91 @@ class TestRemoveEntity:
         """remove_entity returns False when the entity doesn't exist."""
         result = remove_entity(minimal_state, "nonexistent")
         assert result is False
+
+
+class TestReferentialIntegrity:
+    """Issue #92: remove must not leave dangling {@id} references."""
+
+    def _linked_state(self):
+        state = CrateState()
+        state.add_entity(_ent("inv_1", "Investigation", name="Inv"))
+        state.add_entity(_ent("study_1", "Study", name="St", investigation_id="inv_1"))
+        state.add_entity(_ent("assay_1", "Assay", name="As", study_id="study_1"))
+        # a process consuming two samples (list-valued reference)
+        state.add_entity(_ent("s1", "Sample", name="s1"))
+        state.add_entity(_ent("s2", "Sample", name="s2"))
+        state.add_entity(
+            _ent("proc_1", "LabProcess", process_type="EndpointReadout",
+                 assay_id="assay_1", samples=["s1", "s2"])
+        )
+        return state
+
+    def test_find_referrers_scalar_and_list(self):
+        state = self._linked_state()
+        # study_1 is referenced by assay_1 via study_id
+        refs = find_referrers(state, "study_1")
+        assert ("assay_1", "study_id") in {(e.entity_id, f) for e, f in refs}
+        # s1 is referenced by proc_1 via the list-valued samples field
+        refs_s1 = find_referrers(state, "s1")
+        assert ("proc_1", "samples") in {(e.entity_id, f) for e, f in refs_s1}
+
+    def test_find_referrers_none_for_leaf(self):
+        state = self._linked_state()
+        assert find_referrers(state, "s2") == [] or all(
+            e.entity_id != "s2" for e, _ in find_referrers(state, "proc_1")
+        )
+        # proc_1 is referenced by nothing
+        assert find_referrers(state, "proc_1") == []
+
+    def test_remove_referenced_entity_refuses_with_actionable_error(self):
+        state = self._linked_state()
+        with pytest.raises(ValueError, match="assay_1"):
+            remove_entity(state, "study_1")
+        # entity is NOT removed when the call is refused
+        assert state.get_entity("study_1") is not None
+
+    def test_remove_unreferenced_entity_succeeds(self):
+        state = self._linked_state()
+        assert remove_entity(state, "proc_1") is True
+        assert state.get_entity("proc_1") is None
+
+    def test_cascade_clears_scalar_reference(self):
+        state = self._linked_state()
+        assert remove_entity(state, "study_1", cascade=True) is True
+        assert state.get_entity("study_1") is None
+        # assay_1's study_id is gone (no dangling ref)
+        assert "study_id" not in state.get_entity("assay_1").fields
+
+    def test_cascade_prunes_from_list_reference(self):
+        state = self._linked_state()
+        assert remove_entity(state, "s1", cascade=True) is True
+        # s2 survives in the samples list; s1 is pruned
+        assert state.get_entity("proc_1").fields["samples"] == ["s2"]
+
+    def test_no_dangling_id_in_built_graph_after_cascade(self, tmp_path):
+        state = self._linked_state()
+        # add a File the process produces, then remove the File with cascade
+        state.add_entity(_ent("f_raw", "File", name="raw.csv", dest_path="raw.csv"))
+        set_entity_field(state, "proc_1", "result", "f_raw")
+        remove_entity(state, "f_raw", cascade=True)
+        out = tmp_path / "crate"
+        result = build_crate(state, str(out))
+        assert result["success"] is True
+        with open(out / "ro-crate-metadata.json") as fh:
+            graph = json.load(fh)["@graph"]
+        ids = {e.get("@id") for e in graph}
+        # the removed File must not be referenced anywhere in the built graph
+        blob = json.dumps(graph)
+        assert "f_raw" not in blob and "#File_f_raw" not in ids
+
+    def test_rename_via_name_keeps_entity_id_and_links(self):
+        # "Renaming" is done by changing the name field; entity_id stays stable,
+        # so referrers (which point at entity_id) are never orphaned (#92).
+        state = self._linked_state()
+        update_entity(state, "study_1", {"name": "Renamed Study"})
+        assert state.get_entity("study_1") is not None  # entity_id unchanged
+        # the assay still references the (same-id) study
+        assert state.get_entity("assay_1").fields["study_id"] == "study_1"
 
 
 class TestListEntities:


### PR DESCRIPTION
Closes #92.

## Problem
The builder rebuilds the crate from `CrateState` on every iteration, so a
reference left dangling in state surfaces as a dangling `{"@id": ...}` in the
built `ro-crate-metadata.json` (ro-crate-py's own `delete` warns it does not
clean referrers). `remove_entity` did **no** referrer check, so deleting a
referenced entity orphaned every `*_id`/ref pointing at it.

## Fix
- **`find_referrers(state, entity_id)`** — scans every entity's reference fields
  (`_REF_FIELDS`, the same set the crate mapping resolves), handling scalar,
  `{"@id": ...}`, and list values; returns `(referrer, field)` tuples.
- **`remove_entity(state, entity_id, cascade=False)`** — by default **refuses**
  with an actionable error naming the referrers; `cascade=True` clears the
  target out of every referrer first, then removes it. `cascade` is exposed in
  the tool spec.

### Rename
`entity_id` is the stable key — references point at it, and "renaming" changes
the `name` field, never the `entity_id`. So renaming never orphans links
(regression test included). Decoupling the id from the name needs no behaviour
change; minted `@id`s already derive from `entity_id`.

## Tests (TDD) — `TestReferentialIntegrity`
`find_referrers` (scalar + list), refuse-with-named-referrers, unreferenced
succeeds, cascade clears scalar ref / prunes from list, **no dangling `@id` in
the built graph after cascade**, and rename-keeps-id-and-links.

8 new tests; full suite **480 passed**. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)