### PR TITLE
feat(config): model tiering — strong orchestrator + cheap drafter model (#96)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,41 @@ The `MemorySaver` checkpointer is passed to `graph.compile()`. It is a **checkpo
 
 The `MemorySaver` does not affect routing or the node topology — it is purely a persistence mechanism for state snapshots.
 
+#### Model Tiering (Issue #96)
+
+The weak model the agent runs on (e.g. DeepSeek-flash) collapses on multi-turn
+orchestration and error recovery — the build→validate→re-draft loop — but stays
+fine at bounded extraction. Model tiering lets a stronger model drive the
+orchestration node while a cheap model does the bounded drafting work, without
+any change to the graph topology.
+
+Construction is centralised in `_build_chat_model(provider, model, base_url,
+max_retries, role)` (`builder/agents/agent_loop.py`). The `role` parameter
+selects the tier when no explicit `model` is passed:
+
+- `role="orchestrator"` (default) → the primary model
+  (`VITRO_OPENAI_MODEL` / `VITRO_ANTHROPIC_MODEL`).
+- `role="drafter"` → the cheap drafter model
+  (`VITRO_OPENAI_DRAFTER_MODEL` / `VITRO_ANTHROPIC_DRAFTER_MODEL`) **when
+  configured**.
+
+The drafter model is provider-agnostic and resolved by
+`config.get_drafter_model()` (env var → `[openai]`/`[anthropic] drafter_model`
+config key, mirroring the primary-model precedence). **Default = single model:**
+when no drafter model is set, `role="drafter"` resolves to the same primary
+model as the orchestrator, so behaviour is identical to a single-model setup —
+a strict no-op. Because drafters are currently pure state-mutation functions
+invoked by the orchestration node (they make no LLM call of their own), this
+ships the *capability* and config knob; the drafter tier binds when a drafter
+path makes its own model call.
+
+**Decision gate (future work):** upgrading the *orchestrator* to a stronger
+model is a separate, profiling-gated decision. Instrument `profile.ndjson` for
+iterations-per-task, recursion-limit hits, and REQUIRED-issue fix success;
+upgrade the orchestrator only if failures are reasoning/recovery-shaped
+(looping, mis-sequencing), not malformed output (which schemas + SHACL already
+catch). Guardrails are a one-time cost; a stronger model is recurring per token.
+
 ## 5. The Agent Toolbox
 
 ### File & ARC Tools

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ export VITRO_OPENAI_BASE_URL="http://localhost:11434/v1"  # or OPENAI_BASE_URL
 
 # Optional: model name (default: gpt-4o)
 export VITRO_OPENAI_MODEL="llama3.2"           # or OPENAI_MODEL
+
+# Optional: cheap drafter model for bounded extraction (model tiering).
+# Unset = single model (the drafter uses VITRO_OPENAI_MODEL).
+export VITRO_OPENAI_DRAFTER_MODEL="gpt-4o-mini"
 ```
 
 #### Anthropic
@@ -88,6 +92,10 @@ export VITRO_ANTHROPIC_API_KEY="sk-ant-..."    # or ANTHROPIC_API_KEY
 
 # Optional: model name (default: claude-sonnet-4-20250514)
 export VITRO_ANTHROPIC_MODEL="claude-sonnet-4-20250514"  # or ANTHROPIC_MODEL
+
+# Optional: cheap drafter model for bounded extraction (model tiering).
+# Unset = single model (the drafter uses VITRO_ANTHROPIC_MODEL).
+export VITRO_ANTHROPIC_DRAFTER_MODEL="claude-haiku-4"
 ```
 
 ---
@@ -122,10 +130,14 @@ You can pre-populate this file so the builder doesn't prompt you on first run:
 api_key = "sk-proj-..."
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
+# Optional: cheap drafter model (model tiering). Omit for a single model.
+drafter_model = "gpt-4o-mini"
 
 [anthropic]
 api_key = "sk-ant-..."
 model = "claude-sonnet-4-20250514"
+# Optional: cheap drafter model (model tiering). Omit for a single model.
+drafter_model = "claude-haiku-4"
 
 [_global]
 # How many times to retry LLM API calls on transient errors
@@ -146,8 +158,10 @@ Environment variables (``VITRO_*``) always win over the config file:
 | ``VITRO_OPENAI_API_KEY`` | API key for OpenAI / compatible providers | — |
 | ``VITRO_OPENAI_BASE_URL`` | API base URL override | ``https://api.openai.com/v1`` |
 | ``VITRO_OPENAI_MODEL`` | Model name for OpenAI | ``gpt-4o`` |
+| ``VITRO_OPENAI_DRAFTER_MODEL`` | Cheap drafter model for OpenAI (model tiering) | — (uses ``VITRO_OPENAI_MODEL``) |
 | ``VITRO_ANTHROPIC_API_KEY`` | API key for Anthropic | — |
 | ``VITRO_ANTHROPIC_MODEL`` | Model name for Anthropic | ``claude-sonnet-4-20250514`` |
+| ``VITRO_ANTHROPIC_DRAFTER_MODEL`` | Cheap drafter model for Anthropic (model tiering) | — (uses ``VITRO_ANTHROPIC_MODEL``) |
 | ``VITRO_MAX_RETRIES`` | LLM API retry count on transient errors | ``3`` |
 | ``VITRO_MAX_ITERATIONS`` | Max tool-calling iterations per request | ``100`` |
 
@@ -306,10 +320,12 @@ This works for ``requests``, ``httpx``, ``openai``, and all other HTTP clients.
 | `OPENAI_BASE_URL` | Fallback | — | Same, unprefixed fallback |
 | `VITRO_OPENAI_MODEL` | No | `gpt-4o` | Model name for OpenAI-compatible providers |
 | `OPENAI_MODEL` | Fallback | `gpt-4o` | Same, unprefixed fallback |
+| `VITRO_OPENAI_DRAFTER_MODEL` | No | — (uses `VITRO_OPENAI_MODEL`) | Cheap drafter model (model tiering). Unset → single model, unchanged behaviour |
 | `VITRO_ANTHROPIC_API_KEY` | For Anthropic | — | Anthropic API key |
 | `ANTHROPIC_API_KEY` | Fallback | — | Same, unprefixed fallback |
 | `VITRO_ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Model name for Anthropic |
 | `ANTHROPIC_MODEL` | Fallback | `claude-sonnet-4-20250514` | Same, unprefixed fallback |
+| `VITRO_ANTHROPIC_DRAFTER_MODEL` | No | — (uses `VITRO_ANTHROPIC_MODEL`) | Cheap drafter model (model tiering). Unset → single model, unchanged behaviour |
 | `VITRO_MAX_RETRIES` | No | `3` | Max retry attempts for LLM API calls (configurable via ``[openai]`` / ``[anthropic]`` in config file) |
 | `VITRO_MAX_ITERATIONS` | No | `100` | Max tool-calling iterations per request before the agent stops to avoid endless loops. Set in `[agent]` section of config file. |
 

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -313,6 +313,7 @@ def _build_chat_model(
     model: str | None = None,
     base_url: str | None = None,
     max_retries: int | None = None,
+    role: str = "orchestrator",
 ) -> Any:
     """Build a LangChain chat model for the given or detected provider.
 
@@ -320,12 +321,24 @@ def _build_chat_model(
     local proxies, etc.) via the ``OPENAI_BASE_URL`` environment variable
     or the ``base_url`` parameter.
 
+    Model tiering (Issue #96): a single ``_build_chat_model`` centralises
+    construction so a different model can be bound per *role* without changing
+    the graph topology. The strong ``"orchestrator"`` keeps the primary model
+    (``VITRO_OPENAI_MODEL`` / ``VITRO_ANTHROPIC_MODEL``); the cheap
+    ``"drafter"`` uses ``VITRO_OPENAI_DRAFTER_MODEL`` /
+    ``VITRO_ANTHROPIC_DRAFTER_MODEL`` *when configured*. With no drafter model
+    set, the drafter resolves to the same primary model as the orchestrator —
+    a strict no-op (single model, identical to today's behaviour).
+
     Args:
         provider: One of ``"openai"``, ``"anthropic"``.  If ``None``, auto-detect.
         model: Model name override (e.g. ``"gpt-4o-mini"``, ``"llama3.2"``).
-            Falls back to provider defaults.
+            An explicit value wins over role-based resolution. Falls back to
+            provider/role defaults.
         base_url: Custom API base URL for OpenAI-compatible providers.
             Falls back to ``OPENAI_BASE_URL`` env var, then provider default.
+        role: ``"orchestrator"`` (default) or ``"drafter"``. Selects the model
+            tier when ``model`` is not given explicitly.
 
     Returns:
         A LangChain ``BaseChatModel`` instance.
@@ -345,6 +358,16 @@ def _build_chat_model(
             "(or ANTHROPIC_API_KEY) environment variable, or pass "
             "--provider openai|anthropic."
         )
+
+    # Model tiering: when the caller asks for the drafter role and no explicit
+    # model was given, prefer the configured drafter model. If none is set,
+    # ``model`` stays ``None`` and the provider branch resolves the primary
+    # model exactly as before (strict no-op default).
+    if model is None and role == "drafter":
+        if provider == "openai":
+            model = os.environ.get("VITRO_OPENAI_DRAFTER_MODEL") or None
+        elif provider == "anthropic":
+            model = os.environ.get("VITRO_ANTHROPIC_DRAFTER_MODEL") or None
 
     if provider == "openai":
         from langchain_openai import ChatOpenAI

--- a/builder/config.py
+++ b/builder/config.py
@@ -173,9 +173,11 @@ def merge_with_env(config: dict[str, Any]) -> dict[str, Any]:
         ("openai", "api_key"): "VITRO_OPENAI_API_KEY",
         ("openai", "base_url"): "VITRO_OPENAI_BASE_URL",
         ("openai", "model"): "VITRO_OPENAI_MODEL",
+        ("openai", "drafter_model"): "VITRO_OPENAI_DRAFTER_MODEL",
         ("openai", "model_provider"): "VITRO_OPENAI_MODEL_PROVIDER",
         ("anthropic", "api_key"): "VITRO_ANTHROPIC_API_KEY",
         ("anthropic", "model"): "VITRO_ANTHROPIC_MODEL",
+        ("anthropic", "drafter_model"): "VITRO_ANTHROPIC_DRAFTER_MODEL",
         ("anthropic", "model_provider"): "VITRO_ANTHROPIC_MODEL_PROVIDER",
         ("_global", "max_retries"): "VITRO_MAX_RETRIES",
     }
@@ -239,6 +241,39 @@ def get_model_provider() -> str | None:
     if family == "anthropic":
         return cfg.get("anthropic", {}).get("model_provider")
     return None
+
+
+def get_drafter_model() -> str | None:
+    """Return the configured *drafter* model name, or ``None`` if unset.
+
+    Model tiering (Issue #96) lets the cheap, bounded-extraction drafter use a
+    different model from the strong orchestrator. The drafter model is read for
+    the active API family:
+
+    - ``openai``    -> ``VITRO_OPENAI_DRAFTER_MODEL``
+    - ``anthropic`` -> ``VITRO_ANTHROPIC_DRAFTER_MODEL``
+
+    Precedence mirrors the primary-model knobs: the env var wins, then the
+    config-file value (``[openai] drafter_model`` / ``[anthropic]
+    drafter_model``).
+
+    Returns *None* when no drafter model is configured — callers MUST treat this
+    as "use the primary model", so the default is a strict no-op (single model,
+    identical to today's behaviour).
+    """
+    family = get_provider()
+    if family == "openai":
+        env_var = "VITRO_OPENAI_DRAFTER_MODEL"
+    elif family == "anthropic":
+        env_var = "VITRO_ANTHROPIC_DRAFTER_MODEL"
+    else:
+        return None
+
+    val = os.environ.get(env_var)
+    if val:
+        return val
+    cfg = load_config()
+    return cfg.get(family, {}).get("drafter_model")
 
 
 def is_configured() -> bool:
@@ -408,6 +443,7 @@ __all__ = [
     "is_configured",
     "get_provider",
     "get_model_provider",
+    "get_drafter_model",
     "describe_config",
     "interactive_setup",
     "get_max_iterations",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -293,6 +293,102 @@ class TestBuildChatModel:
                 os.environ.pop("VITRO_MAX_RETRIES", None)
 
 
+class TestModelTiering:
+    """Tests for the drafter model tier (Issue #96).
+
+    A distinct, cheap drafter model can be selected via
+    ``VITRO_OPENAI_DRAFTER_MODEL`` while the orchestrator keeps the primary
+    model. With no drafter model configured, the drafter role resolves to the
+    *same* model as the orchestrator — a strict no-op by default.
+    """
+
+    def _set_openai(self) -> dict[str, str | None]:
+        saved = {
+            "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+            "VITRO_OPENAI_API_KEY": os.environ.get("VITRO_OPENAI_API_KEY"),
+            "VITRO_OPENAI_MODEL": os.environ.get("VITRO_OPENAI_MODEL"),
+            "OPENAI_MODEL": os.environ.get("OPENAI_MODEL"),
+            "VITRO_OPENAI_DRAFTER_MODEL": os.environ.get("VITRO_OPENAI_DRAFTER_MODEL"),
+        }
+        os.environ.pop("VITRO_OPENAI_API_KEY", None)
+        os.environ.pop("VITRO_OPENAI_MODEL", None)
+        os.environ.pop("OPENAI_MODEL", None)
+        os.environ.pop("VITRO_OPENAI_DRAFTER_MODEL", None)
+        os.environ["OPENAI_API_KEY"] = "sk-test"
+        return saved
+
+    def _restore(self, saved: dict[str, str | None]) -> None:
+        for var, val in saved.items():
+            if val is not None:
+                os.environ[var] = val
+            else:
+                os.environ.pop(var, None)
+
+    def test_drafter_role_uses_drafter_model_when_set(self):
+        """role='drafter' picks up VITRO_OPENAI_DRAFTER_MODEL."""
+        from builder.agents.agent_loop import _build_chat_model
+
+        saved = self._set_openai()
+        os.environ["VITRO_OPENAI_MODEL"] = "gpt-4o"
+        os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = "gpt-4o-mini"
+        try:
+            model = _build_chat_model(provider="openai", role="drafter")
+            assert model.model_name == "gpt-4o-mini"
+        finally:
+            self._restore(saved)
+
+    def test_orchestrator_role_ignores_drafter_model(self):
+        """role='orchestrator' keeps the primary model even if a drafter is set."""
+        from builder.agents.agent_loop import _build_chat_model
+
+        saved = self._set_openai()
+        os.environ["VITRO_OPENAI_MODEL"] = "gpt-4o"
+        os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = "gpt-4o-mini"
+        try:
+            model = _build_chat_model(provider="openai", role="orchestrator")
+            assert model.model_name == "gpt-4o"
+        finally:
+            self._restore(saved)
+
+    def test_drafter_role_falls_back_to_primary_when_unset(self):
+        """No-op by default: with no drafter model, the drafter == orchestrator."""
+        from builder.agents.agent_loop import _build_chat_model
+
+        saved = self._set_openai()
+        os.environ["VITRO_OPENAI_MODEL"] = "gpt-4o"
+        try:
+            orchestrator = _build_chat_model(provider="openai", role="orchestrator")
+            drafter = _build_chat_model(provider="openai", role="drafter")
+            assert drafter.model_name == orchestrator.model_name == "gpt-4o"
+        finally:
+            self._restore(saved)
+
+    def test_default_role_is_orchestrator(self):
+        """Calling without a role keeps today's behaviour (primary model)."""
+        from builder.agents.agent_loop import _build_chat_model
+
+        saved = self._set_openai()
+        os.environ["VITRO_OPENAI_MODEL"] = "gpt-4o"
+        os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = "gpt-4o-mini"
+        try:
+            model = _build_chat_model(provider="openai")
+            assert model.model_name == "gpt-4o"
+        finally:
+            self._restore(saved)
+
+    def test_explicit_model_arg_overrides_role(self):
+        """An explicit model= wins over role-based resolution."""
+        from builder.agents.agent_loop import _build_chat_model
+
+        saved = self._set_openai()
+        os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = "gpt-4o-mini"
+        try:
+            model = _build_chat_model(provider="openai", model="llama3.2", role="drafter")
+            assert model.model_name == "llama3.2"
+        finally:
+            self._restore(saved)
+
+
 class TestBuildLangchainTools:
     """Tests for building LangChain tools from the engine registry."""
 

--- a/tests/test_config_drafter_model.py
+++ b/tests/test_config_drafter_model.py
@@ -1,0 +1,117 @@
+"""Tests for the drafter-model tier in builder/config.py (Issue #96).
+
+Model tiering lets the cheap drafter use a distinct model from the strong
+orchestrator. These tests pin two guarantees:
+
+1. ``VITRO_OPENAI_DRAFTER_MODEL`` / ``VITRO_ANTHROPIC_DRAFTER_MODEL`` are mapped
+   from the config file into the environment, mirroring the primary-model knob.
+2. ``get_drafter_model`` resolves the drafter model when configured and returns
+   ``None`` (strict no-op → caller falls back to the primary model) when unset.
+"""
+
+from __future__ import annotations
+
+import os
+
+from builder import config
+
+
+class TestDrafterModelEnvMapping:
+    """`merge_with_env` must surface the drafter-model config keys as env vars."""
+
+    def test_openai_drafter_model_mapped_from_config(self) -> None:
+        old = os.environ.pop("VITRO_OPENAI_DRAFTER_MODEL", None)
+        try:
+            config.merge_with_env({"openai": {"drafter_model": "gpt-4o-mini"}})
+            assert os.environ.get("VITRO_OPENAI_DRAFTER_MODEL") == "gpt-4o-mini"
+        finally:
+            if old is not None:
+                os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = old
+            else:
+                os.environ.pop("VITRO_OPENAI_DRAFTER_MODEL", None)
+
+    def test_anthropic_drafter_model_mapped_from_config(self) -> None:
+        old = os.environ.pop("VITRO_ANTHROPIC_DRAFTER_MODEL", None)
+        try:
+            config.merge_with_env({"anthropic": {"drafter_model": "claude-haiku-4"}})
+            assert os.environ.get("VITRO_ANTHROPIC_DRAFTER_MODEL") == "claude-haiku-4"
+        finally:
+            if old is not None:
+                os.environ["VITRO_ANTHROPIC_DRAFTER_MODEL"] = old
+            else:
+                os.environ.pop("VITRO_ANTHROPIC_DRAFTER_MODEL", None)
+
+    def test_env_var_wins_over_config(self) -> None:
+        old = os.environ.get("VITRO_OPENAI_DRAFTER_MODEL")
+        os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = "from-env"
+        try:
+            config.merge_with_env({"openai": {"drafter_model": "from-config"}})
+            assert os.environ["VITRO_OPENAI_DRAFTER_MODEL"] == "from-env"
+        finally:
+            if old is not None:
+                os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = old
+            else:
+                os.environ.pop("VITRO_OPENAI_DRAFTER_MODEL", None)
+
+
+class TestGetDrafterModel:
+    """`get_drafter_model` resolves the tier, defaulting to None (no-op)."""
+
+    def test_returns_none_when_unset(self) -> None:
+        old_o = os.environ.pop("VITRO_OPENAI_DRAFTER_MODEL", None)
+        old_a = os.environ.pop("VITRO_ANTHROPIC_DRAFTER_MODEL", None)
+        old_key = os.environ.get("VITRO_OPENAI_API_KEY")
+        os.environ["VITRO_OPENAI_API_KEY"] = "sk-test"
+        try:
+            assert config.get_drafter_model() is None
+        finally:
+            for var, val in (
+                ("VITRO_OPENAI_DRAFTER_MODEL", old_o),
+                ("VITRO_ANTHROPIC_DRAFTER_MODEL", old_a),
+            ):
+                if val is not None:
+                    os.environ[var] = val
+            if old_key is not None:
+                os.environ["VITRO_OPENAI_API_KEY"] = old_key
+            else:
+                os.environ.pop("VITRO_OPENAI_API_KEY", None)
+
+    def test_returns_openai_drafter_model_when_set(self) -> None:
+        old_o = os.environ.get("VITRO_OPENAI_DRAFTER_MODEL")
+        old_key = os.environ.get("VITRO_OPENAI_API_KEY")
+        os.environ["VITRO_OPENAI_API_KEY"] = "sk-test"
+        os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = "gpt-4o-mini"
+        try:
+            assert config.get_drafter_model() == "gpt-4o-mini"
+        finally:
+            if old_o is not None:
+                os.environ["VITRO_OPENAI_DRAFTER_MODEL"] = old_o
+            else:
+                os.environ.pop("VITRO_OPENAI_DRAFTER_MODEL", None)
+            if old_key is not None:
+                os.environ["VITRO_OPENAI_API_KEY"] = old_key
+            else:
+                os.environ.pop("VITRO_OPENAI_API_KEY", None)
+
+    def test_returns_anthropic_drafter_model_when_anthropic_active(self) -> None:
+        old_a = os.environ.get("VITRO_ANTHROPIC_DRAFTER_MODEL")
+        old_okey = os.environ.pop("VITRO_OPENAI_API_KEY", None)
+        old_ukey = os.environ.pop("OPENAI_API_KEY", None)
+        old_akey = os.environ.get("VITRO_ANTHROPIC_API_KEY")
+        os.environ["VITRO_ANTHROPIC_API_KEY"] = "sk-ant-test"
+        os.environ["VITRO_ANTHROPIC_DRAFTER_MODEL"] = "claude-haiku-4"
+        try:
+            assert config.get_drafter_model() == "claude-haiku-4"
+        finally:
+            if old_a is not None:
+                os.environ["VITRO_ANTHROPIC_DRAFTER_MODEL"] = old_a
+            else:
+                os.environ.pop("VITRO_ANTHROPIC_DRAFTER_MODEL", None)
+            if old_akey is not None:
+                os.environ["VITRO_ANTHROPIC_API_KEY"] = old_akey
+            else:
+                os.environ.pop("VITRO_ANTHROPIC_API_KEY", None)
+            if old_okey is not None:
+                os.environ["VITRO_OPENAI_API_KEY"] = old_okey
+            if old_ukey is not None:
+                os.environ["OPENAI_API_KEY"] = old_ukey


### PR DESCRIPTION
## Summary

Implements **model tiering** (issue #96): the cheap, bounded-extraction drafter can use a different model from the strong orchestration node — without any change to the LangGraph topology. Construction stays centralised in `_build_chat_model`.

## What changed

- **New config var (provider-agnostic):** `VITRO_OPENAI_DRAFTER_MODEL` / `VITRO_ANTHROPIC_DRAFTER_MODEL`, added to the `merge_with_env` mapping in `builder/config.py` (mirrors the existing primary-model knob: env var wins, then `[openai]`/`[anthropic] drafter_model` config-file key). New resolver `config.get_drafter_model()`.
- **Per-node binding via `_build_chat_model`:** new `role` parameter (`"orchestrator"` default, `"drafter"`). The orchestrator keeps the primary model; the drafter role uses the configured drafter model when set, else falls back to the primary model. An explicit `model=` argument always wins over role-based resolution.
- **Docs:** AGENTS.md model-tiering subsection (under the Agent Graph section) and README env-var tables + `config.toml` example.

## Default-unchanged guarantee (strict no-op)

When `VITRO_OPENAI_DRAFTER_MODEL` / `VITRO_ANTHROPIC_DRAFTER_MODEL` is **unset**, `role="drafter"` resolves to the **same** primary model as the orchestrator — behaviour is identical to today's single-model setup. Covered by `test_drafter_role_falls_back_to_primary_when_unset` and `test_default_role_is_orchestrator`, plus `get_drafter_model()` returning `None` when unset.

Note: drafters are currently pure state-mutation functions invoked by the orchestration node (no LLM call of their own), so this ships the **capability + config knob**; the drafter tier binds when a drafter path makes its own model call.

## Profiling decision gate (future work — out of scope)

Upgrading the **orchestrator** to a stronger model is a separate, profiling-gated decision. Instrument `profile.ndjson` for iterations-per-task, recursion-limit hits, and REQUIRED-issue fix success; upgrade only if failures are reasoning/recovery-shaped (looping, mis-sequencing), not malformed output (which schemas + SHACL already catch). This PR does **not** upgrade the orchestrator or change any default.

## TDD

- 🔴→🟢 `tests/test_config_drafter_model.py` — env mapping (openai/anthropic), env-wins-over-config, `get_drafter_model` resolution + None-when-unset.
- 🔴→🟢 `TestModelTiering` in `tests/test_agent_loop.py` — drafter uses drafter model, orchestrator ignores it, **no-config no-op**, default role, explicit-model override.

## Verification

- `uv run --extra langchain pytest` → **539 passed** (11 new).
- `uv run ty check` → no new diagnostics (changed files produce the same pre-existing diagnostics as `main`; new test file adds none).
- `uvx ruff check` on changed files → clean.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)