### PR TITLE
test(eval): end-to-end agent-output-quality evaluation harness (#59)

### DIFF
--- a/tests/fixtures/svhps21_input/README.md
+++ b/tests/fixtures/svhps21_input/README.md
@@ -1,0 +1,15 @@
+# S-VHPS21 — MCT8 cellular uptake of triiodothyronine
+
+A cell-based in vitro assay screening chemicals for their capacity to inhibit
+triiodothyronine (T3) uptake by human monocarboxylate transporter 8 (MCT8),
+using an MCT8-overexpressing MDCK1 cell model.
+
+- Accession: S-VHPS21
+- DOI: 10.6019/S-VHPS21
+- Author: Fabian Wagenaars (ORCID 0000-0003-4766-7358), Universiteit Utrecht
+- Cell line: MDCK1 MCT8-overexpressing cells
+- Compound: Triiodothyronine
+
+This is a minimal, synthetic research folder used as a deterministic input
+fixture for the end-to-end agent-output-quality evaluation test (Issue #59).
+No real experimental data is committed.

--- a/tests/fixtures/svhps21_input/processed_data/ic50_results.csv
+++ b/tests/fixtures/svhps21_input/processed_data/ic50_results.csv
@@ -1,0 +1,2 @@
+compound,cell_line,endpoint,value,unit
+Triiodothyronine,MDCK1 MCT8-overexpressing cells,IC50,0.84,uM

--- a/tests/fixtures/svhps21_input/raw_data/uptake_raw.csv
+++ b/tests/fixtures/svhps21_input/raw_data/uptake_raw.csv
@@ -1,0 +1,5 @@
+well,compound,concentration_uM,t3_uptake_cpm
+A1,Triiodothyronine,0.0,12050
+A2,Triiodothyronine,0.1,9870
+A3,Triiodothyronine,1.0,5430
+A4,Triiodothyronine,10.0,1120

--- a/tests/test_e2e_agent_eval.py
+++ b/tests/test_e2e_agent_eval.py
@@ -1,0 +1,290 @@
+"""End-to-end agent-output-quality evaluation harness (Issue #59).
+
+The build/validate layer is well covered, but nothing exercises the *agent
+orchestration* path — whether a realistic file-scan input, driven through a
+sequence of tool calls, yields a complete and correct crate. This test fills
+that gap with a **deterministic, offline, no-LLM** evaluation harness.
+
+Instead of invoking a live LLM, we hand-script the exact sequence of
+``engine.run_tool(...)`` calls that an agent *would* make for the S-VHPS21
+study (the fully-specified golden fixture from #97), reusing the same realistic
+values an agent would have inferred from the input folder:
+
+    scan_files            -> inventory the input directory (via the real guard)
+    draft_investigation   \
+    draft_study            |  ISA backbone + contributors + domain entities,
+    draft_assay            >  wired by entity_id references
+    draft_person           |  (Investigation -> Study -> Assay -> LabProcess)
+    draft_organization     |
+    draft_cell_line_sample |
+    draft_molecular_entity |
+    draft_process         /
+    build_and_validate    -> in-memory 3-pass SHACL gate (no disk)
+    build_crate           -> materialise the on-disk RO-Crate
+    validate              -> re-validate the crate read back from disk
+    assess_mit_coverage   -> MIT score floor
+    assess_fair_maturity  -> FAIR/DSM score floor
+
+It then asserts crate completeness & wiring on the built ``ro-crate-metadata.json``
+(required entity types, ``hasPart``/``about`` containment, ``conformsTo`` profile
+declaration) and a FAIR/MIT score floor — so an output-quality regression (agent
+stops drafting a key entity, wiring breaks, scores drop) fails the suite.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from builder.engine import AgentEngine
+from tests.fixtures.vhps_golden_crates import VHPS_STUDIES
+
+FIXTURE_INPUT_DIR = Path(__file__).parent / "fixtures" / "svhps21_input"
+
+
+def _scripted_build(engine: AgentEngine) -> dict:
+    """Drive the deterministic scripted tool sequence for S-VHPS21.
+
+    Every value an agent would have inferred from the folder is hard-coded from
+    the S-VHPS21 golden spec so the run is fully deterministic and offline.
+    Returns the ``build_and_validate`` result for the caller to assert on.
+    """
+    spec = VHPS_STUDIES["S-VHPS21"]
+    given, _, family = spec.author_name.partition(" ")
+
+    # --- 0. crate-level metadata the session establishes (root name/identifier).
+    # This is CrateState.metadata, not a per-entity draft — the agent/session
+    # sets it from the study accession (mirrors the golden fixture + the
+    # validator-wiring test). The root data entity needs a non-empty identifier.
+    engine.state.metadata.title = spec.title
+    engine.state.metadata.description = spec.description
+    engine.state.metadata.accession = spec.accession
+    engine.state.metadata.input_path = str(FIXTURE_INPUT_DIR)
+
+    # --- 1. scan: inventory the input dir through the real approved-roots guard
+    scanned = engine.run_tool("scan_files", path=str(FIXTURE_INPUT_DIR))
+    assert scanned, "scanner returned no files for the fixture input dir"
+
+    # --- 2. draft the ISA backbone, wired by entity_id references
+    inv = engine.run_tool(
+        "draft_investigation",
+        hints={
+            "name": spec.title,
+            "description": spec.description,
+            "identifier": spec.accession,
+        },
+    )
+    study = engine.run_tool(
+        "draft_study",
+        investigation_id=inv.entity_id,
+        hints={
+            "name": spec.title,
+            "description": spec.description,
+            "identifier": spec.accession,
+            "datePublished": spec.release_date,
+        },
+    )
+    assay = engine.run_tool(
+        "draft_assay",
+        study_id=study.entity_id,
+        hints={"name": spec.assay_name, "identifier": f"{spec.accession}-assay"},
+    )
+
+    # --- 3. contributors
+    engine.run_tool(
+        "draft_person",
+        name=spec.author_name,
+        hints={
+            "givenName": given,
+            "familyName": family or given,
+            "orcid": spec.author_orcid,
+        },
+    )
+    engine.run_tool("draft_organization", name=spec.organization, hints={})
+
+    # --- 4. domain entities
+    cell = engine.run_tool("draft_cell_line_sample", name=spec.cell_line, hints={})
+    compound = engine.run_tool("draft_molecular_entity", name=spec.compound, hints={})
+
+    # --- 5. the Exposure LabProcess anchoring the assay's derivation chain
+    engine.run_tool(
+        "draft_process",
+        assay_id=assay.entity_id,
+        process_type="Exposure",
+        hints={
+            "name": f"{spec.compound} uptake exposure",
+            "samples": cell.entity_id,
+            "chemicals": compound.entity_id,
+        },
+    )
+
+    # --- 6. in-memory 3-pass SHACL gate (no disk)
+    return engine.run_tool("build_and_validate", severity="required")
+
+
+@dataclass
+class ScriptedRun:
+    """The artefacts of one scripted scan->draft->build->validate run."""
+
+    engine: AgentEngine
+    build_and_validate: dict
+
+
+@pytest.fixture
+def scripted_run() -> ScriptedRun:
+    """A fresh engine that has run the full scripted scan->draft sequence."""
+    engine = AgentEngine()
+    engine.initialize()  # establish session_id (no input scan; we scan via run_tool)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = _scripted_build(engine)
+    return ScriptedRun(engine=engine, build_and_validate=result)
+
+
+class TestScriptedAgentSequenceConformance:
+    """The scripted sequence yields a crate that passes all three SHACL passes."""
+
+    def test_build_and_validate_passes_all_three_at_required(self, scripted_run):
+        result = scripted_run.build_and_validate
+        assert result["ok"] is True, result["issues"]
+        assert result["conformance"] == {"base": True, "isa": True, "tox": True}
+        assert result["issues"] == []
+
+    def test_required_entity_types_present_in_state(self, scripted_run):
+        state = scripted_run.engine.state
+        assert len(state.list_entities("Investigation")) == 1
+        assert len(state.list_entities("Study")) == 1
+        assert len(state.list_entities("Assay")) == 1
+        assert len(state.list_entities("LabProcess")) >= 1
+
+
+class TestBuiltCrateCompletenessAndWiring:
+    """Assert completeness & wiring on the on-disk ro-crate-metadata.json."""
+
+    @pytest.fixture
+    def graph(self, scripted_run, tmp_path) -> list[dict]:
+        """Materialise the crate to disk via build_crate, re-validate, return @graph."""
+        out = tmp_path / "crate"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            build_res = scripted_run.engine.run_tool("build_crate", output_path=str(out))
+            assert build_res["success"] is True, build_res["error"]
+
+            # Re-validate the crate read back from disk (the round-trip path).
+            report = scripted_run.engine.run_tool("validate", crate_path=build_res["crate_path"])
+        assert report.base_passed, report.required_issues
+        assert report.isa_passed, report.required_issues
+        assert report.tox_passed, report.required_issues
+
+        metadata = json.loads(
+            (out / "ro-crate-metadata.json").read_text(encoding="utf-8")
+        )
+        assert "@context" in metadata
+        return metadata["@graph"]
+
+    def _by_id(self, graph: list[dict]) -> dict[str, dict]:
+        return {e["@id"]: e for e in graph if "@id" in e}
+
+    def _additional_types(self, graph: list[dict]) -> set[str]:
+        types: set[str] = set()
+        for e in graph:
+            at = e.get("additionalType")
+            if isinstance(at, str):
+                types.add(at)
+            elif isinstance(at, list):
+                types.update(t for t in at if isinstance(t, str))
+        return types
+
+    def test_required_entity_types_present_in_graph(self, graph):
+        """Investigation + Study + Assay are present as typed Datasets."""
+        addl = self._additional_types(graph)
+        assert {"Investigation", "Study", "Assay"} <= addl, addl
+        # LabProcess present (typed via @type, e.g. LabProcess/Exposure)
+        type_blob = json.dumps([e.get("@type") for e in graph])
+        assert "LabProcess" in type_blob, type_blob
+
+    def test_haspart_about_wiring(self, graph):
+        """Root --hasPart--> Investigation/Study; Study --hasPart--> Assay;
+        Assay --about--> LabProcess."""
+        by_id = self._by_id(graph)
+
+        def ids(node: dict, key: str) -> set[str]:
+            val = node.get(key, [])
+            if isinstance(val, dict):
+                val = [val]
+            return {v["@id"] for v in val if isinstance(v, dict) and "@id" in v}
+
+        def additional_type(node: dict) -> set[str]:
+            at = node.get("additionalType")
+            if isinstance(at, list):
+                return {t for t in at if isinstance(t, str)}
+            return {at} if isinstance(at, str) else set()
+
+        def types_of(node_ids: set[str]) -> set[str]:
+            types: set[str] = set()
+            for i in node_ids:
+                if i in by_id:
+                    types |= additional_type(by_id[i])
+            return types
+
+        # Root Data Entity is the "./" Dataset.
+        root = by_id["./"]
+        assert root.get("@type") == "Dataset"
+
+        # Root hasPart references both the Investigation and the Study.
+        root_part_types = types_of(ids(root, "hasPart"))
+        assert "Investigation" in root_part_types, root_part_types
+        assert "Study" in root_part_types, root_part_types
+
+        # Study hasPart references the Assay.
+        study = next(n for n in graph if "Study" in additional_type(n))
+        assert "Assay" in types_of(ids(study, "hasPart")), study.get("hasPart")
+
+        # Assay about references the LabProcess (the experimental process).
+        assay = next(n for n in graph if "Assay" in additional_type(n))
+        about_ids = ids(assay, "about")
+        assert about_ids, "Assay has no `about` link to its LabProcess"
+        about_types = json.dumps([by_id[i].get("@type") for i in about_ids if i in by_id])
+        assert "LabProcess" in about_types, about_types
+
+    def test_conformsto_declares_isa_and_isatox_profiles(self, graph):
+        """The metadata descriptor's conformsTo declares RO-Crate + ISA + ISA-Tox."""
+        descriptor = next(
+            e for e in graph if e.get("@id") == "ro-crate-metadata.json"
+        )
+        conforms = descriptor.get("conformsTo")
+        if isinstance(conforms, dict):
+            conforms = [conforms]
+        ids = [c.get("@id", "") for c in conforms or []]
+        blob = " ".join(ids)
+        assert any("w3id.org/ro/crate" in i for i in ids), ids
+        assert "isa" in blob.lower(), ids
+        # ISA-Tox profile declared alongside ISA (the domain extension layer).
+        assert sum("isa" in i.lower() for i in ids) >= 2, ids
+
+
+class TestScoreFloors:
+    """A FAIR/MIT score floor on the built crate — guards against silent drops."""
+
+    def test_mit_coverage_floor(self, scripted_run):
+        report = scripted_run.engine.run_tool("assess_mit_coverage")
+        assert report.module_scores, "MIT report has no module scores"
+        # The scripted crate fills the ISA backbone + key domain fields. Assert a
+        # conservative non-zero floor so a regression that stops drafting key
+        # entities (dropping coverage to 0) fails here. The General Information
+        # module specifically must have completions from the drafted entities.
+        assert report.overall_score > 0.0, report.overall_score
+        general = report.module_scores.get("General Information", {})
+        assert general.get("completed", 0) >= 2, report.module_scores
+
+    def test_fair_maturity_floor(self, scripted_run):
+        report = scripted_run.engine.run_tool("assess_fair_maturity")
+        passed = [r for r in report.indicator_results if r.get("passed") is True]
+        assert passed, "no FAIR indicators passed"
+        # DSM level is cumulative; the scripted crate has title+description+
+        # entities+ids, clearing the lowest tiers.
+        assert report.dsm_level >= 1, report.dsm_level


### PR DESCRIPTION
## Summary

Adds the missing **end-to-end agent-output-quality evaluation test** (Issue #59). The build/validate layer was well covered, but nothing exercised *agent orchestration* — whether a realistic file-scan input, driven through a sequence of tool calls, yields a complete and correct crate. This fills that gap with a **deterministic, offline (no-LLM, no-network)** harness.

Instead of invoking a live LLM, it hand-scripts the exact sequence of `engine.run_tool(...)` calls an agent *would* make for the S-VHPS21 study, reusing the fully-specified golden spec from #97 for the drafting hints.

## Scripted sequence

```
(session metadata: title/description/accession/input_path)
scan_files            -> inventory the fixture input dir via the real approved-roots guard
draft_investigation   \
draft_study            |  ISA backbone + contributors + domain entities,
draft_assay            >  wired by entity_id references
draft_person           |  (Investigation -> Study -> Assay -> LabProcess)
draft_organization     |
draft_cell_line_sample |
draft_molecular_entity |
draft_process (Exposure)/
build_and_validate    -> in-memory 3-pass SHACL gate (no disk)
build_crate           -> materialise the on-disk RO-Crate
validate              -> re-validate the crate read back from disk
assess_mit_coverage   -> MIT score floor
assess_fair_maturity  -> FAIR/DSM score floor
```

## Assertions

- **Conformance**: `build_and_validate` passes base + ISA + ISA-Tox at REQUIRED (no issues); the on-disk crate re-validates clean across all three passes.
- **Required entity types**: Investigation + Study + Assay + LabProcess present in both state and the built `@graph`.
- **Wiring** on the built `ro-crate-metadata.json`: root `./` `hasPart` -> Investigation + Study; Study `hasPart` -> Assay; Assay `about` -> LabProcess.
- **conformsTo**: the metadata descriptor declares RO-Crate 1.1 + ISA + ISA-Tox profiles (verified against current `_crate_mapping` placement — descriptor, not Root Data Entity).
- **Score floors**: MIT overall > 0 with General Information module completions >= 2; FAIR DSM level >= 1 with passing indicators.

## Fixtures

- Reuses the S-VHPS21 golden spec (`tests/fixtures/vhps_golden_crates.py`, #97) for deterministic drafting hints.
- Adds a minimal synthetic input folder `tests/fixtures/svhps21_input/` (README + raw/processed CSVs) so `scan_files` runs through the real scanner + approved-roots guard. No real experimental data.

## Verification

- New: 7 tests, all pass.
- Full suite (with `--extra langchain`, matching CI): **512 passed**.
- `uv run ty check`: no new diagnostics from the added files.
- **Load-bearing check**: dropping a key draft (e.g. the LabProcess/Study) fails the completeness, wiring, and MIT-floor assertions — the test is not trivially green.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)