### PR TITLE
fix(agent): write validation results back to state.validation (#153)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -554,6 +554,7 @@ def _build_system_prompt_with_state(
     entity_count: int,
     file_count: int,
     iteration_count: int,
+    next_fix: str | None = None,
 ) -> str:
     """Build a lightweight state brief appended to the system prompt.
 
@@ -563,13 +564,21 @@ def _build_system_prompt_with_state(
 
     Returns a single short line like:
     ``[Session: sid | Files: 5 | Entities: 3 | Iteration: 42]``
+
+    When ``next_fix`` is given (the top REQUIRED validation issue, surfaced from
+    ``state.validation`` after the #153 write-back), a second line names it so a
+    weak model has a durable next-step pointer and stops re-deriving the
+    BASE->ISA->TOX plan from the system prompt every turn.
     """
-    return (
+    brief = (
         f"[Session: {session_id} | "
         f"Files: {file_count} | "
         f"Entities: {entity_count} | "
         f"Iteration: {iteration_count}]"
     )
+    if next_fix:
+        brief += f"\n[Next REQUIRED fix: {next_fix}]"
+    return brief
 
 
 # Tool names whose verbose output already lives in CrateState, so replaying it
@@ -687,6 +696,7 @@ def _assemble_model_messages(
     entity_count: int,
     file_count: int,
     iteration_count: int,
+    next_fix: str | None = None,
     max_history_tokens: int | None = None,
 ) -> list:
     """Assemble the message list for a model invocation with a cache-friendly
@@ -728,6 +738,7 @@ def _assemble_model_messages(
         entity_count=entity_count,
         file_count=file_count,
         iteration_count=iteration_count,
+        next_fix=next_fix,
     )
     return [
         SystemMessage(content=SYSTEM_PROMPT),
@@ -782,12 +793,17 @@ def _build_agent_graph(
         # Stable SYSTEM_PROMPT prefix + history, with the volatile per-turn state
         # brief at the tail so the cacheable prefix isn't busted (Issue #60). The
         # brief is rebuilt each call and never persisted to history (Issue #66).
+        # The top REQUIRED validation issue (populated by the #153 write-back) is
+        # surfaced in the brief as a durable next-step pointer for a weak model.
+        required_issues = engine.state.validation.required_issues
+        next_fix = required_issues[0] if required_issues else None
         model_messages = _assemble_model_messages(
             messages,
             session_id=engine.state.session_id,
             entity_count=len(engine.state.list_entities()),
             file_count=len(engine.state.scanned_files),
             iteration_count=engine.state.iteration_count,
+            next_fix=next_fix,
         )
         response = model.invoke(model_messages)
         # Return only the new response; the add_messages reducer appends it

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import builder.config as _config
-from builder.state import CrateState
+from builder.state import CrateState, ValidationReport
 from builder.tools.profiler import ProfilingLogger
 
 if TYPE_CHECKING:
@@ -44,6 +44,33 @@ def _directory_to_approve(scanned_path: str) -> str:
         # Mirror unzip_file's extraction layout: <parent>/<stem>_extracted
         return str(p.parent / f"{p.stem}_extracted")
     return str(p.parent)
+
+
+# Validation layers stack as a pyramid (BASE -> ISA -> TOX); ordering REQUIRED
+# issues by layer puts the next *unblocking* fix first.
+_VALIDATION_LAYER_ORDER = {"base": 0, "isa": 1, "tox": 2}
+
+
+def _order_required_issues(issues: list[dict[str, Any]]) -> list[str]:
+    """Return REQUIRED-severity issues as strings, ordered base -> isa -> tox.
+
+    ``build_and_validate`` reports issues as routable dicts
+    (``{entity_id, property, message, severity, profile, fix}``); the
+    :class:`ValidationReport` stores them as human-readable strings consumed by
+    ``get_hint`` and the maturity report. We keep only REQUIRED-severity issues
+    (the blocking ones) and order them by validation layer so the first entry is
+    the next fix that unblocks the pyramid. The sort is stable, preserving the
+    validator's within-layer order.
+    """
+    required = [i for i in issues if i.get("severity") == "required"]
+    required.sort(key=lambda i: _VALIDATION_LAYER_ORDER.get(i.get("profile") or "", 99))
+    lines: list[str] = []
+    for issue in required:
+        profile = issue.get("profile") or "?"
+        entity = issue.get("entity_id") or "?"
+        message = issue.get("message") or ""
+        lines.append(f"[{profile}] {entity}: {message}".rstrip())
+    return lines
 
 
 class AgentEngine:
@@ -239,6 +266,13 @@ class AgentEngine:
             else:
                 result = spec.fn(**kwargs)
 
+        # Fold a validation verdict back into state.validation so get_hint, the
+        # interactive header, and the maturity report (#150 renders *from*
+        # state.validation) reflect the latest result instead of stale defaults
+        # (#153). Orchestration-layer side effect, mirroring the scan_files
+        # write-back above; the validation tools themselves stay pure.
+        self._writeback_validation(tool_name, result)
+
         self.state.iteration_count += 1
         self.state.log_reasoning(
             f"run_tool: {tool_name}",
@@ -272,6 +306,35 @@ class AgentEngine:
             )
 
         return result
+
+    def _writeback_validation(self, tool_name: str, result: Any) -> None:
+        """Fold a validation result into ``state.validation`` (#153).
+
+        ``validate`` returns a fully-formed :class:`ValidationReport` (disk,
+        three-pass) — adopt it wholesale. ``build_and_validate`` returns the
+        in-memory routable dict (``{"ok", "conformance", "issues"}``); map its
+        per-layer ``conformance`` onto the report and record the REQUIRED issues
+        ordered base -> isa -> tox. Layers absent from ``conformance`` (a scoped
+        ``profile=`` call) keep their prior value, and an errored result is left
+        untouched so a transient failure never wipes known issues.
+        """
+        if tool_name == "validate" and isinstance(result, ValidationReport):
+            self.state.validation = result
+            return
+        if tool_name == "build_and_validate" and isinstance(result, dict):
+            if "error" in result:
+                return
+            conformance = result.get("conformance") or {}
+            if not conformance:
+                return
+            report = self.state.validation
+            if "base" in conformance:
+                report.base_passed = bool(conformance["base"])
+            if "isa" in conformance:
+                report.isa_passed = bool(conformance["isa"])
+            if "tox" in conformance:
+                report.tox_passed = bool(conformance["tox"])
+            report.required_issues = _order_required_issues(result.get("issues") or [])
 
     def close_profiler(self) -> None:
         """Close the profiling log file, if open.

--- a/tests/test_validation_writeback.py
+++ b/tests/test_validation_writeback.py
@@ -1,0 +1,117 @@
+"""Tests for validation write-back to state.validation (Issue #153).
+
+`build_and_validate` / `validate` compute a verdict but historically dropped it:
+nothing ever assigned ``state.validation``, so ``get_hint``, the interactive
+header, and the maturity report (#150 renders *from* ``state.validation``) all
+read stale defaults. These tests pin the fix: ``AgentEngine.run_tool`` folds a
+validation result back into ``state.validation`` (orchestration layer, mirroring
+the existing scan_files write-back), and the next REQUIRED fix is surfaced in the
+per-turn state brief so the weak model stops re-deriving the plan every turn.
+"""
+
+from __future__ import annotations
+
+from builder.engine import AgentEngine, _order_required_issues
+
+
+class TestValidationWriteBack:
+    def test_build_and_validate_writes_conformance_to_state(self):
+        engine = AgentEngine()
+        engine.initialize()
+        assert engine.state.validation.base_passed is False  # default before any validate
+        engine.run_tool("build_and_validate", profile="base")
+        assert engine.state.validation.base_passed is True
+
+    def test_build_and_validate_all_populates_required_issues(self):
+        """A minimal crate passes BASE but fails ISA (missing root identifier);
+        the ISA REQUIRED issues must land in state.validation."""
+        engine = AgentEngine()
+        engine.initialize()
+        engine.run_tool("build_and_validate")  # profile defaults to "all"
+        v = engine.state.validation
+        assert v.base_passed is True
+        assert v.isa_passed is False
+        assert v.required_issues, "ISA REQUIRED issues should be recorded in state"
+
+    def test_error_result_does_not_clobber_required_issues(self):
+        """A failed/errored validate must not wipe previously known issues."""
+        engine = AgentEngine()
+        engine.initialize()
+        engine.run_tool("build_and_validate")  # populates required_issues
+        before = list(engine.state.validation.required_issues)
+        assert before
+        engine.run_tool("build_and_validate", severity="bogus")  # error path
+        assert engine.state.validation.required_issues == before
+
+    def test_get_hint_reflects_validation_after_writeback(self):
+        """get_hint reads state.validation; before #153 it was never populated,
+        so it could not reflect a real validation. Drive the real write-back with
+        a synthetic build_and_validate result (deterministic, no SHACL needed)
+        and confirm get_hint now surfaces the recorded REQUIRED issue."""
+        engine = AgentEngine()
+        engine.initialize()
+        engine.run_tool("draft_investigation", hints={"name": "X"})  # >=1 entity
+        engine._writeback_validation(
+            "build_and_validate",
+            {
+                "ok": False,
+                "conformance": {"base": True, "isa": False, "tox": False},
+                "issues": [
+                    {
+                        "severity": "required",
+                        "profile": "isa",
+                        "entity_id": "./",
+                        "message": "missing identifier",
+                    }
+                ],
+            },
+        )
+        from builder.tools.session import get_hint
+
+        hint = get_hint(engine.state)
+        assert "Fix REQUIRED validation issues" in hint
+        assert "missing identifier" in hint
+
+
+class TestOrderRequiredIssues:
+    def test_orders_base_isa_tox_and_drops_non_required(self):
+        issues = [
+            {"severity": "required", "profile": "tox", "entity_id": "#m", "message": "tox issue"},
+            {"severity": "required", "profile": "base", "entity_id": "./", "message": "base issue"},
+            {"severity": "recommended", "profile": "base", "entity_id": "./", "message": "drop me"},
+            {"severity": "required", "profile": "isa", "entity_id": "./", "message": "isa issue"},
+        ]
+        out = _order_required_issues(issues)
+        assert len(out) == 3  # the recommended issue is dropped
+        assert "base issue" in out[0]
+        assert "isa issue" in out[1]
+        assert "tox issue" in out[2]
+
+    def test_empty_in_empty_out(self):
+        assert _order_required_issues([]) == []
+
+
+class TestStateBriefNextFix:
+    def test_brief_includes_next_required_fix(self):
+        from builder.agents.agent_loop import _build_system_prompt_with_state
+
+        brief = _build_system_prompt_with_state(
+            session_id="s",
+            entity_count=1,
+            file_count=0,
+            iteration_count=3,
+            next_fix="[isa] ./: add identifier",
+        )
+        assert "Next REQUIRED fix" in brief
+        assert "add identifier" in brief
+
+    def test_brief_omits_next_fix_when_none(self):
+        from builder.agents.agent_loop import _build_system_prompt_with_state
+
+        brief = _build_system_prompt_with_state(
+            session_id="s",
+            entity_count=1,
+            file_count=0,
+            iteration_count=3,
+        )
+        assert "Next REQUIRED fix" not in brief


### PR DESCRIPTION
## What & why

`build_and_validate` / `validate` computed a verdict but **never persisted it** — nothing assigned `state.validation`. So `get_hint`, the interactive header dots, and the maturity report (#150 renders *from* `state.validation`) all read stale defaults. This is a latent bug now live on `main` (#150 merged), and it's also the keystone for the agent-loop latency work (#154–#156) and the model-tiering decision gate (#96).

Closes #153.

## Changes

**`builder/engine.py`** — write-back in the orchestration layer (mirrors the existing `scan_files` write-back; the validation tools themselves stay pure, so the MCP-server reuse boundary holds):
- `AgentEngine._writeback_validation(tool_name, result)` runs after tool dispatch in `run_tool`. `validate` (disk) returns a `ValidationReport` → adopted wholesale; `build_and_validate` returns the routable dict → its `conformance` maps onto `state.validation` with **scoped per-layer updates** (a `profile="base"` call only touches `base_passed`) and an **error guard** so a transient/errored validate never wipes known issues.
- `_order_required_issues(issues)` keeps REQUIRED-severity issues, orders them **base → isa → tox** (stable sort, so the first entry is the next *unblocking* fix), and stringifies as `[profile] entity: message`.

**`builder/agents/agent_loop.py`** — surfaces the top REQUIRED fix in the per-turn state brief: `_build_system_prompt_with_state(..., next_fix=...)`, threaded through `_assemble_model_messages` and computed in `call_model` from `state.validation.required_issues[0]`. Zero extra round-trips; stays at the cache-safe tail (#60).

## Tests (TDD)

New `tests/test_validation_writeback.py` (8 tests, written red-first):
- write-back populates `state.validation` from `build_and_validate`;
- `profile="all"` records the ISA REQUIRED issues;
- an errored validate does not clobber known issues;
- `get_hint` now reflects the written-back validation;
- `_order_required_issues` orders base→isa→tox and drops non-REQUIRED;
- the brief includes / omits the next-fix line correctly.

## Verification

- 8/8 new tests pass; 86 pass across the touched suites (engine, build_and_validate, validation, session, agent_loop).
- `ruff check` clean (CI is lint-only).
- Pre-existing `langchain_openai`/`langchain_anthropic` import failures in `TestBuildChatModel`/`TestModelTiering` are environmental (the `langchain` extra isn't installed) and fail identically on the base commit — not introduced here.

## Note

The `build_and_validate` path is fully tested; the `validate` (disk) branch is a type-guarded wholesale adopt, covered by the `isinstance` guard but not a dedicated written-crate test. Easy to add if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
