### PR TITLE
feat(builder): auto-include un-placed scanned files as a root fallback (#175)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -643,6 +643,19 @@ is conformant to materialise the on-disk RO-Crate directory (payload included).
 (`assemble_crate(..., materialize_payload=False)`) skips writing the Exposure
 condition-table placeholder CSV so validation stays a zero-disk operation.
 
+**Auto-included scanned files (#175).** `assemble_crate(..., include_all_scanned=True)`
+(the default, used by `export_crate`) packages *every* scanned file that the agent
+has **not** already drafted as a `File` entity, attaching it to the root `hasPart`
+as a plain `File` leaf — an honest *fallback* so the exported crate never silently
+drops a data file. It is **inclusion only, not placement**: files the agent has
+explicitly placed (under a Study/Assay, wired as a process `result`/`object`, or
+given a role) already have a `File` entity and are deduped out by resolved source
+path, so the agent's semantic association always wins. Reserved RO-Crate filenames
+are skipped. The hot `build_and_validate` path passes `include_all_scanned=False` —
+plain leaves don't change the validation verdict, so skipping them keeps the ReAct
+loop fast. Semantic placement of file *groups* (which assay, which role) stays an
+agent task (bulk placement tool — follow-up).
+
 ### Assessment Tools
 ```
 assess_mit_coverage() → MITReport

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -337,6 +337,7 @@ def populate_crate(
     output_dir: Path | None = None,
     *,
     materialize_payload: bool = True,
+    include_all_scanned: bool = True,
 ) -> None:
     """Populate `crate` from `state` using the ISA-Tox domain model.
 
@@ -347,10 +348,20 @@ def populate_crate(
     #87) no payload file is written to disk — the condition-table File node is
     still added to the graph so the metadata document validates, but its CSV is
     not created. This keeps validation a zero-disk operation.
+
+    ``include_all_scanned`` (#175) auto-includes every un-placed scanned file as a
+    root ``File`` leaf so the crate packages the whole dataset; the hot
+    build_and_validate path passes False (plain leaves don't move the verdict).
     """
     idx: dict[str, Any] = {}
     _populate_root_and_conformance(state, crate)
-    _add_leaves(state, crate, idx, materialize_payload=materialize_payload)
+    _add_leaves(
+        state,
+        crate,
+        idx,
+        materialize_payload=materialize_payload,
+        include_all_scanned=include_all_scanned,
+    )
     _add_structural(state, crate, idx)
     _add_processes(state, crate, idx, output_dir, materialize_payload=materialize_payload)
     _wire_mentions(state, idx)
@@ -622,6 +633,7 @@ def _add_leaves(
     idx: dict[str, Any],
     *,
     materialize_payload: bool = True,
+    include_all_scanned: bool = True,
 ) -> None:
     for org in state.list_entities("Organization"):
         _idx_add(
@@ -755,6 +767,73 @@ def _add_leaves(
                 properties=_scalar_props(cl, skip=("name", "accession")) or None,
             ),
         )
+
+    if include_all_scanned:
+        _add_scanned_leaves(state, crate, materialize_payload=materialize_payload)
+
+
+# RO-Crate-reserved filenames that must never be auto-added as payload leaves.
+_RESERVED_CRATE_FILES = frozenset(
+    {"ro-crate-metadata.json", "ro-crate-preview.html", "ro-crate-graph.mmd"}
+)
+
+
+def _add_scanned_leaves(
+    state: CrateState, crate: ROCrate, *, materialize_payload: bool
+) -> None:
+    """Package every scanned file not already a drafted File entity (#175).
+
+    Auto-include is an honest *fallback*: files the agent has not explicitly
+    placed are attached to the root ``hasPart`` as plain ``File`` leaves (dataset
+    data whose assay/role is simply not annotated yet), so the exported crate
+    never silently drops a file. Files the agent drafted/placed take precedence —
+    they already have a File entity, so they are deduped out here by resolved
+    source path (and dest). Semantic placement (under a Study/Assay/process, with
+    a role) stays an agent decision via the drafting/linking tools; this only
+    catches the untouched tail.
+    """
+    input_path = state.metadata.input_path
+    root = Path(input_path).resolve() if input_path else None
+
+    covered_src: set[str] = set()
+    covered_dest: set[str] = set()
+    for fe in state.list_entities("File"):
+        src = _file_source(fe, input_path)
+        if src:
+            covered_src.add(str(Path(src).resolve()))
+        covered_dest.add(_file_dest(fe))
+
+    seen_dest: set[str] = set()
+    for fc in state.scanned_files:
+        if fc.filename in _RESERVED_CRATE_FILES:
+            continue
+        abspath = Path(fc.path)
+        if not abspath.is_absolute() and input_path:
+            abspath = Path(input_path) / fc.path
+        try:
+            abspath = abspath.resolve()
+        except OSError:
+            continue
+        if str(abspath) in covered_src:
+            continue
+
+        dest: str | None = None
+        if root is not None:
+            try:
+                dest = abspath.relative_to(root).as_posix()
+            except ValueError:
+                dest = None
+        if not dest:
+            dest = f"data/{fc.filename}"
+        if dest in _RESERVED_CRATE_FILES or dest in covered_dest or dest in seen_dest:
+            continue
+        seen_dest.add(dest)
+
+        source = str(abspath) if (materialize_payload and abspath.is_file()) else None
+        props: dict[str, Any] = {"@type": "File", "name": fc.filename}
+        if fc.mime_type:
+            props["encodingFormat"] = fc.mime_type
+        crate.add(File(crate, source, dest_path=dest, properties=props))
 
 
 # ---------------------------------------------------------------------------

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -39,6 +39,7 @@ def assemble_crate(
     output_dir: Path | None = None,
     *,
     materialize_payload: bool = True,
+    include_all_scanned: bool = True,
 ) -> ROCrate:
     """Assemble an in-memory `ROCrate` from CrateState — no disk write.
 
@@ -53,6 +54,12 @@ def assemble_crate(
             for the pure in-memory path.
         materialize_payload: When False, no payload file is written (see
             :func:`builder.tools._crate_mapping.populate_crate`).
+        include_all_scanned: When True (default), every file in
+            ``state.scanned_files`` that is not already a drafted ``File`` entity
+            is auto-included as a ``File`` leaf, so the crate packages the whole
+            dataset (#175). The in-memory ``build_and_validate`` path passes
+            False — plain leaves don't change the validation verdict and skipping
+            them keeps the ReAct loop fast.
 
     Returns:
         A populated :class:`ROCrate`. Nothing is written unless the caller
@@ -60,7 +67,13 @@ def assemble_crate(
     """
     crate = ROCrate()
     crate.metadata.extra_contexts = ISA_TOX_CONTEXT
-    populate_crate(state, crate, output_dir, materialize_payload=materialize_payload)
+    populate_crate(
+        state,
+        crate,
+        output_dir,
+        materialize_payload=materialize_payload,
+        include_all_scanned=include_all_scanned,
+    )
     return crate
 
 

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -203,7 +203,16 @@ def build_and_validate(
     from profiles.validator import validate_crate_dict
 
     try:
-        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+        # include_all_scanned=False: the auto-included scanned-file leaves (#175)
+        # are plain File nodes that don't change the validation verdict, so we skip
+        # them on this hot in-loop path to keep build_and_validate fast. export_crate
+        # uses the default (True) so the written crate packages the whole dataset.
+        crate = assemble_crate(
+            state,
+            output_dir=None,
+            materialize_payload=False,
+            include_all_scanned=False,
+        )
         metadata_doc = crate.metadata.generate()
         results = validate_crate_dict(metadata_doc, severity=severity, profile=profile)
     except Exception as e:  # noqa: BLE001 — surface as a tool error, never crash the loop

--- a/tests/test_tools_builder.py
+++ b/tests/test_tools_builder.py
@@ -6,8 +6,8 @@ import json
 import tempfile
 from pathlib import Path
 
-from builder.state import CrateState, Entity, EntityProvenance
-from builder.tools.builder import build_crate, export_crate
+from builder.state import CrateState, Entity, EntityProvenance, FileClassification
+from builder.tools.builder import assemble_crate, build_crate, export_crate
 
 
 def _ent(entity_id, type_, **fields):
@@ -17,6 +17,68 @@ def _ent(entity_id, type_, **fields):
         fields=fields,
         _provenance=EntityProvenance(created_by="user"),
     )
+
+
+def _file_ids(crate):
+    """@id of every File node in the generated crate graph."""
+    graph = crate.metadata.generate()["@graph"]
+    ids = []
+    for node in graph:
+        t = node.get("@type")
+        types = t if isinstance(t, list) else [t]
+        if "File" in types:
+            ids.append(node["@id"])
+    return ids
+
+
+class TestAutoIncludeScanned:
+    """Issue #175: assemble_crate packages every scanned file by default (option B)."""
+
+    def _state_with_files(self, tmp_path):
+        (tmp_path / "raw").mkdir()
+        (tmp_path / "raw" / "a.mzML").write_text("x")
+        (tmp_path / "raw" / "b.csv").write_text("x")
+        (tmp_path / "notes.txt").write_text("x")
+        state = CrateState()
+        state.metadata.title = "T"
+        state.metadata.description = "d"
+        state.metadata.accession = "ACC-1"
+        state.metadata.input_path = str(tmp_path)
+        state.scanned_files = [
+            FileClassification(
+                str(tmp_path / "raw" / "a.mzML"), "a.mzML", 1, "application/x-mzml"
+            ),
+            FileClassification(str(tmp_path / "raw" / "b.csv"), "b.csv", 1, "text/csv"),
+            FileClassification(str(tmp_path / "notes.txt"), "notes.txt", 1, "text/plain"),
+        ]
+        # The agent drafted b.csv (with a role) — its entity must take precedence.
+        state.add_entity(
+            _ent("file_b", "File", name="b.csv", path="raw/b.csv", role="raw_data")
+        )
+        return state
+
+    def test_auto_includes_all_scanned_files(self, tmp_path):
+        state = self._state_with_files(tmp_path)
+        crate = assemble_crate(state, output_dir=tmp_path, materialize_payload=True)
+        ids = _file_ids(crate)
+        # Every scanned file is in the crate, mirroring its path under input_path.
+        assert any(i.endswith("raw/a.mzML") for i in ids), ids
+        assert any(i.endswith("notes.txt") for i in ids), ids
+        # The drafted b.csv appears exactly once (no auto-duplicate).
+        assert sum(1 for i in ids if i.endswith("b.csv")) == 1, ids
+
+    def test_include_all_scanned_false_keeps_only_drafted(self, tmp_path):
+        state = self._state_with_files(tmp_path)
+        crate = assemble_crate(
+            state,
+            output_dir=None,
+            materialize_payload=False,
+            include_all_scanned=False,
+        )
+        ids = _file_ids(crate)
+        assert not any(i.endswith("a.mzML") for i in ids), ids
+        assert not any(i.endswith("notes.txt") for i in ids), ids
+        assert any(i.endswith("b.csv") for i in ids), ids
 
 
 class TestEmbeddedGraph:


### PR DESCRIPTION
Closes #175. The inclusion half of the hybrid file-handling design.

## Problem
A file only entered the crate via a per-file `draft_file` call — `_add_leaves` built File nodes solely from drafted `File` entities, and `scanned_files` was never projected. So a real toxicology dataset's hundreds/thousands of files were silently left out (the LLM can't draft a File entity per file).

## Fix (option B, as an honest fallback)
`assemble_crate(..., include_all_scanned=True)` (default; used by `export_crate`) packages **every scanned file the agent has not already placed** as a plain `File` leaf on the root `hasPart`.

- **Inclusion, not placement.** Files the agent placed (drafted, given a role, wired as a process `result`/`object`, or attached under a Study/Assay) already have a `File` entity and are **deduped out** here by resolved source path + dest — the agent's semantic association always wins. Root-level = "dataset data, assay/role not annotated yet" (honest, doesn't over-claim).
- dest mirrors the file's path under `input_path`; `encodingFormat` from the scanned `mime_type`; reserved RO-Crate filenames skipped.
- The hot `build_and_validate` path passes `include_all_scanned=False` — plain leaves don't change the validation verdict, so skipping them keeps the ReAct loop fast. Only `export_crate` packages the full set.

Group-level **semantic placement** (which assay, which role) stays an agent task — coming as a bulk `attach_files` tool in a follow-up PR (the other half of the hybrid).

## Tests (TDD)
- `tests/test_tools_builder.py::TestAutoIncludeScanned`: all scanned files appear in the exported `@graph`; a drafted file appears exactly once (no auto-duplicate); `include_all_scanned=False` keeps only drafted files.
- **25 passed** (builder + build_and_validate), ruff + ty clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>