### PR TITLE
docs(agents): fix §5 toolbox drift — drop scaffold_arc phantom, document 11 real tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,17 +432,29 @@ catch). Guardrails are a one-time cost; a stronger model is recurring per token.
 
 ## 5. The Agent Toolbox
 
-### File & ARC Tools
-*These are called during session initialization, not by the LLM during the agent loop.*
+### File Tools
+*The scanner/sampler triad below is engine-routed (not in `TOOL_SPECS`); the
+full readers are specced and LLM-callable during the agent loop.*
 ```
 scan_files(path: str) → [FileClassification]
 read_file_sample(path: str, lines: int = 20, mode: str = "content") → str | None
   mode: "content" (first N lines), "summary" (file-type-aware), "overview" (metadata + summary)
 read_multiple_files(paths: list[str], lines: int = 50, mode: str = "content") → dict
   mode: same options as read_file_sample
-scaffold_arc(scanned_files: [FileClassification]) → ARCTree
+read_file(path: str) → str | None             # full read by extension (txt, csv, json, xlsx, docx, md, pdf)
+read_excel(path: str) → str | None            # .xlsx → pipe-delimited text
+read_docx(path: str) → str | None             # .docx → plain text
+extract_pdf_text(path: str) → str             # structured PDF: [Page N] text, tables, image metadata
+preview_archive(path: str) → dict             # list a .zip's members + metadata without extracting
+unzip_file(path: str, output_dir: str | None = None) → str   # extract a .zip, returns extraction path
 ```
-`scaffold_arc` creates the ARC folder tree from the template and sorts scanned files into the correct ARC buckets. Called after `scan_files` and before the agent loop starts.
+`scan_files`, `read_file_sample`, and `read_multiple_files` run during session
+initialization to classify inputs and feed the state brief. The full readers
+(`read_file`/`read_excel`/`read_docx`/`extract_pdf_text`) and the archive tools
+(`preview_archive`/`unzip_file`) are dispatchable so the agent can pull a file's
+full contents on demand. There is **no `scaffold_arc` tool** — ARC is an *output*
+format only (D7); the ARC folder tree is materialised at export time by
+`builder/writers/arc_writer.py::write_arc`, not assembled from scanned inputs.
 
 ### Entity Drafting Tools
 ```
@@ -451,7 +463,9 @@ draft_study(investigation_id: str, hints: dict) → Entity
 draft_assay(study_id: str, hints: dict) → Entity
 draft_molecular_entity(name: str, hints: dict) → Entity
 draft_cell_line_sample(name: str, hints: dict) → Entity
+draft_sample(hints: dict) → Entity                       # material input/output in the derivation chain
 draft_process(assay_id: str, process_type: str, hints: dict) → Entity
+draft_protocol(hints: dict) → Entity                     # LabProtocol a LabProcess can follow
 draft_person(name: str, hints: dict) → Entity
 draft_organization(name: str, hints: dict) → Entity
 draft_publication(doi: str, hints: dict) → Entity
@@ -577,10 +591,18 @@ assess_fair_maturity() → FAIRReport
 ### Session & HITL Tools
 ```
 present_to_human(context: str, options: [str]) → HumanResponse
+request_input(prompt: str, field_type: str | None = None) → HumanResponse
 save_session(label: str) → SessionInfo
+list_sessions() → [SessionInfo]
+load_session(session_id: str) → SessionStatus
 get_status() → SessionStatus
 get_hint() → str
 ```
+`present_to_human` offers a choice between `options`; `request_input` asks the
+human for a single free-form value (e.g. a compound name, CAS number, or cell
+line accession) when a lookup needs a missing identifier. `list_sessions` and
+`load_session` drive the resume flow (§7); `present_to_human`/`request_input`
+are engine-routed HITL tools (not in `TOOL_REGISTRY`), the rest are specced.
 
 ### Profiling
 Every tool call and graph node execution is automatically timed and recorded by `ProfilingLogger` (see [docs/profiling.md](docs/profiling.md)). Profile data is written to `sessions/<session_id>/profile.ndjson` as newline-delimited JSON with event types including `tool_call`, `node_start`, and `node_end`. This file is the primary input for timing analysis, debugging, and live status in future web UIs.

--- a/tests/test_agents_doc_toolbox.py
+++ b/tests/test_agents_doc_toolbox.py
@@ -1,0 +1,85 @@
+"""Guard test for AGENTS.md §5 "The Agent Toolbox".
+
+Ensures the hand-written tool list in the design doc cannot drift away from the
+real, dispatchable toolbox — i.e. it can never reintroduce a phantom tool like
+the long-gone ``scaffold_arc`` (Issue #145). Every tool name documented in §5
+must be a real, LLM-callable tool: either specced in ``TOOL_SPECS`` or one of the
+engine's special-cased / session-init tools.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from builder.agents.tools_spec import TOOL_SPECS
+
+_AGENTS_MD = Path(__file__).resolve().parent.parent / "AGENTS.md"
+
+# Tool names that are real and callable but are intentionally NOT in TOOL_SPECS
+# (engine-routed HITL/scanner helpers and the session-init scanner). These mirror
+# the special-cased set asserted in tests/test_tools_spec.py.
+_ENGINE_SPECIAL_CASED: set[str] = {
+    "present_to_human",
+    "request_input",
+    "scan_files",
+    "read_file_sample",
+    "read_multiple_files",
+    "unzip_file",
+    "preview_archive",
+}
+
+# Matches a tool invocation at the start of a code-fence line, e.g.
+#   draft_study(investigation_id: str, hints: dict) → Entity
+#   /verify_all_identifiers() → [VerificationResult]
+_TOOL_CALL_RE = re.compile(r"^/?([a-z_][a-z0-9_]*)\s*\(")
+
+
+def _spec_names() -> set[str]:
+    return {str(spec["name"]) for spec in TOOL_SPECS}
+
+
+def _section_5_text() -> str:
+    """Return the raw text of AGENTS.md §5 (up to the next top-level heading)."""
+    text = _AGENTS_MD.read_text(encoding="utf-8")
+    start = text.index("## 5. The Agent Toolbox")
+    rest = text[start + len("## 5. The Agent Toolbox") :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _documented_tool_names() -> set[str]:
+    """Tool names that appear as ``name(...)`` lines inside §5 code fences."""
+    names: set[str] = set()
+    in_fence = False
+    for line in _section_5_text().splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            continue
+        match = _TOOL_CALL_RE.match(line.strip())
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+def test_section_5_documents_only_real_tools() -> None:
+    """No phantom tools: §5 names ⊆ (TOOL_SPECS ∪ engine special-cased)."""
+    documented = _documented_tool_names()
+    callable_tools = _spec_names() | _ENGINE_SPECIAL_CASED
+    phantom = documented - callable_tools
+    assert not phantom, (
+        f"AGENTS.md §5 documents tool(s) that do not exist in TOOL_SPECS or the "
+        f"engine special-cased set: {sorted(phantom)}"
+    )
+
+
+def test_section_5_documents_every_specced_tool() -> None:
+    """No silent omissions: every specced tool is documented in §5."""
+    documented = _documented_tool_names()
+    missing = _spec_names() - documented
+    assert not missing, (
+        f"AGENTS.md §5 is missing dispatchable tool(s) that are in TOOL_SPECS: "
+        f"{sorted(missing)}"
+    )


### PR DESCRIPTION
Closes #145.

## What
AGENTS.md §5 "The Agent Toolbox" had drifted from the actual dispatchable toolbox. This PR reconciles the doc with ground truth and adds a guard test.

- **Removed the phantom** `scaffold_arc(scanned_files) -> ARCTree`. No such tool exists in `builder/agents/tools_spec.py::TOOL_SPECS`, the `TOOL_REGISTRY`, or engine routing. ARC is an *output* format only (design decision D7); §5 now points to `builder/writers/arc_writer.py::write_arc`, which materialises the ARC folder tree at export time.
- **Documented the 11 real, specced + dispatchable tools** that were missing from §5:
  - Entity Drafting: `draft_protocol`, `draft_sample`
  - File tools: `read_file`, `read_excel`, `read_docx`, `extract_pdf_text`, `preview_archive`, `unzip_file`
  - Session & HITL: `request_input`, `list_sessions`, `load_session`
- Clarified which §5 entries are engine-routed (HITL/scanner, not in `TOOL_REGISTRY`) vs. specced.

## Why
The phantom misleads contributors and any agent reading the design doc; the omissions hid a third of the real toolbox. No code-behavior change — documentation + one new test.

## Verification
Cross-checked §5 against ground truth: `TOOL_SPECS` (50 names) and every `TOOL_REGISTRY.register(...)` call in `builder/tools/*.py`. The doc/spec gap was exactly the 11 tools above and the single `scaffold_arc` phantom — confirmed programmatically.

## Test (TDD)
Added `tests/test_agents_doc_toolbox.py`:
- `test_section_5_documents_only_real_tools` — §5 code-fence tool names ⊆ (`TOOL_SPECS` ∪ engine special-cased); fails on any phantom.
- `test_section_5_documents_every_specced_tool` — every specced tool is documented in §5.

Confirmed red before the doc edit (named `scaffold_arc` + the 11 missing tools), green after.

```
uv run pytest tests/test_agents_doc_toolbox.py tests/test_tools_spec.py tests/test_tool_registry.py -q
20 passed
uv run ruff check tests/test_agents_doc_toolbox.py   # All checks passed!
uv run ty check   tests/test_agents_doc_toolbox.py   # All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)