### PR TITLE
feat(tools): list_scanned_files — retrieve the full scan inventory from state (#172)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,7 +535,7 @@ list_scanned_files(name_contains=None, mime_contains=None, offset=0, limit=200) 
 `list_scanned_files` retrieves the **full** raw scan inventory from
 `CrateState.scanned_files`. `scan_files` only surfaces a ~15-file sample and its
 output is later pruned from history (D12), so this is how the agent re-reads the
-complete file list to bind files to `File`/process entities — paginated
+complete file list to decide which files to place/annotate — paginated
 (`offset`/`limit`) and filterable (`name_contains`/`mime_contains`) so it stays
 token-bounded, and compact (no `first_rows` preview).
 `set_fields` is the **single consolidated mutation tool** (Issue #90). It

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,7 +530,14 @@ extensionless name leaves the field unset.
 set_fields(entity_id: str, fields: dict, source="llm") → Entity
 remove_entity(entity_id: str, cascade: bool = False) → bool
 list_entities(entity_type: str | None) → [Entity]
+list_scanned_files(name_contains=None, mime_contains=None, offset=0, limit=200) → {total_scanned, matched, files:[{path, filename, size, mime_type}]}
 ```
+`list_scanned_files` retrieves the **full** raw scan inventory from
+`CrateState.scanned_files`. `scan_files` only surfaces a ~15-file sample and its
+output is later pruned from history (D12), so this is how the agent re-reads the
+complete file list to bind files to `File`/process entities — paginated
+(`offset`/`limit`) and filterable (`name_contains`/`mime_contains`) so it stays
+token-bounded, and compact (no `first_rows` preview).
 `set_fields` is the **single consolidated mutation tool** (Issue #90). It
 replaced three redundant tools — `update_entity` and `bulk_set_fields` were
 byte-identical, and `set_entity_field` was just the single-field (one-key dict)

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -205,7 +205,7 @@ def _unreadable_file_message(path: str, tool_name: str = "read_file_sample") -> 
         f"{tool_name} could not return text for '{name}'. It is missing, too "
         f"large (>100MB), or binary/corrupt — e.g. .xls/.xlsx are Office/zip "
         f"containers and .prism/.pzf are GraphPad Prism binaries. Do NOT retry "
-        f"{tool_name} on it. Use the scan preview already in state, try "
+        f"{tool_name} on it. Use list_scanned_files to see the inventory, try "
         f"read_excel/read_file for spreadsheets or Office docs, or skip this file "
         f"and continue drafting entities."
     )
@@ -597,7 +597,7 @@ def _build_system_prompt_with_state(
 # Tool names whose verbose output already lives in CrateState, so replaying it
 # verbatim in the transcript is pure waste once the model has consumed it. The
 # scan inventory is the canonical example — the full listing is stored in
-# CrateState.scanned_files, queryable via get_status / list_entities (Issue #61).
+# CrateState.scanned_files, queryable via list_scanned_files (Issue #61, #172).
 _STATE_BACKED_TOOLS = frozenset({"scan_files", "read_file_sample", "read_multiple_files"})
 
 # Above this length (chars), a consumed state-backed tool output is pruned to a
@@ -630,10 +630,16 @@ def _prune_state_backed_outputs(messages: list) -> list:
             and getattr(msg, "name", None) in _STATE_BACKED_TOOLS
             and len(str(msg.content)) > _PRUNE_CONTENT_THRESHOLD
         ):
+            scan_hint = (
+                " Call list_scanned_files to retrieve the full file inventory "
+                "(paginated/filterable)."
+                if msg.name == "scan_files"
+                else ""
+            )
             stub = (
                 f"[{msg.name} output pruned from history to save tokens — the full "
-                f"result is stored in the session state (CrateState). Use get_status "
-                f"or list_entities to query it; do not re-run {msg.name}.]"
+                f"result is stored in the session state (CrateState).{scan_hint} "
+                f"Do not re-run {msg.name}.]"
             )
             pruned.append(
                 ToolMessage(

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -40,7 +40,7 @@ Entity management & provenance:
 - set_fields: Set one or more fields on an existing entity (the single mutation tool)
 - remove_entity: Remove an entity (refuses if still referenced unless cascade=true)
 - list_entities: List entities, optionally filtered by type
-- list_scanned_files: Retrieve the full scanned-file inventory (path/filename/size/mime) — scan_files only shows a sample, so use this to see every file (paginated/filterable)
+- list_scanned_files: Retrieve the full scanned-file inventory (path/filename/size/mime) — scan_files only shows a sample, so use this to browse the inventory and decide which files to place/annotate (paginated/filterable)
 - link: Wire a provenance edge (object/input/samples = consumed, result/output = produced) between two entities
 - check_provenance: Lint the derivation chain for dangling process outputs and orphan files (report-only)
 

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -40,6 +40,7 @@ Entity management & provenance:
 - set_fields: Set one or more fields on an existing entity (the single mutation tool)
 - remove_entity: Remove an entity (refuses if still referenced unless cascade=true)
 - list_entities: List entities, optionally filtered by type
+- list_scanned_files: Retrieve the full scanned-file inventory (path/filename/size/mime) — scan_files only shows a sample, so use this to see every file (paginated/filterable)
 - link: Wire a provenance edge (object/input/samples = consumed, result/output = produced) between two entities
 - check_provenance: Lint the derivation chain for dangling process outputs and orphan files (report-only)
 

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -243,6 +243,19 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "list_scanned_files",
+        "description": "Retrieve the FULL scanned-file inventory from session state (path, filename, size, mime_type). scan_files only shows a ~15-file sample and its output is pruned from history, so use this to see every file you must bind to File/process entities. Paginated and filterable: pass name_contains / mime_contains to narrow, offset / limit to page (default limit 200). Returns {total_scanned, matched, offset, limit, returned, files:[...]}.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name_contains": {"type": "string", "description": "Only files whose filename or path contains this substring (case-insensitive)."},
+                "mime_contains": {"type": "string", "description": "Only files whose mime_type contains this substring, e.g. 'csv', 'image'."},
+                "offset": {"type": "integer", "description": "Pagination start index (default 0)."},
+                "limit": {"type": "integer", "description": "Max files to return (default 200)."},
+            },
+        },
+    },
+    {
         "name": "lookup_compound",
         "description": "Look up chemical compound via PubChem",
         "parameters": {

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -244,7 +244,7 @@ TOOL_SPECS = [
     },
     {
         "name": "list_scanned_files",
-        "description": "Retrieve the FULL scanned-file inventory from session state (path, filename, size, mime_type). scan_files only shows a ~15-file sample and its output is pruned from history, so use this to see every file you must bind to File/process entities. Paginated and filterable: pass name_contains / mime_contains to narrow, offset / limit to page (default limit 200). Returns {total_scanned, matched, offset, limit, returned, files:[...]}.",
+        "description": "Retrieve the FULL scanned-file inventory from session state (path, filename, size, mime_type). scan_files only shows a ~15-file sample and its output is pruned from history, so use this to browse the inventory and decide which files to place/annotate (e.g. which group is an assay's raw data, which is a protocol). Paginated and filterable: pass name_contains / mime_contains to narrow, offset / limit to page (default limit 200). Returns {total_scanned, matched, offset, limit, returned, files:[...]}.",
         "parameters": {
             "type": "object",
             "properties": {

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -249,6 +249,7 @@ _TOOL_ICONS: dict[str, str] = {
     "draft_defined_term": "\U0001f4cb", "draft_property_value": "\U0001f4cb",
     "draft_file": "\U0001f4cb",
     "list_entities": "\U0001f4cb",
+    "list_scanned_files": "\U0001f4c2",
     "remove_entity": "\U0001f4cb", "set_fields": "\U0001f4dd",
     "link": "\U0001f517", "check_provenance": "\U0001f9ec",
     "lookup_compound": "\U0001f50d", "lookup_cell_line": "\U0001f50d",

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -12,6 +12,7 @@ from builder.state import (
     CompletionSource,
     CrateState,
     Entity,
+    FileClassification,
 )
 from builder.tools._crate_mapping import _REF_FIELDS
 
@@ -160,6 +161,68 @@ def list_entities(state: CrateState, entity_type: str | None = None) -> list[Ent
     return state.list_entities(entity_type=entity_type)
 
 
+def list_scanned_files(
+    state: CrateState,
+    name_contains: str | None = None,
+    mime_contains: str | None = None,
+    offset: int = 0,
+    limit: int = 200,
+) -> dict[str, Any]:
+    """Return the raw scanned-file inventory from ``CrateState`` (paginated).
+
+    ``scan_files`` only surfaces a small sample, and its tool output is later
+    pruned from history to save tokens — so the agent uses this to retrieve the
+    full list of files it must bind to ``File``/process entities. Returns compact
+    records (``path``/``filename``/``size``/``mime_type``) only — never the heavy
+    ``first_rows`` preview — so the result stays token-bounded.
+
+    Args:
+        state: The crate state to query.
+        name_contains: Keep only files whose ``filename`` or ``path`` contains
+            this substring (case-insensitive).
+        mime_contains: Keep only files whose ``mime_type`` contains this
+            substring (e.g. ``"csv"``, ``"image"``).
+        offset: Pagination start index into the (filtered) list.
+        limit: Maximum number of records to return.
+
+    Returns:
+        ``{"total_scanned", "matched", "offset", "limit", "returned", "files": [...]}``
+        where ``files`` is the requested page of compact records.
+    """
+    name_q = name_contains.lower() if name_contains else None
+    mime_q = mime_contains.lower() if mime_contains else None
+
+    def _match(fc: FileClassification) -> bool:
+        if name_q is not None and (
+            name_q not in (fc.filename or "").lower()
+            and name_q not in (fc.path or "").lower()
+        ):
+            return False
+        if mime_q is not None and mime_q not in (fc.mime_type or "").lower():
+            return False
+        return True
+
+    matched = [fc for fc in state.scanned_files if _match(fc)]
+    start = max(0, offset)
+    page = matched[start : start + max(0, limit)]
+    return {
+        "total_scanned": len(state.scanned_files),
+        "matched": len(matched),
+        "offset": offset,
+        "limit": limit,
+        "returned": len(page),
+        "files": [
+            {
+                "path": fc.path,
+                "filename": fc.filename,
+                "size": fc.size,
+                "mime_type": fc.mime_type,
+            }
+            for fc in page
+        ],
+    }
+
+
 def set_entity_field(
     state: CrateState,
     entity_id: str,
@@ -187,6 +250,7 @@ def bulk_set_fields(
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
 TOOL_REGISTRY.register("list_entities", list_entities, takes_state=True)
+TOOL_REGISTRY.register("list_scanned_files", list_scanned_files, takes_state=True)
 TOOL_REGISTRY.register("remove_entity", remove_entity, takes_state=True)
 # The single consolidated mutation tool (Issue #90, sub-task 2). update_entity,
 # bulk_set_fields and set_entity_field were redundant (the first two byte-

--- a/tests/test_tools_management.py
+++ b/tests/test_tools_management.py
@@ -6,12 +6,13 @@ import json
 
 import pytest
 
-from builder.state import CrateState, Entity, EntityProvenance
+from builder.state import CrateState, Entity, EntityProvenance, FileClassification
 from builder.tools.builder import build_crate
 from builder.tools.management import (
     bulk_set_fields,
     find_referrers,
     list_entities,
+    list_scanned_files,
     remove_entity,
     set_entity_field,
     update_entity,
@@ -25,6 +26,69 @@ def _ent(entity_id, type_, **fields):
         fields=fields,
         _provenance=EntityProvenance(created_by="llm"),
     )
+
+
+def _fc(path, filename, size, mime):
+    return FileClassification(
+        path=path, filename=filename, size=size, mime_type=mime
+    )
+
+
+class TestListScannedFiles:
+    """list_scanned_files retrieves the full inventory the scan tool/pruning hide."""
+
+    def _state(self, n=5):
+        state = CrateState()
+        state.scanned_files = [
+            _fc(f"/data/raw/file{i}.csv", f"file{i}.csv", 100 + i, "text/csv")
+            for i in range(n)
+        ]
+        return state
+
+    def test_returns_full_inventory_compact(self):
+        out = list_scanned_files(self._state(5))
+        assert out["total_scanned"] == 5
+        assert out["matched"] == 5
+        assert out["returned"] == 5
+        assert len(out["files"]) == 5
+        # Compact records only — never the heavy first_rows preview.
+        assert set(out["files"][0]) == {"path", "filename", "size", "mime_type"}
+
+    def test_empty_inventory(self):
+        out = list_scanned_files(CrateState())
+        assert out["total_scanned"] == 0
+        assert out["files"] == []
+
+    def test_filter_by_name_contains(self):
+        state = CrateState()
+        state.scanned_files = [
+            _fc("/d/a.csv", "a.csv", 1, "text/csv"),
+            _fc("/d/raw_meas.mzML", "raw_meas.mzML", 2, "application/x-mzml"),
+        ]
+        out = list_scanned_files(state, name_contains="raw")
+        assert out["matched"] == 1
+        assert out["files"][0]["filename"] == "raw_meas.mzML"
+
+    def test_filter_by_mime_contains(self):
+        state = CrateState()
+        state.scanned_files = [
+            _fc("/d/a.csv", "a.csv", 1, "text/csv"),
+            _fc("/d/b.png", "b.png", 2, "image/png"),
+        ]
+        out = list_scanned_files(state, mime_contains="image")
+        assert out["matched"] == 1
+        assert out["files"][0]["filename"] == "b.png"
+
+    def test_pagination(self):
+        out = list_scanned_files(self._state(10), offset=3, limit=4)
+        assert out["total_scanned"] == 10
+        assert out["matched"] == 10
+        assert out["offset"] == 3
+        assert out["limit"] == 4
+        assert out["returned"] == 4
+        assert [f["filename"] for f in out["files"]] == [
+            f"file{i}.csv" for i in (3, 4, 5, 6)
+        ]
 
 
 class TestUpdateEntity:
@@ -290,8 +354,8 @@ class TestConsolidatedMutationTool:
     """The three redundant mutation tools collapse into one registered tool."""
 
     def test_only_set_fields_is_registered_not_the_redundant_three(self):
-        from builder.tools.registry import TOOL_REGISTRY
         import builder.tools.management  # noqa: F401  (triggers registration)
+        from builder.tools.registry import TOOL_REGISTRY
 
         names = set(TOOL_REGISTRY.list())
         assert "set_fields" in names


### PR DESCRIPTION
Closes #172.

## Problem (observed running the tool)
The agent can't enumerate the files it must bind to entities. `scan_files` returns only a ~15-file sample (`summarize_scan_result`, `scanner.py:1219`), and `_prune_state_backed_outputs` (`agent_loop.py`) later replaces even that with a stub — whose claim that the data is *"queryable via get_status / list_entities"* was **false** (`get_status` returns counts; `list_entities` returns drafted entities, not the raw `scanned_files` inventory). So after pruning the agent sees only a count.

## Fix
New `list_scanned_files(name_contains=None, mime_contains=None, offset=0, limit=200)` over `CrateState.scanned_files`: compact records (`path`/`filename`/`size`/`mime_type` — **not** the heavy `first_rows`), paginated + filterable so it stays token-bounded. Returns `{total_scanned, matched, offset, limit, returned, files:[...]}`.

Synced all drift-guard points (registry, `TOOL_SPECS`, `system_prompt`, dashboard, AGENTS.md §5) and repointed the prune stub, the unreadable-file hint, and the `#61` comment at the new tool so the model knows how to retrieve the inventory.

## Tests (TDD)
- `tests/test_tools_management.py::TestListScannedFiles`: full inventory, compact shape, `name_contains`/`mime_contains` filters, pagination, empty state.
- Drift + doc guards stay green; **50 passed** (management + spec + registry + doc-guard), **108 passed** across pruning/scan/signal suites. ruff + ty clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>