### PR TITLE
feat(mapping): emit typed CSVW condition tables (#94)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -506,6 +506,61 @@ def _synth_sample(crate: ROCrate, sid: str, name: str, derives_from: Any = None)
 
 _CONDITION_TABLE_HEADER = "cell_line,compound,concentration,unit,duration\n"
 
+# Typed CSVW columns for the condition table: each maps a CSV column to an
+# ontology property (propertyUrl) with a declared datatype. The cell-line and
+# compound columns additionally resolve to in-crate entity ids (valueUrl, filled
+# at build time), so the per-well design table is machine-readable rather than a
+# header-only placeholder. Issue #94.
+_CONDITION_TABLE_COLUMNS: tuple[dict[str, str], ...] = (
+    {"titles": "cell_line", "datatype": "string", "propertyUrl": "http://schema.org/name"},
+    {"titles": "compound", "datatype": "string", "propertyUrl": "http://schema.org/mentions"},
+    {"titles": "concentration", "datatype": "double", "propertyUrl": "http://schema.org/value"},
+    {"titles": "unit", "datatype": "string", "propertyUrl": "http://schema.org/unitText"},
+    {"titles": "duration", "datatype": "string", "propertyUrl": "http://schema.org/duration"},
+)
+
+
+def _node_id(node: Any) -> str | None:
+    """The @id of an ro-crate node (None if it has none)."""
+    return getattr(node, "id", None)
+
+
+def _build_condition_table_schema(
+    crate: ROCrate, exp_slug: str, cells: list[Any], chems: list[Any]
+) -> ContextEntity:
+    """The csvw:Schema entity describing the condition table's typed columns.
+
+    Each column is a ``csvw:Column`` graph node (ro-crate-py requires nested
+    objects to be referenceable entities, not inline dicts) carrying a datatype
+    and propertyUrl. The cell-line and compound columns additionally carry a
+    ``valueUrl`` resolving to the in-crate Sample / MolecularEntity id, so a
+    row's value maps to its entity.
+    """
+    value_urls = {
+        "cell_line": _node_id(cells[0]) if cells else None,
+        "compound": _node_id(chems[0]) if chems else None,
+    }
+    schema = crate.add(
+        ContextEntity(
+            crate,
+            f"#{exp_slug}_condition_table_schema",
+            properties={
+                "@type": ["csvw:Schema", "CreativeWork"],
+                "name": "Condition table schema",
+            },
+        )
+    )
+    for col in _CONDITION_TABLE_COLUMNS:
+        title = col["titles"]
+        props: dict[str, Any] = {"@type": "csvw:Column", **col}
+        if value_urls.get(title):
+            props["valueUrl"] = value_urls[title]
+        column = crate.add(
+            ContextEntity(crate, f"#{exp_slug}_col_{title}", properties=props)
+        )
+        schema.append_to("columns", column)
+    return schema
+
 
 def _synth_condition_table(
     crate: ROCrate,
@@ -521,11 +576,14 @@ def _synth_condition_table(
     Modelled as a ``File`` (the CSV) that is also a ``csvw:Table`` — a bare
     csvw:Table is rejected by the base ISA shape, which requires a process result
     to be a File/Sample/BioSample. A header-only placeholder CSV is materialised
-    so the File is valid in-payload; per-row CSVW population (tableSchema columns
-    with valueUrl, CSV intake) is planned — see the wizard's
-    intake/condition_table.py. The table links (schema:about) the cell line(s) and
-    compound(s) it concerns, so the compound is connected to the Exposure THROUGH
-    its result (a MolecularEntity cannot be a process object under the ISA shape).
+    so the File is valid in-payload, and the table is described by a typed CSVW
+    schema (``tableSchema`` + ``conformsTo`` → a ``csvw:Schema`` whose columns
+    carry datatype/propertyUrl, with the cell-line/compound columns resolving to
+    their entity ids via ``valueUrl``; #94). Per-row CSV population (intake of the
+    actual well values) remains future work. The table also links (schema:about)
+    the cell line(s) and compound(s) it concerns, so the compound is connected to
+    the Exposure THROUGH its result (a MolecularEntity cannot be a process object
+    under the ISA shape).
     """
     rel = f"data/{_slug(exp_pid)}_condition_table.csv"
     # Only touch disk when materialising payload for an on-disk export. The
@@ -546,6 +604,14 @@ def _synth_condition_table(
     )
     for ent in list(cells) + list(chems):
         table.append_to("about", ent)
+    # Typed CSVW: a linked schema entity carries the per-column datatype +
+    # propertyUrl (and valueUrl resolving the cell-line/compound columns to their
+    # entity ids). The table points to it via tableSchema (canonical CSVW) and
+    # conformsTo (RO-Crate conformance — not a bare inline tableSchema dict).
+    # Issue #94.
+    schema = _build_condition_table_schema(crate, _slug(exp_pid), cells, chems)
+    table["tableSchema"] = {"@id": schema.id}
+    table.append_to("conformsTo", schema)
     return table
 
 

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -127,6 +127,40 @@ class TestLabProcessSubtypes:
         # the compound is connected to the Exposure THROUGH the condition table
         assert "#MolecularEntity_chem_1" in _ids(table.get("about"))
 
+    def test_exposure_condition_table_is_typed_csvw(self, tmp_path):
+        # Issue #94: the condition table must be typed CSVW — a linked schema
+        # entity with per-column datatype + propertyUrl, the cell-line/compound
+        # columns resolving to their entity ids (valueUrl).
+        state = self._state_with_process(
+            "Exposure",
+            samples="sample_cult",
+            chemicals="chem_1",
+            duration="24h",
+        )
+        state.add_entity(_ent("sample_cult", "Sample", name="cultured"))
+        state.add_entity(_ent("chem_1", "MolecularEntity", name="Silychristin A"))
+        _, by_id = _build(state, tmp_path)
+        proc = by_id["#LabProcess_proc_1"]
+        table = by_id[_ids(proc.get("output"))[0]]
+
+        # the table is linked to a schema entity via conformsTo (not a bare key)
+        schema_ids = [s for s in _ids(table.get("conformsTo")) if "schema" in s]
+        assert schema_ids, "condition table must conformTo a schema entity"
+        schema = by_id[schema_ids[0]]
+        stype = schema["@type"] if isinstance(schema["@type"], list) else [schema["@type"]]
+        assert "csvw:Schema" in stype
+
+        cols = [by_id[cid] for cid in _ids(schema.get("columns"))]
+        by_title = {c["titles"]: c for c in cols}
+        assert set(by_title) == {"cell_line", "compound", "concentration", "unit", "duration"}
+        # every column is typed: datatype + propertyUrl
+        for col in by_title.values():
+            assert col["datatype"]
+            assert col["propertyUrl"]
+        # entity-resolving columns carry references to the resolved entities
+        assert "#MolecularEntity_chem_1" in str(by_title["compound"].get("valueUrl"))
+        assert "#Sample_sample_cult" in str(by_title["cell_line"].get("valueUrl"))
+
     def test_endpoint_readout_result_is_file(self, tmp_path):
         state = self._state_with_process(
             "EndpointReadout",


### PR DESCRIPTION
Closes #94.

## Problem
The Exposure's condition table — the per-well design table that anchors the
`Exposure → EndpointReadout` chain — was a **header-only placeholder**: a
`File`/`csvw:Table` with `about` links but **no** `tableSchema`, **no** typed
columns, **no** `conformsTo`→schema.

## Fix
Emit a typed CSVW schema:
- A `csvw:Schema` entity with one `csvw:Column` node per column (`cell_line`,
  `compound`, `concentration`, `unit`, `duration`), each carrying a `datatype`
  and an ontology `propertyUrl`.
- The **cell-line** and **compound** columns resolve to their in-crate
  `Sample` / `MolecularEntity` ids via `valueUrl`.
- The table links the schema through both `tableSchema` (canonical CSVW) and
  `conformsTo` (RO-Crate conformance — a **linked schema entity**, not a bare
  inline `tableSchema` dict).

Columns are graph nodes rather than inline dicts because ro-crate-py requires
nested objects to be referenceable entities (an inline dict raises
`no @id in {...}`).

## Test (TDD)
`test_exposure_condition_table_is_typed_csvw`: the built table `conformsTo` a
`csvw:Schema`; the schema has 5 columns each with `datatype` + `propertyUrl`; the
compound/cell-line columns carry `valueUrl` references to their entities.

A full Exposure crate still passes **base/isa/tox at REQUIRED** (verified
empirically — the CSVW additions don't regress validation). Full suite: 473
passed; ruff + ty clean.

## Deferred
Per-row CSV intake (the actual well values) remains future work — this lands the
schema/typing layer the legacy wizard had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)