### PR TITLE
feat(agent): cache-friendly prompt — hoist state brief to the message tail (#60)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -549,6 +549,47 @@ def _build_system_prompt_with_state(
     )
 
 
+def _assemble_model_messages(
+    messages: list,
+    *,
+    session_id: str,
+    entity_count: int,
+    file_count: int,
+    iteration_count: int,
+) -> list:
+    """Assemble the message list for a model invocation with a cache-friendly
+    layout (Issue #60).
+
+    Layout: ``[SystemMessage(SYSTEM_PROMPT), *history, SystemMessage(state_brief)]``.
+
+    The leading system message is kept **byte-stable** (``SYSTEM_PROMPT`` only, no
+    volatile state appended), so every provider can cache the stable
+    ``tools + system + history`` prefix across turns (history is append-only). The
+    per-turn state brief (session id, counts, iteration) — which changes every
+    iteration — is placed as the **last** message, where it cannot bust the prefix
+    cache. Previously the brief was appended to the system message, so the cache
+    broke right after the prompt and the (growing, expensive) history was never
+    cached.
+
+    Neither the system message nor the brief is persisted into MemorySaver
+    history — both are rebuilt fresh on every invocation, so they never accumulate
+    (Issue #66). Only the model's response is returned to the reducer.
+    """
+    from langchain_core.messages import SystemMessage
+
+    state_brief = _build_system_prompt_with_state(
+        session_id=session_id,
+        entity_count=entity_count,
+        file_count=file_count,
+        iteration_count=iteration_count,
+    )
+    return [
+        SystemMessage(content=SYSTEM_PROMPT),
+        *messages,
+        SystemMessage(content=state_brief),
+    ]
+
+
 def _build_agent_graph(
     llm: Any,
     tools: list[Any],
@@ -573,7 +614,6 @@ def _build_agent_graph(
     Returns:
         A compiled ``CompiledStateGraph`` ready for ``.invoke()``.
     """
-    from langchain_core.messages import SystemMessage
     from langgraph.checkpoint.memory import MemorySaver
     from langgraph.graph import START, StateGraph
     from langgraph.prebuilt import ToolNode
@@ -590,20 +630,19 @@ def _build_agent_graph(
     model = llm.bind_tools(tools) if tools else llm
 
     def call_model(state: dict[str, Any]) -> dict[str, Any]:
-        """Model node: prepend system prompt and invoke the tool-bound LLM."""
+        """Model node: build a cache-friendly message list and invoke the LLM."""
         assert engine is not None, "AgentEngine must be set before call_model is invoked"
         messages = state.get("messages", [])
-        # Prepend system prompt with lightweight state brief on every invocation.
-        # The state brief is re-built each time so it never accumulates in
-        # MemorySaver history (Issue #66).
-        state_brief = _build_system_prompt_with_state(
+        # Stable SYSTEM_PROMPT prefix + history, with the volatile per-turn state
+        # brief at the tail so the cacheable prefix isn't busted (Issue #60). The
+        # brief is rebuilt each call and never persisted to history (Issue #66).
+        model_messages = _assemble_model_messages(
+            messages,
             session_id=engine.state.session_id,
             entity_count=len(engine.state.list_entities()),
             file_count=len(engine.state.scanned_files),
             iteration_count=engine.state.iteration_count,
         )
-        system_msg = SystemMessage(content=f"{SYSTEM_PROMPT}\n\n{state_brief}")
-        model_messages = [system_msg, *messages]
         response = model.invoke(model_messages)
         # Return only the new response; the add_messages reducer appends it
         return {"messages": [response]}

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -541,4 +541,49 @@ class TestRecursionLimit:
         assert _recursion_limit(-5) == 2
 
 
+class TestCacheFriendlyPrompt:
+    """Issue #60: the system message must be byte-stable across iterations so the
+    tools+system+history prefix stays cacheable (provider-agnostic prompt caching);
+    the volatile per-turn state brief is delivered as the trailing message where it
+    cannot bust the prefix cache."""
+
+    def test_system_message_is_stable_and_brief_is_trailing(self):
+        """First message == SYSTEM_PROMPT verbatim (no state appended); the state
+        brief is the LAST message; history is preserved in between."""
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        from builder.agents.agent_loop import _assemble_model_messages
+        from builder.agents.system_prompt import SYSTEM_PROMPT
+
+        history = [HumanMessage(content="hello")]
+        msgs = _assemble_model_messages(
+            history,
+            session_id="sid",
+            entity_count=3,
+            file_count=5,
+            iteration_count=42,
+        )
+
+        assert isinstance(msgs[0], SystemMessage)
+        assert msgs[0].content == SYSTEM_PROMPT  # byte-stable, no state appended
+        assert msgs[1] is history[0]  # history preserved, in order
+        assert isinstance(msgs[-1], SystemMessage)
+        assert "Iteration: 42" in msgs[-1].content
+        assert "sid" in msgs[-1].content
+
+    def test_system_prefix_identical_across_iterations(self):
+        """The stable prefix is byte-identical even as state changes, while the
+        trailing brief reflects the new state (only the cache tail varies)."""
+        from builder.agents.agent_loop import _assemble_model_messages
+
+        a = _assemble_model_messages(
+            [], session_id="s", entity_count=1, file_count=1, iteration_count=1
+        )
+        b = _assemble_model_messages(
+            [], session_id="s", entity_count=2, file_count=9, iteration_count=99
+        )
+        assert a[0].content == b[0].content  # stable cacheable prefix
+        assert a[-1].content != b[-1].content  # volatile tail varies per turn
+
+
 


### PR DESCRIPTION
Implements the reframed #60. The fix is structural, not Anthropic-specific.

## Problem
`call_model` appended the per-turn state brief (`[Session | Files | Entities | Iteration]`) to the **system message** — the front of every request. Because that brief changes every iteration, it broke the provider's cacheable **prefix** right after the prompt, so the growing (and most expensive) tool-result history below it was **never cached**. The default provider (DeepSeek, OpenAI-compatible) does automatic prefix caching, so this was leaving real savings on the table.

## Fix
New `_assemble_model_messages(...)` lays the request out as:
```
[ SystemMessage(SYSTEM_PROMPT),  *history,  SystemMessage(state_brief) ]
```
- **Leading system message is byte-stable** (`SYSTEM_PROMPT` only) → the `tools + system + history` prefix is cacheable across turns (history is append-only).
- **Volatile state brief moves to the tail**, where it can't bust the prefix cache.
- Neither the system message nor the brief is persisted to MemorySaver history — both rebuilt fresh each call (preserves Issue #66's no-accumulation guarantee).
- Removed the now-unused `SystemMessage` import from `_build_agent_graph`.

This is **provider-agnostic**: DeepSeek/OpenAI auto-cache the stable prefix; the Anthropic `cache_control` breakpoint becomes a clean optional add on that path (out of scope here). Stacks with #61 (history trimming).

## Tests (TDD)
`TestCacheFriendlyPrompt`: the leading system message equals `SYSTEM_PROMPT` verbatim and is byte-identical across iterations, while the trailing brief reflects current state (only the cache tail varies); history is preserved in order. Full suite: **530 passed**.

## Note / provider compatibility
The state brief is delivered as a trailing `SystemMessage` (the issue's recommended layout). For the default OpenAI-compatible path this is accepted; langchain's `ChatAnthropic` hoists `SystemMessage`s into the top-level `system` param. If any provider rejects a trailing system role, switching the tail to a `HumanMessage` is a one-line change.

> Carries one pre-existing `ty` diagnostic at `agent_loop.py` (`StateGraph(AgentState)`), fixed separately in #120.

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)