### PR TITLE
fix(types): resolve all 25 ty diagnostics (clean ty check)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -612,7 +612,7 @@ def _build_agent_graph(
 
     # Use a typed state with add_messages reducer so ToolNode and model
     # both append to the message list rather than replacing it.
-    graph: Any = StateGraph(AgentState)
+    graph: Any = StateGraph(AgentState)  # ty: ignore[invalid-argument-type]
     graph.add_node("model", _wrap_model_node(call_model, profiler, iteration_getter))
     graph.add_node("tools", _wrap_tools_node(tool_node, profiler, iteration_getter))
 

--- a/builder/config.py
+++ b/builder/config.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import os
 import sys
 import tomllib
-from datetime import datetime
+from datetime import datetime, tzinfo
 from datetime import timezone as _timezone_mod
 from pathlib import Path
 from typing import Any
@@ -56,7 +56,7 @@ DEFAULTS: dict[str, Any] = {
 _DEFAULT_TIMEZONE = "Europe/Amsterdam"
 
 
-def get_timezone() -> _timezone_mod:
+def get_timezone() -> tzinfo:
     """Return the configured local timezone as a ``datetime.tzinfo``.
 
     Precedence (highest to lowest):

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -655,7 +655,8 @@ def format_session_summary(session_id: str, records: list[dict[str, Any]]) -> An
     last_model = (token_last or {}).get("model_name") or ""
     last_str = ""
     if last_in is not None:
-        last_str = f"  · last {last_model}: {last_in}→{last_out} ({int(last_in) + int(last_out)})"
+        last_total = int(last_in) + int(last_out or 0)
+        last_str = f"  · last {last_model}: {last_in}→{last_out} ({last_total})"
 
     # Compute costs — use get_model_provider for the model-specific vendor prefix
     from builder.config import get_model_provider

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -135,7 +135,7 @@ def read_docx(
         return None
 
     try:
-        doc = Document(file_path)
+        doc = Document(str(file_path))
     except Exception:
         logger.exception("Error opening DOCX file: %s", path)
         return None

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -526,14 +526,14 @@ def _summarize_json(path: Path) -> str | None:
 
     if isinstance(data, dict):
         keys = list(data.keys())
-        parts.append(f"Top-level keys ({len(keys)}): {', '.join(keys)}")
+        parts.append(f"Top-level keys ({len(keys)}): {', '.join(str(k) for k in keys)}")
         for k in keys:
             v = data[k]
             if isinstance(v, list):
                 parts.append(f"  {k}: array[{len(v)}]")
             elif isinstance(v, dict):
                 subkeys = list(v.keys())
-                parts.append(f"  {k}: object {{{', '.join(subkeys[:5])}}}")
+                parts.append(f"  {k}: object {{{', '.join(str(sk) for sk in subkeys[:5])}}}")
             elif isinstance(v, str):
                 preview = v[:80].replace("\n", " ")
                 parts.append(f'  {k}: string "{preview}"')
@@ -543,7 +543,7 @@ def _summarize_json(path: Path) -> str | None:
         parts.append(f"Top-level array with {len(data)} items")
         if data and isinstance(data[0], dict):
             keys = list(data[0].keys())
-            parts.append(f"  Item keys: {', '.join(keys)}")
+            parts.append(f"  Item keys: {', '.join(str(k) for k in keys)}")
     else:
         parts.append(f"Top-level value: {type(data).__name__} = {data}")
 
@@ -602,7 +602,7 @@ def _summarize_pdf(path: Path) -> str | None:
     try:
         import pdfplumber
     except ImportError:
-        pdfplumber = None  # type: ignore[assignment]
+        pdfplumber = None  # ty: ignore[invalid-assignment]
 
     if pdfplumber is not None:
         try:
@@ -645,7 +645,7 @@ def _summarize_docx(path: Path) -> str | None:
         return None
 
     try:
-        doc = Document(path)
+        doc = Document(str(path))
     except Exception:
         return None
 
@@ -727,11 +727,12 @@ def _format_size(size_bytes: int) -> str:
     """Format bytes as human-readable string."""
     if size_bytes == 0:
         return "0 B"
+    size = float(size_bytes)
     for unit in ("B", "KB", "MB", "GB"):
-        if abs(size_bytes) < 1024:
-            return f"{size_bytes:.1f} {unit}"
-        size_bytes /= 1024
-    return f"{size_bytes:.1f} TB"
+        if abs(size) < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
 
 
 def read_multiple_files(

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -162,8 +162,8 @@ def _synthesize_fix(issue: RoutableIssue) -> str:
 
 def build_and_validate(
     state: CrateState,
-    severity: str = "required",
-    profile: str = "all",
+    severity: str | None = "required",
+    profile: str | None = "all",
 ) -> dict[str, Any]:
     """Build the crate from CrateState in memory and validate it — no disk write.
 

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -57,7 +57,7 @@ class _PatchedVersioning:
 
 # Pre-seed so rocrate_validator/__init__.py finds this instead of the real
 # versioning module and never reaches the broken get_config() call.
-_sys.modules["rocrate_validator.utils.versioning"] = _PatchedVersioning  # type: ignore[attr-defined]
+_sys.modules["rocrate_validator.utils.versioning"] = _PatchedVersioning  # ty: ignore[invalid-assignment]
 
 import rocrate_validator.utils.config as _rv_config  # noqa: E402 — intentional bootstrap
 import rocrate_validator.utils.versioning as _rv_versioning  # noqa: E402
@@ -76,7 +76,7 @@ def _patched_get_config() -> dict:
     return cfg
 
 
-_rv_config.get_config = _patched_get_config
+_rv_config.get_config = _patched_get_config  # ty: ignore[invalid-assignment]
 _rv_config._config = None
 # Restore the real versioning module for correct semantics downstream.
 _sys.modules["rocrate_validator.utils.versioning"] = _rv_versioning

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -439,7 +439,7 @@ class TestToolSpinnerCallback:
         from builder.agents.agent_loop import _ToolSpinnerCallback
 
         spinner = _FakeSpinner()
-        _ToolSpinnerCallback(spinner).on_tool_start({"name": "scan_files"}, "/data")
+        _ToolSpinnerCallback(spinner).on_tool_start({"name": "scan_files"}, "/data")  # ty: ignore[invalid-argument-type]
 
         assert spinner.tools == ["scan_files"]
 
@@ -448,7 +448,7 @@ class TestToolSpinnerCallback:
         from builder.agents.agent_loop import _ToolSpinnerCallback
 
         spinner = _FakeSpinner()
-        _ToolSpinnerCallback(spinner).on_tool_start({}, "")
+        _ToolSpinnerCallback(spinner).on_tool_start({}, "")  # ty: ignore[invalid-argument-type]
 
         assert spinner.tools == ["tool"]
 
@@ -457,7 +457,7 @@ class TestToolSpinnerCallback:
         from builder.agents.agent_loop import _ToolSpinnerCallback
 
         spinner = _FakeSpinner()
-        cb = _ToolSpinnerCallback(spinner)
+        cb = _ToolSpinnerCallback(spinner)  # ty: ignore[invalid-argument-type]
         cb.on_tool_start({"name": "lookup_compound"}, "aspirin")
         cb.on_tool_end("result")
 

--- a/tests/test_crate_mapping_namespace.py
+++ b/tests/test_crate_mapping_namespace.py
@@ -18,7 +18,7 @@ from builder.tools.builder import build_crate
 def _entity(entity_id: str, entity_type: str, **fields) -> Entity:
     return Entity(
         entity_id=entity_id,
-        type=entity_type,  # type: ignore[arg-type]
+        type=entity_type,  # ty: ignore[invalid-argument-type]
         fields=fields,
         _provenance=EntityProvenance(created_by="llm"),
     )

--- a/tests/test_http_resilience.py
+++ b/tests/test_http_resilience.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 import responses
+from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError as ReqConnectionError
 from requests.exceptions import Timeout
 
@@ -77,7 +78,7 @@ class TestHttpGetJson:
             params={"q": "v"},
             headers={"Accept": "application/json"},
         )
-        assert "q=v" in responses.calls[0].request.url
+        assert "q=v" in (responses.calls[0].request.url or "")
 
 
 class TestSessionRetryConfig:
@@ -85,6 +86,7 @@ class TestSessionRetryConfig:
 
     def test_retry_configuration(self):
         adapter = get_session().get_adapter("https://example.org")
+        assert isinstance(adapter, HTTPAdapter)
         retry = adapter.max_retries
         assert retry.total == 3
         assert retry.backoff_factor == 0.5

--- a/tests/test_provenance_tools.py
+++ b/tests/test_provenance_tools.py
@@ -172,5 +172,7 @@ class TestCheckProvenance:
         link(state, "er", "result", "raw")
         assert check_provenance(state)["ok"] is True
 
-        del state.get_entity("er").fields["result"]
+        er = state.get_entity("er")
+        assert er is not None
+        del er.fields["result"]
         assert check_provenance(state)["ok"] is False

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -187,7 +187,7 @@ def test_no_tool_description_references_absent_tool():
 
     for spec in TOOL_SPECS:
         name = spec["name"]
-        desc = spec.get("description", "")
+        desc = str(spec.get("description", ""))
 
         refs = _collect_referenced_tools(desc)
 
@@ -275,7 +275,7 @@ def test_no_duplicate_tool_names_in_tool_specs():
     """
     from collections import Counter
 
-    counts = Counter(spec["name"] for spec in TOOL_SPECS)  # ty: ignore
+    counts = Counter(spec["name"] for spec in TOOL_SPECS)
     duplicates = {name: n for name, n in counts.items() if n > 1}
     assert not duplicates, f"Duplicate tool names in TOOL_SPECS: {duplicates}"
 

--- a/tests/test_tools_validation.py
+++ b/tests/test_tools_validation.py
@@ -96,7 +96,7 @@ class TestValidate:
                 ),
             ]
 
-        validator_mod.validate_crate = patched_validate
+        validator_mod.validate_crate = patched_validate  # ty: ignore[invalid-assignment]
 
         import sys as _sys
 
@@ -140,7 +140,7 @@ class TestValidate:
                 ),
             ]
 
-        validator_mod.validate_crate = patched_validate
+        validator_mod.validate_crate = patched_validate  # ty: ignore[invalid-assignment]
 
         import sys as _sys
 


### PR DESCRIPTION
Brings `uv run ty check` from **25 diagnostics → 0** ("All checks passed!"). Full suite green (528 passed); `ruff` clean.

## Production fixes (real type correctness)
- **`config.get_timezone`** annotated `-> tzinfo` (was `timezone`; it returns a `ZoneInfo`).
- **`build_and_validate`** `severity`/`profile` typed `str | None` — the body already treats `None` as "use default" (weak models emit explicit nulls), so the signature now matches reality. Fixes the two `severity=None, profile=None` test calls without a suppression.
- **`dashboard`** token line guards `None` `last_out` (`int(last_out or 0)`); refactored to keep the line under 100 cols.
- **`scanner._format_size`** uses a `float` accumulator (was `size_bytes /= 1024` on an `int` param).
- **`file_readers`/`scanner`** pass `str(path)` to `Document()` (python-docx wants `str | IO[bytes]`, not `Path`).
- **`scanner`** JSON-key joins stringify keys; pdfplumber import fallback uses a proper `# ty: ignore`.

## Intentional patterns — targeted `# ty: ignore[rule]`
- `StateGraph(AgentState)` (langgraph `StateT` TypeVar bound doesn't recognise our `TypedDict`).
- `profiles/validator.py` bootstrap-shim monkeypatches (consistent with the file's existing accepted pattern, AGENTS.md D11).
- Test monkeypatches / doubles: `_FakeSpinner`, `validator_mod.validate_crate = …`, `Entity(type=…)`.

## Test fixes
- None-guard `get_entity()` before `del …fields[…]`.
- `assert isinstance(adapter, HTTPAdapter)` to narrow before `.max_retries`.
- Stringify `spec.get("description")`; `"q=v" in (url or "")`; dropped a stale blanket `# ty: ignore`.

No behaviour change — types and suppressions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)