### PR TITLE
fix(scanner,readers): scientific MIME registry + unified 100MB file-reader ceiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,24 @@ roots (see [Guard Rails](#guard-rails-approved-scan-roots) above).
 - `read_file_sample` accepts `precomputed_size` and `already_text` to avoid redundant stat()/MIME syscalls
 - `_safe_walk` prunes hidden/`.git`/`__MACOSX` directories in-place via `os.walk` `dirnames[:]` mutation, avoiding the cost of descending and then filtering
 
+**MIME detection (Issue #148):** `_detect_mime_type` resolves in order — stdlib
+`mimetypes`, then a scientific-format registry (`_SCIENTIFIC_MIME_TYPES`) covering
+MS/microscopy/flow extensions the stdlib does not know (`.mzML` →
+`application/x-mzml`, `.fcs` → `application/vnd.isac.fcs`, vendor binaries
+`.raw/.wiff/.czi/.nd2/.lif/.d/...` → `application/octet-stream`), consulted BEFORE
+the text-content sniff so binaries are never mislabeled `text/plain`, with
+`application/octet-stream` as the true default for unknown binary. A NUL byte in
+the header now reliably forces the binary default. `encoding_format_for_name`
+exposes the same extension→media-type derivation (no disk read) for entity
+drafting.
+
+**Size ceilings (Issue #148):** the dedicated readers in `file_readers.py` share
+the scanner's 100 MB ceiling (`_MAX_BYTES`), not the old 1 MB cap that silently
+returned `None` for ordinary mid-size files; row/line caps keep memory bounded.
+The agent loop turns a bare `None` from any file reader
+(`read_file_sample`/`read_file`/`read_excel`/`read_docx`) into an actionable
+"unreadable/too-large — skip it" message so a weak model stops re-calling it.
+
 #### Entity Drafters (`builder/tools/drafters.py`)
 Generate metadata entities from files, conversation, or existing metadata.
 Each drafter collects hints, calls the LLM, and ensures identifiers come from
@@ -464,6 +482,13 @@ scalar keys plus reference keys, the latter a strict subset of `_REF_FIELDS`
 (asserted by test) so the advertised reference vocabulary and the crate-mapping
 resolver cannot drift. The schema is open (`additionalProperties: true`), so a
 weak model sees the high-value keys without the long tail being forbidden.
+
+`draft_file` auto-derives `encodingFormat` from the file extension (`name`, then
+`path`) when the caller omits it (Issue #148), via the same scientific-format-aware
+MIME registry the scanner uses — so `run.mzML` becomes `application/x-mzml` and
+`acquisition.fcs` becomes `application/vnd.isac.fcs` rather than being left blank
+or mislabeled `text/plain`. An explicit `encoding_format` always wins; an
+extensionless name leaves the field unset.
 
 ### Entity Management Tools
 ```

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -182,22 +182,32 @@ def _build_args_schema(name: str, params: dict[str, Any]) -> type[BaseModel] | N
     return create_model(f"{name}_args", **fields, __base__=BaseModel)
 
 
-def _unreadable_file_message(path: str) -> str:
-    """Actionable message for the LLM when read_file_sample can't return text.
+# File-reading tools that hand back a bare ``None`` for files that are missing,
+# too large, or binary/corrupt. A bare ``None`` gives a weak model nothing to act
+# on, so it re-calls the tool forever and hits the iteration cap (#101, #148).
+_FILE_READ_TOOLS = frozenset(
+    {"read_file_sample", "read_file", "read_excel", "read_docx"}
+)
 
-    read_file_sample returns a bare ``None`` for files that are missing, too
-    large, or binary (e.g. .xls/.xlsx Office containers, GraphPad .prism/.pzf).
-    A bare ``None`` gives the model nothing to act on, so a weak model re-calls
-    the tool forever and hits the iteration cap (#101). This turns it into a
-    clear "stop, do something else" signal.
+
+def _unreadable_file_message(path: str, tool_name: str = "read_file_sample") -> str:
+    """Actionable message for the LLM when a file reader can't return text.
+
+    The file-reading tools (read_file_sample / read_file / read_excel /
+    read_docx) return a bare ``None`` for files that are missing, too large
+    (>100MB), or binary/corrupt (e.g. .xls/.xlsx Office containers, GraphPad
+    .prism/.pzf). A bare ``None`` gives the model nothing to act on, so a weak
+    model re-calls the tool forever and hits the iteration cap (#101, #148).
+    This turns it into a clear "stop, do something else" signal.
     """
     name = (path or "").replace("\\", "/").rsplit("/", 1)[-1] or path or "the file"
     return (
-        f"read_file_sample could not return text for '{name}'. It is missing, too "
-        f"large (>100MB), or binary — e.g. .xls/.xlsx are Office/zip containers and "
-        f".prism/.pzf are GraphPad Prism binaries. Do NOT retry read_file_sample on "
-        f"it. Use the scan preview already in state, try read_excel/read_file for "
-        f"spreadsheets or Office docs, or skip this file and continue drafting entities."
+        f"{tool_name} could not return text for '{name}'. It is missing, too "
+        f"large (>100MB), or binary/corrupt — e.g. .xls/.xlsx are Office/zip "
+        f"containers and .prism/.pzf are GraphPad Prism binaries. Do NOT retry "
+        f"{tool_name} on it. Use the scan preview already in state, try "
+        f"read_excel/read_file for spreadsheets or Office docs, or skip this file "
+        f"and continue drafting entities."
     )
 
 
@@ -245,10 +255,13 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     from builder.tools.scanner import summarize_scan_result
 
                     return summarize_scan_result(result)
-                # read_file_sample returns None for missing/oversized/binary files;
-                # hand the LLM an actionable message so it stops re-calling it (#101).
-                if tool_name == "read_file_sample" and result is None:
-                    return _unreadable_file_message(kwargs.get("path", ""))
+                # The file-reading tools return None for missing/oversized/binary
+                # files; hand the LLM an actionable message so it stops re-calling
+                # them (#101, #148).
+                if tool_name in _FILE_READ_TOOLS and result is None:
+                    return _unreadable_file_message(
+                        kwargs.get("path", ""), tool_name
+                    )
                 return result
 
             _run.__name__ = tool_name

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -17,7 +17,11 @@ logger = logging.getLogger(__name__)
 # Limits
 # ---------------------------------------------------------------------------
 
-_MAX_BYTES = 1_000_000  # 1 MB — skip files larger than this
+# Unified size ceiling (Issue #148): matches scanner.read_file_sample /
+# extract_pdf_text (100 MB). The readers cap rows/lines independently, so memory
+# stays bounded even for large files; the old 1 MB ceiling silently returned
+# None for ordinary mid-size files (e.g. a 5 MB CSV), starving the agent.
+_MAX_BYTES = 100 * 1024 * 1024  # 100 MB — skip files larger than this
 _MAX_ROWS = 500  # max rows to return from structured formats
 
 

--- a/builder/tools/provenance.py
+++ b/builder/tools/provenance.py
@@ -28,6 +28,7 @@ from typing import Any
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools._crate_mapping import PROVENANCE_RELATIONS
 from builder.tools.drafters import _make_entity_id
+from builder.tools.scanner import encoding_format_for_name
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,11 @@ def draft_file(
         path: Crate-relative destination path for the file (``dest_path``). When
             omitted the mapping derives ``data/<name>``.
         role: Optional role label for the file (e.g. "raw_data", "figure").
-        encoding_format: Optional IANA media type (schema:encodingFormat).
+        encoding_format: Optional IANA media type (schema:encodingFormat). When
+            omitted it is auto-derived from the file extension (``name`` first,
+            then ``path``) via the scientific-format-aware registry (Issue #148),
+            so e.g. ``run.mzML`` becomes ``application/x-mzml`` rather than being
+            left blank or mislabeled text/plain. An explicit value always wins.
 
     Returns:
         The newly created File Entity.
@@ -69,6 +74,13 @@ def draft_file(
         fields["dest_path"] = path
     if role:
         fields["role"] = role
+    if not encoding_format:
+        # Auto-derive from the extension (name, then dest path) when the caller
+        # omits it. Returns None for extensionless/unknown names, leaving the
+        # field unset rather than guessing.
+        encoding_format = encoding_format_for_name(name) or (
+            encoding_format_for_name(path) if path else None
+        )
     if encoding_format:
         fields["encodingFormat"] = encoding_format
     entity = Entity(

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -48,8 +48,83 @@ def _is_within(dest: Path, target: Path) -> bool:
         return False
 
 
+# Scientific-format MIME registry (Issue #148).
+#
+# ``mimetypes.guess_type`` returns ``None`` for mass-spec / microscopy / flow
+# formats (.mzML, .raw, .wiff, .fcs, .czi, .nd2, .lif, .d, ...), so the old
+# text-sniff fallback would decode their bytes and mislabel them as
+# ``text/plain``. This map is consulted BEFORE the text sniff so these formats
+# get a meaningful media type, and binary vendor formats default to
+# ``application/octet-stream`` (the true default for unknown binary content)
+# rather than ``text/plain``.
+#
+# Where a registered/community media type exists we use it (mzML ->
+# application/x-mzml, FCS -> application/vnd.isac.fcs); otherwise the format is
+# an opaque vendor binary and maps to application/octet-stream.
+_SCIENTIFIC_MIME_TYPES: dict[str, str] = {
+    # Mass spectrometry — open/standard
+    ".mzml": "application/x-mzml",
+    ".mzxml": "application/x-mzxml",
+    ".mzdata": "application/x-mzdata",
+    ".imzml": "application/x-mzml",
+    ".mgf": "text/plain",
+    # Mass spectrometry — vendor binaries
+    ".raw": "application/octet-stream",  # Thermo / Waters raw
+    ".wiff": "application/octet-stream",  # SCIEX
+    ".wiff2": "application/octet-stream",
+    ".d": "application/octet-stream",  # Agilent / Bruker directory bundle
+    ".baf": "application/octet-stream",  # Bruker
+    ".tdf": "application/octet-stream",  # Bruker timsTOF
+    ".yep": "application/octet-stream",  # Bruker
+    ".fid": "application/octet-stream",  # Bruker / NMR FID
+    # Flow cytometry
+    ".fcs": "application/vnd.isac.fcs",
+    # Microscopy / imaging — vendor binaries
+    ".czi": "application/octet-stream",  # Zeiss
+    ".nd2": "application/octet-stream",  # Nikon
+    ".lif": "application/octet-stream",  # Leica
+    ".lsm": "application/octet-stream",  # Zeiss
+    ".oib": "application/octet-stream",  # Olympus
+    ".oif": "application/octet-stream",  # Olympus
+    ".ims": "application/octet-stream",  # Imaris
+    ".vsi": "application/octet-stream",  # Olympus
+    ".ndpi": "application/octet-stream",  # Hamamatsu
+    ".svs": "application/octet-stream",  # Aperio
+    ".scn": "application/octet-stream",  # Leica slide
+    ".dm3": "application/octet-stream",  # Gatan
+    ".dm4": "application/octet-stream",  # Gatan
+    # Open imaging containers
+    ".ome.tiff": "image/tiff",
+    ".ome.tif": "image/tiff",
+}
+
+
+def _scientific_mime_for(file_path: Path) -> str | None:
+    """Return a registered media type for known scientific file extensions.
+
+    Handles both single-suffix (``.mzML``) and compound (``.ome.tiff``)
+    extensions, case-insensitively. Returns ``None`` when the extension is not
+    in the scientific registry.
+    """
+    # Prefer the longest matching compound suffix (e.g. .ome.tiff over .tiff).
+    suffixes = [s.lower() for s in file_path.suffixes]
+    for start in range(len(suffixes)):
+        compound = "".join(suffixes[start:])
+        if compound in _SCIENTIFIC_MIME_TYPES:
+            return _SCIENTIFIC_MIME_TYPES[compound]
+    return None
+
+
 def _detect_mime_type(file_path: Path) -> str:
     """Detect the MIME type of a file using mimetypes and content sniffing.
+
+    Resolution order (Issue #148):
+
+    1. ``mimetypes.guess_type`` (stdlib extension table).
+    2. The scientific-format registry (:data:`_SCIENTIFIC_MIME_TYPES`) for
+       MS / microscopy / flow extensions the stdlib does not know.
+    3. A text-content sniff (CSV / TSV / plain text).
+    4. ``application/octet-stream`` as the true default for unknown binary.
 
     Args:
         file_path: Path to the file.
@@ -57,33 +132,72 @@ def _detect_mime_type(file_path: Path) -> str:
     Returns:
         A MIME type string.
     """
-    # Fallback: guess from extension
+    # Step 1: stdlib extension table.
     mime_type, _ = mimetypes.guess_type(str(file_path))
     if mime_type:
         return mime_type
-    # Fallback: try content sniffing for common text formats
+
+    # Step 2: scientific-format registry (BEFORE the text sniff so binary
+    # vendor formats are not mislabeled text/plain).
+    scientific = _scientific_mime_for(file_path)
+    if scientific is not None:
+        return scientific
+
+    # Step 3: content sniffing for common text formats.
     try:
         with file_path.open("rb") as f:
             header = f.read(512)
 
-        # Check for CSV/TSV by looking for commas/tabs in the first line
-        if header.startswith(b",") or (b"," in header.split(b"\n")[0][:256]):
-            return "text/csv"
-        if header.startswith(b"\t") or (b"\t" in header.split(b"\n")[0][:256]):
-            return "text/tab-separated-values"
+        # A NUL byte is a reliable binary marker — even though it decodes as
+        # valid UTF-8, it never appears in genuine text, so refuse to call such
+        # content text/* and fall through to octet-stream.
+        if b"\x00" not in header:
+            # Check for CSV/TSV by looking for commas/tabs in the first line
+            if header.startswith(b",") or (b"," in header.split(b"\n")[0][:256]):
+                return "text/csv"
+            if header.startswith(b"\t") or (b"\t" in header.split(b"\n")[0][:256]):
+                return "text/tab-separated-values"
 
-        # Check if it looks like plain text (printable ASCII or common UTF-8)
-        try:
-            header.decode("utf-8")
-            return "text/plain"
-        except (UnicodeDecodeError, UnicodeError):
-            pass
+            # Check if it looks like plain text (printable ASCII or common UTF-8)
+            try:
+                header.decode("utf-8")
+                return "text/plain"
+            except (UnicodeDecodeError, UnicodeError):
+                pass
     except PermissionError:
         logger.warning("Permission denied reading: %s", file_path)
     except OSError:
         pass
 
+    # Step 4: true default for unknown binary content.
     return "application/octet-stream"
+
+
+def encoding_format_for_name(name: str) -> str | None:
+    """Derive an IANA media type from a file name/extension alone (no disk read).
+
+    Used to auto-populate ``schema:encodingFormat`` when drafting File entities
+    (Issue #148). Consults the stdlib ``mimetypes`` table first, then the
+    scientific-format registry (:data:`_SCIENTIFIC_MIME_TYPES`). Returns
+    ``None`` when the name carries no recognised extension, so callers can leave
+    ``encodingFormat`` unset rather than guess.
+
+    Args:
+        name: A file name or crate-relative path (e.g. ``run.mzML``,
+            ``data/results.csv``).
+
+    Returns:
+        A media-type string, or ``None`` if the extension is unknown.
+    """
+    if not name:
+        return None
+    path = Path(name)
+    if not path.suffix:
+        return None
+    mime_type, _ = mimetypes.guess_type(path.name)
+    if mime_type:
+        return mime_type
+    return _scientific_mime_for(path)
 
 
 _TABULAR_MIME_TYPES = {

--- a/tests/test_binary_file_feedback.py
+++ b/tests/test_binary_file_feedback.py
@@ -73,3 +73,28 @@ class TestAgentUnreadableMessage:
         out = tools["read_file_sample"].invoke({"path": str(p)})
         assert isinstance(out, str)
         assert out  # non-empty actionable message instead of None
+
+    def test_message_names_the_offending_tool(self):
+        # Issue #148: the recovery message is now reused across the file readers,
+        # so it must name whichever tool produced the bare None.
+        from builder.agents.agent_loop import _unreadable_file_message
+
+        msg = _unreadable_file_message("/data/sheet.xlsx", "read_excel")
+        assert "read_excel" in msg
+        assert "sheet.xlsx" in msg
+
+    @pytest.mark.parametrize("tool_name", ["read_file", "read_excel", "read_docx"])
+    def test_other_readers_return_message_not_none(self, tmp_path, tool_name):
+        # Issue #148: read_file / read_excel / read_docx previously handed the
+        # LLM a bare None for missing/binary/too-large files; they must now get
+        # the same actionable "skip it" guidance as read_file_sample.
+        pytest.importorskip("langchain_core")
+        from builder.agents.agent_loop import _build_langchain_tools
+        from builder.engine import AgentEngine
+
+        p = _write_binary(tmp_path, "blob.xlsx")
+        tools = {t.name: t for t in _build_langchain_tools(AgentEngine())}
+        out = tools[tool_name].invoke({"path": str(p)})
+        assert isinstance(out, str)
+        assert out
+        assert tool_name in out

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -1,0 +1,42 @@
+"""Tests for builder/tools/file_readers.py size ceilings (Issue #148).
+
+file_readers previously capped at 1 MB and silently returned None for 1-100 MB
+files, while scanner.read_file_sample / extract_pdf_text cap at 100 MB. This
+mismatch meant read_file('big.csv') gave the agent a bare None for a perfectly
+readable mid-size file. The readers already cap rows/lines so memory stays
+bounded; the byte ceiling is unified to 100 MB.
+"""
+
+from __future__ import annotations
+
+from builder.tools import file_readers
+from builder.tools.file_readers import _MAX_BYTES, read_file
+
+
+class TestSizeCeiling:
+    def test_max_bytes_matches_scanner_ceiling(self):
+        # Unified ceiling: 100 MB, same as scanner.read_file_sample /
+        # extract_pdf_text — not the old 1 MB.
+        assert _MAX_BYTES == 100 * 1024 * 1024
+
+    def test_read_file_5mb_csv_returns_content(self, tmp_path):
+        csv = tmp_path / "big.csv"
+        # ~5 MB CSV: a header plus enough rows to exceed the old 1 MB cap.
+        with csv.open("w", encoding="utf-8") as f:
+            f.write("col1,col2,col3\n")
+            # each row ~ 30 bytes; ~180k rows -> ~5 MB
+            for i in range(180_000):
+                f.write(f"{i},value_{i},extra_{i}\n")
+        assert csv.stat().st_size > 1_000_000  # would have been skipped before
+
+        result = read_file(str(csv), max_lines=10)
+        assert result is not None
+        assert "col1,col2,col3" in result
+
+    def test_read_file_over_ceiling_still_returns_none(self, tmp_path, monkeypatch):
+        # Above the unified ceiling we still skip (returns None) rather than
+        # streaming an unbounded file into the model.
+        monkeypatch.setattr(file_readers, "_MAX_BYTES", 100, raising=True)
+        csv = tmp_path / "huge.csv"
+        csv.write_text("a,b\n" + "1,2\n" * 1000)
+        assert read_file(str(csv), max_bytes=100) is None

--- a/tests/test_provenance_tools.py
+++ b/tests/test_provenance_tools.py
@@ -61,6 +61,34 @@ class TestDraftFile:
         assert fe.fields["name"] == "loose.csv"
         assert "role" not in fe.fields
 
+    def test_draft_file_auto_derives_encoding_format_from_name(self):
+        # Issue #148: when the caller omits encoding_format, derive a sensible
+        # IANA media type from the file extension instead of leaving it blank.
+        state = CrateState()
+        fe = draft_file(state, name="run.mzML")
+        ef = fe.fields.get("encodingFormat")
+        assert ef is not None
+        # mzML must not be mislabeled as plain text.
+        assert ef != "text/plain"
+        assert ef == "application/x-mzml"
+
+    def test_draft_file_auto_derives_encoding_format_from_path(self):
+        # When name has no usable extension, fall back to the destination path.
+        state = CrateState()
+        fe = draft_file(state, name="acquisition", path="data/run.fcs")
+        assert fe.fields.get("encodingFormat") == "application/vnd.isac.fcs"
+
+    def test_draft_file_explicit_encoding_format_wins(self):
+        # An explicit encoding_format must not be overridden by auto-derivation.
+        state = CrateState()
+        fe = draft_file(state, name="run.mzML", encoding_format="application/xml")
+        assert fe.fields["encodingFormat"] == "application/xml"
+
+    def test_draft_file_no_extension_leaves_encoding_unset(self):
+        state = CrateState()
+        fe = draft_file(state, name="README")
+        assert "encodingFormat" not in fe.fields
+
 
 class TestLink:
     def _state(self):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -816,3 +816,57 @@ class TestReducedStats:
 
         assert sample is not None
         assert "a,b" in sample
+
+
+class TestScientificMimeRegistry:
+    """Issue #148: scientific-format extensions resolve to real IANA media types.
+
+    mimetypes.guess_type returns None for .mzML/.raw/.wiff/.fcs/etc. and the
+    text-sniff fallback then mislabels their binary bytes as text/plain. A small
+    extension->media-type registry, consulted before the text sniff, fixes that
+    and keeps application/octet-stream as the true default for unknown binaries.
+    """
+
+    def test_known_scientific_extensions_map_to_real_media_types(self, tmp_path):
+        from builder.tools.scanner import _detect_mime_type
+
+        # extension -> expected media type (not text/plain via the sniff path)
+        cases = {
+            "x.mzML": "application/x-mzml",
+            "x.raw": "application/octet-stream",  # generic vendor raw -> binary
+            "x.wiff": "application/octet-stream",
+            "x.fcs": "application/vnd.isac.fcs",
+            "x.czi": "application/octet-stream",
+            "x.nd2": "application/octet-stream",
+            "x.lif": "application/octet-stream",
+        }
+        for name, expected in cases.items():
+            p = tmp_path / name
+            # Write bytes that would *decode* as UTF-8 text so the old text-sniff
+            # fallback would mislabel them as text/plain.
+            p.write_bytes(b"some ascii looking header\n")
+            assert _detect_mime_type(p) == expected, name
+
+    def test_mzml_not_text_plain(self, tmp_path):
+        from builder.tools.scanner import _detect_mime_type
+
+        p = tmp_path / "run.mzML"
+        p.write_bytes(b"<?xml version='1.0'?>\n<mzML></mzML>\n")
+        mime = _detect_mime_type(p)
+        assert mime != "text/plain"
+        assert mime != "application/octet-stream"
+
+    def test_unknown_binary_extension_defaults_to_octet_stream(self, tmp_path):
+        from builder.tools.scanner import _detect_mime_type
+
+        p = tmp_path / "blob.zzzunknown"
+        # Real binary content (NUL bytes) — must not be called text/plain.
+        p.write_bytes(b"\x00\x01\x02\x03binary\x00stuff")
+        assert _detect_mime_type(p) == "application/octet-stream"
+
+    def test_plain_text_still_text_plain(self, tmp_path):
+        from builder.tools.scanner import _detect_mime_type
+
+        p = tmp_path / "notes.unknownext"
+        p.write_bytes(b"just some plain readable text\n")
+        assert _detect_mime_type(p) == "text/plain"


### PR DESCRIPTION
Closes #148.

Two small, related quality fixes (neither is a conformance gate).

## 1. Scientific MIME registry
`builder/tools/scanner.py:_detect_mime_type` used `mimetypes.guess_type` (returns `None` for `.mzML/.raw/.wiff/.fcs/...`) and then a text-content sniff that decoded those binary bytes and mislabeled them `text/plain`.

- Added `_SCIENTIFIC_MIME_TYPES` — a small extension→IANA-style media-type map for common MS / microscopy / flow formats (`.mzML`, `.raw`, `.wiff`, `.fcs`, `.czi`, `.nd2`, `.lif`, `.d`, ...), consulted **before** the text sniff. Open/standard formats get a real type (`.mzML` → `application/x-mzml`, `.fcs` → `application/vnd.isac.fcs`); opaque vendor binaries map to `application/octet-stream`, the true default for unknown binary.
- A NUL byte in the header now reliably forces the binary default (NUL is valid UTF-8, so the old sniff wrongly called such files `text/plain`).
- New `encoding_format_for_name(name)` derives a media type from an extension alone (no disk read). `builder/tools/provenance.py:draft_file` uses it to auto-populate `encodingFormat` (from `name`, then `path`) when the caller omits `encoding_format`. An explicit value always wins; an extensionless name leaves the field unset.

## 2. Unify file-reader size ceilings
`builder/tools/file_readers.py:_MAX_BYTES` was 1 MB and silently returned `None` for 1–100 MB files, while `scanner.read_file_sample` / `extract_pdf_text` cap at 100 MB.

- Raised `_MAX_BYTES` to `100 * 1024 * 1024` to match. The readers already cap rows/lines, so memory stays bounded; a ~5 MB CSV now returns content instead of a silent `None`.
- Extended the bare-`None` recovery in `builder/agents/agent_loop.py` so `read_file` / `read_excel` / `read_docx` (not just `read_file_sample`) hand the LLM the actionable "unreadable/too-large — skip it" message, naming the offending tool.

## Tests (TDD — failing first, then green)
- `tests/test_file_readers.py` (new): `_MAX_BYTES == 100MB`; `read_file` on a >1 MB / ~5 MB CSV returns content; still skips above the ceiling.
- `tests/test_scanner.py::TestScientificMimeRegistry`: known scientific extensions map correctly; `.mzML` is not `text/plain`; unknown binary → `octet-stream`; plain text still `text/plain`.
- `tests/test_provenance_tools.py::TestDraftFile`: `draft_file('run.mzML')` yields `application/x-mzml`; derives from `path`; explicit value wins; extensionless leaves it unset.
- `tests/test_binary_file_feedback.py`: `read_file`/`read_excel`/`read_docx` return the actionable message (naming the tool), never bare `None`.

**Evidence:** targeted + drift-guard suites green —
`122 passed` across `test_file_readers.py test_provenance_tools.py test_scanner.py test_binary_file_feedback.py test_tools_spec.py test_tool_registry.py test_entity_draft_schema.py`. `ruff` clean; `ty` clean on touched files. AGENTS.md updated.

Note: the full suite has 10 pre-existing failures in `tests/test_agent_loop.py::TestBuildChatModel`/`TestModelTiering` — `ModuleNotFoundError: No module named 'langchain_openai'`/`langchain_anthropic` (optional provider packages not installed in this environment); they fail identically with these changes stashed and are unrelated to this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)