### PR TITLE
fix(dashboard): live updates throttled — decouple watchfiles step from render interval (#121)

### DIFF
--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -730,6 +730,34 @@ def format_session_summary(session_id: str, records: list[dict[str, Any]]) -> An
 # Live dashboard (TUI)
 # ---------------------------------------------------------------------------
 
+# watchfiles' ``step`` is a debounce *quiet-period* (ms): changes are only
+# yielded once the filesystem has been quiet for this long. It must stay small
+# (the watchfiles default) so a steady stream of profiler writes is surfaced
+# promptly — it is NOT the render cadence. Deriving it from ``refresh_interval``
+# (2000ms) starved the watch loop, so the dashboard only updated on load (#121).
+# The user-facing refresh rate is Rich ``Live(refresh_per_second=...)`` instead.
+_WATCH_STEP_MS = 50
+
+
+def _read_records_cached(
+    profile_path: Path, last_mtime: float, cached: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], float]:
+    """Return ``(records, mtime)``, re-reading ``profile.ndjson`` only when its
+    mtime changed; otherwise reuse *cached*.
+
+    Reusing the cache matters when the watch loop fires for a *crate_state.json*
+    change while ``profile.ndjson`` is unchanged: returning ``[]`` there would
+    blank the profile panel to the "no data" placeholder on every CrateState
+    update (#121).
+    """
+    try:
+        current_mtime = profile_path.stat().st_mtime
+    except OSError:
+        return cached, last_mtime
+    if current_mtime != last_mtime:
+        return read_profile(profile_path), current_mtime
+    return cached, current_mtime
+
 
 def _render_static(session_id: str, records: list[dict[str, Any]]) -> None:
     """Render a one-shot summary to stdout."""
@@ -808,17 +836,13 @@ def _run_live_dashboard(
     session_path = profile_path.parent
     crate_state_path = session_path / "crate_state.json"
     last_mtime: float = 0.0
-    last_crate_mtime: float = 0.0
+    records: list[dict[str, Any]] = []
 
     def _build() -> Layout:
-        nonlocal last_mtime, last_crate_mtime
-        # Re-read profile only if changed (avoid pointless I/O)
-        try:
-            current_mtime = profile_path.stat().st_mtime
-        except OSError:
-            current_mtime = last_mtime
-        records = read_profile(profile_path) if current_mtime != last_mtime else []
-        last_mtime = current_mtime
+        nonlocal last_mtime, records
+        # Re-read profile only when it changed; reuse the cache otherwise so a
+        # crate_state-only refresh doesn't blank the profile panel (#121).
+        records, last_mtime = _read_records_cached(profile_path, last_mtime, records)
         return format_session_summary(session_id, records)
 
     try:
@@ -831,14 +855,15 @@ def _run_live_dashboard(
         console.print(_build())
         return
 
+    # Watch both profile.ndjson and crate_state.json so CrateState updates too.
+    watch_paths = [str(profile_path)]
+    if crate_state_path.exists():
+        watch_paths.append(str(crate_state_path))
+
     with Live(
         _build(), console=console, refresh_per_second=1 / refresh_interval, screen=False
     ) as live:
-        # watchfiles step is in milliseconds; convert from our seconds-based interval
-        step_ms = int(refresh_interval * 1000)
-        # Watch both profile.ndjson and crate_state.json so CrateState updates too
-        watch_paths = [str(profile_path)]
-        if crate_state_path.exists():
-            watch_paths.append(str(crate_state_path))
-        for _changes in watch(*watch_paths, step=step_ms):
+        # `step` is watchfiles' debounce quiet-period (see _WATCH_STEP_MS), not
+        # the render interval — keep it small so updates aren't throttled.
+        for _changes in watch(*watch_paths, step=_WATCH_STEP_MS):
             live.update(_build())

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -288,3 +288,94 @@ class TestTokenSummary:
         output = capture.get()
         assert "Cumulative" in output
         assert "0" in output
+
+
+class TestLiveRefresh:
+    """Regression guards for the live dashboard auto-refresh (#121).
+
+    The dashboard appeared to "only update on load" because watchfiles' ``step``
+    (a debounce quiet-period) was set to the render interval (2000ms), so a
+    steady stream of profiler writes never went quiet long enough to be yielded.
+    A secondary bug blanked the profile panel whenever only crate_state.json
+    changed (profile mtime unchanged -> records became []).
+    """
+
+    def test_watch_step_is_small_and_decoupled_from_refresh_interval(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """``watch()`` must be called with a small fixed ``step`` (the watchfiles
+        default), independent of ``refresh_interval`` — otherwise updates are
+        throttled to multi-second intervals and the dashboard looks frozen."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools.dashboard import _WATCH_STEP_MS, _run_live_dashboard
+
+        profile_path = tmp_path / "profile.ndjson"
+        profile_path.write_text(json.dumps({"event": "node_end", "node": "model"}) + "\n")
+
+        captured: dict = {}
+
+        def fake_watch(*paths, **kwargs):
+            captured["step"] = kwargs.get("step")
+            captured["paths"] = paths
+            return iter(())  # no changes -> loop body skipped, returns immediately
+
+        class _DummyLive:
+            def __init__(self, *a, **k) -> None:
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a) -> bool:
+                return False
+
+            def update(self, *a) -> None:
+                pass
+
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", _DummyLive)
+
+        _run_live_dashboard(profile_path, "sess", refresh_interval=2.0)
+
+        assert _WATCH_STEP_MS <= 100
+        assert captured["step"] == _WATCH_STEP_MS
+        # The bug was step == int(refresh_interval * 1000) == 2000.
+        assert captured["step"] != 2000
+
+    def test_records_cache_reused_when_profile_unchanged(self, tmp_path) -> None:
+        """A crate_state-only refresh (profile.ndjson mtime unchanged) reuses the
+        cached records instead of returning [] (which blanked the panel)."""
+        from builder.tools.dashboard import _read_records_cached
+
+        profile_path = tmp_path / "profile.ndjson"
+        profile_path.write_text(json.dumps({"event": "node_end", "node": "model"}) + "\n")
+
+        records, mtime = _read_records_cached(profile_path, 0.0, [])
+        assert records, "first read should load records"
+        assert mtime != 0.0
+
+        again, mtime2 = _read_records_cached(profile_path, mtime, records)
+        assert again == records, "unchanged profile must reuse cached records, not blank"
+        assert mtime2 == mtime
+
+    def test_records_cache_rereads_on_change(self, tmp_path) -> None:
+        """When profile.ndjson mtime changes, records are re-read fresh."""
+        import os
+
+        from builder.tools.dashboard import _read_records_cached
+
+        profile_path = tmp_path / "profile.ndjson"
+        profile_path.write_text(json.dumps({"event": "node_end", "node": "model"}) + "\n")
+
+        records, mtime = _read_records_cached(profile_path, 0.0, [])
+        assert len(records) == 1
+
+        with open(profile_path, "a") as fh:
+            fh.write(json.dumps({"event": "node_end", "node": "tools"}) + "\n")
+        os.utime(profile_path, (mtime + 1, mtime + 1))
+
+        records2, mtime2 = _read_records_cached(profile_path, mtime, records)
+        assert len(records2) == 2
+        assert mtime2 != mtime


### PR DESCRIPTION
Fixes the dashboard "only updates on load" freeze you hit. Root cause confirmed by an adversarially-verified experiment (watchfiles 1.2.0, macOS).

## Root cause
`_run_live_dashboard` set the watchfiles debounce **`step`** from the render interval:
```python
step_ms = int(refresh_interval * 1000)   # 2000ms (refresh_interval default 2.0)
for _changes in watch(*watch_paths, step=step_ms):
    live.update(_build())
```
watchfiles' `step` is a **quiet-period debounce** — changes are only yielded once the filesystem has been quiet that long. The profiler flushes a steady stream of events (`profiler.py:130-131`, <2s apart), so the file never went quiet for 2s → yields coalesced/starved. **Measured:** `step=2000` → first yield ~4s, 1–2 yields per 10s stream; `step=50` → per-event yields at ~0.1s.

## Fix
- Pin `step` to a small fixed `_WATCH_STEP_MS` (50, the watchfiles default). `refresh_interval` now drives **only** `Live(refresh_per_second=…)`.
- Extract `_read_records_cached(...)`: reuse the last-read records when `profile.ndjson` is unchanged, so a **crate_state-only** refresh no longer blanks the profile panel to the "no data" placeholder. Removed the dead `last_crate_mtime` variable.

## Tests (TDD)
3 new regression tests in `TestLiveRefresh`: `watch()` called with a small step decoupled from `refresh_interval`; cache reused when profile unchanged; re-read on change. Full suite: **531 passed**.

> Note: this branch still shows one pre-existing `ty` diagnostic at `dashboard.py:658` (unrelated token line) — that's fixed separately in **#120**; after both land, `dashboard.py` is fully `ty`-clean.

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)