### PR TITLE
test(repair): 120s timeout for validation-heavy repair tests (fixes red main CI)

### DIFF
--- a/tests/test_tools_repair.py
+++ b/tests/test_tools_repair.py
@@ -13,9 +13,16 @@ These tests are fully offline (validation runs against the bundled context, see
 
 from __future__ import annotations
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
 from builder.tools.repair import fix_required_issues
-from builder.tools.validation import build_and_validate
+
+# Every test exercises fix_required_issues, which runs the (deliberately uncached,
+# owlrl-heavy) SHACL validator one or more times — legitimately slower than the
+# 30s suite-wide CI default. Mirror tests/test_e2e_agent_eval.py and give this
+# validation-heavy module headroom; the marker overrides the CLI --timeout.
+pytestmark = pytest.mark.timeout(120)
 
 
 def _entity(entity_id: str, type_: EntityType, **fields) -> Entity:
@@ -80,12 +87,9 @@ class TestDeterministicLinkRepair:
         """A missing process output with exactly one in-state File is auto-linked."""
         state = _endpoint_readout_missing_result(n_files=1)
 
-        before = build_and_validate(state)
-        assert any(
-            i["profile"] == "tox" and (i["property"] or "").endswith("result")
-            for i in before["issues"]
-        ), before["issues"]
-
+        # fix_required_issues validates internally (before + after), so we assert
+        # via its return value + the mutated state rather than running extra full
+        # SHACL sweeps here (keeps this validation-heavy test within budget).
         result = fix_required_issues(state)
 
         # The File is now wired as the EndpointReadout's result in state.
@@ -102,12 +106,9 @@ class TestDeterministicLinkRepair:
             (item["issue"]["property"] or "").endswith("result")
             for item in result["fixed"]
         ), result["fixed"]
-        # Re-validation confirms the issue really cleared.
-        after = build_and_validate(state)
-        assert not any(
-            (i["property"] or "").endswith("result") and i["profile"] == "tox"
-            for i in after["issues"]
-        ), after["issues"]
+        # result["ok"] is True (asserted above) IS the re-validation confirmation:
+        # fix_required_issues re-runs the validator after the repair and only
+        # reports ok when no REQUIRED issue remains — no extra sweep needed here.
 
     def test_each_fixed_item_records_what_was_done(self):
         state = _endpoint_readout_missing_result(n_files=1)


### PR DESCRIPTION
**Hotfix for red `main`.** #182 merged with `tests/test_tools_repair.py` whose end-to-end link-repair test drives the (deliberately uncached, owlrl-heavy) SHACL validator up to ~12 full passes — over CI's `--timeout=30` on the slower runner.

Fix (targeted, not a global CI bump — keeps fail-fast on genuinely hung tests):
- Module-level `pytestmark = pytest.mark.timeout(120)`, mirroring `tests/test_e2e_agent_eval.py`.
- Drop the two redundant `build_and_validate` sweeps from `test_links_unique_file_as_process_result` — `fix_required_issues` already validates before+after internally; `result["ok"]` is the re-validation confirmation.

Verified: `uv run --extra langchain pytest tests/test_tools_repair.py --timeout=30` → **11 passed in ~62s** (marker overrides the CLI timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)