### PR TITLE
feat(crate): wire looked-up identifiers as PropertyValue nodes + DOI/PubMed propertyID fix (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,6 +533,27 @@ EndpointReadout / DataAnalysis constructors so each `ParameterValue` carries its
 Characteristics — `schema:additionalProperty` PropertyValue nodes carrying the
 value and, when known, the property's ontology IRI.
 
+**Looked-up identifiers round-trip as `schema:PropertyValue` nodes** (Issue #180,
+deterministic build path — no new LLM tools). `_crate_mapping._identifier_pv(name,
+value, property_id_url=None)` mints an identifier PropertyValue with a stable id
+mirroring rocrate-wizard's `param_id` (`#param_<slug(name)>_<sha1("name|value")[:10]>`)
+and emits `propertyID` as an `{"@id": …}` node when a url is given. At build time:
+a Person carrying `orcid` gains an `ORCID` PropertyValue identifier
+(`propertyID {"@id": https://orcid.org}`); a MolecularEntity carrying
+`cas`/`casrn`/`cas_number` and/or `pubchem_cid` gains `[CAS, PubChem CID]`
+identifiers in that order (CAS has no `propertyID`; PubChem CID's is
+`{"@id": https://pubchem.ncbi.nlm.nih.gov/compound}`). These source fields are
+consumed structurally (kept off the node as raw literals). A Person's
+`affiliation` and a Publication's `author` are resolved to `{"@id"}` references
+(via `_wire_reference` / `_resolve_many`) rather than emitted as literals, so
+`Person.affiliation` points at its Organization and `ScholarlyArticle.author`
+is an array of `Person` references. No identifier is ever fabricated — only values
+already in state (from a lookup) are wired (D5). `draft_property_value` defaults
+and `@id`-wraps the `propertyID` for a PropertyValue named `DOI`
+(`OBI_0002110`) or `PubMedID` (`OBI_0001617`), the IRIs the tox
+`{10,11}_*_property_value.ttl` shapes require as `sh:hasValue` nodes — so a
+DOI/PubMedID PropertyValue passes the tox pass instead of silently failing.
+
 `draft_file` auto-derives `encodingFormat` from the file extension (`name`, then
 `path`) when the caller omits it (Issue #148), via the same scientific-format-aware
 MIME registry the scanner uses — so `run.mzML` becomes `application/x-mzml` and
@@ -1183,8 +1204,9 @@ SHACL/MIT requirements (267 elements, 82 tools mapped) **and** a real gold crate
 **Two conditional Violation traps** (the "wiring contract" — fire only when those
 entities exist, both code-fixable; document for callers):
 1. A `PropertyValue` named `DOI`/`PubMedID` is SHACL-duck-typed and MUST carry
-   `propertyID` as an **`@id` IRI node** (the OBI IRI). `draft_property_value` emits it as
-   a string literal → silent Violation. Fix: default + `@id`-wrap by name.
+   `propertyID` as an **`@id` IRI node** (the OBI IRI: `DOI`→`OBI_0002110`,
+   `PubMedID`→`OBI_0001617`). **Fixed (#180):** `draft_property_value` now defaults
+   the IRI by name and `@id`-wraps it (was a silent string-literal Violation).
 2. `EndpointReadout`/`DataAnalysis` have **no `result`/`object` build-time fallback**
    (unlike CellCulture/Exposure); a process with no explicit output fires a Violation.
    Fix: synthesize/`link` outputs (fold into `draft_process_chain`).
@@ -1204,13 +1226,17 @@ spine replaces the `should_continue` ReAct loop; (5) shrink tail agent; (6) **A/
 harness — decision gate**; (7) prompt + docs.
 
 Toolbox completion (companion issue, parallel disjoint lanes): `materialize_aop_subgraph`;
-the identifier-PropertyValue family (`draft_person_with_identifiers`,
-`enrich_molecular_entity_identifiers`, `draft_publication_with_authors`, sharing one
-`_identifier_pv` helper); reference-wiring resolver extensions (`affiliation`, `funder`,
-root `about`, `author` into `_REF_FIELDS`/`_wire_mentions`); CSVW schema extensions
+~~the identifier-PropertyValue family~~ **done (#180)** — landed as deterministic
+build-path wiring (shared `_crate_mapping._identifier_pv`), **not** new LLM tools, per
+§14's "prefer the deterministic build path": Person `orcid` → ORCID PropertyValue,
+MolecularEntity `cas`/`pubchem_cid` → `[CAS, PubChem CID]`, plus `Person.affiliation`
+and `Publication.author` resolved as `{@id}` references and the
+`draft_property_value` DOI/PubMed `propertyID` fix; a dedicated
+`draft_publication_with_authors` composite (synthesizing `#CitationAuthor_*` Person
+nodes from Crossref author lists) remains deferred follow-up. Remaining lanes:
+reference-wiring resolver extensions (`funder`, root `about`); CSVW schema extensions
 (condition-table columns, `raw_measurements`); `set_crate_metadata` (fidelity, **not** a
-validity blocker — `datePublished` is auto-set by ro-crate-py); `draft_property_value`
-DOI/PubMed `propertyID` fix.
+validity blocker — `datePublished` is auto-set by ro-crate-py).
 
 > **Tool-registration contract:** every new LLM tool must be registered in **four**
 > lockstep places — `TOOL_REGISTRY`, `TOOL_SPECS`, the system-prompt "## Your Tools"

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -313,6 +313,11 @@ _STRUCT_FIELDS = frozenset(
         "orcid",
         "ror",
         "pubchem_cid",
+        # MolecularEntity identifier sources promoted to identifier PropertyValue
+        # nodes (#180) — kept off the node as raw literals.
+        "cas",
+        "casrn",
+        "cas_number",
         "doi",
         "dest_path",
         "path",
@@ -374,6 +379,70 @@ def populate_crate(
 
 def _slug(text: str) -> str:
     return re.sub(r"[^\w.-]", "_", str(text)).strip("_") or "x"
+
+
+# ---------------------------------------------------------------------------
+# Identifier PropertyValue nodes (#180)
+#
+# Looked-up identifiers (a Person's ORCID, a MolecularEntity's CAS / PubChem CID)
+# round-trip into the crate as `schema:PropertyValue` identifier nodes carrying
+# their scheme (`name` + optional `propertyID` as an `@id` IRI node) instead of
+# collapsing into an indistinguishable string. Ids mirror rocrate-wizard's
+# `param_id` scheme (`#param_<slug(name)>_<sha1("name|value")[:10]>`) so the
+# output matches the gold crate. NEVER fabricate values (D5) — only fields that
+# came from a lookup or are already in state are wired here.
+# ---------------------------------------------------------------------------
+
+
+def _identifier_pv(
+    crate: ROCrate, name: str, value: str, property_id_url: str | None = None
+) -> ContextEntity:
+    """Build (and add) a schema:PropertyValue identifier node with a stable id.
+
+    The id is ``param_id(name, value)`` (the wizard scheme); ``propertyID`` is
+    emitted as ``{"@id": property_id_url}`` when a url is given, else omitted.
+    Returns the added node so callers can reference it.
+    """
+    props: dict[str, Any] = {"@type": "PropertyValue", "name": name, "value": str(value)}
+    if property_id_url:
+        props["propertyID"] = {"@id": property_id_url}
+    return crate.add(ContextEntity(crate, param_id(name, str(value)), properties=props))
+
+
+# Per-MolecularEntity identifier fields, in the order the gold crate lists them
+# (CAS first, then PubChem CID). Each tuple is
+# (field aliases, scheme name, propertyID url | None).
+_MOLECULAR_IDENTIFIERS: tuple[tuple[tuple[str, ...], str, str | None], ...] = (
+    (("cas", "casrn", "cas_number"), "CAS", None),
+    (
+        ("pubchem_cid",),
+        "PubChem CID",
+        "https://pubchem.ncbi.nlm.nih.gov/compound",
+    ),
+)
+
+
+def _first_field(entity: Entity, aliases: tuple[str, ...]) -> str | None:
+    """The first non-empty value among ``aliases`` on ``entity`` (or None)."""
+    for alias in aliases:
+        value = entity.fields.get(alias)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _build_identifier_pvs(
+    crate: ROCrate,
+    specs: tuple[tuple[tuple[str, ...], str, str | None], ...],
+    entity: Entity,
+) -> list[ContextEntity]:
+    """The ordered identifier PropertyValue nodes for ``entity`` (empty if none)."""
+    out: list[ContextEntity] = []
+    for aliases, scheme_name, property_id_url in specs:
+        value = _first_field(entity, aliases)
+        if value is not None:
+            out.append(_identifier_pv(crate, scheme_name, value, property_id_url))
+    return out
 
 
 def _scalar_props(entity: Entity, skip: tuple[str, ...] = ()) -> dict[str, Any]:
@@ -652,22 +721,37 @@ def _add_leaves(
         )
 
     for person in state.list_entities("Person"):
-        node = crate.add(Person(crate, _mint_id(person), properties=_scalar_props(person)))
+        # affiliation is a reference, not a literal: resolve it to the in-crate
+        # Organization node (or keep a bare IRI), and never emit it as a string.
+        node = crate.add(
+            Person(crate, _mint_id(person), properties=_scalar_props(person, skip=("affiliation",)))
+        )
         _idx_add(idx, person, node)
+        # A looked-up ORCID round-trips as an ORCID PropertyValue identifier (#180).
+        orcid = person.fields.get("orcid")
+        if orcid not in (None, ""):
+            bare = str(orcid).strip().rsplit("/", 1)[-1]
+            node.append_to(
+                "identifier", _identifier_pv(crate, "ORCID", bare, "https://orcid.org")
+            )
+        _wire_reference(
+            node, "affiliation", person.fields.get("affiliation"), idx, keep_literal=True
+        )
         crate.root_dataset.append_to("author", node)
 
     for chem in state.list_entities("MolecularEntity"):
-        _idx_add(
-            idx,
-            chem,
-            crate.add(
-                ContextEntity(
-                    crate,
-                    _mint_id(chem),
-                    properties={"@type": "MolecularEntity", **_scalar_props(chem)},
-                )
-            ),
+        node = crate.add(
+            ContextEntity(
+                crate,
+                _mint_id(chem),
+                properties={"@type": "MolecularEntity", **_scalar_props(chem)},
+            )
         )
+        _idx_add(idx, chem, node)
+        # Looked-up CAS / PubChem CID round-trip as identifier PropertyValues, in
+        # gold-crate order (CAS first, then PubChem CID) (#180).
+        for pv in _build_identifier_pvs(crate, _MOLECULAR_IDENTIFIERS, chem):
+            node.append_to("identifier", pv)
 
     for dt in state.list_entities("DefinedTerm"):
         _idx_add(
@@ -728,6 +812,10 @@ def _add_leaves(
             )
         )
         _idx_add(idx, pub, node)
+        # ScholarlyArticle.author is an array of Person references (#180). Persons
+        # are added earlier in this pass, so their nodes resolve from the index.
+        for author in _resolve_many(idx, pub.fields.get("author")):
+            node.append_to("author", author)
         crate.root_dataset.append_to("citation", node)
 
     for fe in state.list_entities("File"):
@@ -1326,6 +1414,31 @@ def _build_process(
 # ---------------------------------------------------------------------------
 # Ontology annotations (AOP / Key Event / organism / …) via schema:mentions
 # ---------------------------------------------------------------------------
+
+
+def _wire_reference(
+    node: Any, prop: str, value: Any, idx: dict[str, Any], *, keep_literal: bool = False
+) -> None:
+    """Set ``node[prop]`` to a single entity reference when one can be resolved.
+
+    The value may reference an in-crate entity (resolved via the index), an inline
+    ``{"@id": …}`` object, or a bare resolvable IRI / ``#``-fragment — each emitted
+    as an ``@id`` reference. A plain free-text value is kept verbatim only when
+    ``keep_literal`` is True (e.g. a free-text affiliation is valid schema.org and
+    dropping it would lose data); otherwise it is left unset rather than emitted as
+    a string on a reference-only property. No-ops on None/empty.
+    """
+    if value in (None, ""):
+        return
+    ent = _resolve_one(idx, value)
+    if ent is not None:
+        node[prop] = ent
+    elif isinstance(value, dict) and value.get("@id"):
+        node[prop] = {"@id": value["@id"]}
+    elif isinstance(value, str) and ("://" in value or value.startswith("#")):
+        node[prop] = {"@id": value}
+    elif keep_literal and isinstance(value, str):
+        node[prop] = value
 
 
 def _wire_mention(node: Any, prop: str, value: Any, idx: dict[str, Any]) -> None:

--- a/builder/tools/drafters.py
+++ b/builder/tools/drafters.py
@@ -17,6 +17,17 @@ VALID_PROCESS_TYPES = frozenset(
     }
 )
 
+# A PropertyValue named "DOI"/"PubMedID" is SHACL-duck-typed by the tox profile
+# (profiles/shapes/tox/10_doi_property_value.ttl, 11_pubmed_id_property_value.ttl)
+# and MUST carry schema:propertyID with the exact OBI IRI as an @id node (the
+# `sh:hasValue` of each shape). Default the IRI by name and always emit it as a
+# reference object so the value is machine-resolvable rather than a string literal
+# that silently fails the tox pass.
+_IDENTIFIER_PROPERTY_IDS: dict[str, str] = {
+    "DOI": "http://purl.obolibrary.org/obo/OBI_0002110",  # digital object identifier
+    "PubMedID": "http://purl.obolibrary.org/obo/OBI_0001617",  # PubMed identifier
+}
+
 
 def _make_entity_id(prefix: str, name: str, hints: dict) -> str:
     """Generate a stable entity_id from hints, falling back to name."""
@@ -259,6 +270,20 @@ def draft_property_value(state: CrateState, name: str, hints: dict) -> Entity:
     ):
         if snake in merged_hints:
             merged_hints[camel] = merged_hints.pop(snake)
+
+    # DOI / PubMedID PropertyValues MUST pin propertyID to the OBI IRI as an @id
+    # node, or the tox profile raises a silent Violation. Default the IRI by name
+    # when absent, and wrap any supplied IRI string as a reference object.
+    obi_iri = _IDENTIFIER_PROPERTY_IDS.get(name)
+    if obi_iri is not None:
+        supplied = merged_hints.get("propertyID")
+        iri = obi_iri
+        if isinstance(supplied, dict) and supplied.get("@id"):
+            iri = supplied["@id"]
+        elif isinstance(supplied, str) and supplied:
+            iri = supplied
+        merged_hints["propertyID"] = {"@id": iri}
+
     entity_id = _make_entity_id("pv", name, merged_hints)
     entity = Entity(
         entity_id=entity_id,

--- a/tests/test_crate_mapping_identifiers.py
+++ b/tests/test_crate_mapping_identifiers.py
@@ -1,0 +1,249 @@
+"""Looked-up identifiers round-trip into the crate as PropertyValue nodes (#180).
+
+The deterministic build path (`populate_crate`) turns identifier-bearing fields
+on Person / MolecularEntity into `schema:PropertyValue` identifier nodes whose
+shapes match the gold crate
+(`crates_out/S-VHPS21_rocrate/ro-crate-metadata.json`):
+
+* Person.orcid -> a single ORCID PropertyValue ref, propertyID an `@id` IRI node.
+* MolecularEntity cas + pubchem_cid -> `[CAS, PubChem CID]` PropertyValue refs.
+* Person.affiliation -> an `{@id}` reference to its Organization (ROR), not a literal.
+* ScholarlyArticle.author -> an array of Person references.
+
+Entity ids mirror rocrate-wizard's `param_id` scheme
+(`#param_<slug(name)>_<sha1("name|value")[:10]>`) so the output matches the gold
+crate byte-for-byte at the id level. All assertions read the assembled JSON-LD
+graph; no network and no SHACL (no `build_and_validate`) so the module is fast.
+"""
+
+from __future__ import annotations
+
+from rocrate.rocrate import ROCrate
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools._crate_mapping import populate_crate
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _graph(state: CrateState) -> list[dict]:
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, None, materialize_payload=False, include_all_scanned=False)
+    return crate.metadata.generate()["@graph"]
+
+
+def _by_id(graph: list[dict], node_id: str) -> dict | None:
+    return next((n for n in graph if n.get("@id") == node_id), None)
+
+
+def _node_of_type(graph: list[dict], type_name: str) -> dict | None:
+    for n in graph:
+        t = n.get("@type")
+        if t == type_name or (isinstance(t, list) and type_name in t):
+            return n
+    return None
+
+
+def _ref_ids(value: object) -> list[str]:
+    """The list of @id strings referenced by an identifier/author property value."""
+    items = value if isinstance(value, list) else [value]
+    out: list[str] = []
+    for it in items:
+        if isinstance(it, dict):
+            ref = it.get("@id")
+            if isinstance(ref, str):
+                out.append(ref)
+    return out
+
+
+def _person_state() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Person crate"
+    person = Entity(
+        entity_id="person_wagenaars",
+        type="Person",
+        fields={"name": "F.M.A. Wagenaars", "orcid": "0000-0003-4766-7358"},
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+    state.add_entity(person)
+    return state
+
+
+class TestPersonOrcidIdentifier:
+    def test_person_carries_orcid_property_value_ref(self):
+        graph = _graph(_person_state())
+        person = _by_id(graph, "https://orcid.org/0000-0003-4766-7358")
+        assert person is not None, "Person @id must be its ORCID URL"
+        ids = _ref_ids(person.get("identifier"))
+        assert ids == ["#param_ORCID_241def7f8f"], (
+            f"Person.identifier must reference the ORCID PropertyValue, got {ids}"
+        )
+
+    def test_orcid_property_value_node_matches_gold(self):
+        graph = _graph(_person_state())
+        pv = _by_id(graph, "#param_ORCID_241def7f8f")
+        assert pv is not None, "ORCID PropertyValue node must be in the graph"
+        assert pv.get("@type") == "PropertyValue"
+        assert pv.get("name") == "ORCID"
+        assert pv.get("value") == "0000-0003-4766-7358"
+        # propertyID MUST be an @id IRI node, not a string literal.
+        assert pv.get("propertyID") == {"@id": "https://orcid.org"}
+
+    def test_person_without_orcid_has_no_identifier(self):
+        state = CrateState()
+        state.add_entity(
+            Entity(
+                entity_id="p_noid",
+                type="Person",
+                fields={"name": "Jane Doe"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        graph = _graph(state)
+        person = _node_of_type(graph, "Person")
+        assert person is not None
+        assert "identifier" not in person, "No fabricated identifier without an ORCID (D5)"
+
+
+def _molecular_state() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Compound crate"
+    chem = Entity(
+        entity_id="chem_silychristin",
+        type="MolecularEntity",
+        fields={
+            "name": "Silychristin A",
+            "cas": "33889-69-9",
+            "pubchem_cid": "441764",
+        },
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+    state.add_entity(chem)
+    return state
+
+
+class TestMolecularEntityIdentifiers:
+    def test_entity_id_is_pubchem_compound_url(self):
+        graph = _graph(_molecular_state())
+        chem = _by_id(graph, "https://pubchem.ncbi.nlm.nih.gov/compound/441764")
+        assert chem is not None, "MolecularEntity @id must be the PubChem compound URL"
+
+    def test_identifier_array_order_cas_then_cid(self):
+        graph = _graph(_molecular_state())
+        chem = _by_id(graph, "https://pubchem.ncbi.nlm.nih.gov/compound/441764")
+        assert chem is not None
+        ids = _ref_ids(chem.get("identifier"))
+        assert ids == [
+            "#param_CAS_27336af8c7",
+            "#param_PubChem_CID_bc4c668bae",
+        ], f"identifier must be [CAS, PubChem CID] refs, got {ids}"
+
+    def test_cas_property_value_has_no_property_id(self):
+        graph = _graph(_molecular_state())
+        cas = _by_id(graph, "#param_CAS_27336af8c7")
+        assert cas is not None
+        assert cas.get("@type") == "PropertyValue"
+        assert cas.get("name") == "CAS"
+        assert cas.get("value") == "33889-69-9"
+        assert "propertyID" not in cas, "CAS PropertyValue carries no propertyID (gold)"
+
+    def test_pubchem_cid_property_value_has_property_id_node(self):
+        graph = _graph(_molecular_state())
+        cid = _by_id(graph, "#param_PubChem_CID_bc4c668bae")
+        assert cid is not None
+        assert cid.get("@type") == "PropertyValue"
+        assert cid.get("name") == "PubChem CID"
+        assert cid.get("value") == "441764"
+        assert cid.get("propertyID") == {
+            "@id": "https://pubchem.ncbi.nlm.nih.gov/compound"
+        }
+
+    def test_no_raw_cas_literal_on_node(self):
+        graph = _graph(_molecular_state())
+        chem = _by_id(graph, "https://pubchem.ncbi.nlm.nih.gov/compound/441764")
+        assert chem is not None
+        # cas/casrn must not leak onto the node as a bare literal; it lives in the PV.
+        assert "cas" not in chem and "casrn" not in chem
+
+
+class TestPersonAffiliation:
+    def test_affiliation_resolves_to_org_reference(self):
+        state = CrateState()
+        state.metadata.title = "Affiliation crate"
+        state.add_entity(
+            Entity(
+                entity_id="org_vu",
+                type="Organization",
+                fields={"name": "VU Amsterdam", "ror": "008xxew50"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="person_hamers",
+                type="Person",
+                fields={
+                    "name": "Timo Hamers",
+                    "orcid": "0000-0002-5733-3290",
+                    "affiliation": "org_vu",
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        graph = _graph(state)
+        person = _by_id(graph, "https://orcid.org/0000-0002-5733-3290")
+        assert person is not None
+        assert person.get("affiliation") == {"@id": "https://ror.org/008xxew50"}, (
+            "affiliation must be an {@id} reference to the Organization node"
+        )
+
+    def test_freetext_affiliation_kept_as_literal(self):
+        """A free-text affiliation (no resolvable org / IRI) is valid schema.org and kept."""
+        state = CrateState()
+        state.metadata.title = "Affiliation crate"
+        state.add_entity(
+            Entity(
+                entity_id="p_lit",
+                type="Person",
+                fields={"name": "Jane Doe", "affiliation": "Some University"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        graph = _graph(state)
+        person = _node_of_type(graph, "Person")
+        assert person is not None
+        assert person.get("affiliation") == "Some University"
+
+
+class TestPublicationAuthors:
+    def test_scholarly_article_author_references_persons(self):
+        state = CrateState()
+        state.metadata.title = "Publication crate"
+        state.add_entity(
+            Entity(
+                entity_id="person_a",
+                type="Person",
+                fields={"name": "Martin Scholze", "orcid": "0000-0002-9569-7562"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="pub_mct8",
+                type="Publication",
+                fields={
+                    "name": "MCT8 screening",
+                    "doi": "10.1016/j.tiv.2023.105770",
+                    "author": ["person_a"],
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        graph = _graph(state)
+        article = _by_id(graph, "https://doi.org/10.1016/j.tiv.2023.105770")
+        assert article is not None
+        assert article.get("@type") == "ScholarlyArticle"
+        ids = _ref_ids(article.get("author"))
+        assert ids == ["https://orcid.org/0000-0002-9569-7562"], (
+            f"author must be an array of Person references, got {ids}"
+        )

--- a/tests/test_property_value_doi_pubmed.py
+++ b/tests/test_property_value_doi_pubmed.py
@@ -1,0 +1,78 @@
+"""DOI / PubMedID PropertyValues carry their OBI propertyID as an @id node (#180).
+
+The tox profile SHACL-duck-types a `schema:PropertyValue` named "DOI" or
+"PubMedID" and REQUIRES `schema:propertyID` to *have value* a specific OBI IRI
+(an `@id` node, not a string literal):
+
+* DOI      -> http://purl.obolibrary.org/obo/OBI_0002110  (digital object identifier)
+* PubMedID -> http://purl.obolibrary.org/obo/OBI_0001617  (PubMed identifier)
+
+(IRIs verified against profiles/shapes/tox/10_doi_property_value.ttl and
+11_pubmed_id_property_value.ttl — the `sh:hasValue` of each shape.)
+
+`draft_property_value` previously emitted `propertyID` as a string literal (when
+supplied) and never defaulted it, so a DOI/PubMedID PropertyValue silently failed
+the tox pass. These tests assert the default + `@id`-wrap at draft time, that an
+explicit IRI is still `@id`-wrapped, and (offline, with the bundled context) that
+a DOI PropertyValue now passes tox validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools.drafters import draft_property_value
+from builder.tools.validation import build_and_validate
+
+# build_and_validate runs the heavy SHACL passes; CI gates pytest at --timeout=30
+# (see tests/test_tools_repair.py / test_e2e_agent_eval.py).
+pytestmark = pytest.mark.timeout(120)
+
+OBI_DOI = "http://purl.obolibrary.org/obo/OBI_0002110"
+OBI_PUBMED = "http://purl.obolibrary.org/obo/OBI_0001617"
+
+
+class TestDraftDefaultsPropertyID:
+    def test_doi_defaults_obi_property_id_as_id_node(self):
+        state = CrateState()
+        entity = draft_property_value(state, "DOI", {"value": "10.1234/abcd"})
+        assert entity.fields.get("propertyID") == {"@id": OBI_DOI}
+
+    def test_pubmed_defaults_obi_property_id_as_id_node(self):
+        state = CrateState()
+        entity = draft_property_value(state, "PubMedID", {"value": "37123456"})
+        assert entity.fields.get("propertyID") == {"@id": OBI_PUBMED}
+
+    def test_explicit_doi_property_id_is_wrapped_as_id_node(self):
+        """A model that passes the correct IRI as a bare string still gets a node."""
+        state = CrateState()
+        entity = draft_property_value(
+            state, "DOI", {"value": "10.1234/abcd", "property_id": OBI_DOI}
+        )
+        assert entity.fields.get("propertyID") == {"@id": OBI_DOI}
+
+    def test_non_identifier_name_unchanged(self):
+        """A regular PropertyValue keeps its supplied propertyID string verbatim."""
+        state = CrateState()
+        entity = draft_property_value(
+            state,
+            "Passage Number",
+            {"value": "5", "property_id": "http://purl.obolibrary.org/obo/EFO_0007061"},
+        )
+        assert entity.fields.get("propertyID") == "http://purl.obolibrary.org/obo/EFO_0007061"
+
+
+class TestDoiPropertyValuePassesTox:
+    def test_doi_property_value_validates(self):
+        state = CrateState()
+        state.metadata.title = "DOI crate"
+        draft_property_value(state, "DOI", {"value": "10.1016/j.tiv.2023.105770"})
+        result = build_and_validate(state, severity="required", profile="tox")
+        doi_issues = [
+            issue
+            for issue in result.get("issues", [])
+            if "propertyID" in str(issue.get("message", ""))
+            or "DOI" in str(issue.get("message", ""))
+        ]
+        assert not doi_issues, f"DOI PropertyValue must not raise a tox Violation: {doi_issues}"


### PR DESCRIPTION
## What

Looked-up identifiers were silently **dropped** instead of round-tripping into the crate. This lane (#180 Lane B) wires them into the **deterministic build path** (`_crate_mapping`) — **no new LLM tools**, in keeping with AGENTS §14's "prefer the deterministic build path" — so they appear exactly as in the gold crate (`crates_out/S-VHPS21_rocrate`).

### Landed
- **Shared helper** `_crate_mapping._identifier_pv(name, value, property_id_url=None)` — mints a `schema:PropertyValue` with a stable id mirroring rocrate-wizard's `param_id` (`#param_<slug(name)>_<sha1("name|value")[:10]>`), emitting `propertyID` as an `{"@id"}` node when a url is given. Verified to reproduce the gold ids byte-for-byte (`#param_ORCID_241def7f8f`, `#param_CAS_27336af8c7`, `#param_PubChem_CID_bc4c668bae`).
- **Person.identifier** ← ORCID `PropertyValue` (`propertyID {"@id": https://orcid.org}`); Person `@id` is its ORCID URL.
- **MolecularEntity.identifier** ← `[CAS, PubChem CID]` in gold order (CAS has no `propertyID`; PubChem CID's is `{"@id": https://pubchem.ncbi.nlm.nih.gov/compound}`). Source fields (`cas`/`casrn`/`cas_number`/`pubchem_cid`) consumed structurally — kept off the node as literals; entity `@id` is the PubChem compound URL when a CID exists.
- **Person.affiliation** and **ScholarlyArticle.author** resolved to `{"@id"}` references (`_wire_reference`/`_resolve_many`). A free-text affiliation is kept as a valid schema.org literal rather than dropped.
- **Validity fix (most important):** `draft_property_value` now defaults + `@id`-wraps `propertyID` for a PropertyValue named `DOI`/`PubMedID`. Previously it emitted `propertyID` as a string literal → silent tox Violation.

### Verified OBI IRIs (against the tox shapes' `sh:hasValue`)
- `DOI` → `http://purl.obolibrary.org/obo/OBI_0002110` (`profiles/shapes/tox/10_doi_property_value.ttl`)
- `PubMedID` → `http://purl.obolibrary.org/obo/OBI_0001617` (`profiles/shapes/tox/11_pubmed_id_property_value.ttl`)

Both emitted as `@id` IRI nodes (the shapes require a node, not a string literal).

## Why deterministic build path (not new tools)
AGENTS §14.4 lists the identifier-PropertyValue family as deterministic build-path extensions sharing one `_identifier_pv` helper. The agent already calls `lookup_*` then stores `orcid`/`cas`/`pubchem_cid`/`author` on entities; the only gap was the build dropping them. Wiring at build time avoids tool proliferation and the four-place registration churn.

## D5
No identifier is ever fabricated — only values already in state (from a lookup) are wired.

## Tests (offline, mocked context)
- `tests/test_crate_mapping_identifiers.py` — build-path PropertyValue/reference shapes match the gold crate at the id level (graph-only, no SHACL → no timeout marker needed).
- `tests/test_property_value_doi_pubmed.py` — draft-time `propertyID` defaulting/`@id`-wrap + a DOI PropertyValue now **passes the tox SHACL pass**. Module-level `pytest.mark.timeout(120)` (CI runs `--timeout=30`; the #184 lesson).

## Deferred follow-up
A `draft_publication_with_authors` composite that synthesizes `#CitationAuthor_*` Person nodes from Crossref author lists (the gold crate's non-ORCID citation authors). Publication `author` references already wire today when authors exist as Person entities in state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)