### PR TITLE
fix(mapping): declare profiles on Root Data Entity, descriptor base-only (#91)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -464,18 +464,28 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
     if not crate.root_dataset.get("license"):
         crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
 
-    # conformsTo lives on the metadata descriptor (RO-Crate 1.1 placement,
-    # isa_tox.md §Conformance). The crate declares the ISA + ISA-Tox profiles it
-    # TARGETS unconditionally — the three-layer (RO-Crate → ISA → ISA-Tox)
-    # duck-typing architecture rests on this declaration, and validation should
-    # be able to see the profiles a crate claims (Issue #89, "guidance over
-    # strictness"). Declaration is therefore independent of any prior validation
-    # pass; conformance is reported separately via build_and_validate (#87).
-    conforms: list[dict[str, str]] = [
-        {"@id": ROCRATE_SPEC},
-        {"@id": PROFILE_ISA},
-        {"@id": PROFILE_ISATOX},
-    ]
+    # Conformance placement follows RO-Crate 1.2 (ro-crate-1.2.0.md §Profiles,
+    # isa_tox.md §Conformance): the metadata file descriptor's conformsTo is
+    # reserved for the single base-spec URI, while the profiles the crate targets
+    # are declared on the Root Data Entity (./) — Issue #91.
+    #
+    # The base spec stays pinned to 1.1 (not 1.2) deliberately: roc-validator
+    # 0.10.0 bundles no ro-crate-1.2 base profile, and its base pass hard-requires
+    # the 1.1 URI on the descriptor (profiles/ro-crate/must/1_file-descriptor_
+    # metadata.ttl: `sh:hasValue <https://w3id.org/ro/crate/1.1>`). Declaring 1.2
+    # there fails REQUIRED validation, which build_and_validate (#87) and the
+    # golden fixtures (#97) rely on staying green. ro-crate-py 0.15 still emits a
+    # 1.2 @context; fully unifying the version on 1.2 is deferred until an upstream
+    # validator ships a 1.2 base profile (tracked on #91).
+    crate.metadata["conformsTo"] = {"@id": ROCRATE_SPEC}
+
+    # Profiles the crate TARGETS, declared on ./ unconditionally — the three-layer
+    # (RO-Crate → ISA → ISA-Tox) duck-typing architecture rests on this
+    # declaration and validation should be able to see the profiles a crate claims
+    # (#89, "guidance over strictness"), independent of any prior validation pass;
+    # conformance is reported separately via build_and_validate (#87).
+    for pid in (PROFILE_ISA, PROFILE_ISATOX):
+        crate.root_dataset.append_to("conformsTo", {"@id": pid})
     crate.add(
         ContextEntity(
             crate,
@@ -497,7 +507,6 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
             },
         )
     )
-    crate.metadata["conformsTo"] = conforms
 
 
 def _cell_line_term(crate: ROCrate) -> ContextEntity:

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -286,19 +286,17 @@ class TestIdentifiersAndConformance:
         _, by_id = _build(state, tmp_path)
         assert "https://orcid.org/0000-0002-1825-0097" in by_id
 
-    def test_conformsto_declares_isa_and_tox_unconditionally(self, tmp_path):
-        # Issue #89: a fresh crate (no validation passes recorded) must still
-        # declare the ISA + ISA-Tox profiles it TARGETS — the three-layer
-        # duck-typing architecture rests on the crate advertising the profiles
-        # it aims for ("guidance over strictness"), not gating them on a prior
-        # validation pass (chicken-and-egg).
+    def test_profiles_declared_on_root_data_entity(self, tmp_path):
+        # Issue #91: RO-Crate 1.2 recommends profile declarations on the Root
+        # Data Entity (./), reserving the metadata descriptor's conformsTo for
+        # the single base-spec URI. The ISA + ISA-Tox profiles the crate TARGETS
+        # are therefore declared on ./ — unconditionally, on a fresh state (#89).
         state = CrateState()
         _, by_id = _build(state, tmp_path)
-        descriptor = by_id["ro-crate-metadata.json"]
-        conforms = _ids(descriptor.get("conformsTo"))
-        assert "https://w3id.org/ro/crate/1.1" in conforms
-        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in conforms
-        assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
+
+        root_conforms = _ids(by_id["./"].get("conformsTo"))
+        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in root_conforms
+        assert "https://w3id.org/ro/crate/isa-tox/1.0" in root_conforms
         # both declared profiles also exist as Profile contextual entities
         for pid in (
             "https://github.com/nfdi4plants/isa-ro-crate-profile",
@@ -307,17 +305,12 @@ class TestIdentifiersAndConformance:
             pt = by_id[pid]["@type"]
             assert "Profile" in (pt if isinstance(pt, list) else [pt])
 
-    def test_conformsto_includes_profiles_when_validated(self, tmp_path):
+    def test_descriptor_conformsto_is_base_spec_only(self, tmp_path):
+        # Issue #91: the metadata file descriptor's conformsTo is reserved for
+        # the single base-spec URI (profiles moved to ./). The base spec stays
+        # 1.1 because roc-validator 0.10.0 bundles no 1.2 base profile and its
+        # base pass requires the 1.1 URI on the descriptor (sh:hasValue).
         state = CrateState()
-        state.validation.isa_passed = True
-        state.validation.tox_passed = True
         _, by_id = _build(state, tmp_path)
-        descriptor = by_id["ro-crate-metadata.json"]
-        conforms = _ids(descriptor.get("conformsTo"))
-        assert "https://w3id.org/ro/crate/isa-tox/1.0" in conforms
-        # ISA layer is declared with the IRI the shapes actually extend
-        assert "https://github.com/nfdi4plants/isa-ro-crate-profile" in conforms
-        # each declared profile also exists as a Profile contextual entity
-        prof = by_id["https://github.com/nfdi4plants/isa-ro-crate-profile"]
-        pt = prof["@type"]
-        assert "Profile" in (pt if isinstance(pt, list) else [pt])
+        desc_conforms = _ids(by_id["ro-crate-metadata.json"].get("conformsTo"))
+        assert desc_conforms == ["https://w3id.org/ro/crate/1.1"]

--- a/tests/test_e2e_agent_eval.py
+++ b/tests/test_e2e_agent_eval.py
@@ -251,20 +251,32 @@ class TestBuiltCrateCompletenessAndWiring:
         about_types = json.dumps([by_id[i].get("@type") for i in about_ids if i in by_id])
         assert "LabProcess" in about_types, about_types
 
-    def test_conformsto_declares_isa_and_isatox_profiles(self, graph):
-        """The metadata descriptor's conformsTo declares RO-Crate + ISA + ISA-Tox."""
+    def test_conformsto_isa_and_isatox_on_root_descriptor_base_only(self, graph):
+        """Profile conformsTo placement follows RO-Crate 1.2 (#91): the ISA +
+        ISA-Tox profiles the crate targets are declared on the Root Data Entity
+        (``./``), while the metadata descriptor's conformsTo is the single
+        base-spec URI only (no profile URIs)."""
+
+        def conforms_ids(node):
+            conforms = node.get("conformsTo")
+            if isinstance(conforms, dict):
+                conforms = [conforms]
+            return [c.get("@id", "") for c in conforms or []]
+
+        root = next(e for e in graph if e.get("@id") == "./")
         descriptor = next(
             e for e in graph if e.get("@id") == "ro-crate-metadata.json"
         )
-        conforms = descriptor.get("conformsTo")
-        if isinstance(conforms, dict):
-            conforms = [conforms]
-        ids = [c.get("@id", "") for c in conforms or []]
-        blob = " ".join(ids)
-        assert any("w3id.org/ro/crate" in i for i in ids), ids
-        assert "isa" in blob.lower(), ids
-        # ISA-Tox profile declared alongside ISA (the domain extension layer).
-        assert sum("isa" in i.lower() for i in ids) >= 2, ids
+
+        root_ids = conforms_ids(root)
+        desc_ids = conforms_ids(descriptor)
+
+        # Root Data Entity declares both targeted profiles (ISA + ISA-Tox).
+        assert sum("isa" in i.lower() for i in root_ids) >= 2, root_ids
+
+        # Descriptor conformsTo is the base spec only — no profile URIs there.
+        assert any("w3id.org/ro/crate" in i for i in desc_ids), desc_ids
+        assert not any("isa" in i.lower() for i in desc_ids), desc_ids
 
 
 class TestScoreFloors:


### PR DESCRIPTION
**Re-lands PR #105**, which was accidentally merged into its stacked base branch (`jh-89-conformsto-unconditional`) instead of `main`, so the change never reached `main`.

## What this does
1. **Mapping (#91):** moves the ISA + ISA-Tox profile `conformsTo` from the **metadata file descriptor** to the **Root Data Entity** (`./`) — the RO-Crate 1.2 recommended placement. The descriptor's `conformsTo` is reserved for the single base-spec URI (RO-Crate 1.1).
2. **e2e test (#59):** updates `test_e2e_agent_eval.py`'s conformsTo assertion to match the new placement (ISA + ISA-Tox on `./`, descriptor base-only). Bundled here so the placement change and its test land **atomically** — #112 (the e2e harness) merged before this could be coordinated separately, so its assertion lives in `main` and must flip with this change.

## Scope note (version flip deferred)
Base spec stays pinned to **1.1** — roc-validator 0.10.0 bundles no `ro-crate-1.2` base profile and its base pass hard-requires the 1.1 URI on the descriptor. Fully unifying on 1.2 is tracked in #110 (blocked on crs4/rocrate-validator#164).

## Tests
Full suite green (528 passed), including the updated `test_conformsto_isa_and_isatox_on_root_descriptor_base_only` and the `test_descriptor_conformsto_is_base_spec_only` / `test_profiles_declared_on_root_data_entity` placement tests.

Addresses #91 (placement half; version flip tracked in #110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)