### PR TITLE
feat(builder): ship ro-crate-preview.html in exported crates (#86)

### DIFF
--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -95,6 +95,12 @@ def export_crate(state: CrateState, output_path: str | None = None) -> dict[str,
         output_dir.mkdir(parents=True, exist_ok=True)
 
         crate = assemble_crate(state, output_dir, materialize_payload=True)
+        # Embed the standard ro-crate-py preview (ro-crate-preview.html, a
+        # CreativeWork about ./) so the written crate is browsable without
+        # tooling (#86).
+        from rocrate.model.preview import Preview
+
+        crate.add(Preview(crate))
         crate.write(str(output_dir))
 
         logger.info("Crate exported to %s", output_path)

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,58 @@
+"""Tests for the bundled RO-Crate preview (#86).
+
+We ship the standard `ro-crate-preview.html` that ro-crate-py generates — a
+human-readable summary (a CreativeWork `about` the Root Data Entity) — on every
+on-disk export, so a written crate is browsable without tooling.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.builder import build_crate
+
+
+def _state(tmp_path: Path) -> CrateState:
+    state = CrateState()
+    state.session_id = "sess-prev"
+    state.metadata.title = "My Tox Study"
+    state.metadata.description = "An in vitro assay crate."
+    state.metadata.output_path = str(tmp_path / "out")
+    state.add_entity(
+        Entity(
+            entity_id="inv1",
+            type="Investigation",
+            fields={"name": "Investigation One"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    return state
+
+
+class TestPreviewWritten:
+    """export_crate writes ro-crate-preview.html into the crate."""
+
+    def test_export_writes_preview_html(self, tmp_path: Path) -> None:
+        state = _state(tmp_path)
+        res = build_crate(state)
+        assert res["success"], res["error"]
+
+        preview = Path(res["crate_path"]) / "ro-crate-preview.html"
+        assert preview.is_file()
+        page = preview.read_text(encoding="utf-8")
+        assert "<html" in page.lower()
+        assert page.strip() != ""
+
+    def test_preview_referenced_in_metadata(self, tmp_path: Path) -> None:
+        state = _state(tmp_path)
+        res = build_crate(state)
+        meta = json.loads(
+            (Path(res["crate_path"]) / "ro-crate-metadata.json").read_text(encoding="utf-8")
+        )
+        graph = meta["@graph"]
+        prev = next((e for e in graph if e.get("@id") == "ro-crate-preview.html"), None)
+        assert prev is not None, "preview not referenced in ro-crate-metadata.json"
+        assert prev.get("@type") == "CreativeWork"
+        assert prev.get("about") == {"@id": "./"}


### PR DESCRIPTION
Adds a human-readable `ro-crate-preview.html` to every on-disk crate so it's browsable without tooling.

## What
`export_crate` now adds **ro-crate-py's standard `Preview`** before `crate.write()`, emitting `ro-crate-preview.html` (a `CreativeWork` `about` `./`) into the crate root. Per your steer, this uses the **bundled ro-crate-py preview** — no custom template for now.

## Tests (TDD)
`tests/test_preview.py`: the preview file is written into the crate, and it's referenced in `ro-crate-metadata.json` as a `CreativeWork` about `./`. Full suite: **603 passed**; `ty` + `ruff` clean.

## Notes
- The preview adds one `CreativeWork` node to the `@graph`; golden-fixture and validation tests stay green.
- A richer, domain-specific preview (embedding the #85 maturity report and the #130 entity-graph) can replace the stock one later — this is the minimal, standard host.

Closes #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)