### PR TITLE
ci(claude): permit gh issue create in the @claude action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write # Allows `gh issue create` (the allowed tool below) to succeed
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -35,6 +35,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Permit Claude to open GitHub issues (e.g. file follow-up/blocked
+          # issues). Pairs with `issues: write` in the permissions block above.
+          claude_args: "--allowedTools Bash(gh issue create:*)"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
Lets the `@claude` GitHub action open issues (e.g. file follow-up / blocked issues).

- `claude_args: "--allowedTools Bash(gh issue create:*)"` — allows the `gh issue create` command.
- `issues: read` → `issues: write` in the job permissions, so the token `gh` uses can actually create the issue.

Scope is intentionally narrow (only `gh issue create`). The `claude-code-review.yml` workflow is left unchanged (no reviewer issue-creation, per request).

> Note: also requires the Claude GitHub App installation to have **Issues: Read & Write** on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)