### PR TITLE
fix(provenance): flag broken derivation-chain continuity (#140)

### DIFF
--- a/builder/tools/provenance.py
+++ b/builder/tools/provenance.py
@@ -140,6 +140,11 @@ def _ref_ids(value: Any) -> set[str]:
     return out
 
 
+def _process_type(proc: Entity) -> str:
+    """The domain discriminator of a LabProcess (process_type or additionalType)."""
+    return proc.fields.get("process_type") or proc.fields.get("additionalType") or ""
+
+
 def _issue(entity_id: str, prop: str, message: str, fix: str) -> dict[str, Any]:
     """A routable issue in #87's shape (REQUIRED, ISA layer)."""
     return {
@@ -155,12 +160,21 @@ def _issue(entity_id: str, prop: str, message: str, fix: str) -> dict[str, Any]:
 def check_provenance(state: CrateState) -> dict[str, Any]:
     """Report-only connectivity lint over the derivation chain.
 
-    Surfaces (without modifying state) two classes of break:
+    Surfaces (without modifying state) three classes of break:
 
     1. A domain LabProcess that produces no output where the build has no
        fallback (EndpointReadout / DataAnalysis) — the chain dangles there.
     2. A File referenced by no process input/output and not part of any
        ``hasPart`` — an orphan data entity with no producer.
+    3. *Continuity* (Issue #140): a process consumes a ``Sample`` that no
+       process produces and that is not a CellCulture seed — the derivation
+       chain is broken upstream of that process (its input does not trace back
+       to a cultured/exposed material). Only applied when the crate actually
+       models sample material-flow (some process produces a Sample output), and
+       only to ``Sample`` inputs (``File`` inputs may be imported starting data;
+       ``CellLineSample``/``MolecularEntity`` are external starting materials),
+       so legitimate primary-cell, data-only, and multi-assay crates are not
+       false-flagged.
 
     Args:
         state: The crate state to lint.
@@ -186,7 +200,7 @@ def check_provenance(state: CrateState) -> dict[str, Any]:
 
     # Rule 1: dangling process output (no build-time fallback for these types).
     for proc in processes:
-        ptype = proc.fields.get("process_type") or proc.fields.get("additionalType") or ""
+        ptype = _process_type(proc)
         if ptype in _OUTPUT_REQUIRED_TYPES and not any(
             proc.fields.get(f) for f in _OUTPUT_FIELDS
         ):
@@ -215,6 +229,49 @@ def check_provenance(state: CrateState) -> dict[str, Any]:
                     f"it to a dataset's hasPart.",
                 )
             )
+
+    # Rule 3: derivation-chain continuity. Build the set of entity_ids produced
+    # by some process; if any produced entity is a Sample, the crate models
+    # sample material-flow, so every consumed Sample must trace back to a
+    # producer (or be a CellCulture seed). A consumed Sample that does neither
+    # means the chain is broken upstream — exactly the mid-chain break a flat
+    # presence lint cannot see.
+    produced: set[str] = set()
+    for proc in processes:
+        for fld in _OUTPUT_FIELDS:
+            produced |= _ref_ids(proc.fields.get(fld))
+    models_sample_flow = any(
+        (e := state.get_entity(pid)) is not None and e.type == "Sample"
+        for pid in produced
+    )
+    if models_sample_flow:
+        seeds: set[str] = set()
+        for proc in processes:
+            if _process_type(proc) == "CellCulture":
+                for fld in _INPUT_FIELDS:
+                    seeds |= _ref_ids(proc.fields.get(fld))
+        for proc in processes:
+            for fld in _INPUT_FIELDS:
+                for tid in _ref_ids(proc.fields.get(fld)):
+                    target = state.get_entity(tid)
+                    if target is None or target.type != "Sample":
+                        continue
+                    if tid in produced or tid in seeds:
+                        continue
+                    issues.append(
+                        _issue(
+                            proc.entity_id,
+                            fld,
+                            f"{_process_type(proc) or 'LabProcess'} "
+                            f"'{proc.entity_id}' consumes sample '{tid}', but no "
+                            f"process produces it and it is not a culture seed — "
+                            f"the derivation chain is broken upstream.",
+                            f"Wire the producing step's output to this input, e.g. "
+                            f"link('<upstream_process_id>', 'result', '{tid}'), or "
+                            f"point this input at the correct cultured/exposed "
+                            f"sample.",
+                        )
+                    )
 
     return {"ok": not issues, "issues": issues}
 

--- a/tests/test_provenance_tools.py
+++ b/tests/test_provenance_tools.py
@@ -11,8 +11,13 @@ from __future__ import annotations
 import pytest
 
 from builder.state import CrateState, Entity, EntityProvenance
-from builder.tools._crate_mapping import PROVENANCE_RELATIONS, _REF_FIELDS
-from builder.tools.provenance import check_provenance, draft_file, link
+from builder.tools._crate_mapping import _REF_FIELDS, PROVENANCE_RELATIONS
+from builder.tools.provenance import (
+    _INPUT_FIELDS,
+    check_provenance,
+    draft_file,
+    link,
+)
 
 
 def _ent(entity_id, type_, **fields):
@@ -160,6 +165,78 @@ class TestCheckProvenance:
         report = check_provenance(state)
         assert report["ok"] is True, report
         assert report["issues"] == []
+
+    def test_flags_disconnected_sample_input(self):
+        # Issue #140: each process individually has an output (so Rule 1 is
+        # silent), but the EndpointReadout consumes an UNRELATED sample instead
+        # of the CellCulture's cultured output — the derivation chain is broken
+        # in the middle. The per-node presence lint missed this; the continuity
+        # rule must catch it.
+        state = CrateState()
+        state.add_entity(_ent("cc", "LabProcess", process_type="CellCulture"))
+        state.add_entity(_ent("er", "LabProcess", process_type="EndpointReadout"))
+        state.add_entity(_ent("cells", "CellLineSample", name="HepG2"))
+        state.add_entity(_ent("cultured", "Sample", name="cultured"))
+        state.add_entity(_ent("unrelated", "Sample", name="unrelated"))
+        state.add_entity(_ent("raw", "File", name="raw.csv"))
+        link(state, "cc", "object", "cells")
+        link(state, "cc", "result", "cultured")
+        link(state, "er", "samples", "unrelated")  # <-- should be 'cultured'
+        link(state, "er", "result", "raw")
+
+        report = check_provenance(state)
+        assert report["ok"] is False, report
+        broken = [i for i in report["issues"] if i["entity_id"] == "er"]
+        assert broken, report
+        issue = broken[0]
+        assert issue["property"] in _INPUT_FIELDS
+        assert "unrelated" in issue["message"]
+        assert issue["severity"] == "required"
+        assert issue["fix"]
+
+    def test_culture_seed_sample_not_flagged(self):
+        # A CellCulture seeded with a primary-tissue Sample (not a CellLineSample)
+        # that no process produces is a legitimate starting material, not a break.
+        state = CrateState()
+        state.add_entity(_ent("cc", "LabProcess", process_type="CellCulture"))
+        state.add_entity(_ent("primary", "Sample", name="primary hepatocytes"))
+        state.add_entity(_ent("cultured", "Sample", name="cultured"))
+        link(state, "cc", "object", "primary")
+        link(state, "cc", "result", "cultured")
+
+        assert check_provenance(state)["ok"] is True, check_provenance(state)
+
+    def test_minimal_readout_with_unproduced_sample_not_flagged(self):
+        # When NO process produces a Sample output, the crate does not model
+        # sample material-flow, so a standalone readout consuming an exposed
+        # Sample is a valid minimal crate — the continuity rule must stay silent
+        # (only Rule 1's missing-output check applies, and here output exists).
+        state = CrateState()
+        state.add_entity(_ent("er", "LabProcess", process_type="EndpointReadout"))
+        state.add_entity(_ent("s", "Sample", name="exposed"))
+        state.add_entity(_ent("raw", "File", name="raw.csv"))
+        link(state, "er", "samples", "s")
+        link(state, "er", "result", "raw")
+
+        assert check_provenance(state)["ok"] is True, check_provenance(state)
+
+    def test_imported_raw_file_input_not_flagged(self):
+        # DataAnalysis consuming an imported raw File that no EndpointReadout
+        # produced is a valid data-only crate — File inputs are never flagged by
+        # the continuity rule (only Samples are).
+        state = CrateState()
+        state.add_entity(_ent("cc", "LabProcess", process_type="CellCulture"))
+        state.add_entity(_ent("cells", "CellLineSample", name="HepG2"))
+        state.add_entity(_ent("cultured", "Sample", name="cultured"))
+        state.add_entity(_ent("da", "LabProcess", process_type="DataAnalysis"))
+        state.add_entity(_ent("raw", "File", name="raw.csv"))
+        state.add_entity(_ent("fig", "File", name="fig.png"))
+        link(state, "cc", "object", "cells")
+        link(state, "cc", "result", "cultured")
+        link(state, "da", "object", "raw")  # imported raw File, no producer
+        link(state, "da", "result", "fig")
+
+        assert check_provenance(state)["ok"] is True, check_provenance(state)
 
     def test_removing_a_link_reintroduces_an_issue(self):
         # Guards that the connected-chain pass is not vacuous: drop the readout's


### PR DESCRIPTION
Closes #140. Follow-up to #88.

## Problem
`check_provenance` was a **per-node presence lint**, not a continuity check:
- Rule 1: `EndpointReadout`/`DataAnalysis` with no output
- Rule 2: orphan `File` (in no process I/O, no `hasPart`)

It never verified that a process's consumed `Sample` traces back to a producer. So a **mid-chain break** — e.g. an `EndpointReadout` consuming an *unrelated* `Sample` instead of the cultured output, where each half is internally complete — passed `ok: True`. That's exactly the reproducibility break a connectivity lint exists to catch.

## Fix — Rule 3 (continuity)
When the crate models sample material-flow (some process produces a `Sample` output), every consumed `Sample` must be either produced by a process **or** be a `CellCulture` seed; otherwise the chain is broken upstream and we emit a routable issue (same #87 `{entity_id, property, message, fix, severity, profile}` shape, report-only).

### Why this formulation (and not "every output must be consumed")
The canonical ISA-Tox chain has legitimately-unconsumed outputs (the Exposure condition `table`) and branching (`EndpointReadout` consumes the *cultured sample*, not the Exposure output). A naive "outputs must be consumed" rule would false-flag valid crates. So Rule 3 is deliberately scoped to avoid false positives on:
- **Documentation outputs** (condition table consumed by nobody) — outputs are never required to be consumed.
- **Primary-cell designs** — a `CellCulture` seed `Sample` with no producer is exempt.
- **Data-only crates** — `File` inputs are never flagged (only `Sample` inputs); imported raw data has no producer.
- **Minimal crates / multi-assay** — gated on the crate actually modeling sample-flow; no global single-component requirement.

## Tests (TDD — failing test written first)
Added to `tests/test_provenance_tools.py`:
- `test_flags_disconnected_sample_input` — the mid-chain break now returns `ok: False` naming the disconnected input (this was the failing test).
- `test_culture_seed_sample_not_flagged`, `test_minimal_readout_with_unproduced_sample_not_flagged`, `test_imported_raw_file_input_not_flagged` — false-positive guards.
- Existing `test_passes_connected_chain` / `test_removing_a_link_reintroduces_an_issue` still green (regression guards).

**17 passed**, ruff + ty clean. Single file changed (`provenance.py`) + its test.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>