### PR TITLE
fix(report): render maturity conformance from state.validation, not a fresh validate (#85)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -898,11 +898,12 @@ turned off with `export_crate(..., embed_graph=False)`. Inline-rendering the Mer
 **Maturity report (`ro-crate-maturity.html`, #85).** `export_crate` also embeds a human-readable
 maturity report as a `File` + `CreativeWork` `about` `./` (same mechanism as the graph). It is
 rendered by `builder/writers/maturity_report.py` (`build_maturity_html`) and covers four axes:
-profile adherence (computed in-memory via `validate_crate_dict` at export, with REQUIRED/RECOMMENDED
-issues surfaced as suggestions), FAIR indicators + DSM level (`assess_fair_maturity`), OECD MIT
-coverage (`assess_mit_coverage`), and a derived reproducibility-readiness checklist. Embedding is
-automatic, best-effort (a reporting failure never fails the export), and can be turned off with
-`export_crate(..., embed_report=False)`.
+profile adherence (rendered from the crate's existing `state.validation` — REQUIRED/RECOMMENDED
+issues surfaced as suggestions; it does **not** re-run the SHACL validator, so the embed adds no
+validation cost to export — validation stays a separate step), FAIR indicators + DSM level
+(`assess_fair_maturity`), OECD MIT coverage (`assess_mit_coverage`), and a derived
+reproducibility-readiness checklist. Embedding is automatic, best-effort (a reporting failure never
+fails the export), and can be turned off with `export_crate(..., embed_report=False)`.
 
 ## 12. Project Structure
 

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -115,14 +115,10 @@ def _embed_maturity_report(crate: ROCrate, state: CrateState) -> None:
     """
     from io import StringIO
 
-    from builder.writers.maturity_report import (
-        REPORT_FILENAME,
-        build_maturity_html,
-        conformance_from_metadata,
-    )
+    from builder.writers.maturity_report import REPORT_FILENAME, build_maturity_html
 
-    conformance = conformance_from_metadata(crate.metadata.generate())
-    page = build_maturity_html(state, conformance=conformance)
+    # Renders from state.validation (no re-validate) so export stays cheap (#85).
+    page = build_maturity_html(state)
     crate.add(
         File(
             crate,

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -13,58 +13,37 @@ four axes from the issue:
 ``export_crate`` embeds the rendered page as a ``CreativeWork`` ``about`` ``./``,
 mirroring the entity-graph (#130) and preview (#86) artifacts.
 
-``build_maturity_html`` is pure (FAIR/MIT come from the deterministic assessors;
-``conformance`` is injected) so it unit-tests without running the SHACL validator.
-``conformance_from_metadata`` computes the conformance section from an in-memory
-metadata document for the embed path.
+``build_maturity_html`` is pure and cheap: FAIR/MIT come from the deterministic
+assessors and the profile-adherence section is rendered from the crate's existing
+``state.validation`` — it does **not** run the SHACL validator. That keeps the
+embed in ``export_crate`` free of validation cost; validation is a separate step.
 """
 
 from __future__ import annotations
 
 import html
-from typing import Any
 
-from builder.state import CrateState
+from builder.state import CrateState, ValidationReport
 from builder.tools.fair_assessment import assess_fair_maturity
 from builder.tools.mit_assessment import assess_mit_coverage
 
 REPORT_FILENAME = "ro-crate-maturity.html"
 
-# Map a validate_crate_dict pass key to a human label.
-_PROFILE_LABELS = {"base": "RO-Crate 1.1", "isa": "ISA", "tox": "ISA-Tox"}
 
+def _validation_has_signal(validation: ValidationReport) -> bool:
+    """True if a validation has actually run (some pass set, or any issue logged).
 
-def conformance_from_metadata(metadata_doc: dict[str, Any]) -> list[dict[str, Any]]:
-    """Run the in-memory validator and summarise it for the report.
-
-    Returns one entry per pass: ``{profile, label, passed_required, required,
-    recommended}`` where ``required``/``recommended`` are issue message strings.
-    Best-effort — returns ``[]`` if validation is unavailable.
+    A default :class:`ValidationReport` (all passes ``False``, no issues) means
+    the crate hasn't been validated yet — distinct from "validated and failing".
     """
-    try:
-        from profiles.validator import validate_crate_dict
-    except ImportError:
-        return []
-    try:
-        # "recommended" surfaces REQUIRED + RECOMMENDED so we can offer suggestions.
-        results = validate_crate_dict(metadata_doc, severity="recommended", profile="all")
-    except Exception:
-        return []
-
-    summary: list[dict[str, Any]] = []
-    for res in results:
-        required = [i.message for i in res.issues if i.severity == "required"]
-        recommended = [i.message for i in res.issues if i.severity == "recommended"]
-        summary.append(
-            {
-                "profile": res.profile,
-                "label": _PROFILE_LABELS.get(res.profile, res.profile),
-                "passed_required": res.passed_required,
-                "required": required,
-                "recommended": recommended,
-            }
-        )
-    return summary
+    return bool(
+        validation.base_passed
+        or validation.isa_passed
+        or validation.tox_passed
+        or validation.required_issues
+        or validation.should_issues
+        or validation.may_issues
+    )
 
 
 def _reproducibility_checks(state: CrateState) -> list[tuple[str, bool, str]]:
@@ -132,47 +111,55 @@ def _mark(ok: bool | None) -> str:
 def build_maturity_html(
     state: CrateState,
     *,
-    conformance: list[dict[str, Any]] | None = None,
+    validation: ValidationReport | None = None,
 ) -> str:
     """Render the maturity report HTML for *state*.
 
+    The profile-adherence section is rendered from the crate's existing
+    validation results (``validation`` or, by default, ``state.validation``) —
+    NOT by re-running the SHACL validator. That keeps report generation cheap so
+    embedding it in ``export_crate`` adds no validation cost (#85); validation is
+    a separate step (e.g. ``build_and_validate`` in the agent loop). If no
+    validation has run, the section says so.
+
     Args:
         state: The crate state being reported on.
-        conformance: Optional per-pass conformance summary (see
-            :func:`conformance_from_metadata`). When ``None``, the profile
-            section notes that conformance was not evaluated.
+        validation: Validation results to render. Defaults to
+            ``state.validation``.
     """
     esc = html.escape
     title = state.metadata.title or "RO-Crate"
     fair = assess_fair_maturity(state)
     mit = assess_mit_coverage(state)
+    val = validation if validation is not None else state.validation
 
-    # --- Profile adherence ---
-    if conformance:
-        rows = []
-        suggestions: list[str] = []
-        for c in conformance:
-            rows.append(
-                f"<tr><td>{esc(c['label'])}</td><td>{_mark(c['passed_required'])}</td>"
-                f"<td>{len(c['required'])} required, {len(c['recommended'])} recommended</td></tr>"
-            )
-            for msg in c["required"]:
-                suggestions.append(
-                    f"<li><strong>Must fix ({esc(c['label'])}):</strong> {esc(msg)}</li>"
-                )
-            for msg in c["recommended"][:10]:
-                suggestions.append(f"<li>Recommended ({esc(c['label'])}): {esc(msg)}</li>")
+    # --- Profile adherence (from existing validation results) ---
+    if _validation_has_signal(val):
+        layers = [
+            ("RO-Crate 1.1", val.base_passed),
+            ("ISA", val.isa_passed),
+            ("ISA-Tox", val.tox_passed),
+        ]
+        rows = "".join(
+            f"<tr><td>{esc(label)}</td><td>{_mark(passed)}</td></tr>" for label, passed in layers
+        )
+        suggestions = [
+            f"<li><strong>Must fix:</strong> {esc(msg)}</li>" for msg in val.required_issues
+        ] + [f"<li>Recommended: {esc(msg)}</li>" for msg in val.should_issues[:10]]
         sugg_html = (
             f"<ul class='sugg'>{''.join(suggestions)}</ul>"
             if suggestions
-            else "<p class='ok'>No outstanding profile issues. 🎉</p>"
+            else "<p class='ok'>No outstanding REQUIRED/RECOMMENDED issues.</p>"
         )
         profile_section = (
-            "<table><thead><tr><th>Profile</th><th>REQUIRED</th><th>Issues</th></tr></thead>"
-            f"<tbody>{''.join(rows)}</tbody></table>{sugg_html}"
+            "<table><thead><tr><th>Profile</th><th>REQUIRED passed</th></tr></thead>"
+            f"<tbody>{rows}</tbody></table>{sugg_html}"
         )
     else:
-        profile_section = "<p class='muted'>Conformance was not evaluated for this report.</p>"
+        profile_section = (
+            "<p class='muted'>Not yet validated — run validation to populate "
+            "profile adherence.</p>"
+        )
 
     # --- FAIR ---
     dsm = fair.dsm_level

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from builder.state import CrateState
+from builder.state import CrateState, ValidationReport
 from builder.tools.builder import build_crate, export_crate
 from builder.writers.maturity_report import REPORT_FILENAME, build_maturity_html
 from tests.fixtures.vhps_golden_crates import vhps_fixture_state
@@ -25,23 +25,22 @@ class TestBuildMaturityHtml:
 
     def test_conformance_suggestions_rendered(self) -> None:
         state = vhps_fixture_state("S-VHPS21")
-        conformance = [
-            {
-                "profile": "base",
-                "label": "RO-Crate 1.1",
-                "passed_required": False,
-                "required": ["root MUST have a name"],
-                "recommended": ["consider adding a license"],
-            }
-        ]
-        page = build_maturity_html(state, conformance=conformance)
+        validation = ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            required_issues=["root MUST have a name"],
+            should_issues=["consider adding a license"],
+        )
+        page = build_maturity_html(state, validation=validation)
         assert "Must fix" in page
         assert "root MUST have a name" in page
         assert "consider adding a license" in page
 
-    def test_no_conformance_notes_not_evaluated(self) -> None:
+    def test_unvalidated_state_notes_not_validated(self) -> None:
+        # Fresh state with a default (empty) ValidationReport.
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
-        assert "not evaluated" in page.lower()
+        assert "not yet validated" in page.lower()
 
     def test_escapes_html(self) -> None:
         state = CrateState()
@@ -58,6 +57,9 @@ class TestEmbeddedInCrate:
         state = vhps_fixture_state("S-VHPS21")
         out = tmp_path / "crate"
         state.metadata.output_path = str(out)
+        # Simulate the agent having validated before export — the report renders
+        # this existing state.validation (no re-validate inside export).
+        state.validation = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
         res = build_crate(state)
         assert res["success"], res["error"]
 
@@ -65,8 +67,7 @@ class TestEmbeddedInCrate:
         assert report.is_file()
         page = report.read_text(encoding="utf-8")
         assert "Profile adherence" in page
-        # Conformance was computed at export, so the report is evaluated.
-        assert "not evaluated" not in page.lower()
+        assert "not yet validated" not in page.lower()
 
     def test_report_referenced_in_metadata(self, tmp_path: Path) -> None:
         state = vhps_fixture_state("S-VHPS21")


### PR DESCRIPTION
## What
Follow-up to PR #139 (the maturity report, branch `jh-85-maturity-report`, already squash-merged). The post-merge fix commit `8ffb7ec` never landed on `main` because #139 was already closed by the time it was made.

This PR carries **only** that fix, cherry-picked cleanly onto current `main`. The `tests/test_export_smoke.py` that `main` added (via `ed3b2ec`) after the branch diverged is preserved — merging the whole stale branch would have deleted it.

## Why
The first cut ran `validate_crate_dict` inside `export_crate` to compute the report's profile-adherence section. That added ~3–4s to every export and pushed an e2e fixture past CI's 30s pytest-timeout.

## Change
- Render the profile-adherence section from the crate's existing `state.validation` (the agent already validates in its loop); export no longer re-validates.
- If no validation has run, the report says "not yet validated" rather than recomputing.
- `build_maturity_html` now takes `validation` (defaults to `state.validation`); removed `conformance_from_metadata`.

## Verification (local)
- `tests/test_maturity_report.py`, `tests/test_export_smoke.py`, `tests/test_tools_builder.py` → **21 passed** in ~7s (the smoke test the original fix branch never ran against now passes).
- `ruff` + `ty` clean on changed files.

Closes the loose end on #85.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>