### PR TITLE
fix(lookups): make missing IUCLID/OHT-201 catalogue degrade visibly (#65)

### DIFF
--- a/lookups/iuclid.py
+++ b/lookups/iuclid.py
@@ -21,23 +21,50 @@ from __future__ import annotations
 import difflib
 import functools
 import json
+import logging
 import re
 from pathlib import Path
 
 from rocrate.model import ContextEntity
 from rocrate.rocrate import ROCrate
 
+logger = logging.getLogger(__name__)
+
 _BASE = "https://w3id.org/ro/crate/isa-tox/1.0/iuclid"
 _CATALOG = Path(__file__).resolve().parents[1] / "profiles" / "mit-data" / "oht201_value_sets.json"
 _FUZZY_THRESHOLD = 0.86
 
+_EMPTY_CATALOG: dict = {"phrase_groups": {}, "bindings": {}}
+
 
 @functools.lru_cache(maxsize=1)
 def _catalog() -> dict:
+    """Load the IUCLID/OHT-201 value-set catalogue, degrading visibly if absent.
+
+    The catalogue (``_CATALOG``) is currently not committed to the repo and there
+    is no generator to build it from (issue #65). When it is missing or corrupt
+    the resolver becomes a no-op (``resolve``/``iuclid_term`` return ``None``);
+    this is acceptable, but the degradation must be *visible* rather than a silent
+    swallow, so the absence is logged at WARNING level. Narrowed from a bare
+    ``except Exception`` to only the I/O / parse failures we expect.
+    """
     try:
         return json.loads(_CATALOG.read_text(encoding="utf-8"))
-    except Exception:
-        return {"phrase_groups": {}, "bindings": {}}
+    except FileNotFoundError:
+        logger.warning(
+            "IUCLID/OHT-201 value-set catalogue not found at %s; controlled-vocabulary "
+            "resolution is disabled (resolve/iuclid_term will return None). See issue #65.",
+            _CATALOG,
+        )
+        return dict(_EMPTY_CATALOG)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "IUCLID/OHT-201 value-set catalogue at %s is not valid JSON (%s); "
+            "controlled-vocabulary resolution is disabled. See issue #65.",
+            _CATALOG,
+            exc,
+        )
+        return dict(_EMPTY_CATALOG)
 
 
 def phrase_group_values(phrase_group: str) -> list[dict]:

--- a/tests/test_iuclid.py
+++ b/tests/test_iuclid.py
@@ -66,6 +66,39 @@ class TestCatalogPath:
 
         assert iuclid.phrase_group_values("PG1") == []
 
+    def test_catalog_missing_file_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A missing catalogue must degrade *visibly* — a warning is logged."""
+        missing = tmp_path / "does-not-exist.json"
+        monkeypatch.setattr(iuclid, "_CATALOG", missing)
+        iuclid._catalog.cache_clear()
+
+        with caplog.at_level("WARNING", logger="lookups.iuclid"):
+            result = iuclid._catalog()
+
+        assert result == {"phrase_groups": {}, "bindings": {}}
+        assert any(record.levelname == "WARNING" for record in caplog.records)
+        assert any(str(missing) in record.getMessage() for record in caplog.records)
+
+    def test_catalog_invalid_json_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A corrupt catalogue must degrade visibly too, not raise."""
+        bad = tmp_path / "oht201_value_sets.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        monkeypatch.setattr(iuclid, "_CATALOG", bad)
+        iuclid._catalog.cache_clear()
+
+        with caplog.at_level("WARNING", logger="lookups.iuclid"):
+            result = iuclid._catalog()
+
+        assert result == {"phrase_groups": {}, "bindings": {}}
+        assert any(record.levelname == "WARNING" for record in caplog.records)
+
+    def test_resolve_returns_none_when_catalogue_missing(self, tmp_path, monkeypatch):
+        """resolve() degrades to None (not an error) when the catalogue is absent."""
+        monkeypatch.setattr(iuclid, "_CATALOG", tmp_path / "does-not-exist.json")
+        iuclid._catalog.cache_clear()
+
+        assert iuclid.resolve("Liver", "PG1") is None
+
 
 # ---------------------------------------------------------------------------
 # resolve()


### PR DESCRIPTION
## Summary

`lookups/iuclid.py` resolves free-text values against an OHT-201 value-set
catalogue (`profiles/mit-data/oht201_value_sets.json`) and emits IUCLID-coded
`schema:DefinedTerm`s. But that catalogue is **not committed**, the entire
`profiles/mit-data/` directory is absent, and there is **no generator** in the
repo to build it (`tools/mit/build_value_sets.py`, named in the docstrings, does
not exist). `_catalog()` swallowed the resulting `FileNotFoundError` in a bare
`except Exception`, returning empty maps — so `resolve()`/`iuclid_term()` were a
**permanent silent no-op**. The functions also have **zero production callers**;
`builder/tools/_crate_mapping.py:521` hard-codes the IUCLID code
(`"IUCLID:108174"`) as a static list element rather than going through the
resolver.

## Approach chosen: make-visible (the issue's default), not remove

I kept the resolver and made its failure **visible** rather than removing it:

- The module ships a complete, well-tested matching API (exact → fuzzy → open →
  uncoded) with 13 existing passing tests; that is working code, not dead weight.
- The catalogue may legitimately be committed later, at which point the resolver
  works as-is. Deletion would throw away that capability.
- Removal was offered as an acceptable alternative, but make-visible is the
  cleaner, lower-risk resolution here and is the issue's stated default.

I deliberately **did not** touch the hard-coded `IUCLID:108174` in
`_crate_mapping.py`: wiring `iuclid_term` in is not trivially correct without a
catalogue (it would resolve to nothing), so per the task scope it is left as-is.

## Changes

- `lookups/iuclid.py`: narrow `_catalog()`'s `except Exception` to
  `FileNotFoundError` / `json.JSONDecodeError`, and log a clear `WARNING` naming
  the missing/invalid path and the disabled feature. Observable behaviour
  (empty maps, `resolve()` → `None`) is unchanged.
- `tests/test_iuclid.py`: TDD coverage via `caplog` for the warning on a missing
  catalogue and on a corrupt catalogue, plus an assertion that `resolve()`
  returns `None` when the catalogue is absent. Tests were written first and
  confirmed failing before the fix.

## Verification

- `uv run --extra langchain pytest` → **531 passed**
- `uv run ty check` → 25 diagnostics, all **pre-existing** (unrelated test files;
  count identical with and without this change). **No new diagnostics**; none in
  the changed files.
- `uvx ruff check` on changed files → clean.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)