### PR TITLE
feat(builder): persist ontology terms, plumb units, populate condition-table rows (#141, #143, #144)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,8 +455,18 @@ draft_process(assay_id: str, process_type: str, hints: dict) → Entity
 draft_person(name: str, hints: dict) → Entity
 draft_organization(name: str, hints: dict) → Entity
 draft_publication(doi: str, hints: dict) → Entity
+draft_defined_term(name: str, hints: dict) → Entity
+draft_property_value(name: str, hints: dict) → Entity
 draft_file(name: str, path=None, role=None, encoding_format=None) → Entity
 ```
+`draft_defined_term` persists a looked-up ontology / AOP / Key-Event term as a
+`schema:DefinedTerm` contextual entity (Issue #141): pass the looked-up IRI as the
+`url`/`@id` hint so the node gets a dereferenceable `@id`, and it then round-trips
+into the `@graph` and is referenceable (via `set_fields`/`link`) as a `mentions` /
+`measurementMethod` / `sampleType` target. `draft_property_value` creates a typed
+`schema:PropertyValue` node (`value` + optional `propertyID` + `unitText`/`unitCode`).
+Both back the previously-unfilled `defined_terms` / `property_values` CrateState
+collections the mapping already rendered.
 The `hints` parameter is **typed per entity type** (Issue #90). Each `draft_*`
 tool advertises a JSON-Schema built by `_crate_mapping.draft_hints_schema(type)`
 from the single source of truth `_crate_mapping.ENTITY_DRAFT_SCHEMA` — allowed
@@ -464,6 +474,16 @@ scalar keys plus reference keys, the latter a strict subset of `_REF_FIELDS`
 (asserted by test) so the advertised reference vocabulary and the crate-mapping
 resolver cannot drift. The schema is open (`additionalProperties: true`), so a
 weak model sees the high-value keys without the long tail being forbidden.
+
+`LabProcess` hints additionally advertise a `units` map plus the optional
+subtype parameters (`assay_kit`/`substrate` for EndpointReadout,
+`acceptance_criteria`/`evaluation_criteria` for DataAnalysis) (Issue #143):
+`_build_process` threads `units=f.get('units')` into the Exposure /
+EndpointReadout / DataAnalysis constructors so each `ParameterValue` carries its
+`unitText`, and threads the optional params into the matching subtype. A
+`CellLineSample`'s `passage` / `growth` hints are promoted to ISA Sample
+Characteristics — `schema:additionalProperty` PropertyValue nodes carrying the
+value and, when known, the property's ontology IRI.
 
 ### Entity Management Tools
 ```
@@ -527,12 +547,24 @@ export_crate(output_path: str) → CrateBuildResult
 build_crate(output_path: str) → CrateBuildResult     # back-compat alias of export_crate
 validate(crate_path: str) → ValidationReport
 validate_table(file: str, table_schema: dict, foreign_keys: dict | None = None, entity_id: str | None = None) → {ok, issues}
+populate_condition_table(exposure_id: str, rows_or_csv_path: list[dict] | str, output_dir: str | None = None) → {ok, path, rows}
 ```
 
 `validate_table` is the **data-content (payload) layer** (#95): it validates a
 CSV's rows against a Frictionless `tableSchema` — separate from the SHACL
 metadata passes (see §6, Data-Content Layer). Issues use the same routable shape
 with `profile="data"`.
+
+`populate_condition_table` (Issue #144) writes the per-well rows into an
+Exposure's CSVW condition table — replacing the header-only placeholder #94
+materialises — either from a list of row dicts (keyed by the column titles
+`cell_line`/`compound`/`concentration`/`unit`/`duration`) or by attaching a
+user-supplied plate-map CSV. It targets the exact path the build wires
+(`_crate_mapping._condition_table_rel`), so the #94 CSVW typing (`tableSchema`)
+stays attached to the populated table. The companion bridge
+`data_content.csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)` converts those CSVW
+column descriptors into the Frictionless `{fields:[...]}` shape, so `validate_table`
+needs no hand-authored schema for the populated table.
 
 `build_and_validate` is the agent's primary build/fix loop: it assembles the
 crate from `CrateState` **in memory** and validates the generated JSON-LD

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -31,6 +31,8 @@ Entity drafting:
 - draft_person: Create a Person entity
 - draft_organization: Create an Organization entity
 - draft_publication: Create a Publication entity
+- draft_defined_term: Persist a looked-up ontology/AOP/Key-Event term as a DefinedTerm entity
+- draft_property_value: Create a typed PropertyValue (key/value with optional unit and ontology id)
 - draft_file: Create a File data entity (raw measurements, processed results, figures)
 
 Entity management & provenance:
@@ -57,6 +59,7 @@ Build, validate & assess:
 - build_crate: Alias of export_crate (writes the crate to disk)
 - validate: Run three-pass validation on a crate already written to disk
 - validate_table: Validate a CSV's data content (rows) against its CSVW/Frictionless table schema — the payload layer, separate from SHACL metadata validation
+- populate_condition_table: Write per-well rows into an Exposure's CSVW condition table (or attach a plate-map CSV)
 - assess_mit_coverage: Score MIT coverage
 - assess_fair_maturity: Score FAIR maturity
 

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -168,6 +168,30 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "draft_defined_term",
+        "description": "Create a schema:DefinedTerm contextual entity to PERSIST a looked-up ontology / AOP / Key-Event term so it round-trips into the crate and can be referenced (via set_fields/link) as a mentions / measurementMethod / sampleType target. Pass the looked-up IRI as the 'url' hint so the node gets a dereferenceable @id. Example: draft_defined_term(name='cell viability assay', hints={'term_code': 'BAO:0002993', 'url': 'http://www.bioassayontology.org/bao#BAO_0002993'}).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Term label."},
+                "hints": draft_hints_schema("DefinedTerm"),
+            },
+            "required": ["name", "hints"],
+        },
+    },
+    {
+        "name": "draft_property_value",
+        "description": "Create a schema:PropertyValue contextual entity (a typed key/value with an optional ontology propertyID and unit). Use it for measured/asserted values that other entities reference. Example: draft_property_value(name='Passage Number', hints={'value': '12', 'unit_text': 'passages'}).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Property name."},
+                "hints": draft_hints_schema("PropertyValue"),
+            },
+            "required": ["name", "hints"],
+        },
+    },
+    {
         "name": "set_fields",
         "description": "Set one or more fields on an existing entity (the single mutation tool — pass one key or many). Use it to fill or correct an entity's metadata, e.g. after build_and_validate names a field to fix. Example: set_fields(entity_id='chem_silychristin_a', fields={'identifier': '33889-69-9', 'smiles': 'C[C@H]1...'}).",
         "parameters": {
@@ -363,6 +387,25 @@ TOOL_SPECS = [
                 },
             },
             "required": ["file", "table_schema"],
+        },
+    },
+    {
+        "name": "populate_condition_table",
+        "description": "Write per-well rows into an Exposure's CSVW condition table (replacing the header-only placeholder). Pass rows_or_csv_path as a list of row dicts keyed by the columns cell_line/compound/concentration/unit/duration, or a path to a user-supplied plate-map CSV. The table's CSVW typing (tableSchema) is preserved. Returns {ok, path, rows}. Validate the result with validate_table using the inferred schema.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "exposure_id": {"type": "string", "description": "entity_id of the Exposure LabProcess."},
+                "rows_or_csv_path": {
+                    "description": "A list of row dicts (keys: cell_line/compound/concentration/unit/duration) OR a path to a plate-map CSV.",
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "object"}},
+                        {"type": "string"},
+                    ],
+                },
+                "output_dir": {"type": "string", "description": "Crate root to write the CSV under (optional; defaults to the session output path)."},
+            },
+            "required": ["exposure_id", "rows_or_csv_path"],
         },
     },
     {

--- a/builder/tools/__init__.py
+++ b/builder/tools/__init__.py
@@ -22,15 +22,17 @@ Tool categories:
 from __future__ import annotations
 
 from builder.tools.builder import build_crate, export_crate
-from builder.tools.data_content import validate_table
+from builder.tools.data_content import populate_condition_table, validate_table
 from builder.tools.drafters import (
     draft_assay,
     draft_cell_line_sample,
+    draft_defined_term,
     draft_investigation,
     draft_molecular_entity,
     draft_organization,
     draft_person,
     draft_process,
+    draft_property_value,
     draft_publication,
     draft_study,
 )
@@ -83,12 +85,14 @@ __all__ = [
     "check_provenance",
     "draft_assay",
     "draft_cell_line_sample",
+    "draft_defined_term",
     "draft_file",
     "draft_investigation",
     "draft_molecular_entity",
     "draft_organization",
     "draft_person",
     "draft_process",
+    "draft_property_value",
     "draft_publication",
     "draft_study",
     "export_crate",
@@ -106,6 +110,7 @@ __all__ = [
     "lookup_doi",
     "lookup_orcid",
     "lookup_ror",
+    "populate_condition_table",
     "present_to_human",
     "preview_archive",
     "read_docx",

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -27,7 +27,7 @@ from rocrate.model import ContextEntity, DataEntity, File, Person
 from rocrate.rocrate import ROCrate
 
 from builder.state import CrateState, Entity
-from profiles.models.isa import LabProcess, Sample
+from profiles.models.isa import CharacteristicValue, LabProcess, Sample, param_id
 from profiles.models.tox import (
     CellLineSample,
     LabProcessCellCulture,
@@ -178,6 +178,14 @@ ENTITY_DRAFT_SCHEMA: dict[str, EntityDraftSchema] = {
             "endpoint": "EndpointReadout: the measured endpoint.",
             "data_processing": "DataAnalysis: data-processing description.",
             "software": "DataAnalysis: software used.",
+            "units": (
+                "Per-parameter unit map, e.g. {'Exposure Duration': 'h'}; "
+                "threaded into the matching ParameterValue's unitText."
+            ),
+            "assay_kit": "EndpointReadout: assay kit used (optional ParameterValue).",
+            "substrate": "EndpointReadout: substrate used (optional ParameterValue).",
+            "acceptance_criteria": "DataAnalysis: acceptance criteria (optional ParameterValue).",
+            "evaluation_criteria": "DataAnalysis: evaluation criteria (optional ParameterValue).",
         },
         ref_fields={
             "object": "Input entity the process consumes (alias: input).",
@@ -224,6 +232,24 @@ ENTITY_DRAFT_SCHEMA: dict[str, EntityDraftSchema] = {
         },
         ref_fields={
             "author": "Person id(s) who authored the publication.",
+        },
+    ),
+    "DefinedTerm": EntityDraftSchema(
+        scalar_fields={
+            "name": "Term label (passed as the `name` argument).",
+            "term_code": "Ontology code, e.g. 'BAO:0002993' or 'GO:0006915'.",
+            "in_defined_term_set": "IRI of the term set / ontology the term belongs to.",
+            "url": "Dereferenceable IRI for the term (used as the entity @id).",
+            "description": _DESC,
+        },
+    ),
+    "PropertyValue": EntityDraftSchema(
+        scalar_fields={
+            "name": "Property name (passed as the `name` argument).",
+            "value": "The measured or asserted value.",
+            "property_id": "Ontology IRI identifying the property key.",
+            "unit_text": "Human-readable unit, e.g. 'uM' or 'h'.",
+            "unit_code": "UN/CEFACT unit code, if known.",
         },
     ),
 }
@@ -291,6 +317,16 @@ _STRUCT_FIELDS = frozenset(
         "dest_path",
         "path",
         "contentUrl",
+        # LabProcess kwargs threaded into the typed subtype constructors (#143)
+        # rather than emitted as stray literals on the process node.
+        "units",
+        "assay_kit",
+        "substrate",
+        "acceptance_criteria",
+        "evaluation_criteria",
+        # CellLineSample characteristics promoted to additionalProperty (#143).
+        "passage",
+        "growth",
     }
 )
 
@@ -532,6 +568,42 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
     )
 
 
+# CellLineSample fields promoted to schema:additionalProperty Characteristic
+# PropertyValue nodes (ISA Sample Characteristics): name -> propertyID IRI (#143).
+_CELL_LINE_CHARACTERISTICS: dict[str, str | None] = {
+    "passage": "https://bioregistry.io/EFO:0007061",  # passage number
+    "growth": "http://www.bioassayontology.org/bao#BAO_0002648",  # growth properties
+}
+
+
+def _cell_line_characteristics(crate: ROCrate, cl: Entity) -> list[Any]:
+    """Build CharacteristicValue (PropertyValue) nodes for a CellLineSample.
+
+    Promotes recognised culture-characteristic fields (``passage``, ``growth``)
+    to ISA Sample Characteristics — schema:additionalProperty PropertyValue nodes
+    carrying the value and, when known, the property's ontology IRI as
+    ``propertyID``. Returns an empty list when none are present.
+    """
+    out: list[Any] = []
+    for field_name, property_id in _CELL_LINE_CHARACTERISTICS.items():
+        value = cl.fields.get(field_name)
+        if value in (None, ""):
+            continue
+        props: dict[str, Any] = {}
+        if property_id:
+            props["propertyID"] = {"@id": property_id}
+        out.append(
+            CharacteristicValue(
+                crate,
+                param_id(field_name, str(value)),
+                name=field_name,
+                value=str(value),
+                properties=props or None,
+            )
+        )
+    return out
+
+
 def _cell_line_term(crate: ROCrate) -> ContextEntity:
     """The shared, resolvable 'cell line' DefinedTerm for CellLineSample.sampleType."""
     return crate.add(
@@ -673,6 +745,7 @@ def _add_leaves(
     for cl in state.list_entities("CellLineSample"):
         if cell_term[0] is None:
             cell_term[0] = _cell_line_term(crate)
+        characteristics = _cell_line_characteristics(crate, cl)
         _idx_add(
             idx,
             cl,
@@ -682,6 +755,7 @@ def _add_leaves(
                 name=str(cl.fields.get("name", "")),
                 sample_type=cell_term[0],
                 accession=cl.fields.get("accession"),
+                additionalProperty=characteristics or None,
                 properties=_scalar_props(cl, skip=("name", "accession")) or None,
             ),
         )
@@ -849,6 +923,15 @@ def _synth_sample(crate: ROCrate, sid: str, name: str, derives_from: Any = None)
 
 _CONDITION_TABLE_HEADER = "cell_line,compound,concentration,unit,duration\n"
 
+
+def _condition_table_rel(exp_pid: str) -> str:
+    """Crate-relative path of an Exposure's condition-table CSV.
+
+    Shared by the build (``_synth_condition_table``) and the row-population tool
+    (``populate_condition_table``) so both target the exact same file.
+    """
+    return f"data/{_slug(exp_pid)}_condition_table.csv"
+
 # Typed CSVW columns for the condition table: each maps a CSV column to an
 # ontology property (propertyUrl) with a declared datatype. The cell-line and
 # compound columns additionally resolve to in-crate entity ids (valueUrl, filled
@@ -928,7 +1011,7 @@ def _synth_condition_table(
     the Exposure THROUGH its result (a MolecularEntity cannot be a process object
     under the ISA shape).
     """
-    rel = f"data/{_slug(exp_pid)}_condition_table.csv"
+    rel = _condition_table_rel(exp_pid)
     # Only touch disk when materialising payload for an on-disk export. The
     # in-memory validate path (#87) skips the write; the File node below still
     # carries dest_path=rel so the metadata graph is complete for validation.
@@ -1069,6 +1152,7 @@ def _build_process(
             samples=cells,
             labprotocol=protocol,
             result=out,
+            units=f.get("units"),
         )
 
     if ptype == "EndpointReadout":
@@ -1084,6 +1168,9 @@ def _build_process(
             measured_entity=f.get("measured_entity", "unknown"),
             technical_replicate=f.get("technical_replicate", "1"),
             endpoint=f.get("endpoint", "unknown"),
+            assay_kit=f.get("assay_kit"),
+            substrate=f.get("substrate"),
+            units=f.get("units"),
         )
 
     if ptype == "DataAnalysis":
@@ -1096,6 +1183,9 @@ def _build_process(
             labprotocol=protocol,
             data_processing=f.get("data_processing", ""),
             software=f.get("software", ""),
+            acceptance_criteria=f.get("acceptance_criteria"),
+            evaluation_criteria=f.get("evaluation_criteria"),
+            units=f.get("units"),
         )
 
     # Generic LabProcess (no domain discriminator).

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -261,7 +261,7 @@ _TOOL_ICONS: dict[str, str] = {
     "verify_identifier": "\u2705", "verify_all_identifiers": "\u2705",
     "build_and_validate": "\u2714\ufe0f", "export_crate": "\U0001f3ed",
     "build_crate": "\U0001f3ed", "validate": "\u2714\ufe0f",
-    "validate_table": "\U0001f4c8",
+    "validate_table": "\U0001f4c8", "populate_condition_table": "\U0001f4c8",
     "assess_mit_coverage": "\U0001f52e", "assess_fair_maturity": "\U0001f52e",
     "save_session": "\U0001f4be", "load_session": "\U0001f4c1",
     "list_sessions": "\U0001f4ca", "get_status": "\U0001f4ac",

--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -25,11 +25,27 @@ a data-content fix exactly as it routes a SHACL fix. The ``profile`` is the new
 
 from __future__ import annotations
 
+import csv
 import logging
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# CSVW datatype (from #94's _CONDITION_TABLE_COLUMNS) -> Frictionless field type.
+# Anything unmapped falls back to "string" (Frictionless's permissive default).
+_CSVW_TO_FRICTIONLESS_TYPE: dict[str, str] = {
+    "string": "string",
+    "double": "number",
+    "decimal": "number",
+    "float": "number",
+    "integer": "integer",
+    "int": "integer",
+    "boolean": "boolean",
+    "date": "date",
+    "dateTime": "datetime",
+}
 
 # The routable-issue layer name for data-content issues — deliberately distinct
 # from the SHACL layers ("base" | "isa" | "tox") so the two validation services
@@ -235,9 +251,130 @@ def _compose_message(
     return f"{prefix}{note}{cell_str}"
 
 
+def csvw_to_frictionless(columns: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Convert CSVW column descriptors into a Frictionless table schema.
+
+    The condition table's typed columns are authored once as CSVW
+    (``_crate_mapping._CONDITION_TABLE_COLUMNS``: ``titles`` + ``datatype`` +
+    ``propertyUrl``; #94). This bridges them into the Frictionless
+    ``{"fields": [{"name", "type"}, ...]}`` shape so :func:`validate_table` can
+    check the populated CSV without a separately hand-authored schema — keeping
+    the #94 CSVW typing the single source of truth for both layers (#144).
+
+    Args:
+        columns: An iterable of CSVW column dicts, each with at least a
+            ``titles`` (the column name) and optionally a ``datatype``.
+
+    Returns:
+        A Frictionless table schema descriptor ``{"fields": [...]}``.
+    """
+    fields: list[dict[str, Any]] = []
+    for col in columns:
+        name = col.get("titles") or col.get("name")
+        if not name:
+            continue
+        datatype = str(col.get("datatype", "string"))
+        fields.append(
+            {
+                "name": str(name),
+                "type": _CSVW_TO_FRICTIONLESS_TYPE.get(datatype, "string"),
+            }
+        )
+    return {"fields": fields}
+
+
+def populate_condition_table(
+    state: Any,
+    exposure_id: str,
+    rows_or_csv_path: Sequence[Mapping[str, Any]] | str,
+    *,
+    output_dir: str | None = None,
+) -> dict[str, Any]:
+    """Write per-well rows into an Exposure's CSVW condition table.
+
+    Replaces the header-only placeholder #94 materialises with the actual
+    per-well design table. Two intake modes:
+
+    - ``rows_or_csv_path`` is a list of row dicts (keys are the condition-table
+      column titles): the rows are written under the canonical
+      ``_CONDITION_TABLE_HEADER`` into the Exposure's condition-table CSV at
+      ``<output_dir>/data/<exposure>_condition_table.csv``.
+    - ``rows_or_csv_path`` is a path to a user-supplied plate-map CSV: it is
+      copied verbatim into that destination (its columns are assumed to match
+      the condition-table schema).
+
+    The CSVW typing (#94) is preserved: the populated CSV lives at the same
+    ``dest_path`` the build wires as a typed ``csvw:Table`` with its
+    ``tableSchema`` attached, so populating rows does not strip the table's
+    machine-readable schema.
+
+    Args:
+        state: The crate state (used to resolve the Exposure entity).
+        exposure_id: ``entity_id`` of the Exposure LabProcess.
+        rows_or_csv_path: Either a list of row dicts or a path to a CSV file.
+        output_dir: Crate root directory to write the CSV under. Defaults to the
+            state's configured output path when omitted.
+
+    Returns:
+        ``{"ok": bool, "path": str, "rows": int}`` on success, or
+        ``{"ok": False, "error": str}`` when the Exposure cannot be resolved or
+        the supplied CSV is missing.
+    """
+    # Imported here to avoid a circular import at module load (data_content is
+    # imported by _crate_mapping's consumers, not the other way round).
+    from builder.tools._crate_mapping import (
+        _CONDITION_TABLE_HEADER,
+        _condition_table_rel,
+        _mint_id,
+    )
+
+    proc = state.get_entity(exposure_id)
+    if proc is None:
+        return {"ok": False, "error": f"Exposure entity not found: {exposure_id!r}"}
+    ptype = proc.fields.get("process_type") or proc.fields.get("additionalType") or ""
+    if ptype != "Exposure":
+        return {
+            "ok": False,
+            "error": f"{exposure_id!r} is a {ptype or 'LabProcess'}, not an Exposure.",
+        }
+
+    base_dir = Path(output_dir) if output_dir else None
+    if base_dir is None:
+        out_path = getattr(getattr(state, "metadata", None), "output_path", None)
+        base_dir = Path(out_path) if out_path else Path.cwd()
+
+    rel = _condition_table_rel(_mint_id(proc))
+    dest = base_dir / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    header_cols = _CONDITION_TABLE_HEADER.strip("\n").split(",")
+
+    if isinstance(rows_or_csv_path, str):
+        src = Path(rows_or_csv_path)
+        if not src.is_file():
+            return {"ok": False, "error": f"Plate-map CSV not found: {rows_or_csv_path}"}
+        with src.open(newline="", encoding="utf-8") as fh:
+            reader = list(csv.DictReader(fh))
+        rows: Sequence[Mapping[str, Any]] = reader
+    else:
+        rows = rows_or_csv_path
+
+    with dest.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=header_cols, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({c: row.get(c, "") for c in header_cols})
+
+    logger.debug("Wrote %d condition-table rows to %s", len(rows), dest)
+    return {"ok": True, "path": str(dest), "rows": len(rows)}
+
+
 # ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
 TOOL_REGISTRY.register("validate_table", validate_table, takes_state=False)
+TOOL_REGISTRY.register(
+    "populate_condition_table", populate_condition_table, takes_state=True
+)

--- a/builder/tools/drafters.py
+++ b/builder/tools/drafters.py
@@ -187,6 +187,89 @@ def draft_process(state: CrateState, assay_id: str, process_type: str, hints: di
     return entity
 
 
+def draft_defined_term(state: CrateState, name: str, hints: dict) -> Entity:
+    """Create a schema:DefinedTerm contextual entity from an ontology term.
+
+    Persists a looked-up ontology / AOP / Key-Event term (e.g. from
+    ``lookup_aop`` / ``lookup_bao_term``) so it round-trips into the crate
+    ``@graph`` and can be referenced (via ``link`` / ``set_fields``) as a
+    ``mentions`` / ``measurementMethod`` / ``sampleType`` target.
+
+    Args:
+        state: The crate state to add the entity to.
+        name: Human-readable term label.
+        hints: Field values. Recognised keys (any extras are kept):
+
+            - ``term_code`` / ``termCode``: the ontology code, e.g. ``"BAO:0002993"``.
+            - ``in_defined_term_set`` / ``inDefinedTermSet``: the term set IRI.
+            - ``url`` / ``entity_id`` / ``@id``: a dereferenceable IRI used as the
+              entity's stable ``entity_id`` so the node's ``@id`` resolves.
+
+    Returns:
+        The newly created DefinedTerm Entity.
+    """
+    merged_hints = dict(hints)
+    merged_hints["name"] = name
+    # Normalize the camelCase schema.org property names the model emits.
+    if "term_code" in merged_hints:
+        merged_hints["termCode"] = merged_hints.pop("term_code")
+    if "in_defined_term_set" in merged_hints:
+        merged_hints["inDefinedTermSet"] = merged_hints.pop("in_defined_term_set")
+
+    # A looked-up term carries a dereferenceable IRI; use it as the entity_id so
+    # _mint_id keeps it as the @id (an IRI containing "://" is preserved verbatim).
+    iri = merged_hints.get("entity_id") or merged_hints.get("@id") or merged_hints.get("url")
+    if iri and "entity_id" not in hints:
+        merged_hints["entity_id"] = iri
+        entity_id = str(iri)
+    else:
+        entity_id = _make_entity_id("dt", name, merged_hints)
+    entity = Entity(
+        entity_id=entity_id,
+        type="DefinedTerm",
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+    entity.set_fields_from_dict(merged_hints, source="llm")
+    state.add_entity(entity)
+    return entity
+
+
+def draft_property_value(state: CrateState, name: str, hints: dict) -> Entity:
+    """Create a schema:PropertyValue contextual entity (a typed key/value).
+
+    Args:
+        state: The crate state to add the entity to.
+        name: The property name (also used to mint the entity id).
+        hints: Field values. Recognised keys (any extras are kept):
+
+            - ``value``: the measured / asserted value.
+            - ``property_id`` / ``propertyID``: the ontology IRI for the key.
+            - ``unit_text`` / ``unitText``: a human-readable unit (e.g. ``"uM"``).
+            - ``unit_code`` / ``unitCode``: a UN/CEFACT unit code.
+
+    Returns:
+        The newly created PropertyValue Entity.
+    """
+    merged_hints = dict(hints)
+    merged_hints["name"] = name
+    for snake, camel in (
+        ("property_id", "propertyID"),
+        ("unit_text", "unitText"),
+        ("unit_code", "unitCode"),
+    ):
+        if snake in merged_hints:
+            merged_hints[camel] = merged_hints.pop(snake)
+    entity_id = _make_entity_id("pv", name, merged_hints)
+    entity = Entity(
+        entity_id=entity_id,
+        type="PropertyValue",
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+    entity.set_fields_from_dict(merged_hints, source="llm")
+    state.add_entity(entity)
+    return entity
+
+
 def draft_person(state: CrateState, name: str, hints: dict) -> Entity:
     """Create a Person entity.
 
@@ -328,3 +411,5 @@ TOOL_REGISTRY.register("draft_cell_line_sample", draft_cell_line_sample, takes_s
 TOOL_REGISTRY.register("draft_person", draft_person, takes_state=True)
 TOOL_REGISTRY.register("draft_organization", draft_organization, takes_state=True)
 TOOL_REGISTRY.register("draft_publication", draft_publication, takes_state=True)
+TOOL_REGISTRY.register("draft_defined_term", draft_defined_term, takes_state=True)
+TOOL_REGISTRY.register("draft_property_value", draft_property_value, takes_state=True)

--- a/profiles/models/isa.py
+++ b/profiles/models/isa.py
@@ -455,7 +455,7 @@ class Sample(AutoAddContextEntity):
         crate: ROCrate,
         identifier: str,
         name: str,
-        additionalProperty: ParameterValue | None = None,
+        additionalProperty: ParameterValue | list[ParameterValue] | None = None,
         properties: dict | None = None,
         add: bool = True,
     ):

--- a/profiles/models/tox.py
+++ b/profiles/models/tox.py
@@ -314,7 +314,7 @@ class CellLineSample(Sample):
         name: str,
         sample_type: ContextEntity,  # a schema:DefinedTerm node (e.g. "cell line")
         accession: str | None = None,  # Cellosaurus accession, e.g. "CVCL_0027"
-        additionalProperty: ParameterValue | None = None,
+        additionalProperty: ParameterValue | list[ParameterValue] | None = None,
         properties: dict | None = None,
         add: bool = True,
     ):

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -1,0 +1,74 @@
+"""Tests for Exposure condition-table population + Frictionless bridge (Issue #144).
+
+``populate_condition_table`` writes per-well rows into the Exposure condition
+table CSV (replacing the header-only placeholder from #94). ``csvw_to_frictionless``
+converts the CSVW column descriptors into the Frictionless ``{fields: [...]}``
+shape so ``validate_table`` needs no hand-authored schema.
+"""
+
+from __future__ import annotations
+
+import csv
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools._crate_mapping import _CONDITION_TABLE_COLUMNS
+from builder.tools.data_content import (
+    csvw_to_frictionless,
+    populate_condition_table,
+    validate_table,
+)
+
+
+def _exposure_state() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Exposure crate"
+    state.add_entity(
+        Entity(
+            entity_id="proc_exp",
+            type="LabProcess",
+            fields={"process_type": "Exposure", "name": "Exposure step"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    return state
+
+
+def test_csvw_to_frictionless_maps_columns():
+    schema = csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)
+    assert "fields" in schema
+    names = [f["name"] for f in schema["fields"]]
+    assert names == ["cell_line", "compound", "concentration", "unit", "duration"]
+    by_name = {f["name"]: f for f in schema["fields"]}
+    # double -> number, string -> string (Frictionless types)
+    assert by_name["concentration"]["type"] == "number"
+    assert by_name["cell_line"]["type"] == "string"
+
+
+def test_populate_condition_table_writes_rows(tmp_path):
+    state = _exposure_state()
+    rows = [
+        {"cell_line": "HepG2", "compound": "Aspirin", "concentration": "10",
+         "unit": "uM", "duration": "24h"},
+        {"cell_line": "HepG2", "compound": "Aspirin", "concentration": "100",
+         "unit": "uM", "duration": "24h"},
+    ]
+    result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
+    assert result["ok"] is True
+    csv_path = result["path"]
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = list(csv.DictReader(fh))
+    assert len(reader) == 2
+    assert reader[0]["concentration"] == "10"
+    assert reader[1]["concentration"] == "100"
+
+
+def test_populated_table_validates_with_inferred_schema(tmp_path):
+    state = _exposure_state()
+    rows = [
+        {"cell_line": "HepG2", "compound": "Aspirin", "concentration": "10",
+         "unit": "uM", "duration": "24h"},
+    ]
+    result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
+    schema = csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)
+    report = validate_table(result["path"], schema)
+    assert report["ok"] is True, report

--- a/tests/test_tools_drafters.py
+++ b/tests/test_tools_drafters.py
@@ -3,21 +3,34 @@
 from __future__ import annotations
 
 import pytest
+from rocrate.rocrate import ROCrate
 
 from builder.state import CrateState
+from builder.tools._crate_mapping import populate_crate
 from builder.tools.drafters import (
     draft_assay,
     draft_cell_line_sample,
+    draft_defined_term,
     draft_investigation,
     draft_molecular_entity,
     draft_organization,
     draft_person,
     draft_process,
+    draft_property_value,
     draft_protocol,
     draft_publication,
     draft_sample,
     draft_study,
 )
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _graph(state: CrateState) -> list[dict]:
+    """Assemble the crate from state and return its JSON-LD @graph nodes."""
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, None, materialize_payload=False)
+    return crate.metadata.generate()["@graph"]
 
 
 class TestDraftInvestigation:
@@ -385,3 +398,164 @@ class TestDraftSample:
         fc = entity.get_field_status("protocol_id")
         assert fc is not None
         assert fc.status == "filled"
+
+
+def _node_by_id(graph: list[dict], node_id: str) -> dict | None:
+    for node in graph:
+        if node.get("@id") == node_id:
+            return node
+    return None
+
+
+class TestDraftDefinedTerm:
+    """Tests for draft_defined_term (Issue #141)."""
+
+    def test_creates_defined_term_entity(self):
+        state = CrateState()
+        entity = draft_defined_term(
+            state,
+            "cell viability assay",
+            {
+                "term_code": "BAO:0002993",
+                "in_defined_term_set": "http://www.bioassayontology.org/bao",
+                "url": "http://www.bioassayontology.org/bao#BAO_0002993",
+            },
+        )
+        assert entity.type == "DefinedTerm"
+        assert entity.fields.get("name") == "cell viability assay"
+        assert entity.fields.get("termCode") == "BAO:0002993"
+        assert entity.fields.get("inDefinedTermSet") == "http://www.bioassayontology.org/bao"
+        retrieved = state.get_entity(entity.entity_id)
+        assert retrieved is entity
+
+    def test_lookup_result_id_is_used_as_dereferenceable_id(self):
+        """A DefinedTerm built from a lookup IRI gets a dereferenceable @id."""
+        state = CrateState()
+        draft_defined_term(
+            state,
+            "cell viability assay",
+            {"url": "http://www.bioassayontology.org/bao#BAO_0002993"},
+        )
+        graph = _graph(state)
+        node = _node_by_id(graph, "http://www.bioassayontology.org/bao#BAO_0002993")
+        assert node is not None, "DefinedTerm should be in @graph under its IRI @id"
+        types = node["@type"] if isinstance(node["@type"], list) else [node["@type"]]
+        assert "DefinedTerm" in types
+
+    def test_defined_term_round_trips_into_graph(self):
+        state = CrateState()
+        draft_defined_term(state, "apoptosis", {"term_code": "GO:0006915"})
+        graph = _graph(state)
+        names = [n.get("name") for n in graph]
+        assert "apoptosis" in names
+
+    def test_defined_term_is_referenceable_as_mentions_target(self):
+        """A looked-up DefinedTerm can be wired as a Study schema:mentions target."""
+        state = CrateState()
+        inv = draft_investigation(state, {"name": "Inv"})
+        term = draft_defined_term(state, "liver injury", {"term_code": "MONDO:0005154"})
+        study = draft_study(
+            state, inv.entity_id, {"name": "Study", "mentions": term.entity_id}
+        )
+        graph = _graph(state)
+        # The Study node should mention the DefinedTerm node.
+        study_node = _node_by_id(graph, "#Study_" + study.entity_id)
+        assert study_node is not None, "Study node should be in the graph"
+        mentions = study_node.get("mentions")
+        assert mentions is not None, "Study should carry a mentions edge to the term"
+        ids = [m.get("@id") for m in (mentions if isinstance(mentions, list) else [mentions])]
+        mentioned = [_node_by_id(graph, i) for i in ids]
+        assert any(
+            n is not None
+            and "DefinedTerm" in (n["@type"] if isinstance(n["@type"], list) else [n["@type"]])
+            for n in mentioned
+        ), f"a DefinedTerm should be a mentions target; got {ids}"
+
+
+class TestDraftPropertyValue:
+    """Tests for draft_property_value (Issue #141)."""
+
+    def test_creates_property_value_entity(self):
+        state = CrateState()
+        entity = draft_property_value(
+            state,
+            "Passage Number",
+            {"value": "5", "property_id": "http://purl.obolibrary.org/obo/EFO_0007061"},
+        )
+        assert entity.type == "PropertyValue"
+        assert entity.fields.get("name") == "Passage Number"
+        assert entity.fields.get("value") == "5"
+        assert entity.fields.get("propertyID") == "http://purl.obolibrary.org/obo/EFO_0007061"
+        retrieved = state.get_entity(entity.entity_id)
+        assert retrieved is entity
+
+    def test_property_value_carries_unit(self):
+        state = CrateState()
+        entity = draft_property_value(
+            state, "Concentration", {"value": "10", "unit_text": "uM"}
+        )
+        assert entity.fields.get("unitText") == "uM"
+
+    def test_property_value_round_trips_into_graph(self):
+        state = CrateState()
+        draft_property_value(state, "Passage Number", {"value": "5"})
+        graph = _graph(state)
+        pv_nodes = [
+            n
+            for n in graph
+            if "PropertyValue"
+            in (n["@type"] if isinstance(n.get("@type"), list) else [n.get("@type")])
+        ]
+        assert any(n.get("name") == "Passage Number" for n in pv_nodes)
+
+
+class TestUnitsThreadedIntoProcesses:
+    """Issue #143: units thread through to ParameterValue unitText."""
+
+    def test_exposure_parameter_values_carry_unit_text(self):
+        state = CrateState()
+        inv = draft_investigation(state, {"name": "Inv"})
+        study = draft_study(state, inv.entity_id, {"name": "Study"})
+        assay = draft_assay(state, study.entity_id, {"name": "Assay"})
+        draft_process(
+            state,
+            assay.entity_id,
+            "Exposure",
+            {
+                "name": "24h Exposure",
+                "duration": "24",
+                "units": {"Exposure Duration": "h"},
+            },
+        )
+        graph = _graph(state)
+        units = [n.get("unitText") for n in graph if n.get("unitText")]
+        assert "h" in units, f"Exposure Duration unitText 'h' should appear; got {units}"
+
+    def test_cell_line_passage_growth_become_additional_properties(self):
+        """CellLineSample passage/growth -> additionalProperty PropertyValue nodes."""
+        state = CrateState()
+        draft_cell_line_sample(
+            state,
+            "HepG2",
+            {"accession": "CVCL_0027", "passage": "12", "growth": "adherent"},
+        )
+        graph = _graph(state)
+        pv_nodes = [
+            n
+            for n in graph
+            if "PropertyValue"
+            in (n["@type"] if isinstance(n.get("@type"), list) else [n.get("@type")])
+        ]
+        names = {n.get("name") for n in pv_nodes}
+        assert {"passage", "growth"} <= names, (
+            f"passage/growth PropertyValues expected; got {names}"
+        )
+        # And the CellLineSample must reference them via additionalProperty.
+        cell_nodes = [
+            n
+            for n in graph
+            if n.get("additionalType") == "CellLine"
+        ]
+        assert cell_nodes, "CellLineSample node should exist"
+        addl = cell_nodes[0].get("additionalProperty")
+        assert addl is not None, "CellLineSample should carry additionalProperty"


### PR DESCRIPTION
Closes #141
Closes #143
Closes #144

Lane C — semantic completeness in `_crate_mapping.py` + drafters + tox models.

## #141 — `draft_defined_term` / `draft_property_value`
`CrateState` already had `defined_terms` / `property_values` collections and the
mapping rendered them, but nothing created them. Adds two drafters
(`builder/tools/drafters.py`):
- `draft_defined_term(name, hints={term_code, in_defined_term_set, url, ...})` →
  a `schema:DefinedTerm`. Passing the looked-up IRI as the `url`/`@id` hint gives
  the node a dereferenceable `@id`, so a term from `lookup_aop` / `lookup_bao_term`
  round-trips into the `@graph` and is referenceable (via `set_fields`/`link`) as a
  `mentions` / `measurementMethod` / `sampleType` target.
- `draft_property_value(name, hints={value, property_id, unit_text, unit_code, ...})`
  → a `schema:PropertyValue`.

Typed hints added to `ENTITY_DRAFT_SCHEMA` (advertised ref keys stay ⊆ `_REF_FIELDS`).
Both registered across all drift-guard sync points (registry, TOOL_SPECS,
system_prompt, dashboard, `__init__`).

## #143 — units / optional params / Sample characteristics
- `_build_process` now threads `units=f.get('units')` (plus `assay_kit`/`substrate`
  for EndpointReadout and `acceptance_criteria`/`evaluation_criteria` for
  DataAnalysis) into the Exposure / EndpointReadout / DataAnalysis constructors, so
  each `ParameterValue` carries its `unitText`.
- `ENTITY_DRAFT_SCHEMA['LabProcess']` advertises `units` + the optional params.
- `CellLineSample` `passage` / `growth` hints are promoted to ISA Sample
  Characteristics (`schema:additionalProperty` `CharacteristicValue` PropertyValue
  nodes, with the property's ontology IRI). `Sample`/`CellLineSample`
  `additionalProperty` type widened to accept a list.

## #144 — condition-table rows + Frictionless bridge
- `populate_condition_table(exposure_id, rows_or_csv_path, output_dir=None)` writes
  per-well rows into the Exposure condition-table CSV (or attaches a user-supplied
  plate-map CSV), targeting the exact path the build wires
  (`_crate_mapping._condition_table_rel`) so the #94 CSVW `tableSchema` typing stays
  attached.
- `csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)` converts the CSVW columns into the
  Frictionless `{fields:[...]}` shape, so `validate_table` needs no hand-authored
  schema for the populated table.

## Tests (TDD)
- `tests/test_tools_drafters.py`: DefinedTerm/PropertyValue build into the `@graph`;
  a DefinedTerm from a lookup IRI gets a dereferenceable `@id` and is a `mentions`
  target; Exposure `units` → `ParameterValue.unitText`; CellLineSample
  `passage`/`growth` → `additionalProperty` PropertyValue nodes.
- `tests/test_condition_table.py`: `populate_condition_table` writes dosed rows;
  `csvw_to_frictionless` maps columns; `validate_table` with the inferred schema
  returns `ok:True`.

Full required suite green (drafters, condition_table, tools_spec, tool_registry,
entity_draft_schema, build_and_validate, crate_mapping_no_payload, builder_domain,
data_content_validation): **106 passed**. `ruff` + `ty` clean. AGENTS.md updated.

Note: 3 pre-existing failures in `tests/test_agent_loop.py::TestModelTiering` are
environmental (`ModuleNotFoundError: No module named 'langchain_openai'`, an
optional dep not installed) and unrelated to this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)