### PR TITLE
feat(tools): materialize_aop_subgraph — AOP/KeyEvent/KER subgraph from one aop_id (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,6 +477,7 @@ format only (D7); the ARC folder tree is materialised at export time by
 ### Entity Drafting Tools
 ```
 scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=False) → dict  # composite: linked Investigation→Study→Assay in one call (idempotent), the fast path to a BASE-passing crate
+materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
 draft_investigation(hints: dict) → Entity
 draft_study(investigation_id: str, hints: dict) → Entity
 draft_assay(study_id: str, hints: dict) → Entity
@@ -500,6 +501,20 @@ into the `@graph` and is referenceable (via `set_fields`/`link`) as a `mentions`
 `schema:PropertyValue` node (`value` + optional `propertyID` + `unitText`/`unitCode`).
 Both back the previously-unfilled `defined_terms` / `property_values` CrateState
 collections the mapping already rendered.
+`materialize_aop_subgraph` (Issue #180) is the AOP counterpart of
+`scaffold_isa_backbone`: from the single model-supplied numeric `aop_id` it calls
+`lookup_aop` and materialises the entire pathway as typed contextual entities —
+one `aopwiki:AdverseOutcomePathway` carrying its `has_molecular_initiating_event`
+/ `has_key_event` / `has_adverse_outcome` / `has_key_event_relationship` link
+arrays, one `aopwiki:KeyEvent` per MIE/KE/AO (all share `@type KeyEvent`,
+discriminated only by the `eventType` string), and one
+`aopwiki:KeyEventRelationship` per relation (`upstream_event` /
+`downstream_event` by `@id`). Every node is keyed by its resolvable AOP-Wiki IRI,
+so all wiring is deterministic and idempotent and no id is ever fabricated (D5).
+These three types live in the shared `aop_entities` CrateState collection and
+build via `_crate_mapping` as `ContextEntity` nodes typed by their own AOP class.
+With `study_id`, the AOP is wired onto that Study via the `aop` reference (an
+alias of `schema:mentions`), closing the largest gold-crate fidelity gap.
 The `hints` parameter is **typed per entity type** (Issue #90). Each `draft_*`
 tool advertises a JSON-Schema built by `_crate_mapping.draft_hints_schema(type)`
 from the single source of truth `_crate_mapping.ENTITY_DRAFT_SCHEMA` — allowed

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -21,6 +21,7 @@ File scanning & reading:
 
 Entity drafting:
 - scaffold_isa_backbone: Create a linked Investigation+Study+Assay backbone in one call (idempotent) — the fastest path to a BASE-passing crate
+- materialize_aop_subgraph: Turn one AOP-Wiki id into the full subgraph (AdverseOutcomePathway + KeyEvents + KeyEventRelationships, cross-linked) and optionally wire it onto a Study
 - draft_investigation: Create an Investigation entity
 - draft_study: Create a Study entity
 - draft_assay: Create an Assay entity

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -59,6 +59,18 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "materialize_aop_subgraph",
+        "description": "Turn ONE AOP-Wiki id into the full crate subgraph in one call: an AdverseOutcomePathway node plus every KeyEvent (MIE/KE/AO, discriminated by eventType) and KeyEventRelationship, all cross-linked deterministically from AOP-Wiki (never fabricated). Pass only the numeric aop_id; optionally pass study_id to wire the AOP onto that Study (schema:mentions). Idempotent (keyed by AOP-Wiki IRI). Prefer this over lookup_aop + manual drafting when you want the whole pathway in the crate. Example: materialize_aop_subgraph(aop_id='610', study_id='study_silychristin_exposure').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "aop_id": {"type": "string", "description": "Numeric AOP-Wiki identifier, e.g. '610'."},
+                "study_id": {"type": "string", "description": "Optional entity_id of a Study to wire the AOP onto (via the aop/mentions reference)."},
+            },
+            "required": ["aop_id"],
+        },
+    },
+    {
         "name": "draft_molecular_entity",
         "description": "Create a MolecularEntity from a compound name. Look the compound up first (lookup_compound) so you can pass a verified pubchem_cid. Example: draft_molecular_entity(name='Silychristin A', hints={'pubchem_cid': '443515', 'identifier': '33889-69-9'}).",
         "parameters": {

--- a/builder/readers/existing_crate.py
+++ b/builder/readers/existing_crate.py
@@ -26,6 +26,10 @@ _VALID_TYPES = frozenset(
         "DefinedTerm",
         "PropertyValue",
         "File",
+        # AOP-Wiki subgraph nodes round-trip by their own @type (Issue #180).
+        "AdverseOutcomePathway",
+        "KeyEvent",
+        "KeyEventRelationship",
     }
 )
 _DATASET_SUBTYPES = frozenset({"Investigation", "Study", "Assay"})

--- a/builder/state.py
+++ b/builder/state.py
@@ -47,6 +47,11 @@ EntityType = Literal[
     "DefinedTerm",
     "PropertyValue",
     "File",
+    # AOP-Wiki subgraph contextual entities (Issue #180). MIE/KE/AO all share
+    # @type KeyEvent and are discriminated only by their eventType string.
+    "AdverseOutcomePathway",
+    "KeyEvent",
+    "KeyEventRelationship",
 ]
 
 CompletionStatus = Literal["missing", "filled", "verified"]
@@ -577,6 +582,11 @@ ENTITY_TYPE_MAP: dict[str, str] = {
     "DefinedTerm": "defined_terms",
     "PropertyValue": "property_values",
     "File": "files",
+    # The AOP-Wiki subgraph (AOP + KeyEvent + KeyEventRelationship) shares one
+    # collection; all three are AOP contextual entities (Issue #180).
+    "AdverseOutcomePathway": "aop_entities",
+    "KeyEvent": "aop_entities",
+    "KeyEventRelationship": "aop_entities",
 }
 
 # ENTITY_TYPE_MAP is a module-level constant; derive shared collection
@@ -620,6 +630,7 @@ class EntityStore:
     defined_terms: dict[str, Entity] = field(default_factory=dict)
     property_values: dict[str, Entity] = field(default_factory=dict)
     files: dict[str, Entity] = field(default_factory=dict)
+    aop_entities: dict[str, Entity] = field(default_factory=dict)
 
     def _collection_for_type(self, entity_type: str) -> dict[str, Entity]:
         """Return the entity collection dict for a given entity type."""

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -488,6 +488,9 @@ _ENTITY_TYPES = (
     "DefinedTerm",
     "PropertyValue",
     "File",
+    "AdverseOutcomePathway",
+    "KeyEvent",
+    "KeyEventRelationship",
 )
 
 
@@ -691,6 +694,30 @@ def _add_leaves(
                 )
             ),
         )
+
+    # AOP-Wiki subgraph nodes (Issue #180). Each is a contextual entity typed by
+    # its own AOP class (AdverseOutcomePathway / KeyEvent / KeyEventRelationship)
+    # whose @id is the resolvable AOP-Wiki IRI. Their link properties
+    # (has_*/upstream_event/downstream_event) are already {"@id": …} reference
+    # objects pointing at sibling AOP node @ids, so the subgraph is cross-linked
+    # verbatim — no fabricated ids (D5). They are kept out of _REF_FIELDS so
+    # _scalar_props preserves them rather than stripping them as resolver inputs.
+    for aop_type in ("AdverseOutcomePathway", "KeyEvent", "KeyEventRelationship"):
+        for aop_entity in state.list_entities(aop_type):
+            _idx_add(
+                idx,
+                aop_entity,
+                crate.add(
+                    ContextEntity(
+                        crate,
+                        _mint_id(aop_entity),
+                        properties={
+                            "@type": aop_entity.type,
+                            **_scalar_props(aop_entity),
+                        },
+                    )
+                ),
+            )
 
     for pub in state.list_entities("Publication"):
         node = crate.add(

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from builder.state import CrateState, Entity
+from builder.state import CrateState, Entity, EntityProvenance, EntityType
 from builder.tools.drafters import draft_assay, draft_investigation, draft_study
 
 
@@ -90,8 +90,139 @@ def scaffold_isa_backbone(
 
 
 # ---------------------------------------------------------------------------
+# AOP-Wiki subgraph materialisation (Issue #180)
+# ---------------------------------------------------------------------------
+
+# AOP-Wiki @type string -> CrateState EntityType. The three classes share one
+# collection (state.ENTITY_TYPE_MAP); the build types each node by its own class.
+_AOP_NODE_TYPES: dict[str, EntityType] = {
+    "AdverseOutcomePathway": "AdverseOutcomePathway",
+    "KeyEvent": "KeyEvent",
+    "KeyEventRelationship": "KeyEventRelationship",
+}
+
+
+def _materialize_aop_node(state: CrateState, node: dict[str, Any]) -> Entity | None:
+    """Persist one AOP-Wiki node dict into CrateState as a typed entity.
+
+    The node's resolvable AOP-Wiki IRI (``@id``) becomes the entity_id, so
+    :func:`builder.tools._crate_mapping._mint_id` keeps it verbatim as the built
+    node's ``@id`` and the subgraph's ``has_*`` / ``upstream_event`` /
+    ``downstream_event`` reference objects (which already point at sibling IRIs)
+    cross-link without any id resolution. Idempotent: a node whose IRI is already
+    in state is left untouched (no duplicate, no clobber).
+
+    Returns the materialised (or pre-existing) Entity, or ``None`` for a
+    malformed node missing its ``@id`` / ``@type``.
+    """
+    iri = node.get("@id")
+    node_type = _AOP_NODE_TYPES.get(str(node.get("@type")))
+    if not iri or node_type is None:
+        return None
+    existing = state.get_entity(str(iri))
+    if existing is not None:
+        return existing
+    fields = {k: v for k, v in node.items() if k not in ("@id", "@type")}
+    entity = Entity(
+        entity_id=str(iri),
+        type=node_type,
+        _provenance=EntityProvenance(created_by="lookup"),
+    )
+    entity.set_fields_from_dict(fields, source="lookup")
+    state.add_entity(entity)
+    return entity
+
+
+def materialize_aop_subgraph(
+    state: CrateState,
+    aop_id: str,
+    study_id: str | None = None,
+) -> dict[str, Any]:
+    """Turn ONE AOP-Wiki id into the full, cross-linked crate subgraph.
+
+    Looks the AOP up via :func:`builder.tools.lookups.lookup_aop` and
+    deterministically materialises its complete subgraph into ``state``:
+
+    - one ``AdverseOutcomePathway`` node carrying its ``name`` / ``identifier`` /
+      ``url`` (and ``alternateName`` when present) plus the
+      ``has_molecular_initiating_event`` / ``has_key_event`` /
+      ``has_adverse_outcome`` / ``has_key_event_relationship`` link arrays;
+    - one ``KeyEvent`` node per molecular-initiating-event / key-event /
+      adverse-outcome — all share ``@type KeyEvent`` and are discriminated only
+      by their ``eventType`` string;
+    - one ``KeyEventRelationship`` node per relation, linking its
+      ``upstream_event`` and ``downstream_event`` by ``@id``.
+
+    The ONLY model-supplied input is the numeric ``aop_id``; every link and id
+    comes straight from the AOP-Wiki graph, so nothing is fabricated (D5). The
+    nodes are keyed by their resolvable AOP-Wiki IRI, so re-running is idempotent.
+
+    When ``study_id`` names an existing Study, the AOP is wired onto it via the
+    ``aop`` reference (an alias of ``schema:mentions``), connecting the study to
+    the pathway it investigates — mirroring the gold crate (Issue #180).
+
+    Args:
+        state: The crate state to materialise into.
+        aop_id: Numeric AOP-Wiki identifier, e.g. ``"610"``.
+        study_id: Optional entity_id of a Study to wire the AOP onto.
+
+    Returns:
+        On success, ``{"aop_id", "aop_entity_id", "events", "relationships",
+        "wired_to_study"}``. On a lookup miss, ``{"ok": False, "error": ...}``.
+    """
+    from builder.tools.lookups import lookup_aop
+
+    result = lookup_aop(str(aop_id))
+    if not result.get("found"):
+        return {
+            "ok": False,
+            "error": result.get("error", f"AOP '{aop_id}' not found"),
+        }
+
+    data = result["data"]
+    aop_node = data.get("aop") or {}
+    aop_entity = _materialize_aop_node(state, aop_node)
+
+    events = 0
+    for ev in data.get("events", []):
+        if _materialize_aop_node(state, ev) is not None:
+            events += 1
+
+    relationships = 0
+    for rel in data.get("relationships", []):
+        if _materialize_aop_node(state, rel) is not None:
+            relationships += 1
+
+    wired_to_study: str | None = None
+    if study_id and aop_entity is not None:
+        study = state.get_entity(study_id)
+        if study is not None and study.type == "Study":
+            existing_refs = study.fields.get("aop") or []
+            if not isinstance(existing_refs, list):
+                existing_refs = [existing_refs]
+            ref = {"@id": aop_entity.entity_id}
+            ids = {r.get("@id") if isinstance(r, dict) else r for r in existing_refs}
+            if aop_entity.entity_id not in ids:
+                existing_refs = [*existing_refs, ref]
+            study.fields["aop"] = existing_refs
+            study.set_field_status("aop", "filled", "lookup")
+            wired_to_study = study_id
+
+    return {
+        "aop_id": str(aop_id),
+        "aop_entity_id": aop_entity.entity_id if aop_entity else None,
+        "events": events,
+        "relationships": relationships,
+        "wired_to_study": wired_to_study,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
 TOOL_REGISTRY.register("scaffold_isa_backbone", scaffold_isa_backbone, takes_state=True)
+TOOL_REGISTRY.register(
+    "materialize_aop_subgraph", materialize_aop_subgraph, takes_state=True
+)

--- a/tests/test_tools_aop_subgraph.py
+++ b/tests/test_tools_aop_subgraph.py
@@ -1,0 +1,236 @@
+"""Tests for the ``materialize_aop_subgraph`` composite tool (Issue #180).
+
+``materialize_aop_subgraph`` turns ONE AOP-Wiki id into the full crate subgraph
+and wires it deterministically: an ``AdverseOutcomePathway`` node with its
+MIE/KE/AO and KeyEventRelationship link arrays, one ``KeyEvent`` node per event
+(discriminated only by ``eventType``), one ``KeyEventRelationship`` per relation,
+and — when a ``study_id`` is supplied — the AOP wired onto that Study via the
+``aop`` / ``mentions`` reference.
+
+The only model-supplied input is the numeric ``aop_id``; everything else is the
+deterministic AOP-Wiki graph (D5: never fabricate ids). Tests never hit the
+network — the AOP-Wiki HTTP is mocked from the bundled AOP-610 fixture exactly
+as the existing lookup tests do (per project policy, lookups stay offline).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools.composites import materialize_aop_subgraph
+from builder.tools.drafters import draft_investigation, draft_study
+from builder.tools.validation import build_and_validate
+from lookups import _http, aopwiki
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.fixture(autouse=True)
+def _offline_aop(monkeypatch):
+    """Serve the bundled AOP-610 fixture instead of hitting AOP-Wiki."""
+    aop_data = _load("aopwiki_aop610.json")
+
+    def fake_get_json(url, **kwargs):
+        if url.endswith("/aops/610.json"):
+            return aop_data
+        # Per-event detail endpoint: .../events/<id>.json
+        eid = url.rsplit("/", 1)[1].removesuffix(".json")
+        return {"short_name": f"Event {eid}", "biological_organization": "Cellular"}
+
+    aopwiki.lookup_aop.cache_clear()
+    aopwiki._event_details.cache_clear()
+    _http.reset_host_throttle()
+    monkeypatch.setattr(aopwiki, "http_get_json", fake_get_json)
+    monkeypatch.setattr(_http, "_HOST_MIN_INTERVAL", 0.0)
+    # The tools-layer lookup_aop is independently lru_cached.
+    from builder.tools import lookups as tool_lookups
+
+    tool_lookups.lookup_aop.cache_clear()
+    yield
+    aopwiki.lookup_aop.cache_clear()
+    aopwiki._event_details.cache_clear()
+    # A test may monkeypatch the tools-layer lookup_aop with a plain function
+    # (no lru_cache); guard the cache_clear so teardown never raises.
+    if hasattr(tool_lookups.lookup_aop, "cache_clear"):
+        tool_lookups.lookup_aop.cache_clear()
+    _http.reset_host_throttle()
+
+
+def _by_type(state: CrateState, type_name: str) -> list:
+    return [e for e in state.list_entities() if e.type == type_name]
+
+
+class TestMaterializeState:
+    def test_materializes_typed_entities(self):
+        state = CrateState()
+        result = materialize_aop_subgraph(state, "610")
+
+        # The AOP-610 fixture is 1 MIE + 2 KE + 1 AO + 3 relationships.
+        aops = _by_type(state, "AdverseOutcomePathway")
+        events = _by_type(state, "KeyEvent")
+        kers = _by_type(state, "KeyEventRelationship")
+        assert len(aops) == 1
+        assert len(events) == 4  # MIE + 2 KE + AO all share @type KeyEvent
+        assert len(kers) == 3
+
+        # Result reports the materialized ids/counts.
+        assert result["aop_id"] == "610"
+        assert result["events"] == 4
+        assert result["relationships"] == 3
+        assert result["aop_entity_id"] == aops[0].entity_id
+
+    def test_event_types_discriminated_only_by_event_type_field(self):
+        state = CrateState()
+        materialize_aop_subgraph(state, "610")
+        events = _by_type(state, "KeyEvent")
+        # Every event node is @type KeyEvent; the only discriminator is eventType.
+        types = {e.fields.get("eventType") for e in events}
+        assert "Molecular Initiating Event" in types
+        assert "Key Event" in types
+        assert "Adverse Outcome" in types
+
+    def test_aop_carries_link_arrays(self):
+        state = CrateState()
+        materialize_aop_subgraph(state, "610")
+        aop = _by_type(state, "AdverseOutcomePathway")[0]
+        assert aop.fields["has_molecular_initiating_event"]
+        assert aop.fields["has_key_event"]
+        assert aop.fields["has_adverse_outcome"]
+        assert aop.fields["has_key_event_relationship"]
+        assert aop.fields["identifier"] == "610"
+        assert aop.fields["url"] == "https://aopwiki.org/aops/610"
+
+    def test_relationships_link_upstream_downstream(self):
+        state = CrateState()
+        materialize_aop_subgraph(state, "610")
+        ker = _by_type(state, "KeyEventRelationship")[0]
+        assert "@id" in ker.fields["upstream_event"]
+        assert "@id" in ker.fields["downstream_event"]
+
+    def test_idempotent_no_duplicates(self):
+        state = CrateState()
+        materialize_aop_subgraph(state, "610")
+        materialize_aop_subgraph(state, "610")
+        assert len(_by_type(state, "AdverseOutcomePathway")) == 1
+        assert len(_by_type(state, "KeyEvent")) == 4
+        assert len(_by_type(state, "KeyEventRelationship")) == 3
+
+    def test_unknown_aop_returns_error(self, monkeypatch):
+        from builder.tools import lookups as tool_lookups
+
+        monkeypatch.setattr(
+            tool_lookups,
+            "lookup_aop",
+            lambda aop_id: {"found": False, "data": {}, "error": "nope"},
+        )
+        state = CrateState()
+        result = materialize_aop_subgraph(state, "999999")
+        assert result.get("ok") is False
+        assert _by_type(state, "AdverseOutcomePathway") == []
+
+
+class TestMaterializeBuild:
+    def test_graph_contains_cross_linked_subgraph(self):
+        state = CrateState()
+        materialize_aop_subgraph(state, "610")
+        report = build_and_validate(state)
+        # The build itself succeeds (no exception → report has conformance).
+        assert "conformance" in report
+
+        from builder.tools.builder import assemble_crate
+
+        graph = assemble_crate(
+            state, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+
+        aop = next(n for n in graph if n.get("@type") == "AdverseOutcomePathway")
+        kes = [n for n in graph if n.get("@type") == "KeyEvent"]
+        kers = [n for n in graph if n.get("@type") == "KeyEventRelationship"]
+        assert len(kes) == 4
+        assert len(kers) == 3
+
+        # The AOP @id is the resolvable AOP-Wiki IRI and its has_* arrays point at
+        # the KeyEvent / KER node @ids (cross-linked, not fabricated).
+        assert aop["@id"] == "https://aopwiki.org/aops/610"
+        ke_ids = {n["@id"] for n in kes}
+        ker_ids = {n["@id"] for n in kers}
+        mie_targets = {r["@id"] for r in aop["has_molecular_initiating_event"]}
+        assert mie_targets <= ke_ids
+        ker_targets = {r["@id"] for r in aop["has_key_event_relationship"]}
+        assert ker_targets == ker_ids
+
+        # Each KER links upstream/downstream KeyEvent @ids.
+        ker = kers[0]
+        assert ker["upstream_event"]["@id"] in ke_ids
+        assert ker["downstream_event"]["@id"] in ke_ids
+
+
+class TestMaterializeStudyWiring:
+    def test_wires_aop_onto_study(self):
+        state = CrateState()
+        inv = draft_investigation(state, {"name": "Inv"})
+        study = draft_study(state, inv.entity_id, {"name": "Study"})
+        materialize_aop_subgraph(state, "610", study_id=study.entity_id)
+
+        # The AOP id is recorded on the Study's `aop` reference field.
+        refs = study.fields.get("aop")
+        assert refs is not None
+        ids = [r.get("@id") if isinstance(r, dict) else r for r in refs]
+        assert "https://aopwiki.org/aops/610" in ids
+
+    def test_study_wiring_round_trips_into_graph(self):
+        state = CrateState()
+        inv = draft_investigation(state, {"name": "Inv"})
+        study = draft_study(state, inv.entity_id, {"name": "Study"})
+        materialize_aop_subgraph(state, "610", study_id=study.entity_id)
+
+        from builder.tools.builder import assemble_crate
+
+        graph = assemble_crate(
+            state, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+        study_node = next(n for n in graph if n.get("additionalType") == "Study")
+        # schema:mentions alias `aop` connects the Study to the AOP IRI.
+        mention_ids = {
+            r.get("@id")
+            for key in ("aop", "mentions")
+            for r in (
+                study_node.get(key, [])
+                if isinstance(study_node.get(key), list)
+                else [study_node.get(key)]
+            )
+            if isinstance(r, dict)
+        }
+        assert "https://aopwiki.org/aops/610" in mention_ids
+
+    def test_missing_study_id_is_ignored(self):
+        state = CrateState()
+        # No study exists; passing a bogus id must not raise.
+        result = materialize_aop_subgraph(state, "610", study_id="nonexistent")
+        assert result["aop_id"] == "610"
+
+
+class TestMaterializeRoundTrip:
+    def test_subgraph_survives_build_read_build(self, tmp_path):
+        from builder.readers.existing_crate import read_existing_crate
+        from builder.tools.builder import export_crate
+
+        state = CrateState()
+        materialize_aop_subgraph(state, "610")
+        export_crate(state, str(tmp_path / "crate"))
+
+        reread = read_existing_crate(str(tmp_path / "crate"))
+        assert len(_by_type(reread, "AdverseOutcomePathway")) == 1
+        assert len(_by_type(reread, "KeyEvent")) == 4
+        assert len(_by_type(reread, "KeyEventRelationship")) == 3
+        # The AOP node keeps its resolvable IRI as the entity_id (no '#' prefix).
+        aop = _by_type(reread, "AdverseOutcomePathway")[0]
+        assert aop.entity_id == "https://aopwiki.org/aops/610"


### PR DESCRIPTION
## What

Adds a state-mutating, LLM-callable composite tool
`materialize_aop_subgraph(aop_id: str, study_id: str | None = None)` that turns
**one** AOP-Wiki id into the full crate subgraph and wires it — closing the
largest gold-crate fidelity gap from #180 (the AOP-610 subgraph in
`S-VHPS21_rocrate`: 1 `AdverseOutcomePathway` + ~16 `KeyEvent` + ~19
`KeyEventRelationship`, fully cross-linked).

From the single model-supplied numeric `aop_id` it calls `lookup_aop` and
deterministically materialises the entire pathway as typed contextual entities:

- one **`AdverseOutcomePathway`** carrying `name`/`identifier`/`url` (and
  `alternateName`) plus `has_molecular_initiating_event` / `has_key_event` /
  `has_adverse_outcome` / `has_key_event_relationship` link arrays;
- one **`KeyEvent`** per MIE/KE/AO — all share `@type KeyEvent`, discriminated
  only by the `eventType` string (also `biologicalOrganization`, `short_name`);
- one **`KeyEventRelationship`** per relation (`upstream_event` /
  `downstream_event` by `@id`).

When `study_id` names an existing Study, the AOP is wired onto it via the `aop`
reference (an alias of `schema:mentions`), mirroring the gold crate.

## How

- Every node is keyed by its resolvable AOP-Wiki IRI, so all wiring is
  deterministic and idempotent and **no id is fabricated** (D5). The only
  model-supplied input is `aop_id`; the existing `lookups/aopwiki.py::lookup_aop`
  already returns the three-bucket structure (`aop`/`events`/`relationships`)
  with links pre-assembled, so it is reused unchanged.
- Three new entity types (`AdverseOutcomePathway`, `KeyEvent`,
  `KeyEventRelationship`) live in a shared `aop_entities` CrateState collection
  and build via `_crate_mapping` as `ContextEntity` nodes typed by their own AOP
  class. Their link properties are kept out of `_REF_FIELDS` so `_scalar_props`
  preserves them verbatim. The context aliases already exist in
  `profiles/context.py`.
- The new types also round-trip through `read_existing_crate`, so
  build → read → build stays idempotent.
- Registered in lockstep across **TOOL_REGISTRY**, **TOOL_SPECS**, the
  system-prompt `## Your Tools` catalogue, and **AGENTS.md §5**.

## Tests (TDD, offline)

AOP-Wiki HTTP is mocked from the bundled `tests/fixtures/aopwiki_aop610.json`
fixture (per project policy, lookups stay offline). Covers: state
materialisation of the typed entities + link arrays; `eventType`-only
discrimination; the cross-linked `@graph` after build; `study_id` wiring (state +
round-trip into the graph); idempotency; the not-found path; and a
build → read → build round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)