### PR TITLE
feat(validation): flip RO-Crate base spec to 1.2 (#110)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ perfectly detailed crate that doesn't build at all.
 ### Validation Gate Ordering
 
 The three-pass validation in `profiles/validator.py` has a strict dependency:
-- **Base RO-Crate 1.1** must pass before ISA validation is meaningful
+- **Base RO-Crate 1.2** must pass before ISA validation is meaningful
 - **ISA Profile** must pass before ISA-Tox validation is meaningful
 - **ISA-Tox Profile** depends on both lower layers
 
@@ -308,7 +308,7 @@ This project builds on the existing RO-Crate Python ecosystem rather than reinve
 | Package | PyPI | What it provides | How we use it |
 |---------|------|-----------------|---------------|
 | [`ro-crate-py`](https://github.com/ResearchObject/ro-crate-py) | `uv add rocrate`<br>(import `rocrate`) | Official Python SDK for creating and manipulating RO-Crates. Provides `ROCrate`, `ContextEntity`, `File`, and other base entity classes. | The entity model classes in `profiles/models/isa.py` and `profiles/models/tox.py` subclass `rocrate.model.ContextEntity` and `rocrate.model.File`. The builder uses `ROCrate` to assemble the crate and serialise `ro-crate-metadata.json`. |
-| [`rocrate-validator`](https://github.com/crs4/rocrate-validator) | `uv add roc-validator`<br>(import `rocrate_validator`) | Official SHACL-based validation library. Supports multi-profile validation (base RO-Crate → ISA → domain extensions) with severity levels. | `profiles/validator.py` wraps this in three passes (RO-Crate 1.1, ISA, ISA-Tox), suppressing inherited-profile duplicates so each pass reports only its own layer. |
+| [`rocrate-validator`](https://github.com/crs4/rocrate-validator) | `uv add roc-validator`<br>(import `rocrate_validator`) | Official SHACL-based validation library. Supports multi-profile validation (base RO-Crate → ISA → domain extensions) with severity levels. | `profiles/validator.py` wraps this in three passes (RO-Crate 1.2, ISA, ISA-Tox), suppressing inherited-profile duplicates so each pass reports only its own layer. |
 | [`rocrate-wizard`](https://github.com/ResearchObject/rocrate-wizard) *(external frontend)* | TBD | Frontend/UI layer that uses this backend (vitro-crate) to provide a user-facing RO-Crate builder. | This repo is the dependency — `rocrate-wizard` imports from `vitro-crate` and adds the web UI/CLI on top. Referenced in the ARC template's conversion workflow. |
 
 These packages are imported directly — we do not fork or vendor them. Version requirements are declared in `pyproject.toml`.
@@ -589,7 +589,7 @@ Every tool call and graph node execution is automatically timed and recorded by 
 
 | Layer | Severity | Meaning | Agent Action |
 |-------|----------|---------|--------------|
-| Base RO-Crate 1.1 | REQUIRED | Structural validity | MUST fix before proceeding |
+| Base RO-Crate 1.2 | REQUIRED | Structural validity | MUST fix before proceeding |
 | ISA Profile | REQUIRED | ISA conformance | MUST fix |
 | ISA Profile | SHOULD | Recommended metadata | Fix if data available |
 | ISA Profile | MAY | Optional metadata | Note for user |

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -36,7 +36,7 @@ from profiles.models.tox import (
     LabProcessExposure,
 )
 
-ROCRATE_SPEC = "https://w3id.org/ro/crate/1.1"
+ROCRATE_SPEC = "https://w3id.org/ro/crate/1.2"
 # The ISA layer the tox profile actually extends (profiles/shapes/tox/profile.ttl
 # prof:isProfileOf) and that resolves — the w3id ISA permalink is not yet live.
 PROFILE_ISA = "https://github.com/nfdi4plants/isa-ro-crate-profile"
@@ -492,14 +492,10 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
     # reserved for the single base-spec URI, while the profiles the crate targets
     # are declared on the Root Data Entity (./) — Issue #91.
     #
-    # The base spec stays pinned to 1.1 (not 1.2) deliberately: roc-validator
-    # 0.10.0 bundles no ro-crate-1.2 base profile, and its base pass hard-requires
-    # the 1.1 URI on the descriptor (profiles/ro-crate/must/1_file-descriptor_
-    # metadata.ttl: `sh:hasValue <https://w3id.org/ro/crate/1.1>`). Declaring 1.2
-    # there fails REQUIRED validation, which build_and_validate (#87) and the
-    # golden fixtures (#97) rely on staying green. ro-crate-py 0.15 still emits a
-    # 1.2 @context; fully unifying the version on 1.2 is deferred until an upstream
-    # validator ships a 1.2 base profile (tracked on #91).
+    # The base spec is now 1.2 (ROCRATE_SPEC). The #105 deferral to 1.1 is lifted:
+    # roc-validator 0.11.0 ships a ro-crate-1.2 base profile
+    # (crs4/rocrate-validator#164), so the base pass validates against 1.2 and
+    # build_and_validate (#87) + the golden fixtures (#97) stay green — Issue #110.
     crate.metadata["conformsTo"] = {"@id": ROCRATE_SPEC}
 
     # Profiles the crate TARGETS, declared on ./ unconditionally — the three-layer
@@ -897,7 +893,9 @@ def _build_condition_table_schema(
         title = col["titles"]
         props: dict[str, Any] = {"@type": "csvw:Column", **col}
         if value_urls.get(title):
-            props["valueUrl"] = value_urls[title]
+            # Emit valueUrl as an {@id} reference (not a bare string): RO-Crate 1.2
+            # REQUIRES entity links be reference objects, and flags string @ids.
+            props["valueUrl"] = {"@id": value_urls[title]}
         column = crate.add(
             ContextEntity(crate, f"#{exp_slug}_col_{title}", properties=props)
         )

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -132,7 +132,7 @@ _FIX_TEMPLATES: dict[str, str] = {
     "name": "Add a `name` to `{entity}`.",
     "description": "Add a `description` to `{entity}`.",
     "identifier": "Add an `identifier` to `{entity}`.",
-    "conformsTo": "Add `conformsTo` to `{entity}` referencing the RO-Crate 1.1 spec.",
+    "conformsTo": "Add `conformsTo` to `{entity}` referencing the RO-Crate 1.2 spec.",
     "license": "Add a `license` to `{entity}`.",
     "author": "Add an `author` to `{entity}`.",
     "datePublished": "Add a `datePublished` to `{entity}`.",

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -136,7 +136,7 @@ def build_maturity_html(
     # --- Profile adherence (from existing validation results) ---
     if _validation_has_signal(val):
         layers = [
-            ("RO-Crate 1.1", val.base_passed),
+            ("RO-Crate 1.2", val.base_passed),
             ("ISA", val.isa_passed),
             ("ISA-Tox", val.tox_passed),
         ]

--- a/profiles/docs/isa_tox.md
+++ b/profiles/docs/isa_tox.md
@@ -110,20 +110,30 @@ Protocol --reagent---> ont
 
 ## Conformance
 
-A crate following this profile declares conformance using the **RO-Crate 1.1** convention: the
-*RO-Crate Metadata Descriptor* carries the base specification and the profile URIs together in its `conformsTo`
-array, and each referenced profile is declared as a `Profile` contextual entity.
+A crate following this profile declares conformance using the **RO-Crate 1.2** convention: the
+*RO-Crate Metadata Descriptor*'s `conformsTo` carries only the single base-specification URI, while the
+profile URIs the crate targets are declared on the **Root Data Entity** (`./`). Each referenced profile is
+also declared as a `Profile` contextual entity.
 
 ```json
 {
   "@id": "ro-crate-metadata.json",
   "@type": "CreativeWork",
+  "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+  "about": {"@id": "./"}
+}
+```
+
+The Root Data Entity declares the targeted profiles:
+
+```json
+{
+  "@id": "./",
+  "@type": "Dataset",
   "conformsTo": [
-    {"@id": "https://w3id.org/ro/crate/1.1"},
     {"@id": "https://github.com/nfdi4plants/isa-ro-crate-profile"},
     {"@id": "https://w3id.org/ro/crate/isa-tox/1.0"}
-  ],
-  "about": {"@id": "./"}
+  ]
 }
 ```
 
@@ -145,13 +155,11 @@ permalink is not yet registered. The referenced profiles are declared as context
 }
 ```
 
-> **Note — RO-Crate 1.1 vs 1.2 placement.** Under RO-Crate **1.1**, profile conformance is declared on the *Metadata
-> Descriptor*, whose `conformsTo` MAY be an array of the base specification plus profile URIs. RO-Crate **1.2** instead
-> recommends declaring profiles on the *Root Data Entity* (`./`) and reserving the descriptor's `conformsTo` for a single
-> base-specification value. This profile follows the **1.1** placement because the current toolchain targets 1.1:
-> `ro-crate-py` emits a 1.1 `@context`, and the `rocrate-validator` base profile requires
-> `https://w3id.org/ro/crate/1.1` to be present in the descriptor's `conformsTo`. Move to the Root Data Entity placement
-> when the toolchain validates against 1.2.
+> **Note — RO-Crate 1.2 placement.** RO-Crate **1.2** recommends declaring the profiles a crate targets on the
+> *Root Data Entity* (`./`) and reserving the *Metadata Descriptor*'s `conformsTo` for a single base-specification
+> value — which this profile now follows (Issue #110). The earlier 1.1 placement (all URIs on the descriptor) was a
+> temporary measure while the toolchain lagged: it was lifted once `rocrate-validator` 0.11.0 shipped a `ro-crate-1.2`
+> base profile (crs4/rocrate-validator#164), so the base pass validates against 1.2.
 
 A machine-readable [Profile Crate](https://www.researchobject.org/ro-crate/specification/1.2/profiles.html#profile-crate) bundling this
 description with the SHACL shapes MAY additionally be published at the profile URI; this is planned but not yet provided.

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -3,7 +3,7 @@ Thin wrapper around rocrate_validator that runs the three-pass ISA-Tox
 validation and returns structured, plain-English results.
 
 Passes:
-  1. Base RO-Crate 1.1   -> bundled ``ro-crate`` profile
+  1. Base RO-Crate 1.2   -> bundled ``ro-crate`` profile
   2. ISA RO-Crate        -> bundled ``isa-ro-crate`` profile (roc-validator >=0.10)
   3. ISA-Tox RO-Crate    -> our ``tox-ro-crate`` profile, loaded from SHAPES_DIR
                             via ``extra_profiles_path`` and composed on top of the
@@ -334,7 +334,7 @@ class ValidationResult:
 # three passes in validate_crate(); the only difference is the document is fed as
 # a dict via services.validate_metadata_as_dict instead of read from disk.
 _PROFILE_PASSES: dict[str, tuple[str, dict]] = {
-    "base": ("ro-crate-1.1", {}),
+    "base": ("ro-crate-1.2", {}),
     "isa": ("isa-ro-crate", {"disable_inherited_profiles_issue_reporting": True}),
     "tox": (
         "tox-ro-crate",
@@ -345,6 +345,12 @@ _PROFILE_PASSES: dict[str, tuple[str, dict]] = {
         },
     ),
 }
+
+# Checks that validate the on-disk metadata FILE itself (e.g. its byte encoding)
+# and therefore cannot be evaluated on the in-memory dict path — they false-positive
+# on validate_crate_dict where no file exists. Dropped from the dict path only; the
+# on-disk validate_crate still enforces them. (ro-crate-1.2_3.1 = descriptor UTF-8.)
+_DICT_PATH_NA_CHECKS = frozenset({"ro-crate-1.2_3.1"})
 
 # Severity name <-> roc-validator Severity enum.
 _SEVERITY_BY_NAME = {
@@ -453,13 +459,19 @@ def validate_crate_dict(
             **extra,
         )
         result = services.validate_metadata_as_dict(metadata_doc, settings)
-        issues = [_routable_issue(i, key) for i in result.get_issues()]
+        # Drop file-only checks that can't apply to an in-memory document (see
+        # _DICT_PATH_NA_CHECKS), then derive pass/fail from the filtered issues.
+        issues = [
+            ri
+            for i in result.get_issues()
+            if (ri := _routable_issue(i, key)).check_id not in _DICT_PATH_NA_CHECKS
+        ]
         _raise_on_transport_failure(issues, profile=key)
         results.append(
             DictValidationResult(
                 profile=key,
-                passed=not result.has_issues(),
-                passed_required=not result.has_issues(min_severity=models.Severity.REQUIRED),
+                passed=not issues,
+                passed_required=not any(i.severity == "required" for i in issues),
                 issues=issues,
             )
         )
@@ -509,7 +521,7 @@ def validate_crate(crate_dir: Path) -> list[ValidationResult]:
     """Run all three validation passes against crate_dir.
 
     Returns one ValidationResult per pass in order:
-      1. Base RO-Crate 1.1
+      1. Base RO-Crate 1.2
       2. ISA RO-Crate Profile
       3. ISA-Tox RO-Crate Profile
     """
@@ -518,14 +530,14 @@ def validate_crate(crate_dir: Path) -> list[ValidationResult]:
     # --- Pass 1: base RO-Crate 1.1 ---
     settings = services.ValidationSettings(
         rocrate_uri=crate_dir,  # ty: ignore[unknown-argument]
-        profile_identifier="ro-crate-1.1",
+        profile_identifier="ro-crate-1.2",
         requirement_severity=models.Severity.OPTIONAL,
     )
     result = services.validate(settings)
-    _raise_on_transport_failure_result(result, profile="Base RO-Crate 1.1")
+    _raise_on_transport_failure_result(result, profile="Base RO-Crate 1.2")
     results.append(
         ValidationResult(
-            profile="Base RO-Crate 1.1",
+            profile="Base RO-Crate 1.2",
             passed=not result.has_issues(),
             issues=_format_issues(result),
             required_issues=_format_issues(result, models.Severity.REQUIRED),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "rocrate>=0.15.0",
-    "roc-validator>=0.10.0",
+    "roc-validator>=0.11.0",
     "requests>=2.31.0",
     "pyyaml>=6.0",
     "openpyxl>=3.1.0",

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -386,11 +386,11 @@ class TestIdentifiersAndConformance:
             assert "Profile" in (pt if isinstance(pt, list) else [pt])
 
     def test_descriptor_conformsto_is_base_spec_only(self, tmp_path):
-        # Issue #91: the metadata file descriptor's conformsTo is reserved for
-        # the single base-spec URI (profiles moved to ./). The base spec stays
-        # 1.1 because roc-validator 0.10.0 bundles no 1.2 base profile and its
-        # base pass requires the 1.1 URI on the descriptor (sh:hasValue).
+        # Issue #91/#110: the metadata file descriptor's conformsTo is reserved
+        # for the single base-spec URI (profiles moved to ./). The base spec is
+        # now 1.2 — roc-validator 0.11.0 ships a ro-crate-1.2 base profile
+        # (crs4/rocrate-validator#164), so the #105 deferral is lifted.
         state = CrateState()
         _, by_id = _build(state, tmp_path)
         desc_conforms = _ids(by_id["ro-crate-metadata.json"].get("conformsTo"))
-        assert desc_conforms == ["https://w3id.org/ro/crate/1.1"]
+        assert desc_conforms == ["https://w3id.org/ro/crate/1.2"]

--- a/tests/test_e2e_agent_eval.py
+++ b/tests/test_e2e_agent_eval.py
@@ -45,6 +45,13 @@ from tests.fixtures.vhps_golden_crates import VHPS_STUDIES
 
 FIXTURE_INPUT_DIR = Path(__file__).parent / "fixtures" / "svhps21_input"
 
+# This module is a heavy integration harness: each test drives the full scripted
+# tool sequence plus real SHACL validation (build_and_validate + an on-disk
+# round-trip validate). Under RO-Crate 1.2 the validator is slower (larger
+# ontology / pyshacl ontology-mixing), so the global CI --timeout=30 is too tight
+# for these on shared runners. Raise the per-test ceiling for this file only.
+pytestmark = pytest.mark.timeout(120)
+
 
 @pytest.fixture(autouse=True)
 def _no_network(monkeypatch):

--- a/tests/test_offline_validation.py
+++ b/tests/test_offline_validation.py
@@ -48,7 +48,7 @@ def _base_valid_doc() -> dict:
     crate.root_dataset["name"] = "Test"
     crate.root_dataset["description"] = "Test crate"
     crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
-    crate.metadata["conformsTo"] = {"@id": "https://w3id.org/ro/crate/1.1"}
+    crate.metadata["conformsTo"] = {"@id": "https://w3id.org/ro/crate/1.2"}
     return crate.metadata.generate()
 
 
@@ -131,19 +131,16 @@ class TestOfflineContextResolution:
         assert attempted == [], attempted
 
     def test_no_remote_context_check_failures_with_network_down(self):
-        """Checks ``ro-crate-1.1_2.1`` / ``2.2`` (the ones that flaked) stay clean."""
+        """The base pass stays clean with the network down — the remote-context
+        resolution checks (e.g. ro-crate-1.2_2.*) are served from the bundled
+        context, so they don't spuriously fail (the regression that flaked CI)."""
         from profiles.validator import validate_crate_dict
 
         with _network_down():
             results = validate_crate_dict(_base_valid_doc(), profile="base")
 
         base = next(r for r in results if r.profile == "base")
-        offending = [
-            i
-            for i in base.issues
-            if (i.check_id or "").startswith(("ro-crate-1.1_2.1", "ro-crate-1.1_2.2"))
-        ]
-        assert offending == [], [(i.check_id, i.message) for i in offending]
+        assert base.passed_required, [(i.check_id, i.message) for i in base.issues]
 
 
 class TestTransportErrorNotReportedAsRequired:

--- a/uv.lock
+++ b/uv.lock
@@ -4860,7 +4860,7 @@ wheels = [
 
 [[package]]
 name = "roc-validator"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -4874,11 +4874,10 @@ dependencies = [
     { name = "rich" },
     { name = "rich-click" },
     { name = "toml" },
-    { name = "typos" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/052a2fc5c5480ad0b6c95d9ab01b47a9744fa7e4ffe6055cd80f55e7c96f/roc_validator-0.10.0.tar.gz", hash = "sha256:395a6d6ffe196ea836d900f594975d3932716657694f0a83b73e839ed83bf3ba", size = 144446, upload-time = "2026-06-01T15:35:41.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/7a1a0ccfaf22cb5b6453d2b605c9e9924640789223b9fc118ef8d2171fad/roc_validator-0.11.0.tar.gz", hash = "sha256:47151467ed96d6519431f27872a8ef5d44c560b061e36de5e91e3ae8c1720b7e", size = 191485, upload-time = "2026-06-24T08:34:32.755Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/60/2aa10669aa4e3adc75ec03299013ba2a45eedb0507bebacadd713b695d55/roc_validator-0.10.0-py3-none-any.whl", hash = "sha256:2789b154f8cf911197b8d321e7cce8a0fe5e0ba8cbc0f6d1b3461a5cdae00820", size = 274644, upload-time = "2026-06-01T15:35:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/8d/e2edadd43c9de326e2afec99ea3be33d877eeaae629f16e2339f007e55ee/roc_validator-0.11.0-py3-none-any.whl", hash = "sha256:e13618095ee5533372e96dd7ec63791904d23e1d21e55a6b18d8b623ccded986", size = 379236, upload-time = "2026-06-24T08:34:31.079Z" },
 ]
 
 [[package]]
@@ -5688,23 +5687,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typos"
-version = "1.47.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/9b/ae967bee92f0db3916350bd433f700cc0cd2942d51a22f3bfafbc97392f6/typos-1.47.2.tar.gz", hash = "sha256:d303e8c495ea870f750d8b37f2d3c3fe2441b00cf18ca5d7e0b52eca1938c7b7", size = 1829889, upload-time = "2026-06-04T01:03:07.169Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/9f/0612f6272666784ee60bee890afd517641044e5f1cda76ce22252e61b4e1/typos-1.47.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:87df3040f9d34afd9b19a9437045fbb8838a0435eb00f047e4bac48d92f2fc44", size = 3468120, upload-time = "2026-06-04T01:02:51.404Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/cc/9ecd96a40cf5e8aca68cc07c0b7e4a8d8d3376b19c5774a95aeded8a935f/typos-1.47.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:287e2718a058c561baf5f55ec6b466d9270546bcb1951a2c120e594c574b9597", size = 3379520, upload-time = "2026-06-04T01:02:53.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/6e/77d23f926d6f774d6939e24f9545db702e2ee359b21e38006337539d0903/typos-1.47.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e4ef6632b280ce237caaec38d80dd3c2d956e28aa6925f80d4e915335b94a36", size = 8242414, upload-time = "2026-06-04T01:02:55.443Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fd/e292e2bde1144a135949cf6d5615e571eab7f0ff2ba6cca55c074b302dd1/typos-1.47.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd7b310019943e26552809bd17f9f202b45eb0c9694f437f1708ab0868248ced", size = 7327674, upload-time = "2026-06-04T01:02:57.243Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/58/b7a3f4df5ff9ddde7c9e42d29b4c0569662af5dbad3573eedc167cd8d1e1/typos-1.47.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f525edf9b67d3ede552bb70bd4171f23e5e8edec3187189dfe8d1676df630b44", size = 7747368, upload-time = "2026-06-04T01:02:59.031Z" },
-    { url = "https://files.pythonhosted.org/packages/78/18/758682974e36f5b77eb592807fd748ce1c4010509b4255f867433aa3e44f/typos-1.47.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6c36a97ab3dd8c8924cd9b907a32e9aac504fc779d0c3b05e19204ca93385c37", size = 7097338, upload-time = "2026-06-04T01:03:00.932Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/b3/e6bccecd186d8f8c2d592baa7e1b17ef4f02a1e0a5ce4d7f53e9693fd3d9/typos-1.47.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:4eb36a44daed1d719ce417d2a6dd7a323d814ccdc647d9bb20d17ac2bed9e38c", size = 8136631, upload-time = "2026-06-04T01:03:02.744Z" },
-    { url = "https://files.pythonhosted.org/packages/50/90/cceb1be7159dd020c0c9a93371b6444b8bdad7bce55bc7fa119e49d2c264/typos-1.47.2-py3-none-win32.whl", hash = "sha256:d0c01034bc029d8883406f3e2bed46dfa9b090ce6ad4a99e580070ae51307cfa", size = 3139942, upload-time = "2026-06-04T01:03:04.163Z" },
-    { url = "https://files.pythonhosted.org/packages/82/0c/7c44ffabf6020d2fc456912bdcfb0d68102e05775fbc5cf82b88979be2ea/typos-1.47.2-py3-none-win_amd64.whl", hash = "sha256:749bbba363067bfc0e54ccc6e7580750e17f5ef093c91fedf6c2eb27d32efee6", size = 3311629, upload-time = "2026-06-04T01:03:05.718Z" },
-]
-
-[[package]]
 name = "tzdata"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5945,7 +5927,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "roc-validator", specifier = ">=0.10.0" },
+    { name = "roc-validator", specifier = ">=0.11.0" },
     { name = "rocrate", specifier = ">=0.15.0" },
     { name = "watchfiles", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
Unblocked **today**: roc-validator **0.11.0** ships a `ro-crate-1.2` base profile (crs4/rocrate-validator#164), lifting the #105 deferral. This completes #91/#110 — the crate now conforms to **RO-Crate 1.2** end to end.

## Changes
- **Dep:** `roc-validator >=0.11.0`.
- **Base spec → 1.2:** `ROCRATE_SPEC` → `https://w3id.org/ro/crate/1.2`; base-pass `profile_identifier` → `ro-crate-1.2` (dict + disk paths). (Profiles already live on the Root Data Entity from #116.)
- **Real fix surfaced by 1.2's stricter SHACL:** the CSVW condition-table column emitted `valueUrl` as a **bare id string**; 1.2 requires entity links be `{"@id": …}` references. Fixed.
- **Dict-path guard:** 1.2's `ro-crate-1.2_3.1` (descriptor-file UTF-8) check can't apply to an in-memory document → it false-positived on `build_and_validate`. Dropped on the dict path only (`_DICT_PATH_NA_CHECKS`); the on-disk `validate_crate` still checks real file encoding. The #117 transport-failure guard is message-keyed, so it survived the `1.1`→`1.2` check-id change.
- **Tests:** flipped the #105 deferral assertion (`1.1`→`1.2`); made the offline test version-agnostic (asserts the base pass is clean under network-down rather than hardcoding `ro-crate-1.1_2.*` ids).
- **Docs/labels:** AGENTS.md, `isa_tox.md` conformance section (was stale — now documents the 1.2 placement: single base URI on the descriptor, profiles on `./`), validator pass labels, maturity report, validator suggestion text.

## Verification
- Version bump alone was backward-compatible (1.1 suite green) before the flip.
- After flip: golden fixtures + `build_and_validate` + offline validation pass at 1.2; disk + dict paths both clean.
- **Full suite: 675 passed**; `ty` + `ruff` clean.

Closes #110. (Supersedes the 1.1 deferral from #105.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)