### PR TITLE
perf(lookups): parallelize AOP event lookups + batch identifier verification (#62)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -713,6 +713,28 @@ For chemicals: try by name, then CAS, then ChEBI. If all fail, ask user for SMIL
 ### Anti-Hallucination
 The agent **never fabricates identifiers**. Every identifier is verified against its source. If verification fails, the field is cleared and the agent tries alternatives or asks the user.
 
+### Concurrency & Per-Host Rate Limiting (Issue #62)
+Independent lookups with no data dependency are issued **concurrently** via a
+bounded `concurrent.futures.ThreadPoolExecutor` (max ~6 workers), so cold paths
+no longer pay strictly-serial latency:
+
+- `lookups/aopwiki.py:lookup_aop` builds the key-event entities deterministically
+  (pathway order: MIE → KE → AO), then fetches each event's `_event_details`
+  concurrently and merges them back **by identifier** — the assembled result is
+  byte-identical to the serial path and order-independent.
+- `builder/tools/verification.py:verify_all_identifiers` collects its work plan
+  (entity, field) deterministically, runs the per-field verifications
+  concurrently, and returns results in that fixed order. Each task mutates only
+  its own field's status, so there is no cross-task contention.
+
+Politeness is preserved by a **single per-host throttle** in `lookups/_http.py`
+(`_HostRateLimiter` / `throttle_for_url`), applied inside `http_get_json`. It
+enforces a minimum spacing (`_HOST_MIN_INTERVAL`, default 0.1s) between requests
+to the *same* host — replacing the old per-client `time.sleep(0.1)` calls — and
+honours that cap even when many workers fire at once. Different hosts are
+throttled independently, so parallel lookups across services are not serialised.
+Both functions remain `lru_cache`d, so this only benefits cold paths.
+
 ## 11. Key Design Decisions
 
 ### D1: Toolbox over Graph

--- a/builder/tools/verification.py
+++ b/builder/tools/verification.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 from builder.state import CrateState
 from builder.tools.lookups import (
     lookup_cell_line,
@@ -9,6 +11,13 @@ from builder.tools.lookups import (
     lookup_doi,
     lookup_orcid,
 )
+
+# Bound on concurrent identifier verifications. Each verification is an
+# independent network lookup with no data dependency on the others, so they run
+# in a bounded pool; per-host politeness is enforced by the throttle in
+# lookups._http. The lookups themselves are lru_cache'd, so this only helps the
+# cold path (#62).
+_VERIFY_WORKERS = 6
 
 
 def _select_verifier(entity_type: str, field: str):
@@ -172,12 +181,20 @@ def verify_all_identifiers(state: CrateState) -> list[dict]:
     ``casrn``/``cas_number``/``inchikey`` on MolecularEntity, and never attempts
     ``ror`` on Organization (which has no verifier).
 
+    The independent per-field lookups are dispatched concurrently with a bounded
+    thread pool (#62). The work plan is collected deterministically first and the
+    results are returned in that same order, so the output is identical to the
+    serial path regardless of which lookup completes first; per-host politeness
+    is enforced by the throttle in ``lookups._http``.
+
     Returns:
         A list of verification result dicts (one per qualifying filled field).
     """
     verifiable = _get_verifiable_fields()
-    results: list[dict] = []
 
+    # Collect the work plan deterministically (entity order, then completion-key
+    # order) so the returned results never depend on thread scheduling.
+    tasks: list[tuple[str, str]] = []
     for entity in state.list_entities():
         for comp_key, fc in entity._completion.items():
             if fc.status == "filled":
@@ -185,8 +202,20 @@ def verify_all_identifiers(state: CrateState) -> list[dict]:
                 field = comp_key.split(":", 1)[1]
                 if (entity.type, field) not in verifiable:
                     continue
-                result = verify_identifier(state, entity.entity_id, field)
-                results.append(result)
+                tasks.append((entity.entity_id, field))
+
+    if not tasks:
+        return []
+
+    # Each task verifies a distinct (entity, field) pair, mutating only that
+    # field's status — no shared-state contention between tasks.
+    with ThreadPoolExecutor(max_workers=min(_VERIFY_WORKERS, len(tasks))) as pool:
+        results = list(
+            pool.map(
+                lambda task: verify_identifier(state, task[0], task[1]),
+                tasks,
+            )
+        )
 
     return results
 

--- a/lookups/_http.py
+++ b/lookups/_http.py
@@ -22,7 +22,10 @@ stale failure.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import Any
+from urllib.parse import urlsplit
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -30,6 +33,14 @@ from urllib3.util.retry import Retry
 
 DEFAULT_TIMEOUT = 10
 _TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Minimum spacing (seconds) between successive requests to the *same* host.
+# This is the politeness throttle that replaces the per-client
+# ``time.sleep(0.1)`` calls (#62). Centralising it here means the cap is
+# honoured even when independent requests are issued concurrently (e.g. AOP-Wiki
+# event details fetched via a ThreadPoolExecutor). Different hosts are throttled
+# independently, so parallel lookups across services are not serialised.
+_HOST_MIN_INTERVAL = 0.1
 
 
 class TransientLookupError(Exception):
@@ -58,6 +69,70 @@ class _NotFound:
 
 
 NOT_FOUND = _NotFound()
+
+
+class _HostRateLimiter:
+    """Thread-safe per-host throttle enforcing a minimum spacing between requests.
+
+    ``wait(host)`` blocks until at least ``min_interval`` seconds have elapsed
+    since the previous grant *for that host*, then records the grant time. Hosts
+    are tracked independently, so a slow request to one API never throttles a
+    request to a different API. A single lock guards the per-host timestamps and
+    serialises the wait, so concurrent callers for the same host are spaced out
+    deterministically rather than all firing at once.
+    """
+
+    def __init__(self, min_interval: float = _HOST_MIN_INTERVAL) -> None:
+        self._min_interval = min_interval
+        self._lock = threading.Lock()
+        self._next_allowed: dict[str, float] = {}
+
+    def wait(self, host: str) -> None:
+        """Block until this host is allowed to fire its next request."""
+        interval = self._min_interval
+        if interval <= 0:
+            return
+        with self._lock:
+            now = time.monotonic()
+            earliest = self._next_allowed.get(host, 0.0)
+            start = max(now, earliest)
+            # Reserve the slot *before* releasing the lock so concurrent callers
+            # for the same host queue up behind us instead of colliding.
+            self._next_allowed[host] = start + interval
+            sleep_for = start - now
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+    def reset(self) -> None:
+        """Forget all recorded per-host timestamps (used by tests)."""
+        with self._lock:
+            self._next_allowed.clear()
+
+
+_host_throttle = _HostRateLimiter()
+
+
+def _host_of(url: str) -> str:
+    """Return the network location (host[:port]) of a URL, or '' if none."""
+    return urlsplit(url).netloc
+
+
+def throttle_for_url(url: str) -> None:
+    """Apply the shared per-host politeness throttle for ``url``.
+
+    Exposed so callers that issue requests through their own code path (e.g.
+    concurrent AOP-Wiki event-detail fetches) get the same per-host spacing as
+    :func:`http_get_json`. The interval is read live from ``_HOST_MIN_INTERVAL``
+    so tests can tune it via monkeypatch.
+    """
+    _host_throttle._min_interval = _HOST_MIN_INTERVAL
+    _host_throttle.wait(_host_of(url))
+
+
+def reset_host_throttle() -> None:
+    """Reset the shared per-host throttle state (used by tests)."""
+    _host_throttle.reset()
+
 
 _session: requests.Session | None = None
 
@@ -110,6 +185,9 @@ def http_get_json(
         TransientLookupError: on timeout, connection error, a 429/5xx that
             survived retries, or a 200 with a malformed JSON body.
     """
+    # Politeness: space requests to the same host (replaces the per-client
+    # ``time.sleep(0.1)`` calls). Honoured even under concurrent callers (#62).
+    throttle_for_url(url)
     try:
         resp = get_session().get(url, params=params, headers=headers, timeout=timeout)
     except requests.RequestException as exc:

--- a/lookups/aopwiki.py
+++ b/lookups/aopwiki.py
@@ -11,11 +11,16 @@ graph is machine-actionable.
 from __future__ import annotations
 
 import functools
-import time
+from concurrent.futures import ThreadPoolExecutor
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://aopwiki.org"
+
+# Bound on concurrent AOP-Wiki event-detail fetches. The per-host throttle in
+# lookups._http keeps us polite no matter how many workers run; this just caps
+# how many sockets we open at once (#62).
+_EVENT_FETCH_WORKERS = 6
 
 # AOP-Wiki event_type -> human-readable label.
 _EVENT_TYPE_LABEL = {
@@ -39,9 +44,11 @@ def _event_details(event_id: str) -> dict:
 
     Falls back to {} on any failure, so a slow/unavailable event endpoint never
     breaks the surrounding AOP lookup.
+
+    Politeness toward AOP-Wiki is enforced by the per-host throttle inside
+    ``http_get_json`` (lookups._http), so this is safe to call concurrently.
     """
     try:
-        time.sleep(0.1)
         d = http_get_json(f"{_event_url(event_id)}.json")
         if d is NOT_FOUND:
             return {}
@@ -76,7 +83,6 @@ def lookup_aop(aop_id: str) -> dict:
     aop_id = str(aop_id).strip()
     aop_url = f"{_BASE}/aops/{aop_id}"
     try:
-        time.sleep(0.1)
         data = http_get_json(f"{aop_url}.json", timeout=15)
         if data is NOT_FOUND:
             return {}
@@ -84,7 +90,9 @@ def lookup_aop(aop_id: str) -> dict:
         if isinstance(data, dict) and "aop" in data:
             data = data["aop"]
 
-        # Events: MIEs + KEs + AOs, de-duplicated, in pathway order.
+        # Events: MIEs + KEs + AOs, de-duplicated, in pathway order. Build the
+        # base entities first (deterministic, single-threaded) so the final
+        # order never depends on which detail fetch returns first.
         events: list[dict] = []
         seen: set = set()
         for bucket in ("aop_mies", "aop_kes", "aop_aos"):
@@ -93,18 +101,32 @@ def lookup_aop(aop_id: str) -> dict:
                 if eid is None or eid in seen:
                     continue
                 seen.add(eid)
-                entity = {
-                    "@id": _event_url(eid),
-                    "@type": "KeyEvent",
-                    "name": ev.get("event", f"Event {eid}"),
-                    "eventType": _EVENT_TYPE_LABEL.get(
-                        ev.get("event_type", ""), ev.get("event_type", "")
-                    ),
-                    "identifier": str(eid),
-                    "url": f"{_event_url(eid)}.json",
-                }
-                entity.update(_event_details(str(eid)))
-                events.append(entity)
+                events.append(
+                    {
+                        "@id": _event_url(eid),
+                        "@type": "KeyEvent",
+                        "name": ev.get("event", f"Event {eid}"),
+                        "eventType": _EVENT_TYPE_LABEL.get(
+                            ev.get("event_type", ""), ev.get("event_type", "")
+                        ),
+                        "identifier": str(eid),
+                        "url": f"{_event_url(eid)}.json",
+                    }
+                )
+
+        # Enrich each event with its per-event details. These calls are
+        # independent and have no data dependency, so fetch them concurrently
+        # with a bounded pool; the per-host throttle in http_get_json keeps us
+        # polite. Merge results back by identifier so order stays deterministic
+        # and the outcome is identical to the serial path (#62).
+        if events:
+            event_ids = [e["identifier"] for e in events]
+            with ThreadPoolExecutor(
+                max_workers=min(_EVENT_FETCH_WORKERS, len(event_ids))
+            ) as pool:
+                detail_map = dict(zip(event_ids, pool.map(_event_details, event_ids)))
+            for entity in events:
+                entity.update(detail_map[entity["identifier"]])
 
         # Key event relationships, linking upstream -> downstream events by @id.
         relationships: list[dict] = []

--- a/tests/test_aopwiki_concurrency.py
+++ b/tests/test_aopwiki_concurrency.py
@@ -1,0 +1,169 @@
+"""Concurrency tests for lookups/aopwiki.py (#62).
+
+`lookup_aop` enriches each key event with an independent HTTP call. These calls
+have no data dependency, so they are fetched with a bounded ThreadPoolExecutor
+instead of a strictly-serial for-loop. This module asserts:
+
+  * event details are fetched concurrently (calls overlap in time),
+  * the assembled result is byte-identical to the deterministic serial path,
+  * the per-host rate cap is still honoured (politeness preserved).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from lookups import _http, aopwiki
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    aopwiki.lookup_aop.cache_clear()
+    aopwiki._event_details.cache_clear()
+    _http.reset_host_throttle()
+    yield
+    aopwiki.lookup_aop.cache_clear()
+    aopwiki._event_details.cache_clear()
+    _http.reset_host_throttle()
+
+
+def _serial_assemble(aop_data: dict, event_details: dict[str, dict]) -> list[dict]:
+    """Reference serial assembly used to prove results are identical.
+
+    Mirrors the original strictly-serial logic: iterate buckets in order,
+    de-dup by event id, then merge per-event details.
+    """
+    data = aop_data["aop"]
+    events: list[dict] = []
+    seen: set = set()
+    for bucket in ("aop_mies", "aop_kes", "aop_aos"):
+        for ev in data.get(bucket, []):
+            eid = ev.get("event_id")
+            if eid is None or eid in seen:
+                continue
+            seen.add(eid)
+            entity = {
+                "@id": aopwiki._event_url(eid),
+                "@type": "KeyEvent",
+                "name": ev.get("event", f"Event {eid}"),
+                "eventType": aopwiki._EVENT_TYPE_LABEL.get(
+                    ev.get("event_type", ""), ev.get("event_type", "")
+                ),
+                "identifier": str(eid),
+                "url": f"{aopwiki._event_url(eid)}.json",
+            }
+            entity.update(event_details.get(str(eid), {}))
+            events.append(entity)
+    return events
+
+
+class TestAopConcurrency:
+    """lookup_aop fetches event details concurrently and deterministically."""
+
+    def test_results_identical_to_serial(self, monkeypatch):
+        """The concurrent assembly produces exactly the serial result/order."""
+        aop_data = _load("aopwiki_aop610.json")
+
+        # Per-event detail responses, keyed by id. Returned out of any order.
+        details = {
+            "888": {"short_name": "Binding", "biologicalOrganization": "Molecular"},
+            "177": {"short_name": "Mito dysfunction", "biologicalOrganization": "Cellular"},
+            "889": {"short_name": "DA degeneration", "biologicalOrganization": "Tissue"},
+            "890": {"short_name": "Parkinsonism", "biologicalOrganization": "Individual"},
+        }
+
+        def fake_get_json(url, **kwargs):
+            if url.endswith("/aops/610.json"):
+                return aop_data
+            # event detail url: .../events/<id>.json
+            eid = url.rsplit("/", 1)[1].removesuffix(".json")
+            return {
+                "short_name": details[eid]["short_name"],
+                "biological_organization": details[eid]["biologicalOrganization"],
+            }
+
+        monkeypatch.setattr(aopwiki, "http_get_json", fake_get_json)
+        # Throttle off for speed; concurrency correctness is what we check here.
+        monkeypatch.setattr(_http, "_HOST_MIN_INTERVAL", 0.0)
+
+        result = aopwiki.lookup_aop("610")
+
+        expected_events = _serial_assemble(aop_data, details)
+        assert result["events"] == expected_events
+        # Order is the deterministic pathway order: MIE, KEs, AO.
+        assert [e["identifier"] for e in result["events"]] == ["888", "177", "889", "890"]
+        # Per-event enrichment landed on the right event.
+        by_id = {e["identifier"]: e for e in result["events"]}
+        assert by_id["177"]["short_name"] == "Mito dysfunction"
+        assert by_id["890"]["biologicalOrganization"] == "Individual"
+
+    def test_event_details_fetched_concurrently(self, monkeypatch):
+        """The 4 event-detail fetches overlap in time (not strictly serial)."""
+        aop_data = _load("aopwiki_aop610.json")
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def fake_get_json(url, **kwargs):
+            nonlocal active, max_active
+            if url.endswith("/aops/610.json"):
+                return aop_data
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.2)  # hold the "connection" open to force overlap
+                eid = url.rsplit("/", 1)[1].removesuffix(".json")
+                return {"short_name": f"e{eid}", "biological_organization": "x"}
+            finally:
+                with lock:
+                    active -= 1
+
+        monkeypatch.setattr(aopwiki, "http_get_json", fake_get_json)
+        monkeypatch.setattr(_http, "_HOST_MIN_INTERVAL", 0.0)
+
+        start = time.monotonic()
+        result = aopwiki.lookup_aop("610")
+        elapsed = time.monotonic() - start
+
+        assert len(result["events"]) == 4
+        # If serial, 4 events * 0.2s = 0.8s. Concurrent must be well under that.
+        assert elapsed < 0.6, f"event details not concurrent, elapsed={elapsed:.3f}s"
+        assert max_active >= 2, f"expected overlapping fetches, max_active={max_active}"
+
+    def test_concurrent_fetch_respects_rate_cap(self, monkeypatch):
+        """With the per-host throttle on, the event fetches are still spaced."""
+        aop_data = _load("aopwiki_aop610.json")
+        grant_times: list[float] = []
+        lock = threading.Lock()
+
+        def fake_get_json(url, **kwargs):
+            if url.endswith("/aops/610.json"):
+                return aop_data
+            # Apply the real throttle, then record when this request "fires".
+            _http.throttle_for_url(url)
+            with lock:
+                grant_times.append(time.monotonic())
+            eid = url.rsplit("/", 1)[1].removesuffix(".json")
+            return {"short_name": f"e{eid}", "biological_organization": "x"}
+
+        monkeypatch.setattr(aopwiki, "http_get_json", fake_get_json)
+        monkeypatch.setattr(_http, "_HOST_MIN_INTERVAL", 0.1)
+
+        result = aopwiki.lookup_aop("610")
+        assert len(result["events"]) == 4
+
+        grant_times.sort()
+        for earlier, later in zip(grant_times, grant_times[1:]):
+            assert later - earlier >= 0.1 - 0.02, "event fetches violated the rate cap"

--- a/tests/test_http_rate_limit.py
+++ b/tests/test_http_rate_limit.py
@@ -1,0 +1,78 @@
+"""Tests for the per-host rate limiter in the shared HTTP helper (#62).
+
+The deliberate ``time.sleep(0.1)`` politeness delays that used to live in each
+lookup client are replaced by a single thread-safe, per-host throttle in
+``lookups._http``. This keeps the project polite to third-party APIs even when
+independent requests are issued concurrently (e.g. AOP-Wiki event details).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from lookups import _http
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttle():
+    """Reset the per-host throttle state before and after each test."""
+    _http.reset_host_throttle()
+    yield
+    _http.reset_host_throttle()
+
+
+class TestHostRateLimiter:
+    """`_HostRateLimiter.wait` spaces requests to the same host."""
+
+    def test_sequential_calls_to_same_host_are_spaced(self):
+        """Two back-to-back acquisitions for one host are >= min_interval apart."""
+        limiter = _http._HostRateLimiter(min_interval=0.1)
+        start = time.monotonic()
+        limiter.wait("aopwiki.org")
+        limiter.wait("aopwiki.org")
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.1, f"second call should wait, elapsed={elapsed:.3f}s"
+
+    def test_different_hosts_are_independent(self):
+        """A request to a different host is not delayed by another host."""
+        limiter = _http._HostRateLimiter(min_interval=0.5)
+        start = time.monotonic()
+        limiter.wait("aopwiki.org")
+        limiter.wait("pubchem.ncbi.nlm.nih.gov")
+        elapsed = time.monotonic() - start
+        # Two different hosts: neither blocks the other, so well under one
+        # min_interval of total wait.
+        assert elapsed < 0.5, f"distinct hosts must not block each other, elapsed={elapsed:.3f}s"
+
+    def test_concurrent_calls_do_not_exceed_rate_cap(self):
+        """N concurrent acquisitions for one host serialize to >= (N-1)*interval."""
+        limiter = _http._HostRateLimiter(min_interval=0.05)
+        n = 6
+        barrier = threading.Barrier(n)
+        timestamps: list[float] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            barrier.wait()  # release all threads at once
+            limiter.wait("aopwiki.org")
+            with lock:
+                timestamps.append(time.monotonic())
+
+        threads = [threading.Thread(target=worker) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        timestamps.sort()
+        # Minimum spacing between any two consecutive grants respects the cap.
+        for earlier, later in zip(timestamps, timestamps[1:]):
+            gap = later - earlier
+            assert gap >= 0.05 - 0.01, f"consecutive grants too close: {gap:.3f}s"
+        # And the whole batch took at least (n-1) intervals — i.e. the rate cap
+        # was never exceeded by parallelism.
+        total = timestamps[-1] - timestamps[0]
+        assert total >= (n - 1) * 0.05 - 0.02, f"batch finished too fast: {total:.3f}s"

--- a/tests/test_verification_concurrency.py
+++ b/tests/test_verification_concurrency.py
@@ -1,0 +1,138 @@
+"""Concurrency tests for verify_all_identifiers (#62).
+
+`verify_all_identifiers` walks every entity/field and calls a blocking network
+lookup per field. The fields are independent, so they are verified with a
+bounded ThreadPoolExecutor. This module asserts:
+
+  * per-field verifications run concurrently (calls overlap in time),
+  * results are identical to the serial path and order-independent,
+  * every entity's field-status mutation still lands correctly.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools import verification
+
+
+def _entity(state: CrateState, entity_id: str) -> Entity:
+    """Fetch an entity, asserting it exists (keeps the type checker happy)."""
+    ent = state.get_entity(entity_id)
+    assert ent is not None, f"entity {entity_id} missing"
+    return ent
+
+
+def _field_status(state: CrateState, entity_id: str, field: str) -> str:
+    """Return the completion status string for a field, asserting it is set."""
+    fc = _entity(state, entity_id).get_field_status(field)
+    assert fc is not None, f"no completion status for {entity_id}.{field}"
+    return fc.status
+
+
+def _make_state(n_compounds: int) -> CrateState:
+    state = CrateState()
+    for i in range(n_compounds):
+        chem = Entity(
+            entity_id=f"chem_{i:03d}",
+            type="MolecularEntity",
+            fields={"identifier": f"50-00-{i}"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        chem.set_field_status("identifier", "filled", "llm")
+        state.add_entity(chem)
+    return state
+
+
+class TestVerifyAllConcurrency:
+    """verify_all_identifiers verifies independent fields concurrently."""
+
+    def test_results_identical_and_order_independent(self, monkeypatch):
+        """Concurrent verification yields one verified result per filled field."""
+        state = _make_state(5)
+
+        def fake_lookup(query):
+            return {"found": True, "data": {"pubchem_cid": "712"}, "error": None}
+
+        monkeypatch.setattr(verification, "lookup_compound", fake_lookup)
+
+        results = verification.verify_all_identifiers(state)
+
+        # One result per compound, all verified, no duplicates/drops.
+        assert len(results) == 5
+        assert all(r["verified"] for r in results)
+        ids = {r["entity_id"] for r in results}
+        assert ids == {f"chem_{i:03d}" for i in range(5)}
+        # Mutations landed: every entity field is now "verified".
+        for i in range(5):
+            assert _field_status(state, f"chem_{i:03d}", "identifier") == "verified"
+
+    def test_verifications_run_concurrently(self, monkeypatch):
+        """The independent per-field lookups overlap in time."""
+        state = _make_state(6)
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def slow_lookup(query):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.2)
+                return {"found": True, "data": {"pubchem_cid": "712"}, "error": None}
+            finally:
+                with lock:
+                    active -= 1
+
+        monkeypatch.setattr(verification, "lookup_compound", slow_lookup)
+
+        start = time.monotonic()
+        results = verification.verify_all_identifiers(state)
+        elapsed = time.monotonic() - start
+
+        assert len(results) == 6
+        # Serial would be 6 * 0.2 = 1.2s; concurrent must be well under that.
+        assert elapsed < 0.9, f"verifications not concurrent, elapsed={elapsed:.3f}s"
+        assert max_active >= 2, f"expected overlapping lookups, max_active={max_active}"
+
+    def test_matches_serial_outcome_for_mixed_results(self, monkeypatch):
+        """A mix of verified/cleared fields matches what the serial path would do."""
+        state = CrateState()
+        good = Entity(
+            entity_id="chem_good",
+            type="MolecularEntity",
+            fields={"identifier": "50-00-0"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        good.set_field_status("identifier", "filled", "llm")
+        state.add_entity(good)
+
+        bad = Entity(
+            entity_id="chem_bad",
+            type="MolecularEntity",
+            fields={"identifier": "not-real"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        bad.set_field_status("identifier", "filled", "llm")
+        state.add_entity(bad)
+
+        def fake_lookup(query):
+            if query == "50-00-0":
+                return {"found": True, "data": {"pubchem_cid": "712"}, "error": None}
+            return {"found": False, "data": {}, "error": "not found"}
+
+        monkeypatch.setattr(verification, "lookup_compound", fake_lookup)
+
+        results = verification.verify_all_identifiers(state)
+
+        by_id = {r["entity_id"]: r for r in results}
+        assert by_id["chem_good"]["verified"] is True
+        assert by_id["chem_bad"]["verified"] is False
+        # Good kept + marked verified; bad cleared + marked missing.
+        assert _field_status(state, "chem_good", "identifier") == "verified"
+        assert "identifier" not in _entity(state, "chem_bad").fields
+        assert _field_status(state, "chem_bad", "identifier") == "missing"


### PR DESCRIPTION
Closes #62

## What

Independent network lookups with no data dependency are now issued **concurrently** via a bounded `ThreadPoolExecutor` (max ~6 workers), so cold paths no longer pay strictly-serial round-trip latency. Politeness is **preserved** — the per-client `time.sleep(0.1)` toward AOP-Wiki is replaced by comparable per-host rate limiting, not deleted.

### Parallelized
- **`lookups/aopwiki.py:lookup_aop`** — builds the key-event entities first in deterministic pathway order (MIE → KE → AO), fetches each event's `_event_details` concurrently, then merges them back **by identifier**. The assembled result is byte-identical to the serial path and order-independent.
- **`builder/tools/verification.py:verify_all_identifiers`** — collects its `(entity, field)` work plan deterministically, runs the per-field verifications concurrently, and returns results in that fixed order. Each task mutates only its own field's status, so there is no cross-task contention.

### Per-host rate limiting (built on the shared HTTP helper)
- New `_HostRateLimiter` + `throttle_for_url` / `reset_host_throttle` in `lookups/_http.py`, applied inside `http_get_json`. It enforces a minimum per-host spacing (`_HOST_MIN_INTERVAL`, default 0.1s) and honours that cap **even when many workers fire at once**. Different hosts are throttled independently, so parallel lookups across services are not serialised. This replaces the old scattered `time.sleep(0.1)` calls (removed in `aopwiki.py`).

Both functions stay `lru_cache`d, so this only helps cold paths — as expected.

## Acceptance criteria
- [x] AOP event details fetched concurrently with bounded workers + preserved per-host rate limiting.
- [x] `verify_all_identifiers` runs per-field verifications concurrently.
- [x] Results identical to the serial path (order-independent) — proven against a reference serial assembly with mocked lookups.
- [x] Tests assert concurrency without exceeding the rate cap (overlapping fetches via `max_active >= 2`; min-spacing assertions on the throttle).

## Tests (TDD — written failing first)
- `tests/test_http_rate_limit.py` — sequential spacing, host independence, concurrent rate cap.
- `tests/test_aopwiki_concurrency.py` — concurrent fetch overlap, results identical to reference serial assembly, rate cap respected.
- `tests/test_verification_concurrency.py` — concurrent execution, identical & order-independent results across verified/cleared mixes, correct per-field mutations.

## Verification
- Full suite: **563 passed** (`uv run --extra langchain pytest`).
- `uv run ty check` — **All checks passed!** (no new diagnostics).
- `uvx ruff check` on changed source files — clean.
- Identical-to-serial proven by `test_results_identical_to_serial` (AOP) comparing concurrent output element-by-element to a `_serial_assemble` reference, and by `test_matches_serial_outcome_for_mixed_results` (verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)