### PR TITLE
test(lookups): keep lookup_compound ChEBI fallback offline (post-#159)

### DIFF
--- a/tests/test_tools_lookups.py
+++ b/tests/test_tools_lookups.py
@@ -60,7 +60,19 @@ class TestLookupCompound:
         def mock_lookup_pubchem(name):
             return {}
 
+        chebi_calls: list[tuple[str, str]] = []
+
+        def mock_chebi(raw, ontology):
+            chebi_calls.append((raw, ontology))
+            return {}
+
         monkeypatch.setattr("builder.tools.lookups.lookup_pubchem", mock_lookup_pubchem)
+        # Keep the ChEBI fallback offline & deterministic: without this stub the
+        # PubChem-miss path calls the live OLS endpoint, making this unit test
+        # hit the network (CI flake — the regression #117 already fixed once).
+        monkeypatch.setattr(
+            "builder.tools.lookups.lookup_ontology_term_ols", mock_chebi
+        )
         result = lookup_compound("NonexistentCompoundXYZ")
         assert isinstance(result, dict)
         assert result["found"] is False
@@ -68,6 +80,30 @@ class TestLookupCompound:
         assert isinstance(result["error"], str)
         err_lower = result["error"].lower()
         assert "not found" in err_lower or "failed" in err_lower
+        # The fallback was consulted (and intercepted) — proves no live call.
+        assert chebi_calls == [("NonexistentCompoundXYZ", "chebi")]
+
+    def test_falls_back_to_chebi_when_pubchem_misses(self, monkeypatch):
+        # When PubChem indexes nothing, lookup_compound resolves a ChEBI IRI via
+        # OLS (the AGENTS.md §10 name → CAS → ChEBI multi-strategy). Fully mocked
+        # — covers the #146 fallback path with no network.
+        monkeypatch.setattr("builder.tools.lookups.lookup_pubchem", lambda name: {})
+        chebi_hit = {
+            "@id": "http://purl.obolibrary.org/obo/CHEBI_15377",
+            "termCode": "CHEBI:15377",
+            "name": "water",
+        }
+        monkeypatch.setattr(
+            "builder.tools.lookups.lookup_ontology_term_ols",
+            lambda raw, ontology: chebi_hit if ontology == "chebi" else {},
+        )
+        result = lookup_compound("water")
+        assert result["found"] is True
+        assert result["data"]["source"] == "chebi"
+        assert result["data"]["chebi_iri"] == "http://purl.obolibrary.org/obo/CHEBI_15377"
+        assert result["data"]["chebi_id"] == "CHEBI:15377"
+        assert result["data"]["iupac_name"] == "water"
+        assert result["error"] is None
 
     def test_never_throws_exception(self, monkeypatch):
         def mock_lookup_pubchem(name):


### PR DESCRIPTION
## Problem (regression on `main` from #159)
#159 added a ChEBI/OLS fallback to `lookup_compound` for the PubChem-miss path (`builder/tools/lookups.py:91`, `lookup_ontology_term_ols(raw, "chebi")`). But `tests/test_tools_lookups.py::TestLookupCompound::test_returns_correct_structure_on_failure` mocks **only** `lookup_pubchem` (→ `{}`), so the fallback then calls the **live OLS endpoint** — a unit test hitting the network. Same CI-flake class as #117 ("validation tests hit the network"). The test currently "passes" only because the network happens to return *not found* for a nonsense name.

(The sibling `test_never_throws_exception` is unaffected — it makes PubChem *raise*, which short-circuits to the `except` before the fallback.)

## Fix
- Mock `lookup_ontology_term_ols` in the leaky test (and assert it was consulted, so the test actively owns the network boundary).
- Add `test_falls_back_to_chebi_when_pubchem_misses` — dedicated **offline** coverage of the #146 ChEBI fallback path (PubChem miss → ChEBI IRI, `source == "chebi"`), which the original PR exercised only via the unmocked live call.

## Verification
- `tests/test_tools_lookups.py` → **36 passed**.
- **Offline proof:** `TestLookupCompound` (6 tests) **passes with `socket.connect` blocked** — no network.
- `ruff` + `ty` clean.

Found by the adversarial review of #159. Tests-only; no production code change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>