### PR TITLE
feat(validation): Frictionless payload/data-content validation layer (#95)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,7 +456,13 @@ build_and_validate(severity="required", profile="all") → {ok, conformance, iss
 export_crate(output_path: str) → CrateBuildResult
 build_crate(output_path: str) → CrateBuildResult     # back-compat alias of export_crate
 validate(crate_path: str) → ValidationReport
+validate_table(file: str, table_schema: dict, foreign_keys: dict | None = None, entity_id: str | None = None) → {ok, issues}
 ```
+
+`validate_table` is the **data-content (payload) layer** (#95): it validates a
+CSV's rows against a Frictionless `tableSchema` — separate from the SHACL
+metadata passes (see §6, Data-Content Layer). Issues use the same routable shape
+with `profile="data"`.
 
 `build_and_validate` is the agent's primary build/fix loop: it assembles the
 crate from `CrateState` **in memory** and validates the generated JSON-LD
@@ -520,8 +526,31 @@ Every tool call and graph node execution is automatically timed and recorded by 
 | ISA-Tox Profile | REQUIRED | Toxicology conformance | MUST fix |
 | ISA-Tox Profile | SHOULD | Recommended tox fields | Fix if data available |
 | ISA-Tox Profile | MAY | Optional tox fields | Note for user |
+| Data content (Frictionless) | REQUIRED | Payload conformance (CSV rows vs CSVW/Frictionless `tableSchema`) | MUST fix offending cell |
 | MIT Coverage | Score | % of recommended fields | Improvement suggestions |
 | FAIR Indicators | Score | FAIR maturity | Guidance for improvement |
+
+### Data-Content Layer (Frictionless, Issue #95)
+
+The three SHACL passes (base/ISA/ISA-Tox) validate the **metadata descriptor** —
+the structure and semantics of `ro-crate-metadata.json`. They do **not** check
+the **payload**: whether the rows of a referenced CSV actually match its declared
+schema. The Frictionless layer (`builder/tools/data_content.py`,
+`validate_table`) closes that gap, mirroring the metadata/data split in the
+BioHackEU25 report "Towards a Robust Validation Service for Data and Metadata in
+ARC RO-Crates" (Chadwick et al., biohackrxiv `zah28`).
+
+`validate_table(file, table_schema, foreign_keys=None, entity_id=None)` validates
+a CSV's content against a Frictionless `tableSchema` descriptor (column types and
+constraints) and, optionally, that designated columns reference only known
+in-crate ids (`MolecularEntity` / `Sample`) via `foreign_keys`
+(`column -> [allowed_id, ...]`). The obvious payload is the CSVW condition table
+emitted by #94 and any raw-measurement tables. Issues come back in the **same
+routable shape as #87** (`{entity_id, property, message, fix, severity,
+profile}`), with `profile == "data"` so this layer stays cleanly distinct from
+the SHACL layers — SHACL = metadata, Frictionless = payload, never entangled. It
+never raises into the agent loop: setup errors (missing file, malformed schema)
+return `{"ok": False, "issues": [], "error": ...}`.
 
 ### Verification Layer
 Checks that identifiers resolve at their source. Verification failures are REQUIRED — the identifier must be corrected or removed. Leaving a field empty is acceptable (shows up in MIT/FAIR scores but does not block).

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -56,6 +56,7 @@ Build, validate & assess:
 - export_crate: Write the finished RO-Crate to disk (returns a crate_path)
 - build_crate: Alias of export_crate (writes the crate to disk)
 - validate: Run three-pass validation on a crate already written to disk
+- validate_table: Validate a CSV's data content (rows) against its CSVW/Frictionless table schema — the payload layer, separate from SHACL metadata validation
 - assess_mit_coverage: Score MIT coverage
 - assess_fair_maturity: Score FAIR maturity
 

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -343,6 +343,29 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "validate_table",
+        "description": "Validate a CSV's DATA CONTENT against its CSVW/Frictionless table schema (the payload layer, separate from SHACL metadata validation). Checks that each cell matches its declared column type/constraints and that foreign-key columns reference existing entity ids. Use it on the condition table or a raw-measurement table after export. Returns {ok, issues:[{entity_id, property, message, fix, severity, profile}]} with profile='data'; property names the offending column. Pass foreign_keys to check that compound/cell-line columns resolve to known MolecularEntity/Sample ids.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "file": {"type": "string", "description": "Path to the CSV file to validate."},
+                "table_schema": {
+                    "type": "object",
+                    "description": "Frictionless table schema descriptor: {\"fields\": [{\"name\", \"type\", \"constraints\"?}, ...]}. Adapt CSVW datatype columns to this shape.",
+                },
+                "foreign_keys": {
+                    "type": "object",
+                    "description": "Optional map of column_name -> [allowed_id, ...]; each named column's cells must be one of the allowed in-crate ids (e.g. MolecularEntity/Sample). Example: {\"compound\": [\"chem_aspirin\"]}.",
+                },
+                "entity_id": {
+                    "type": "string",
+                    "description": "Optional id of the crate entity that owns the table (echoed on each issue for routing).",
+                },
+            },
+            "required": ["file", "table_schema"],
+        },
+    },
+    {
         "name": "assess_mit_coverage",
         "description": "Score MIT coverage from entity fields",
         "parameters": {"type": "object", "properties": {}},

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -127,6 +127,7 @@ class AgentEngine:
             return cls._registry
 
         import builder.tools.builder  # noqa: F401
+        import builder.tools.data_content  # noqa: F401
         import builder.tools.drafters  # noqa: F401
         import builder.tools.fair_assessment  # noqa: F401
         import builder.tools.lookups  # noqa: F401

--- a/builder/tools/__init__.py
+++ b/builder/tools/__init__.py
@@ -22,6 +22,7 @@ Tool categories:
 from __future__ import annotations
 
 from builder.tools.builder import build_crate, export_crate
+from builder.tools.data_content import validate_table
 from builder.tools.drafters import (
     draft_assay,
     draft_cell_line_sample,
@@ -121,6 +122,7 @@ __all__ = [
     "unzip_file",
     "update_entity",
     "validate",
+    "validate_table",
     "verify_all_identifiers",
     "verify_identifier",
 ]

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -261,6 +261,7 @@ _TOOL_ICONS: dict[str, str] = {
     "verify_identifier": "\u2705", "verify_all_identifiers": "\u2705",
     "build_and_validate": "\u2714\ufe0f", "export_crate": "\U0001f3ed",
     "build_crate": "\U0001f3ed", "validate": "\u2714\ufe0f",
+    "validate_table": "\U0001f4c8",
     "assess_mit_coverage": "\U0001f52e", "assess_fair_maturity": "\U0001f52e",
     "save_session": "\U0001f4be", "load_session": "\U0001f4c1",
     "list_sessions": "\U0001f4ca", "get_status": "\U0001f4ac",

--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -1,0 +1,243 @@
+"""Frictionless payload / data-content validation layer (Issue #95).
+
+This is a **separate layer** from the SHACL metadata validator
+(``profiles/validator.py``). The split mirrors the BioHackEU25 report "Towards a
+Robust Validation Service for Data and Metadata in ARC RO-Crates" (Chadwick et
+al., biohackrxiv ``zah28``):
+
+- **SHACL** checks the *metadata descriptor* — the structure and semantics of
+  ``ro-crate-metadata.json`` (does the graph declare the right entities,
+  properties, profiles).
+- **Frictionless** checks the *payload* — do the rows in a referenced CSV
+  actually match its declared CSVW / Frictionless ``tableSchema`` (column types,
+  value constraints, and foreign keys to ``MolecularEntity`` / ``Sample`` ids)?
+
+The obvious payload to validate here is the CSVW condition table emitted by
+#94 (the per-well design table) and any raw-measurement tables: do the cells
+match the declared datatypes, and do the compound / cell-line columns reference
+ids that actually exist in the crate?
+
+Issues come back in the **same routable shape as #87**
+(``{entity_id, property, message, fix, severity, profile}``) so the agent routes
+a data-content fix exactly as it routes a SHACL fix. The ``profile`` is the new
+``"data"`` layer, keeping it cleanly distinct from ``base`` / ``isa`` / ``tox``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The routable-issue layer name for data-content issues — deliberately distinct
+# from the SHACL layers ("base" | "isa" | "tox") so the two validation services
+# never entangle (Issue #95).
+DATA_CONTENT_PROFILE = "data"
+
+# Frictionless 5 error types we map to a per-column fix hint. Other error types
+# fall back to a generic hint built from the column name.
+_FIX_TEMPLATES: dict[str, str] = {
+    "type-error": "Fix the value in column `{column}` so it matches its declared type.",
+    "constraint-error": "Fix the value in column `{column}` so it satisfies the schema constraint.",
+    "foreign-key": (
+        "Use a `{column}` value that resolves to an existing entity id "
+        "(MolecularEntity / Sample), or add the missing entity."
+    ),
+}
+
+
+def _fix_for(error_type: str, column: str | None) -> str:
+    """Build a short, actionable fix hint for a Frictionless error."""
+    col = column or "the affected column"
+    template = _FIX_TEMPLATES.get(error_type)
+    if template:
+        return template.format(column=col)
+    if column:
+        return f"Correct the data in column `{col}` so it conforms to the table schema."
+    return "Correct the table data so it conforms to the declared table schema."
+
+
+def _routable(
+    *,
+    entity_id: str | None,
+    column: str | None,
+    error_type: str,
+    message: str,
+) -> dict[str, Any]:
+    """A data-content issue in #87's routable shape."""
+    return {
+        "entity_id": entity_id,
+        "property": column,
+        "message": message,
+        "fix": _fix_for(error_type, column),
+        "severity": "required",
+        "profile": DATA_CONTENT_PROFILE,
+    }
+
+
+def validate_table(
+    file: str,
+    table_schema: dict[str, Any],
+    foreign_keys: dict[str, list[str]] | None = None,
+    *,
+    entity_id: str | None = None,
+) -> dict[str, Any]:
+    """Validate a CSV's *content* against its CSVW / Frictionless table schema.
+
+    This is the payload/data-content validation layer (Issue #95): it checks that
+    the rows of ``file`` match the column types and constraints declared in
+    ``table_schema`` and, optionally, that designated columns reference only
+    known entity ids (``MolecularEntity`` / ``Sample``). It does **not** touch
+    the SHACL metadata validator — the two are independent layers.
+
+    Args:
+        file: Path to the CSV file to validate (the condition table or a
+            raw-measurement table).
+        table_schema: A Frictionless table schema descriptor — a ``{"fields":
+            [{"name", "type", "constraints"?}, ...]}`` dict. CSVW column entries
+            (``datatype`` / ``propertyUrl``) emitted by #94 should be adapted to
+            this shape before being passed in.
+        foreign_keys: Optional mapping of ``column_name -> [allowed_id, ...]``.
+            Each named column is checked so every cell value is one of the
+            allowed ids (the in-crate ``MolecularEntity`` / ``Sample`` ids).
+            Values not in the list are reported as foreign-key issues.
+        entity_id: Optional id of the crate entity that owns the table (e.g. the
+            condition-table ``File``), echoed back on each issue so the agent can
+            route the fix to the right node.
+
+    Returns:
+        ``{"ok": bool, "issues": [issue, ...]}`` where each issue is the #87
+        routable shape ``{entity_id, property, message, fix, severity, profile}``
+        with ``profile == "data"``. On a setup error (missing file, malformed
+        schema) ``ok`` is False and an ``"error"`` key carries the reason; the
+        function never raises into the agent loop.
+    """
+    # Imported lazily so the rest of builder.tools imports without frictionless
+    # being installed (it is only needed for this layer).
+    try:
+        from frictionless import Package, Resource, Schema, system
+    except ImportError as e:  # pragma: no cover - dependency declared in pyproject
+        logger.warning("Frictionless not available: %s", e)
+        return {
+            "ok": False,
+            "issues": [],
+            "error": f"Frictionless data-content validation not available: {e}",
+        }
+
+    path = Path(file)
+    if not path.is_file():
+        return {
+            "ok": False,
+            "issues": [],
+            "error": f"Table file not found: {file}",
+        }
+
+    try:
+        schema = Schema.from_descriptor(dict(table_schema))
+    except (TypeError, ValueError, AttributeError) as e:
+        return {
+            "ok": False,
+            "issues": [],
+            "error": f"Invalid table schema: {e}",
+        }
+
+    foreign_keys = foreign_keys or {}
+
+    try:
+        # Frictionless 5 refuses absolute/unsafe paths unless the running context
+        # is marked trusted; this is a local, user-approved file, so opt in.
+        with system.use_context(trusted=True):
+            report = _run_validation(
+                Package, Resource, schema, path, foreign_keys
+            )
+    except Exception as e:  # noqa: BLE001 - surface as a tool error, never crash the loop
+        logger.error("validate_table failed: %s", e)
+        return {"ok": False, "issues": [], "error": str(e)}
+
+    issues = _issues_from_report(report, entity_id)
+    return {"ok": not issues, "issues": issues}
+
+
+def _run_validation(
+    Package: Any,
+    Resource: Any,
+    schema: Any,
+    path: Path,
+    foreign_keys: dict[str, list[str]],
+) -> Any:
+    """Validate the table, wiring optional foreign-key reference resources.
+
+    Foreign keys in Frictionless are checked against a reference *resource*. We
+    synthesise an in-memory single-column resource of allowed ids per foreign-key
+    column and add an inline ``foreignKeys`` rule to the schema, then validate the
+    whole thing as a Package so the lookups resolve.
+    """
+    if not foreign_keys:
+        return Resource(path=str(path), schema=schema).validate()
+
+    ref_resources = []
+    for column, allowed in foreign_keys.items():
+        ref_name = f"_fk_{column}"
+        rows = [{"id": value} for value in allowed]
+        ref_resources.append(Resource(name=ref_name, data=rows))
+        schema.foreign_keys.append(
+            {
+                "fields": [column],
+                "reference": {"resource": ref_name, "fields": ["id"]},
+            }
+        )
+
+    main = Resource(name="table", path=str(path), schema=schema)
+    package = Package(resources=[main, *ref_resources])
+    return package.validate()
+
+
+def _issues_from_report(report: Any, entity_id: str | None) -> list[dict[str, Any]]:
+    """Translate a Frictionless validation report into routable issues."""
+    issues: list[dict[str, Any]] = []
+    for task in report.tasks:
+        for error in task.errors:
+            column = getattr(error, "field_name", None) or None
+            error_type = getattr(error, "type", "") or ""
+            note = getattr(error, "note", None) or str(error)
+            cell = getattr(error, "cell", None)
+            row_number = getattr(error, "row_number", None)
+            message = _compose_message(error_type, column, cell, row_number, note)
+            issues.append(
+                _routable(
+                    entity_id=entity_id,
+                    column=column,
+                    error_type=error_type,
+                    message=message,
+                )
+            )
+    return issues
+
+
+def _compose_message(
+    error_type: str,
+    column: str | None,
+    cell: Any,
+    row_number: int | None,
+    note: str,
+) -> str:
+    """A human-readable, self-contained message that names the offending value."""
+    parts: list[str] = []
+    if row_number is not None:
+        parts.append(f"row {row_number}")
+    if column:
+        parts.append(f"column '{column}'")
+    location = ", ".join(parts)
+    prefix = f"{location}: " if location else ""
+    cell_str = f" (value: {cell!r})" if cell not in (None, "") else ""
+    return f"{prefix}{note}{cell_str}"
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
+
+TOOL_REGISTRY.register("validate_table", validate_table, takes_state=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pdfplumber>=0.11.0",
     "python-docx>=1.1.0",
     "cryptography>=41,<49",  # pinned below 46 to avoid missing DeprecatedIn46 in google-auth
+    "frictionless>=5.19.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_data_content_validation.py
+++ b/tests/test_data_content_validation.py
@@ -1,0 +1,158 @@
+"""Tests for the Frictionless payload/data-content validation layer (Issue #95).
+
+This is a SEPARATE layer from the SHACL metadata validator:
+
+- SHACL (``profiles/validator.py``) checks the *metadata descriptor* — the
+  structure/semantics of ``ro-crate-metadata.json``.
+- Frictionless (``validate_table``) checks the *payload* — do the rows in a CSV
+  actually match the declared CSVW/Frictionless ``tableSchema`` (column types,
+  constraints, foreign keys to ``MolecularEntity`` / ``Sample`` ids)?
+
+Issues come back in the same routable shape as #87
+(``{entity_id, property, message, fix, severity, profile}``) so the agent can
+route a fix the same way it routes a SHACL issue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.tools.data_content import validate_table
+
+# A Frictionless/CSVW table schema mirroring the condition table's typed columns
+# (cell_line: string, compound: string, concentration: number).
+_CONDITION_SCHEMA = {
+    "fields": [
+        {"name": "cell_line", "type": "string"},
+        {"name": "compound", "type": "string"},
+        {"name": "concentration", "type": "number"},
+    ]
+}
+
+
+def _write_csv(tmp_path: Path, name: str, text: str) -> str:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+class TestTypeViolation:
+    def test_type_violating_cell_yields_structured_issue(self, tmp_path):
+        """A non-numeric value in a `number` column yields a data-content issue."""
+        csv = _write_csv(
+            tmp_path,
+            "cond.csv",
+            "cell_line,compound,concentration\n"
+            "HepG2,Aspirin,1.5\n"
+            "HepG2,Aspirin,notanumber\n",
+        )
+
+        result = validate_table(csv, _CONDITION_SCHEMA)
+
+        assert result["ok"] is False
+        assert result["issues"], "expected at least one data-content issue"
+        issue = result["issues"][0]
+        # Same routable shape as #87.
+        assert set(issue) >= {
+            "entity_id",
+            "property",
+            "message",
+            "fix",
+            "severity",
+            "profile",
+        }
+        # The data-content layer is its own profile, distinct from base/isa/tox.
+        assert issue["profile"] == "data"
+        # Routed to the offending column.
+        assert issue["property"] == "concentration"
+        assert "notanumber" in issue["message"]
+
+    def test_conformant_table_passes(self, tmp_path):
+        """A table whose rows all match the schema produces no issues."""
+        csv = _write_csv(
+            tmp_path,
+            "cond.csv",
+            "cell_line,compound,concentration\n"
+            "HepG2,Aspirin,1.5\n"
+            "A549,Paracetamol,2.0\n",
+        )
+
+        result = validate_table(csv, _CONDITION_SCHEMA)
+
+        assert result["ok"] is True
+        assert result["issues"] == []
+
+
+class TestForeignKeys:
+    def test_unknown_foreign_key_value_flagged(self, tmp_path):
+        """A compound id not in the allowed MolecularEntity ids is flagged."""
+        csv = _write_csv(
+            tmp_path,
+            "cond.csv",
+            "cell_line,compound,concentration\n"
+            "sample_hepg2,chem_aspirin,1.5\n"
+            "sample_hepg2,chem_unknown,2.0\n",
+        )
+
+        result = validate_table(
+            csv,
+            _CONDITION_SCHEMA,
+            foreign_keys={"compound": ["chem_aspirin"]},
+        )
+
+        assert result["ok"] is False
+        assert any(
+            "chem_unknown" in issue["message"] for issue in result["issues"]
+        ), "the dangling foreign-key value should be reported"
+
+    def test_known_foreign_key_values_pass(self, tmp_path):
+        csv = _write_csv(
+            tmp_path,
+            "cond.csv",
+            "cell_line,compound,concentration\n"
+            "sample_hepg2,chem_aspirin,1.5\n",
+        )
+
+        result = validate_table(
+            csv,
+            _CONDITION_SCHEMA,
+            foreign_keys={
+                "compound": ["chem_aspirin"],
+                "cell_line": ["sample_hepg2"],
+            },
+        )
+
+        assert result["ok"] is True
+        assert result["issues"] == []
+
+
+class TestRobustness:
+    def test_missing_file_returns_error_not_raises(self, tmp_path):
+        result = validate_table(str(tmp_path / "nope.csv"), _CONDITION_SCHEMA)
+        assert result["ok"] is False
+        assert result["issues"] or result.get("error")
+
+    def test_invalid_schema_returns_error_not_raises(self, tmp_path):
+        csv = _write_csv(tmp_path, "cond.csv", "a\n1\n")
+        # A non-dict schema is a programming error surfaced as a tool error,
+        # never an unhandled exception that would crash the agent loop.
+        result = validate_table(csv, "not a schema")  # ty: ignore[invalid-argument-type]
+        assert result["ok"] is False
+
+
+class TestRegistration:
+    def test_validate_table_registered_as_tool(self):
+        import builder.tools.data_content  # noqa: F401  (triggers registration)
+        from builder.tools.registry import TOOL_REGISTRY
+
+        assert "validate_table" in TOOL_REGISTRY
+        spec = TOOL_REGISTRY.get_spec("validate_table")
+        assert spec is not None
+        # It validates a file on disk against a schema; it does not need CrateState.
+        assert spec.takes_state is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -29,6 +29,7 @@ def _get_registry_tool_names() -> set[str]:
     the full set of registered tool names intended for LLM use.
     """
     import builder.tools.builder
+    import builder.tools.data_content
     import builder.tools.drafters
     import builder.tools.fair_assessment
     import builder.tools.management
@@ -73,6 +74,7 @@ def _get_all_registry_tool_names() -> set[str]:
     source-of-truth assertion.
     """
     import builder.tools.builder  # noqa: F401
+    import builder.tools.data_content  # noqa: F401
     import builder.tools.drafters  # noqa: F401
     import builder.tools.fair_assessment  # noqa: F401
     import builder.tools.file_readers  # noqa: F401

--- a/uv.lock
+++ b/uv.lock
@@ -478,6 +478,37 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/33/29de185079e6675c3f375546e30a559b7ddc75ce972f18d6e566cd9ea4eb/chardet-7.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:75d3c65cc16bddf40b8da1fd25ba84fca5f8070f2b14e86083653c1c85aee971", size = 874870, upload-time = "2026-04-13T21:33:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2f/4c5af01fd1a7506a1d5375403d68925eac70289229492db5aa68b58103d8/chardet-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:29af5999f654e8729d251f1724a62b538b1262d9292cccaefddf8a02aae1ef6a", size = 854859, upload-time = "2026-04-13T21:33:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/36/21/edb36ad5dfa48d7f8eed97ab43931ecdaa8c15166c21b1d614967e49d681/chardet-7.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:626f00299ad62dfe937058a09572beed442ccc7b58f87aa667949b20fd3db235", size = 875032, upload-time = "2026-04-13T21:33:08.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/a32a241d861cf180853a11c8e5a67641cb1b2af13c3a5ccce83ec07e2c9f/chardet-7.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a4904dd5f071b7a7d7f50b4a67a86db3c902d243bf31708f1d5cde2f68239cb", size = 888283, upload-time = "2026-04-13T21:33:10.213Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/e1ee6a77abf3782c00e05b89c4d4328c8353bf9500661c4348df1dd68614/chardet-7.4.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d2879598bc220689e8ce509fe9c3f37ad2fca53a36be9c9bd91abdd91dd364f", size = 879974, upload-time = "2026-04-13T21:33:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/32/60/fca69c534602a7ced04280c952a246ad1edde2a6ca3a164f65d32ac41fe7/chardet-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:4b2799bd58e7245cfa8d4ab2e8ad1d76a5c3a5b1f32318eb6acca4c69a3e7101", size = 943973, upload-time = "2026-04-13T21:33:12.756Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1323,6 +1354,36 @@ wheels = [
 ]
 
 [[package]]
+name = "frictionless"
+version = "5.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "chardet" },
+    { name = "humanize" },
+    { name = "isodate" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "marko" },
+    { name = "petl" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "python-slugify" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rfc3986" },
+    { name = "simpleeval" },
+    { name = "tabulate" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "validators" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/21/3494557b8c72b8375597cdd5b85d46c76eb978994c2f34f5737262047438/frictionless-5.19.0.tar.gz", hash = "sha256:75a060c8806c4a84dd72112ceeb919277d84982b07420295b9b920e8e30a65ab", size = 74375968, upload-time = "2026-04-13T13:05:53.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/3a/e568ea129fbcf9ee0f148178c67f8a2fc4e88de3aa34c840a180bcce4775/frictionless-5.19.0-py3-none-any.whl", hash = "sha256:81436b94a950b1a5cf83e953921e64dc888c00f51400f783ea0aa824319a6d67", size = 535173, upload-time = "2026-04-13T13:05:50.897Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1801,6 +1862,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1899,6 +1969,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -2560,6 +2639,15 @@ xls = [
 xlsx = [
     { name = "openpyxl" },
     { name = "pandas" },
+]
+
+[[package]]
+name = "marko"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/cc/01b80dc58e4d44fe039403ef1ac0008bcb9375364ccd246a4b8bfec29b46/marko-2.2.3.tar.gz", hash = "sha256:e31ec2875383bc62f9093d16babed5a2c2cde601c00d834ea935a2222120ec19", size = 144531, upload-time = "2026-05-28T02:07:39.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/50/0a8fab45fa374820c27cc4c3178c4914c60902ba9d6404a692a979e20dbc/marko-2.2.3-py3-none-any.whl", hash = "sha256:8e1d7a0387281e59dfbc52a381b58c570156970e36b2bbe047f8a3a2f368cacc", size = 42951, upload-time = "2026-05-28T02:07:38.373Z" },
 ]
 
 [[package]]
@@ -3583,6 +3671,15 @@ wheels = [
 ]
 
 [[package]]
+name = "petl"
+version = "1.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/97/e357f6b04f645712ec336d5ff5a1ef53aad6149fb53f39fd316c1b9a11cf/petl-1.7.19.tar.gz", hash = "sha256:238ff9ad3a85fcbbd041a8c24cfbcf6dd9e969f736b71b8ae25064648db0b0a0", size = 427585, upload-time = "2026-06-01T21:44:10.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/30/040c8afebe44b44d8ecef4a1f6ee947cbddba7eaf7527f18653cfff3f073/petl-1.7.19-py3-none-any.whl", hash = "sha256:51565902062d0b94284da6395581eb97ea8db0be1cf687e01861be825718c435", size = 234352, upload-time = "2026-06-01T21:44:09.216Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4316,6 +4413,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4616,6 +4725,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
 ]
 
 [[package]]
@@ -5137,6 +5255,15 @@ wheels = [
 ]
 
 [[package]]
+name = "simpleeval"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5257,12 +5384,30 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]
@@ -5732,11 +5877,21 @@ wheels = [
 ]
 
 [[package]]
+name = "validators"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
+]
+
+[[package]]
 name = "vitro-crate"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },
+    { name = "frictionless" },
     { name = "langchain" },
     { name = "langgraph" },
     { name = "openpyxl" },
@@ -5776,6 +5931,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=41,<49" },
+    { name = "frictionless", specifier = ">=5.19.0" },
     { name = "langchain", specifier = ">=1.3.10" },
     { name = "langchain-anthropic", marker = "extra == 'langchain'", specifier = ">=1" },
     { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=1.3.2" },


### PR DESCRIPTION
## Summary

Adds a **separate data-content (payload) validation layer**, distinct from the SHACL metadata validator, per issue #95.

- **SHACL** (`profiles/validator.py`) checks the *metadata descriptor* — the structure/semantics of `ro-crate-metadata.json`.
- **Frictionless** (new `builder/tools/data_content.py`) checks the *payload* — do the rows of a referenced CSV actually match its declared CSVW/Frictionless `tableSchema`?

This mirrors the metadata/data split in the BioHackEU25 report "Towards a Robust Validation Service for Data and Metadata in ARC RO-Crates" (Chadwick et al., biohackrxiv `zah28`). The two layers stay cleanly decoupled: SHACL = metadata, Frictionless = payload.

## The `validate_table` tool

```
validate_table(file, table_schema, foreign_keys=None, entity_id=None) -> {ok, issues}
```

Validates a CSV's content against a Frictionless `tableSchema` descriptor (column types + constraints) and, optionally, that designated columns reference only known in-crate ids (`MolecularEntity` / `Sample`) via `foreign_keys` (`column -> [allowed_id, ...]`). The obvious payload is the CSVW condition table emitted by #94 and any raw-measurement tables.

## Routable shape reuse (#87)

Issues come back in the **same routable shape as #87** — `{entity_id, property, message, fix, severity, profile}` — with `profile == "data"` so this layer is distinct from `base`/`isa`/`tox`. The agent routes a data-content fix exactly as it routes a SHACL fix. `property` names the offending column. The tool never raises into the agent loop: setup errors (missing file, malformed schema) return `{"ok": False, "issues": [], "error": ...}`.

## TDD

Failing test written first, then minimal implementation:
- type-violating cell -> structured data-content issue (`profile="data"`, `property=<column>`, value named in message)
- conformant table passes (no issues)
- foreign-key value not in the allowed id set is flagged; known ids pass
- robustness: missing file / invalid schema return an error dict, never raise
- registration: `validate_table` is in `TOOL_REGISTRY` with `takes_state=False`

## Wiring

Registered in `TOOL_REGISTRY`, `TOOL_SPECS`, the system-prompt tool list, the profiler dashboard, and `builder/tools/__init__`. The existing prompt/TOOL_SPECS one-for-one sync assertions stay green.

## Dependency

`frictionless>=5.19.0` (pinned at 5.19.0). Imports cleanly. Frictionless 5 guards absolute paths; the tool opts into `system.use_context(trusted=True)` for the local, user-approved file.

## Tests

- Full suite: 535 passed (was 528; +7 new data-content tests)
- `uv run ty check`: no new diagnostics (25 pre-existing, all in untouched test files)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)