### PR TITLE
feat(lookups): generic OLS ontology-term + units + DTXSID/ChEBI authorities (#142, #146)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,10 +505,13 @@ process, returning issues in the same routable shape as `build_and_validate` (#8
 
 ### Lookup Tools
 ```
-lookup_compound(name: str) → CompoundData | None   # PubChem
+lookup_compound(name: str) → CompoundData | None   # PubChem (→ ChEBI fallback)
+lookup_dtxsid(query: str) → DtxsidData | None       # EPA CompTox (DTXSID)
 lookup_cell_line(accession: str) → CellLineData | None  # Cellosaurus
 lookup_aop(aop_id: str) → AOPData | None            # AOP-Wiki
 lookup_bao_term(query: str) → TermData | None       # OLS/BAO
+lookup_ontology_term(query: str, ontology: str) → TermData | None  # OLS (any ontology)
+lookup_unit(unit_string: str) → TermData | None     # OLS/UO (units)
 lookup_orcid(orcid_id: str) → PersonData | None     # ORCID
 lookup_ror(name: str) → OrgData | None              # ROR
 lookup_doi(doi: str) → PublicationData | None       # Crossref
@@ -735,15 +738,21 @@ All lookups follow a consistent pattern: return `{found: bool, data: dict, error
 
 ### Available Services
 - **PubChem**: Name/CAS/CID → SMILES, InChI, formula, mass
+- **CompTox (EPA)**: Name/CAS/InChIKey → DTXSID (the DSSTox anchor identifier)
 - **Cellosaurus**: Accession (CVCL_xxxx) → name, species, disease, site, sex
 - **AOP-Wiki**: AOP ID → full pathway graph (AOP, events, relationships)
-- **BAO / OLS**: Free-text query → best-matching ontology term with IRI
+- **OLS4 (generic)**: Free-text query + ontology short name → best-matching
+  term IRI with a relevance score. Backs `lookup_bao_term` (BAO),
+  `lookup_unit` (UO units), and `lookup_ontology_term` for any OLS-hosted
+  vocabulary (EFO/OBI/NCIT/UBERON/ChEBI/…).
 - **ORCID**: ORCID iD → name, affiliation, affiliation ROR
 - **ROR**: Organization name → ROR ID, website URL
 - **Crossref**: DOI → title, authors, journal, year
 
 ### Multi-Strategy Lookups
-For chemicals: try by name, then CAS, then ChEBI. If all fail, ask user for SMILES/InChI.
+For chemicals, `lookup_compound` tries by name, then CAS, then **ChEBI** (via
+OLS4) — a PubChem miss now falls back to resolving a ChEBI IRI rather than a
+hard not-found. If all fail, ask the user for SMILES/InChI.
 
 ### Anti-Hallucination
 The agent **never fabricates identifiers**. Every identifier is verified against its source. If verification fails, the field is cleared and the agent tries alternatives or asks the user.

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -45,6 +45,9 @@ Lookups & verification:
 - lookup_cell_line: Look up a cell line in Cellosaurus
 - lookup_aop: Look up an AOP in AOP-Wiki
 - lookup_bao_term: Look up a BAO ontology term
+- lookup_ontology_term: Look up a term in any OLS ontology (efo/obi/ncit/uberon/chebi/…)
+- lookup_unit: Resolve a unit string to a UO (Units of Measurement Ontology) IRI
+- lookup_dtxsid: Resolve a chemical to its EPA DTXSID via the CompTox Dashboard
 - lookup_orcid: Look up a person in ORCID
 - lookup_ror: Look up an organization in ROR
 - lookup_doi: Look up a publication in Crossref

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -242,6 +242,36 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "lookup_ontology_term",
+        "description": "Search any OLS-hosted ontology (efo, obi, ncit, uberon, chebi, …) for the best-matching term IRI. Generalises lookup_bao_term to any vocabulary. Returns @id, name, termCode and a relevance score. Example: lookup_ontology_term(query='apoptosis', ontology='efo').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "ontology": {"type": "string", "description": "OLS ontology short name, e.g. 'efo', 'obi', 'chebi', 'uberon'."},
+            },
+            "required": ["query", "ontology"],
+        },
+    },
+    {
+        "name": "lookup_unit",
+        "description": "Resolve a unit string (e.g. 'micromolar', 'hour') to a Units of Measurement Ontology (UO) IRI via OLS. Returns @id (UO IRI), name, termCode.",
+        "parameters": {
+            "type": "object",
+            "properties": {"unit_string": {"type": "string"}},
+            "required": ["unit_string"],
+        },
+    },
+    {
+        "name": "lookup_dtxsid",
+        "description": "Resolve a chemical (by name, CAS RN, or InChIKey) to its EPA DTXSID via the CompTox Dashboard. Returns dtxsid plus name/casrn/inchikey. Example: lookup_dtxsid(query='Bisphenol A').",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
+    {
         "name": "lookup_orcid",
         "description": "Look up person via ORCID",
         "parameters": {

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -253,6 +253,8 @@ _TOOL_ICONS: dict[str, str] = {
     "link": "\U0001f517", "check_provenance": "\U0001f9ec",
     "lookup_compound": "\U0001f50d", "lookup_cell_line": "\U0001f50d",
     "lookup_aop": "\U0001f50d", "lookup_bao_term": "\U0001f50d",
+    "lookup_ontology_term": "\U0001f50d", "lookup_unit": "\U0001f50d",
+    "lookup_dtxsid": "\U0001f50d",
     "lookup_orcid": "\U0001f50d", "lookup_ror": "\U0001f50d",
     "lookup_doi": "\U0001f50d",
     "scan_files": "\U0001f4c2", "read_file_sample": "\U0001f4c2",

--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -18,7 +18,10 @@ from typing import Any
 from lookups._http import TransientLookupError
 from lookups.aopwiki import lookup_aop as lookup_aop_wiki
 from lookups.bao import lookup_bao_term as lookup_bao_term_ols
+from lookups.bao import lookup_ontology_term as lookup_ontology_term_ols
+from lookups.bao import lookup_unit as lookup_unit_ols
 from lookups.cellosaurus import lookup_cellosaurus
+from lookups.comptox import lookup_dtxsid as lookup_dtxsid_comptox
 from lookups.crossref import lookup_doi as lookup_doi_crossref
 from lookups.orcid import lookup_orcid as lookup_orcid_api
 from lookups.pubchem import lookup_pubchem
@@ -81,7 +84,22 @@ def lookup_compound(name: str) -> dict[str, Any]:
             if result and result.get("pubchem_cid"):
                 return _success(result)
 
-        return _failure(f"Compound '{name}' not found in PubChem")
+        # Multi-strategy fallback: PubChem found nothing, so try ChEBI via OLS
+        # (name → CAS → ChEBI, as documented in AGENTS.md §10). This resolves a
+        # ChEBI ontology IRI for compounds PubChem does not index, rather than
+        # returning a hard "not found".
+        chebi = lookup_ontology_term_ols(raw, "chebi")
+        if chebi and chebi.get("@id"):
+            return _success(
+                {
+                    "chebi_id": chebi.get("termCode", ""),
+                    "chebi_iri": chebi["@id"],
+                    "iupac_name": chebi.get("name", raw),
+                    "source": "chebi",
+                }
+            )
+
+        return _failure(f"Compound '{name}' not found in PubChem or ChEBI")
     except TransientLookupError as exc:
         return _failure(f"PubChem unavailable (transient): {exc}", transient=True)
     except Exception as exc:
@@ -166,6 +184,93 @@ def lookup_bao_term(query: str) -> dict[str, Any]:
     except Exception as exc:
         logger.exception("BAO/OLS lookup failed for '%s'", query)
         return _failure(f"BAO/OLS lookup failed: {exc}")
+
+
+@functools.lru_cache(maxsize=256)
+def lookup_ontology_term(query: str, ontology: str) -> dict[str, Any]:
+    """Search any OLS4-hosted ontology for a term matching the query.
+
+    Generalises ``lookup_bao_term`` to any ontology (EFO/OBI/NCIT/UBERON/
+    ChEBI/UO/…), so the agent can ground free-text annotations in the right
+    vocabulary.
+
+    Args:
+        query: Free-text description (e.g. "apoptosis", "liver").
+        ontology: OLS ontology short name (e.g. "efo", "obi", "chebi").
+
+    Returns:
+        Standard lookup dict with keys:
+            found: True if a matching term was found.
+            data: Dict with @id, @type, name, termCode, and (when available)
+                  score keys.
+            error: Error message or None on success.
+    """
+    time.sleep(0.05)
+    try:
+        result = lookup_ontology_term_ols(query, ontology)
+        if result and result.get("@id"):
+            return _success(result)
+        return _failure(f"No '{ontology}' term found for '{query}'")
+    except TransientLookupError as exc:
+        return _failure(f"OLS unavailable (transient): {exc}", transient=True)
+    except Exception as exc:
+        logger.exception("OLS lookup failed for '%s' in '%s'", query, ontology)
+        return _failure(f"OLS lookup failed: {exc}")
+
+
+@functools.lru_cache(maxsize=256)
+def lookup_unit(unit_string: str) -> dict[str, Any]:
+    """Resolve a unit string to a Units of Measurement Ontology (UO) IRI.
+
+    Args:
+        unit_string: Plain-text unit (e.g. "micromolar", "hour").
+
+    Returns:
+        Standard lookup dict with keys:
+            found: True if a matching UO term was found.
+            data: Dict with @id (UO IRI), @type, name, termCode, and (when
+                  available) score keys.
+            error: Error message or None on success.
+    """
+    time.sleep(0.05)
+    try:
+        result = lookup_unit_ols(unit_string)
+        if result and result.get("@id"):
+            return _success(result)
+        return _failure(f"No UO unit found for '{unit_string}'")
+    except TransientLookupError as exc:
+        return _failure(f"UO/OLS unavailable (transient): {exc}", transient=True)
+    except Exception as exc:
+        logger.exception("UO/OLS lookup failed for '%s'", unit_string)
+        return _failure(f"UO/OLS lookup failed: {exc}")
+
+
+@functools.lru_cache(maxsize=256)
+def lookup_dtxsid(query: str) -> dict[str, Any]:
+    """Resolve a chemical to its EPA DTXSID via the CompTox Dashboard.
+
+    Args:
+        query: Chemical name, CAS RN, or InChIKey (e.g. "Bisphenol A",
+               "80-05-7").
+
+    Returns:
+        Standard lookup dict with keys:
+            found: True if a DTXSID was resolved.
+            data: Dict with dtxsid, @id, @type, name, and optionally casrn,
+                  inchikey keys.
+            error: Error message or None on success.
+    """
+    time.sleep(0.05)
+    try:
+        result = lookup_dtxsid_comptox(query)
+        if result and result.get("dtxsid"):
+            return _success(result)
+        return _failure(f"No DTXSID found for '{query}' in CompTox")
+    except TransientLookupError as exc:
+        return _failure(f"CompTox unavailable (transient): {exc}", transient=True)
+    except Exception as exc:
+        logger.exception("CompTox lookup failed for '%s'", query)
+        return _failure(f"CompTox lookup failed: {exc}")
 
 
 @functools.lru_cache(maxsize=256)
@@ -261,6 +366,9 @@ TOOL_REGISTRY.register("lookup_compound", lookup_compound, takes_state=False)
 TOOL_REGISTRY.register("lookup_cell_line", lookup_cell_line, takes_state=False)
 TOOL_REGISTRY.register("lookup_aop", lookup_aop, takes_state=False)
 TOOL_REGISTRY.register("lookup_bao_term", lookup_bao_term, takes_state=False)
+TOOL_REGISTRY.register("lookup_ontology_term", lookup_ontology_term, takes_state=False)
+TOOL_REGISTRY.register("lookup_unit", lookup_unit, takes_state=False)
+TOOL_REGISTRY.register("lookup_dtxsid", lookup_dtxsid, takes_state=False)
 TOOL_REGISTRY.register("lookup_orcid", lookup_orcid, takes_state=False)
 TOOL_REGISTRY.register("lookup_ror", lookup_ror, takes_state=False)
 TOOL_REGISTRY.register("lookup_doi", lookup_doi, takes_state=False)

--- a/builder/tools/verification.py
+++ b/builder/tools/verification.py
@@ -9,6 +9,7 @@ from builder.tools.lookups import (
     lookup_cell_line,
     lookup_compound,
     lookup_doi,
+    lookup_dtxsid,
     lookup_orcid,
 )
 
@@ -23,6 +24,8 @@ _VERIFY_WORKERS = 6
 def _select_verifier(entity_type: str, field: str):
     """Return an appropriate lookup function for an identifier-like field."""
     field_name = field.lower()
+    if entity_type == "MolecularEntity" and field_name == "dtxsid":
+        return lookup_dtxsid, "comptox"
     if entity_type == "MolecularEntity" and field_name in {
         "identifier",
         "cas",
@@ -56,6 +59,8 @@ _VERIFIABLE_FIELDS: frozenset[tuple[str, str]] = frozenset(
         ("MolecularEntity", "cas_number"),
         ("MolecularEntity", "pubchem_cid"),
         ("MolecularEntity", "inchikey"),
+        # MolecularEntity dtxsid maps to the EPA CompTox lookup
+        ("MolecularEntity", "dtxsid"),
         # CellLineSample fields that map to Cellosaurus lookup
         ("CellLineSample", "identifier"),
         ("CellLineSample", "accession"),

--- a/lookups/bao.py
+++ b/lookups/bao.py
@@ -1,40 +1,47 @@
 """
-BioAssay Ontology (BAO) lookup via EBI OLS4 API.
+Generic ontology-term lookup via the EBI OLS4 API.
 
-Used to annotate assay measurement methods, measurement techniques,
-and lab equipment with standardised ontology terms.
+OLS4 hosts dozens of ontologies behind a single search endpoint, so the same
+parser serves BAO (BioAssay Ontology) assay annotations, the Units of
+Measurement Ontology (UO) for quantities, and any other OLS-hosted ontology
+(EFO/OBI/NCIT/UBERON/ChEBI, …).
+
+``lookup_ontology_term`` is the generic primitive; ``lookup_bao_term`` and
+``lookup_unit`` are thin, ontology-pinned wrappers over it.
 """
 
 from __future__ import annotations
 
 import functools
-import time
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://www.ebi.ac.uk/ols4/api/search"
 
 
-@functools.lru_cache(maxsize=512)
-def lookup_bao_term(query: str) -> dict:
-    """Search BAO for the best matching term.
+@functools.lru_cache(maxsize=1024)
+def lookup_ontology_term(query: str, ontology: str, rows: int = 1) -> dict:
+    """Search an OLS4-hosted ontology for the best matching term.
 
     Args:
         query: plain-text description, e.g. "gene expression assay", "RT-qPCR",
-               "QuantStudio 7 Flex"
+               "micromolar".
+        ontology: OLS ontology short name, e.g. "bao", "uo", "efo", "chebi".
+        rows: number of OLS rows to request (only the top hit is returned).
 
     Returns:
-        dict with keys: @id (BAO IRI), @type ("DefinedTerm"), name.
-        Returns {} if no match. Raises TransientLookupError on a transient API
-        failure (timeout / connection / 429 / 5xx).
+        dict with keys: @id (term IRI), @type ("DefinedTerm"), name, termCode,
+        and ``score`` (the OLS4 relevance score, when present). Returns {} if no
+        match. Raises TransientLookupError on a transient API failure
+        (timeout / connection / 429 / 5xx).
     """
-    if not query:
+    if not query or not ontology:
         return {}
     try:
-        time.sleep(0.1)
+        # Politeness throttling is handled centrally in http_get_json (#62).
         data = http_get_json(
             _BASE,
-            params={"q": query, "ontology": "bao", "rows": 1},
+            params={"q": query, "ontology": ontology, "rows": rows},
         )
         if data is NOT_FOUND:
             return {}
@@ -50,13 +57,52 @@ def lookup_bao_term(query: str) -> dict:
         if not iri:
             return {}
 
-        return {
+        result = {
             "@id": iri,
             "@type": "DefinedTerm",
             "name": label,
             "termCode": top.get("short_form", ""),
         }
+        # OLS4 returns a Solr relevance score on each doc; surface it as a
+        # confidence signal when available.
+        score = top.get("score")
+        if score is not None:
+            result["score"] = score
+        return result
     except TransientLookupError:
         raise
     except Exception:
         return {}
+
+
+def lookup_bao_term(query: str) -> dict:
+    """Search BAO for the best matching term (back-compat wrapper).
+
+    Thin wrapper over :func:`lookup_ontology_term` pinned to ``ontology="bao"``.
+
+    Args:
+        query: plain-text description, e.g. "gene expression assay", "RT-qPCR",
+               "QuantStudio 7 Flex"
+
+    Returns:
+        dict with keys: @id (BAO IRI), @type ("DefinedTerm"), name, termCode.
+        Returns {} if no match. Raises TransientLookupError on a transient API
+        failure (timeout / connection / 429 / 5xx).
+    """
+    return lookup_ontology_term(query, "bao")
+
+
+def lookup_unit(unit_string: str) -> dict:
+    """Resolve a unit string to a Units of Measurement Ontology (UO) IRI.
+
+    Thin wrapper over :func:`lookup_ontology_term` pinned to ``ontology="uo"``.
+
+    Args:
+        unit_string: plain-text unit, e.g. "micromolar", "hour", "milligram".
+
+    Returns:
+        dict with keys: @id (UO IRI), @type ("DefinedTerm"), name, termCode, and
+        ``score`` when available. Returns {} if no match. Raises
+        TransientLookupError on a transient API failure.
+    """
+    return lookup_ontology_term(unit_string, "uo")

--- a/lookups/comptox.py
+++ b/lookups/comptox.py
@@ -1,0 +1,87 @@
+"""
+EPA CompTox Chemicals Dashboard lookup.
+
+Resolves a chemical (by name, CAS RN, or InChIKey) to its EPA DSSTox
+substance identifier (DTXSID) via the public CompTox Dashboard search API.
+The DTXSID is the stable key into the EPA hazard/exposure datasets, so it is
+the anchor identifier for the toxicology profile.
+
+Follows the same shape as the other raw lookup modules (``http_get_json`` +
+``lru_cache`` + return ``{}`` on failure, re-raise ``TransientLookupError``).
+"""
+
+from __future__ import annotations
+
+import functools
+from urllib.parse import quote
+
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
+
+# Public CompTox Dashboard search endpoint (no API key required). An exact
+# ("equal") match is tried first; the response is a list of candidate hits.
+_BASE = "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal"
+
+
+def _first_hit(data: object) -> dict | None:
+    """Return the first chemical hit from a CompTox search response, or None.
+
+    The endpoint returns a JSON array of hit objects; older deployments wrap
+    the array in a top-level key, so handle both shapes defensively.
+    """
+    hits: list = []
+    if isinstance(data, list):
+        hits = data
+    elif isinstance(data, dict):
+        candidate = data.get("hits") or data.get("results") or data.get("content") or []
+        if isinstance(candidate, list):
+            hits = candidate
+    for hit in hits:
+        if isinstance(hit, dict) and hit.get("dtxsid"):
+            return hit
+    return None
+
+
+@functools.lru_cache(maxsize=512)
+def lookup_dtxsid(query: str) -> dict:
+    """Resolve a chemical to its EPA DTXSID via the CompTox Dashboard.
+
+    Args:
+        query: a chemical name, CAS RN, or InChIKey, e.g. "Bisphenol A",
+               "80-05-7", or "IISBACLAFKSPIT-UHFFFAOYSA-N".
+
+    Returns:
+        dict with keys: dtxsid, name, casrn, inchikey, @id (a resolvable
+        DTXSID IRI), @type ("MolecularEntity"). Returns {} if no match. Raises
+        TransientLookupError on a transient API failure (timeout / connection /
+        429 / 5xx).
+    """
+    if not query:
+        return {}
+    try:
+        data = http_get_json(f"{_BASE}/{quote(query.strip())}")
+        if data is NOT_FOUND:
+            return {}
+
+        hit = _first_hit(data)
+        if hit is None:
+            return {}
+
+        dtxsid = hit.get("dtxsid", "")
+        if not dtxsid:
+            return {}
+
+        result: dict = {
+            "dtxsid": dtxsid,
+            "@id": f"https://comptox.epa.gov/dashboard/chemical/details/{dtxsid}",
+            "@type": "MolecularEntity",
+            "name": hit.get("preferredName") or hit.get("name") or query,
+        }
+        if hit.get("casrn"):
+            result["casrn"] = hit["casrn"]
+        if hit.get("inchikey") or hit.get("inchiKey"):
+            result["inchikey"] = hit.get("inchikey") or hit.get("inchiKey")
+        return result
+    except TransientLookupError:
+        raise
+    except Exception:
+        return {}

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -18,8 +18,9 @@ from requests.exceptions import ConnectionError, Timeout
 
 from lookups._http import TransientLookupError
 from lookups.aopwiki import lookup_aop
-from lookups.bao import lookup_bao_term
+from lookups.bao import lookup_bao_term, lookup_ontology_term, lookup_unit
 from lookups.cellosaurus import lookup_cellosaurus
+from lookups.comptox import lookup_dtxsid
 from lookups.crossref import lookup_doi
 from lookups.orcid import lookup_orcid
 from lookups.pubchem import lookup_pubchem
@@ -43,7 +44,8 @@ def _clear_caches():
     lookup_pubchem.cache_clear()
     lookup_cellosaurus.cache_clear()
     lookup_aop.cache_clear()
-    lookup_bao_term.cache_clear()
+    lookup_ontology_term.cache_clear()
+    lookup_dtxsid.cache_clear()
     lookup_orcid.cache_clear()
     search_ror.cache_clear()
     lookup_doi.cache_clear()
@@ -409,6 +411,153 @@ class TestBAOContract:
 
         result = lookup_bao_term("something")
         assert result == {}
+
+
+# ===========================================================================
+# Generic OLS ontology term + units (#142)
+# ===========================================================================
+
+
+class TestOntologyTermContract:
+    """Contract tests for lookups/bao.py generic OLS functions."""
+
+    @responses.activate
+    def test_generic_ontology_term_with_score(self):
+        """lookup_ontology_term surfaces the OLS score and respects ontology."""
+        responses.add(
+            responses.GET,
+            "https://www.ebi.ac.uk/ols4/api/search",
+            json={
+                "response": {
+                    "numFound": 1,
+                    "docs": [
+                        {
+                            "iri": "http://www.ebi.ac.uk/efo/EFO_0000311",
+                            "label": "cancer",
+                            "short_form": "EFO_0000311",
+                            "score": 14.2,
+                        }
+                    ],
+                }
+            },
+            status=200,
+        )
+
+        result = lookup_ontology_term("cancer", "efo")
+        assert result["@id"] == "http://www.ebi.ac.uk/efo/EFO_0000311"
+        assert result["termCode"] == "EFO_0000311"
+        assert result["score"] == 14.2
+        # The request must carry the requested ontology and a rows param.
+        sent = responses.calls[0].request
+        assert "ontology=efo" in sent.url
+        assert "rows=" in sent.url
+
+    @responses.activate
+    def test_unit_resolves_to_uo_iri(self):
+        """lookup_unit resolves to a UO IRI via the same OLS endpoint."""
+        responses.add(
+            responses.GET,
+            "https://www.ebi.ac.uk/ols4/api/search",
+            json={
+                "response": {
+                    "numFound": 1,
+                    "docs": [
+                        {
+                            "iri": "http://purl.obolibrary.org/obo/UO_0000064",
+                            "label": "micromolar",
+                            "short_form": "UO_0000064",
+                            "score": 8.0,
+                        }
+                    ],
+                }
+            },
+            status=200,
+        )
+
+        result = lookup_unit("micromolar")
+        assert result["@id"] == "http://purl.obolibrary.org/obo/UO_0000064"
+        assert result["termCode"] == "UO_0000064"
+        assert "ontology=uo" in responses.calls[0].request.url
+
+    @responses.activate
+    def test_bao_wrapper_still_pins_bao(self):
+        """The back-compat lookup_bao_term wrapper still pins ontology=bao."""
+        responses.add(
+            responses.GET,
+            "https://www.ebi.ac.uk/ols4/api/search",
+            json=_load("bao_cell_viability.json"),
+            status=200,
+        )
+
+        result = lookup_bao_term("cell viability assay")
+        assert result["termCode"] == "BAO_0003009"
+        assert "ontology=bao" in responses.calls[0].request.url
+
+
+# ===========================================================================
+# CompTox DTXSID (#146)
+# ===========================================================================
+
+
+class TestCompToxContract:
+    """Contract tests for lookups/comptox.py."""
+
+    @responses.activate
+    def test_resolves_dtxsid_from_list(self):
+        """A list response yields the first hit's DTXSID."""
+        responses.add(
+            responses.GET,
+            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/Bisphenol%20A",
+            json=[
+                {
+                    "dtxsid": "DTXSID7020182",
+                    "preferredName": "Bisphenol A",
+                    "casrn": "80-05-7",
+                    "inchikey": "IISBACLAFKSPIT-UHFFFAOYSA-N",
+                }
+            ],
+            status=200,
+        )
+
+        result = lookup_dtxsid("Bisphenol A")
+        assert result["dtxsid"] == "DTXSID7020182"
+        assert result["@type"] == "MolecularEntity"
+        assert result["casrn"] == "80-05-7"
+        assert result["inchikey"] == "IISBACLAFKSPIT-UHFFFAOYSA-N"
+        assert result["@id"].endswith("DTXSID7020182")
+
+    @responses.activate
+    def test_no_hits_returns_empty(self):
+        responses.add(
+            responses.GET,
+            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/Nope",
+            json=[],
+            status=200,
+        )
+        assert lookup_dtxsid("Nope") == {}
+
+    @responses.activate
+    def test_404_returns_empty(self):
+        responses.add(
+            responses.GET,
+            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/Nope",
+            status=404,
+        )
+        assert lookup_dtxsid("Nope") == {}
+
+    @responses.activate
+    def test_timeout_raises_transient(self):
+        responses.add(
+            responses.GET,
+            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/BPA",
+            body=Timeout("timed out"),
+        )
+        with pytest.raises(TransientLookupError):
+            lookup_dtxsid("BPA")
+
+    @responses.activate
+    def test_empty_query_no_http(self):
+        assert lookup_dtxsid("") == {}
 
 
 # ===========================================================================

--- a/tests/test_tools_lookups.py
+++ b/tests/test_tools_lookups.py
@@ -14,8 +14,11 @@ from builder.tools.lookups import (
     lookup_cell_line,
     lookup_compound,
     lookup_doi,
+    lookup_dtxsid,
+    lookup_ontology_term,
     lookup_orcid,
     lookup_ror,
+    lookup_unit,
 )
 
 
@@ -445,4 +448,171 @@ class TestLookupDOI:
         result = lookup_doi("10.9999/crash")
         assert result["found"] is False
         assert result["data"] == {}
+        assert isinstance(result["error"], str)
+
+
+class TestLookupOntologyTerm:
+    """Tests for lookup_ontology_term — generic OLS ontology lookup (#142)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        lookup_ontology_term.cache_clear()
+        yield
+
+    def test_returns_iri_and_score_on_success(self, monkeypatch):
+        def mock_ols(query, ontology):
+            assert ontology == "efo"
+            return {
+                "@id": "http://www.ebi.ac.uk/efo/EFO_0000311",
+                "@type": "DefinedTerm",
+                "name": "cancer",
+                "termCode": "EFO_0000311",
+                "score": 12.34,
+            }
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_ontology_term_ols", mock_ols)
+        result = lookup_ontology_term("cancer", "efo")
+        assert result["found"] is True
+        assert result["data"]["@id"] == "http://www.ebi.ac.uk/efo/EFO_0000311"
+        assert result["data"]["score"] == 12.34
+        assert result["error"] is None
+
+    def test_returns_failure_when_no_match(self, monkeypatch):
+        monkeypatch.setattr(
+            "builder.tools.lookups.lookup_ontology_term_ols", lambda q, o: {}
+        )
+        result = lookup_ontology_term("zzz", "efo")
+        assert result["found"] is False
+        assert result["data"] == {}
+        assert isinstance(result["error"], str)
+
+    def test_never_throws_exception(self, monkeypatch):
+        def boom(query, ontology):
+            raise RuntimeError("OLS down")
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_ontology_term_ols", boom)
+        result = lookup_ontology_term("crash", "efo")
+        assert result["found"] is False
+        assert isinstance(result["error"], str)
+
+
+class TestLookupUnit:
+    """Tests for lookup_unit — UO unit resolution via OLS (#142)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        lookup_unit.cache_clear()
+        yield
+
+    def test_returns_uo_iri_on_success(self, monkeypatch):
+        def mock_uo(unit_string):
+            return {
+                "@id": "http://purl.obolibrary.org/obo/UO_0000064",
+                "@type": "DefinedTerm",
+                "name": "micromolar",
+                "termCode": "UO_0000064",
+                "score": 9.1,
+            }
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_unit_ols", mock_uo)
+        result = lookup_unit("micromolar")
+        assert result["found"] is True
+        assert result["data"]["@id"] == "http://purl.obolibrary.org/obo/UO_0000064"
+        assert result["data"]["@id"].rsplit("/", 1)[1].startswith("UO_")
+        assert result["error"] is None
+
+    def test_returns_failure_when_no_match(self, monkeypatch):
+        monkeypatch.setattr("builder.tools.lookups.lookup_unit_ols", lambda u: {})
+        result = lookup_unit("notaunit")
+        assert result["found"] is False
+        assert isinstance(result["error"], str)
+
+    def test_never_throws_exception(self, monkeypatch):
+        def boom(unit_string):
+            raise RuntimeError("OLS down")
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_unit_ols", boom)
+        result = lookup_unit("crash")
+        assert result["found"] is False
+        assert isinstance(result["error"], str)
+
+
+class TestLookupDtxsid:
+    """Tests for lookup_dtxsid — EPA CompTox DTXSID resolution (#146)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        lookup_dtxsid.cache_clear()
+        yield
+
+    def test_returns_dtxsid_on_success(self, monkeypatch):
+        def mock_comptox(query):
+            return {
+                "dtxsid": "DTXSID7020182",
+                "@id": "https://comptox.epa.gov/dashboard/chemical/details/DTXSID7020182",
+                "@type": "MolecularEntity",
+                "name": "Bisphenol A",
+                "casrn": "80-05-7",
+                "inchikey": "IISBACLAFKSPIT-UHFFFAOYSA-N",
+            }
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_dtxsid_comptox", mock_comptox)
+        result = lookup_dtxsid("Bisphenol A")
+        assert result["found"] is True
+        assert result["data"]["dtxsid"] == "DTXSID7020182"
+        assert result["data"]["casrn"] == "80-05-7"
+        assert result["error"] is None
+
+    def test_returns_failure_when_no_match(self, monkeypatch):
+        monkeypatch.setattr("builder.tools.lookups.lookup_dtxsid_comptox", lambda q: {})
+        result = lookup_dtxsid("NotAChemical")
+        assert result["found"] is False
+        assert result["data"] == {}
+        assert isinstance(result["error"], str)
+
+    def test_never_throws_exception(self, monkeypatch):
+        def boom(query):
+            raise RuntimeError("CompTox down")
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_dtxsid_comptox", boom)
+        result = lookup_dtxsid("crash")
+        assert result["found"] is False
+        assert isinstance(result["error"], str)
+
+
+class TestLookupCompoundChebiFallback:
+    """lookup_compound falls back to ChEBI (via OLS) when PubChem misses (#146)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        lookup_compound.cache_clear()
+        yield
+
+    def test_falls_back_to_chebi_when_pubchem_empty(self, monkeypatch):
+        monkeypatch.setattr("builder.tools.lookups.lookup_pubchem", lambda q: {})
+
+        def mock_chebi(query, ontology):
+            assert ontology == "chebi"
+            return {
+                "@id": "http://purl.obolibrary.org/obo/CHEBI_28061",
+                "@type": "DefinedTerm",
+                "name": "alpha-D-glucose",
+                "termCode": "CHEBI_28061",
+            }
+
+        monkeypatch.setattr(
+            "builder.tools.lookups.lookup_ontology_term_ols", mock_chebi
+        )
+        result = lookup_compound("alpha-D-glucose")
+        assert result["found"] is True
+        assert result["data"]["chebi_id"] == "CHEBI_28061"
+        assert result["data"]["source"] == "chebi"
+
+    def test_fails_when_both_pubchem_and_chebi_miss(self, monkeypatch):
+        monkeypatch.setattr("builder.tools.lookups.lookup_pubchem", lambda q: {})
+        monkeypatch.setattr(
+            "builder.tools.lookups.lookup_ontology_term_ols", lambda q, o: {}
+        )
+        result = lookup_compound("TotallyMadeUpXYZ")
+        assert result["found"] is False
         assert isinstance(result["error"], str)

--- a/tests/test_tools_verification.py
+++ b/tests/test_tools_verification.py
@@ -129,6 +129,40 @@ class TestVerifyIdentifier:
         assert status is not None
         assert status.status != "missing"
 
+    def test_verifies_molecular_entity_dtxsid(self, minimal_state, monkeypatch):
+        """MolecularEntity.dtxsid re-resolves via the CompTox lookup (#146)."""
+        state = minimal_state
+        chem = Entity(
+            entity_id="chem_bpa",
+            type="MolecularEntity",
+            fields={"dtxsid": "DTXSID7020182"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        chem.set_field_status("dtxsid", "filled", "llm")
+        state.add_entity(chem)
+
+        seen = {}
+
+        def fake_dtxsid(query):
+            seen["query"] = query
+            return {
+                "found": True,
+                "data": {"dtxsid": "DTXSID7020182", "name": "Bisphenol A"},
+                "error": None,
+            }
+
+        monkeypatch.setattr("builder.tools.verification.lookup_dtxsid", fake_dtxsid)
+
+        result = verify_identifier(state, "chem_bpa", "dtxsid")
+
+        assert result["verified"] is True
+        # The stored DTXSID value is what gets re-resolved.
+        assert seen["query"] == "DTXSID7020182"
+        completion = chem.get_field_status("dtxsid")
+        assert completion is not None
+        assert completion.status == "verified"
+        assert "comptox" in chem._provenance.lookups_used
+
     def test_transient_orcid_not_verified_and_kept(self, minimal_state, monkeypatch):
         """A transient ORCID error is neither verified nor cleared (no false +)."""
         state = minimal_state
@@ -216,6 +250,7 @@ class TestVerifiableFieldSet:
         assert "inchikey" in me_fields, "inchikey should be verifiable for MolecularEntity"
         assert "identifier" in me_fields, "identifier should be verifiable for MolecularEntity"
         assert "pubchem_cid" in me_fields, "pubchem_cid should be verifiable for MolecularEntity"
+        assert "dtxsid" in me_fields, "dtxsid should be verifiable for MolecularEntity"
 
     def test_organization_ror_not_verifiable(self):
         """Organization has no verifier, so ror should not be in the set."""


### PR DESCRIPTION
Closes #142 and Closes #146.

## What

Two external lookup authorities, sharing the OLS4 + raw-lookup plumbing:

### #142 — Generic OLS ontology-term lookup + units (UO)
- `lookups/bao.py`: the hard-coded BAO query is promoted into a generic
  `lookup_ontology_term(query, ontology, rows=1)` over the OLS4 search endpoint,
  surfacing the OLS relevance **score** as a confidence signal.
  `lookup_bao_term(query)` is now a thin back-compat wrapper (`ontology='bao'`),
  and `lookup_unit(unit_string)` resolves unit strings to **UO** IRIs
  (`ontology='uo'`). The per-client `time.sleep` is dropped — politeness is the
  per-host throttle in `lookups/_http`.
- `builder/tools/lookups.py`: `{found, data, error}` wrappers
  `lookup_ontology_term` and `lookup_unit` (lru_cache'd), both registered.

### #146 — Chemistry authority (DTXSID + ChEBI)
- `lookups/comptox.py` (new): resolves a chemical (name / CAS / InChIKey) to its
  **EPA DTXSID** via the CompTox Dashboard search API, following the existing raw
  lookup shape (`http_get_json` + `lru_cache` + return `{}` on failure, re-raise
  `TransientLookupError`). Returns a `dtxsid` field plus a resolvable `@id`.
- `builder/tools/lookups.py`: `lookup_dtxsid` wrapper + registration, **and** a
  ChEBI fallback in `lookup_compound` (name → CAS → ChEBI via OLS) — the
  AGENTS.md/README "try by name, then CAS, then ChEBI" promise is now **real**
  instead of a hard not-found. (Chosen: implement, not just doc.)
- `builder/tools/verification.py`: `(MolecularEntity, dtxsid) -> comptox` branch
  added to `_select_verifier` and `_VERIFIABLE_FIELDS`, so the id is verifiable
  and re-resolves at its source.

## Why
Unlocks EFO/OBI/NCIT/UBERON/ChEBI/UO grounding through one OLS primitive and adds
the DTXSID anchor identifier for the tox profile, all behind the existing
`{found, data, error}` contract, `lru_cache`, and per-host throttle.

## Drift guards & docs
All three new agent tools synced across `TOOL_REGISTRY`, `TOOL_SPECS`, the
system-prompt tool list, and the dashboard icon map. `AGENTS.md` §10 + tool
signatures updated.

## Tests (mocked HTTP only — no network)
Extended `tests/test_tools_lookups.py`, `tests/test_lookups_contract.py`, and
`tests/test_tools_verification.py`:
- `lookup_ontology_term` returns IRI + score and sends the requested ontology
- `lookup_unit` returns a UO IRI
- `lookup_dtxsid` returns a DTXSID (list + wrapped responses, 404, timeout)
- `lookup_compound` ChEBI fallback when PubChem misses
- verifying `MolecularEntity.dtxsid` re-resolves via CompTox
- `lookup_bao_term` regression stays green

`uv run pytest tests/test_tools_lookups.py tests/test_tools_verification.py tests/test_lookups_contract.py tests/test_tools_spec.py tests/test_tool_registry.py tests/test_dashboard.py tests/test_entity_draft_schema.py` → 136 passed. ruff + ty clean on changed files.

Note: the 10 pre-existing `tests/test_agent_loop.py` failures on this machine are an unrelated `ModuleNotFoundError: langchain_openai` (missing optional dep), present on `main` and untouched by this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)