### PR TITLE
perf(validator): warm-cache parsed SHACL profiles across validate() calls (#63)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,30 @@ Returns issues by severity: REQUIRED (blocking), SHOULD (recommended), MAY
   IRI, `check_id`, `severity`, and `profile`. This backs `build_and_validate`
   and is the no-disk fast path.
 
+**Warm profile cache (Issue #63).** The agent calls `validate` repeatedly per
+session (initial check, then re-validate after each fix), and `rocrate_validator`
+0.10 re-parses every profile's spec graph, SHACL shapes and ontology graphs on
+*every* `services.validate()` call — `Validator` and its per-call
+`ValidationContext` are rebuilt each time and the per-profile shape registry it
+caches lives on the (discarded) `Profile` objects. The library exposes **no**
+public hook to inject pre-parsed graphs (no `shapes_graph=`/`ont_graph=` argument),
+so a plain `functools.lru_cache` has nothing to wrap. `profiles/validator.py`
+therefore installs a module-level warm cache (`_PROFILE_CACHE`) of the
+crate-independent artifacts it controls — the loaded + warmed `Profile` objects
+(parsed spec graphs, per-profile `ShapesRegistry`, and `requirements`) — by
+overriding `ValidationContext.__load_profiles__` to return the cached profiles on
+a hit. The cache is keyed by `(profiles_path, extra_profiles_path,
+profile_identifier, severity, shapes-dir mtime)`, so it invalidates automatically
+when any `profiles/shapes/**/*.ttl` changes; only the crate's data graph is
+re-read per call. **Honest limitation:** the dominant per-call cost in roc-validator
+0.10 is not the `.ttl` parse (~10–130 ms) but the SHACL/owlrl inference and
+per-profile graph recomposition the library runs fresh inside every `validate()`,
+which is not reachable from outside without reimplementing its validation loop.
+The warm cache removes the re-parse work we own — a consistent ~11–30% wall-clock
+improvement on the 2nd-and-later passes (e.g. tox ~2.7s → ~2.3s) — but cannot
+remove the library-internal inference cost. `clear_profile_cache()` is the
+explicit-invalidation/test hook.
+
 #### MIT & FAIR Assessors (`builder/tools/mit_assessment.py`, `builder/tools/fair_assessment.py`)
 Score against `mit/invitro_tox.yaml` and `fair/indicators.yaml`. Both produce
 scores, not pass/fail.

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -18,6 +18,7 @@ composition is verified working as of roc-validator 0.10.0.
 from __future__ import annotations
 
 import importlib.metadata as _metadata
+import logging
 
 # ---------------------------------------------------------------------------
 # rocrate-validator compatibilty shim  (#57)
@@ -116,6 +117,143 @@ def _patch_bundled_isa_ontology() -> None:
 
 
 _patch_bundled_isa_ontology()
+
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Warm cache of parsed SHACL profiles / shapes / ontology graphs (#63)
+# ---------------------------------------------------------------------------
+# rocrate_validator re-parses every profile's specification graph, SHACL shapes
+# and ontology graphs on *every* ``services.validate()`` call: ``Validator`` and
+# its per-call ``ValidationContext`` are rebuilt each time, ``__load_profiles__``
+# constructs fresh ``Profile`` objects (re-reading the ``.ttl`` files), and the
+# per-profile shape registry is cached *on the Profile instance* — which the
+# library throws away after each call. The library exposes no public hook to
+# inject pre-parsed graphs (no ``shapes_graph=`` / ``ont_graph=`` argument on
+# ``services.validate``), so a plain ``functools.lru_cache`` has nothing to wrap.
+#
+# What we *can* control and cache crate-independently is the loaded + warmed
+# ``Profile`` set. We install an override on ``ValidationContext.__load_profiles__``
+# that returns a cached, warmed profile list when the cache key matches and
+# falls back to the original loader (and warms + caches its result) on a miss.
+# Because the per-Profile shape registry (``ShapesRegistry.get_instance(profile)``)
+# and the parsed ``requirements`` live on the cached Profile objects, the shapes
+# and ontology are not re-parsed on a warm call — only the crate's data graph is
+# re-read per call (inside the per-call ``ValidationContext``).
+#
+# The cache is keyed by ``(profiles_path, extra_profiles_path, profile_identifier,
+# severity, shapes-dir mtime)`` so it invalidates automatically when any shape
+# ``.ttl`` file under SHAPES_DIR changes.
+#
+# Honest limitation: the dominant per-call cost in roc-validator 0.10 is not the
+# ``.ttl`` parsing (~10-130 ms) but the SHACL/owlrl inference and per-profile
+# graph recomposition that the library runs fresh inside every ``validate()`` —
+# neither is reachable from outside the library without reimplementing its
+# validation loop. The warm cache removes the re-parse work we own; it cannot
+# remove the library-internal inference cost. See PR #63 for measurements.
+
+# key -> list[Profile] (the warmed, cached profiles for that context signature)
+_PROFILE_CACHE: dict[tuple, list] = {}
+
+# Sentinel installed exactly once so the override is idempotent across re-imports.
+_CACHE_INSTALLED = False
+
+
+def _shapes_dir_mtime() -> float:
+    """Newest mtime of any ``.ttl`` under SHAPES_DIR (0.0 if none/missing).
+
+    Used as a cache-busting component so edits to any shape file invalidate the
+    warmed profile cache without an explicit clear.
+    """
+    latest = 0.0
+    try:
+        for ttl in SHAPES_DIR.rglob("*.ttl"):
+            try:
+                latest = max(latest, ttl.stat().st_mtime)
+            except OSError:
+                continue
+    except OSError:
+        return 0.0
+    return latest
+
+
+def _profile_cache_key(
+    profile_identifier: str,
+    severity: str,
+    *,
+    profiles_path: str | None = None,
+    extra_profiles_path: str | None = None,
+) -> tuple:
+    """Build the warm-cache key for a validation pass.
+
+    Keyed by the profile identifier, the gate severity, the profiles/extra-profiles
+    paths and the newest shapes-dir mtime so the cache invalidates when shapes
+    change.
+    """
+    return (
+        str(profiles_path) if profiles_path is not None else None,
+        str(extra_profiles_path) if extra_profiles_path is not None else None,
+        profile_identifier,
+        severity,
+        _shapes_dir_mtime(),
+    )
+
+
+def clear_profile_cache() -> None:
+    """Drop all cached warmed profiles (test hook / explicit invalidation)."""
+    _PROFILE_CACHE.clear()
+
+
+def _install_profile_cache() -> None:
+    """Monkeypatch ``ValidationContext.__load_profiles__`` to consult the cache.
+
+    Idempotent: safe to call multiple times. On a cache hit the warmed Profile
+    list is returned verbatim (no re-parse); on a miss the original loader runs,
+    its result is warmed (requirements + per-profile shape registry are forced)
+    and stored under the mtime-keyed signature.
+    """
+    global _CACHE_INSTALLED
+    if _CACHE_INSTALLED:
+        return
+
+    from rocrate_validator.models import ValidationContext
+    from rocrate_validator.requirements.shacl.models import ShapesRegistry
+
+    _original_load = ValidationContext.__load_profiles__
+
+    def _cached_load_profiles(self):  # type: ignore[no-untyped-def]
+        try:
+            key = _profile_cache_key(
+                self.profile_identifier,
+                self.requirement_severity.name.lower(),
+                profiles_path=self.profiles_path,
+                extra_profiles_path=self.settings.extra_profiles_path,
+            )
+        except Exception:  # noqa: BLE001 — never break validation over a cache key
+            return _original_load(self)
+
+        cached = _PROFILE_CACHE.get(key)
+        if cached is not None:
+            return list(cached)
+
+        profiles = _original_load(self)
+        try:
+            # Warm the crate-independent artifacts so a hit skips re-parsing:
+            # parsed requirements + the per-Profile SHACL shape registry.
+            for profile in profiles:
+                _ = profile.requirements
+                ShapesRegistry.get_instance(profile).get_shapes()
+            _PROFILE_CACHE[key] = profiles
+        except Exception as exc:  # noqa: BLE001 — caching is best-effort
+            logger.debug("Profile cache warm-up skipped: %s", exc)
+        return profiles
+
+    ValidationContext.__load_profiles__ = _cached_load_profiles  # type: ignore[method-assign]
+    _CACHE_INSTALLED = True
+
+
+_install_profile_cache()
 
 
 @dataclass

--- a/tests/test_validator_cache.py
+++ b/tests/test_validator_cache.py
@@ -1,0 +1,109 @@
+"""Regression tests for the warm cache of parsed SHACL profiles (#63).
+
+rocrate_validator re-parses every profile's spec graph, SHACL shapes and
+ontology graphs on every ``validate()`` call — there is no public hook to inject
+pre-parsed graphs. ``profiles/validator.py`` therefore installs a module-level
+warm cache of the *crate-independent* artifacts it controls: the loaded +
+warmed ``Profile`` objects (parsed spec graphs, per-profile shape registries and
+requirements). The cache is keyed by ``(profiles_path, extra_profiles_path,
+severity, shapes-dir mtime)`` so it invalidates when any shape ``.ttl`` changes.
+
+Only the crate's data graph is re-read per call.
+
+These tests assert the load-bearing, non-flaky guarantees:
+  * the warmed profile list is the *same object* across consecutive calls
+    (cache hit — the shapes/ontology are not re-loaded), and
+  * the cache key changes (i.e. the cache invalidates) when a shape file's
+    mtime changes.
+
+A loose warm-path timing assertion guards against a gross regression without
+being flaky — the dominant per-call cost lives inside the library's own
+inference, so we only assert the warm call is not dramatically slower.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from rocrate.rocrate import ROCrate
+
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _minimal_doc() -> dict:
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    crate.root_dataset["name"] = "Test"
+    crate.root_dataset["description"] = "Test crate"
+    crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+    crate.metadata["conformsTo"] = {"@id": "https://w3id.org/ro/crate/1.1"}
+    return crate.metadata.generate()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    from profiles.validator import clear_profile_cache
+
+    clear_profile_cache()
+    yield
+    clear_profile_cache()
+
+
+class TestProfileCacheReuse:
+    def test_warmed_profiles_are_reused_across_calls(self):
+        """A second validate reuses the cached (same-object) warmed profiles."""
+        from profiles import validator
+
+        doc = _minimal_doc()
+        validator.validate_crate_dict(doc, profile="tox")
+        snapshot = dict(validator._PROFILE_CACHE)
+        assert snapshot, "expected the tox pass to populate the profile cache"
+
+        validator.validate_crate_dict(doc, profile="tox")
+        # The cached profile lists must be the *same objects* — proof the shapes
+        # and ontology graphs were not re-parsed on the warm call.
+        for key, profiles in validator._PROFILE_CACHE.items():
+            assert profiles is snapshot[key]
+
+    def test_cache_key_invalidates_on_shape_mtime_change(self):
+        """Bumping a shape file's mtime must change the cache key."""
+        from pathlib import Path
+
+        from profiles.validator import SHAPES_DIR, _profile_cache_key
+
+        ttl = next(SHAPES_DIR.rglob("*.ttl"))
+        key_before = _profile_cache_key("tox-ro-crate", "required")
+
+        # Touch the shape file forward in time and rebuild the key.
+        future = time.time() + 10
+        import os
+
+        os.utime(ttl, (future, future))
+        try:
+            key_after = _profile_cache_key("tox-ro-crate", "required")
+        finally:
+            now = time.time()
+            os.utime(ttl, (now, now))
+
+        assert key_before != key_after
+        assert Path(SHAPES_DIR).exists()
+
+    def test_warm_call_not_dramatically_slower(self):
+        """The 2nd consecutive validate must not be slower than the 1st (warm path).
+
+        Loose ratio rather than an absolute timing to avoid flakiness on busy CI.
+        """
+        from profiles import validator
+
+        doc = _minimal_doc()
+        t0 = time.perf_counter()
+        validator.validate_crate_dict(doc, profile="tox")
+        cold = time.perf_counter() - t0
+
+        t1 = time.perf_counter()
+        validator.validate_crate_dict(doc, profile="tox")
+        warm = time.perf_counter() - t1
+
+        # Warm must not be meaningfully slower than cold (allow scheduler noise).
+        assert warm <= cold * 1.5 + 0.5


### PR DESCRIPTION
## Summary

The agent calls `validate` repeatedly per session (initial check, then re-validate after each fix), so the multi-second SHACL validation cost is paid many times per build. This PR adds a **module-level warm cache of the crate-independent parsed profiles** so repeated `validate_crate` / `validate_crate_dict` calls reuse already-parsed shape + ontology artifacts instead of re-parsing them every call.

Closes #63

## Investigation (what the library actually does)

I dug through `rocrate_validator` 0.10 internals before writing any code:

- `services.validate()` builds a fresh `Validator` + per-call `ValidationContext` every time.
- `ValidationContext.__load_profiles__` calls `Profile.load_profiles`, which constructs **new** `Profile` objects each call (re-reading the `.ttl` spec files). The per-profile SHACL shape registry (`ShapesRegistry.get_instance(profile)`) is cached **on the Profile instance** — which the library then discards.
- There is **no public hook** to inject pre-parsed graphs: `services.validate` / `validate_metadata_as_dict` take no `shapes_graph=` / `ont_graph=` argument, so a plain `functools.lru_cache` has nothing to wrap. Reusing a `Validator` instance across calls gives **no** speedup (it rebuilds the context each `validate()`).
- **Empirically, the `.ttl` parse the issue targeted is *not* the bottleneck**: `load_profiles` is ~13 ms and parsing all requirements/shapes is ~130 ms. The dominant ~2.5 s/pass is the SHACL/owlrl inference + the library's per-profile graph recomposition inside `__set_current_validation_profile__`, which runs fresh on every call and is unreachable from outside without reimplementing the validation loop (which would break issue routing, severity gating and inherited-profile suppression the rest of the codebase relies on).

## Approach (the parts we control)

Per the issue's documented fallback ("if the library re-parses internally and gives no hook, implement the module-level warm cache around the parts you control, and document the limitation honestly"):

`profiles/validator.py` installs a module-level `_PROFILE_CACHE` and overrides `ValidationContext.__load_profiles__` to return cached, **warmed** `Profile` objects on a hit (and warm + cache the original loader's result on a miss). Warming forces `profile.requirements` and `ShapesRegistry.get_instance(profile).get_shapes()` so the parsed spec graphs and per-profile shape registries persist across calls. Only the crate's data graph is re-read per call.

### Keying & invalidation

Cache key = `(profiles_path, extra_profiles_path, profile_identifier, severity, shapes-dir mtime)`. The newest mtime of any `profiles/shapes/**/*.ttl` is part of the key, so the cache **invalidates automatically** when any shape file changes. `clear_profile_cache()` is the explicit/test hook.

## Measured speedup (before → after)

2nd-and-later consecutive call vs. cold call, minimal crate, this machine:

| pass  | cold   | warm   | speedup |
|-------|--------|--------|---------|
| base  | 0.260s | 0.199s | 24%     |
| isa   | 0.535s | 0.377s | 30%     |
| tox   | 2.743s | 2.329s | 15%     |
| all   | 3.405s | 3.039s | 11%     |

Correctness is unchanged — identical issue counts per pass with and without the cache.

### Honest limitation

The warm cache removes the re-parse work we own, but it **cannot** remove the library-internal SHACL/owlrl inference + per-profile graph recomposition, which dominate wall-clock and run fresh inside every `validate()`. So the win is a consistent ~11–30% on warm passes, not the larger speedup the issue anticipated (because the `.ttl` parse it assumed was dominant is actually only ~10–130 ms in roc-validator 0.10).

## Tests

`tests/test_validator_cache.py` (new) asserts the load-bearing, non-flaky guarantees:
- warmed profile list is the **same object** across consecutive calls (cache hit → no re-parse),
- cache key **invalidates** when a shape file's mtime changes,
- the warm call is **not** dramatically slower than the cold call (loose ratio, avoids flakiness).

`uv run pytest` → 508 passed. `uvx ruff check` clean on changed files. `AGENTS.md` updated with the design decision + limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)