### PR TITLE
feat(crate): wire root funder/about + assay aliases as references (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1040,6 +1040,10 @@ of the root via `StudyMustBeReferencedFromInvestigation`, so the root cannot its
 - Attaches each **result `File` to its producing Assay's `hasPart`** (de-duped via `_append_unique`)
   and removes it from the root's auto-added `hasPart` (`_remove_child`) — raw/processed data are the
   data of an assay. Files stay reachable from the root transitively (File → Assay → Study → `./`).
+- Re-emits the Assay's **`dataFiles` / `resources` PageTab aliases** (both expand to `schema:hasPart`
+  via `profiles/context.py`) as resolved File references *and* nests those Files under the Assay's
+  `hasPart`, un-parenting them from the root — same move as result Files, so the gold-crate JSON keys
+  round-trip without breaking reachability (`_wire_dataset_aliases`, #180 Lane C).
 
 Round-trip is symmetric: `read_existing_crate` (`builder/readers/existing_crate.py`) recovers the
 **bare** entity_id (stripping the type-qualifier so `#Study_study_1` → `study_1`, not the unbounded
@@ -1233,8 +1237,18 @@ MolecularEntity `cas`/`pubchem_cid` → `[CAS, PubChem CID]`, plus `Person.affil
 and `Publication.author` resolved as `{@id}` references and the
 `draft_property_value` DOI/PubMed `propertyID` fix; a dedicated
 `draft_publication_with_authors` composite (synthesizing `#CitationAuthor_*` Person
-nodes from Crossref author lists) remains deferred follow-up. Remaining lanes:
-reference-wiring resolver extensions (`funder`, root `about`); CSVW schema extensions
+nodes from Crossref author lists) remains deferred follow-up. The
+**reference-wiring resolver extensions** lane is also **done (#180 Lane C)** —
+likewise deterministic build-path wiring (`_crate_mapping._wire_dataset_aliases`),
+**not** new LLM tools: root `funder` → Organization ref(s), root `about` → the
+DataAnalysis LabProcess (mirroring the Assay `about`→LabProcess wiring), Assay
+`measurementMethod` → BAO `DefinedTerm` ref, and the hasPart-family aliases
+`dataFiles`/`resources` re-emitted as resolved File refs while staying nested under
+the assay's `hasPart` (un-parented from the root). All five new alias keys
+(`funder`, `measurementMethod`, `studies`, `assays`, `resources`, `dataFiles`,
+`labProcesses`) joined `_REF_FIELDS` so `_scalar_props` strips them as resolver
+inputs rather than leaking the raw id onto the node (D5: an unresolvable, non-IRI
+value is dropped, never guessed). Remaining lanes: CSVW schema extensions
 (condition-table columns, `raw_measurements`); `set_crate_metadata` (fidelity, **not** a
 validity blocker — `datePublished` is auto-set by ro-crate-py).
 

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -64,7 +64,22 @@ _REF_FIELDS = frozenset(
         "biologicalModels",
         "has_part",
         "hasPart",
+        # hasPart-family aliases (profiles/context.py): studies/assays/resources/
+        # dataFiles all expand to schema:hasPart. Held here so _scalar_props strips
+        # them as resolver inputs rather than leaking the raw id/{@id} onto the node
+        # (#180 Lane C); they are re-emitted as resolved references by
+        # _wire_dataset_aliases.
+        "studies",
+        "assays",
+        "resources",
+        "dataFiles",
         "about",
+        # schema:about alias for a Study/Assay's LabProcess list (PageTab-aligned).
+        "labProcesses",
+        # schema:funder — root/Investigation funding Organization reference(s).
+        "funder",
+        # schema:measurementMethod — the Assay's BAO method DefinedTerm reference.
+        "measurementMethod",
         "aop",
         "organism",
         "anatomy",
@@ -370,6 +385,7 @@ def populate_crate(
     _add_structural(state, crate, idx)
     _add_processes(state, crate, idx, output_dir, materialize_payload=materialize_payload)
     _wire_mentions(state, idx)
+    _wire_dataset_aliases(state, crate, idx)
 
 
 # ---------------------------------------------------------------------------
@@ -1487,3 +1503,91 @@ def _wire_mentions(state: CrateState, idx: dict[str, Any]) -> None:
         for field, prop in _ASSAY_MENTION_FIELDS.items():
             if field in asy.fields:
                 _wire_mention(node, prop, asy.fields[field], idx)
+
+
+# ---------------------------------------------------------------------------
+# Reference-wiring for root funder/about + assay aliases (#180 Lane C)
+#
+# References the build previously dropped, resolved deterministically so they
+# round-trip exactly as the gold crate emits them. NEVER fabricates an id (D5):
+# every reference is resolved from a field already present in state, and an
+# unresolvable, non-IRI value is left off rather than guessed.
+# ---------------------------------------------------------------------------
+
+# Assay reference aliases that expand to schema:hasPart (profiles/context.py).
+# Resolved File/dataset refs are emitted under their PageTab key AND attached to
+# the assay's structural hasPart (un-parented from the root) so containment is
+# preserved and a loose data File is never dumped on the root.
+_ASSAY_HASPART_ALIASES = ("dataFiles", "resources")
+
+
+def _wire_references(node: Any, prop: str, value: Any, idx: dict[str, Any]) -> None:
+    """Append resolved entity reference(s) under ``node[prop]`` (an array prop).
+
+    Mirrors :func:`_wire_mention`: each item may reference an in-crate entity
+    (resolved via the index), an inline ``{"@id": …}`` object, or a bare
+    resolvable IRI / ``#``-fragment — each emitted as an ``@id`` reference,
+    de-duped by id. A plain free-text value is dropped (never emitted as a string
+    on a reference-only property). No-ops on None/empty.
+    """
+    if value in (None, ""):
+        return
+    for item in value if isinstance(value, list) else [value]:
+        if item in (None, ""):
+            continue
+        ent = _resolve_one(idx, item)
+        if ent is not None:
+            _append_unique(node, prop, ent)
+        elif isinstance(item, dict) and item.get("@id"):
+            _append_unique_ref(node, prop, item["@id"])
+        elif isinstance(item, str) and ("://" in item or item.startswith("#")):
+            _append_unique_ref(node, prop, item)
+
+
+def _append_unique_ref(node: Any, prop: str, ref_id: str) -> None:
+    """append_to(node, prop, {"@id": ref_id}) but skip if ``ref_id`` already present."""
+    if ref_id not in _child_ids(node, prop):
+        node.append_to(prop, {"@id": ref_id})
+
+
+def _wire_dataset_aliases(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+    """Resolve root funder/about + assay measurementMethod/dataFiles/resources.
+
+    Runs after structural datasets and processes are added so every reference
+    target (Organization, DataAnalysis LabProcess, DefinedTerm, File) is already
+    in the index.
+
+    * Root (the folded single Investigation) ``funder`` -> Organization ref(s)
+      and ``about`` -> the LabProcess it reports on (mirrors the Assay
+      ``about``->LabProcess wiring, for the Investigation/root).
+    * Assay ``measurementMethod`` -> a single DefinedTerm reference.
+    * Assay ``dataFiles`` / ``resources`` -> File references, also attached to the
+      assay's ``hasPart`` and un-parented from the root (they expand to
+      schema:hasPart, so reachability and containment are preserved).
+    """
+    root = crate.root_dataset
+
+    for inv in state.list_entities("Investigation"):
+        node = _node_for(idx, inv)
+        if node is None:
+            continue
+        _wire_references(node, "funder", inv.fields.get("funder"), idx)
+        _wire_references(node, "about", inv.fields.get("about"), idx)
+
+    for asy in state.list_entities("Assay"):
+        node = _node_for(idx, asy)
+        if node is None:
+            continue
+        _wire_reference(node, "measurementMethod", asy.fields.get("measurementMethod"), idx)
+        for alias in _ASSAY_HASPART_ALIASES:
+            for child in _resolve_many(idx, asy.fields.get(alias)):
+                if child is node:
+                    continue
+                # Emit under the PageTab alias key …
+                _append_unique(node, alias, child)
+                # … and keep it reachable: nest under the assay's hasPart, removing
+                # the root's auto-added top-level reference (it stays reachable
+                # transitively File -> Assay -> Study -> ./). Both expand to
+                # schema:hasPart, so the RDF containment is a single edge.
+                _remove_child(root, "hasPart", child.id)
+                _append_unique(node, "hasPart", child)

--- a/tests/test_crate_mapping_references.py
+++ b/tests/test_crate_mapping_references.py
@@ -1,0 +1,258 @@
+"""Build-path reference wiring: root funder/about + assay aliases (#180 Lane C).
+
+The deterministic build path (`populate_crate`) resolves references the build
+previously dropped, so they round-trip into the crate exactly as the gold crate
+(`crates_out/S-VHPS21_rocrate/ro-crate-metadata.json`) emits them:
+
+* Root (the folded Investigation) ``funder`` -> Organization reference(s).
+* Root ``about`` -> the DataAnalysis LabProcess (mirrors the Assay
+  ``about``->LabProcess wiring, but for the Investigation/root).
+* Assay ``measurementMethod`` -> a BAO ``DefinedTerm`` reference.
+* Assay ``dataFiles`` / ``resources`` -> the assay's data / resource File refs
+  (both expand to schema:hasPart, so the files also stay reachable via hasPart).
+* Study/root ``assays`` -> reverse alias to the Assay children.
+
+None of these are fabricated (D5): every reference is resolved from a field
+already present on the source entity in state. All assertions read the assembled
+JSON-LD graph; no network and no SHACL (no ``build_and_validate``) so the module
+is fast.
+"""
+
+from __future__ import annotations
+
+from rocrate.rocrate import ROCrate
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools._crate_mapping import populate_crate
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+def _graph(state: CrateState) -> list[dict]:
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, None, materialize_payload=False, include_all_scanned=False)
+    return crate.metadata.generate()["@graph"]
+
+
+def _by_id(graph: list[dict], node_id: str) -> dict | None:
+    return next((n for n in graph if n.get("@id") == node_id), None)
+
+
+def _ids(value: object) -> list[str]:
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    out: list[str] = []
+    for it in items:
+        rid = it.get("@id") if isinstance(it, dict) else it
+        if isinstance(rid, str):
+            out.append(rid)
+    return out
+
+
+class TestRootFunder:
+    def _state(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Funded investigation"
+        state.add_entity(
+            _ent("org_zon", "Organization", name="ZonMw", ror="0254y9b08")
+        )
+        state.add_entity(_ent("inv_1", "Investigation", name="Inv", funder="org_zon"))
+        return state
+
+    def test_root_funder_references_organization(self):
+        graph = _graph(self._state())
+        root = _by_id(graph, "./")
+        assert root is not None
+        assert _ids(root.get("funder")) == ["https://ror.org/0254y9b08"], (
+            "root funder must be an {@id} reference to the Organization (gold shape)"
+        )
+
+    def test_funder_iri_reference_kept(self):
+        """A bare ROR IRI funder (no in-crate Organization) is wired as {@id}."""
+        state = CrateState()
+        state.metadata.title = "Funded investigation"
+        state.add_entity(
+            _ent("inv_1", "Investigation", name="Inv", funder="https://ror.org/0254y9b08")
+        )
+        graph = _graph(state)
+        root = _by_id(graph, "./")
+        assert root is not None
+        assert _ids(root.get("funder")) == ["https://ror.org/0254y9b08"]
+
+    def test_no_funder_when_absent(self):
+        state = CrateState()
+        state.metadata.title = "Unfunded"
+        state.add_entity(_ent("inv_1", "Investigation", name="Inv"))
+        graph = _graph(state)
+        root = _by_id(graph, "./")
+        assert root is not None
+        assert "funder" not in root, "no fabricated funder when absent (D5)"
+
+
+class TestRootAbout:
+    def _state(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Reported investigation"
+        state.add_entity(_ent("inv_1", "Investigation", name="Inv", about="report"))
+        state.add_entity(
+            _ent(
+                "report",
+                "LabProcess",
+                process_type="DataAnalysis",
+                name="Crate quality report",
+                software="vitro-crate",
+            )
+        )
+        return state
+
+    def test_root_about_references_dataanalysis_labprocess(self):
+        graph = _graph(self._state())
+        root = _by_id(graph, "./")
+        assert root is not None
+        assert "#LabProcess_report" in _ids(root.get("about")), (
+            "root about must reference the DataAnalysis LabProcess node"
+        )
+        report = _by_id(graph, "#LabProcess_report")
+        assert report is not None
+        assert report.get("additionalType") == "DataAnalysis"
+
+
+class TestAssayMeasurementMethod:
+    def test_measurement_method_references_defined_term(self):
+        # The BAO DefinedTerm's @id IS its resolvable IRI (gold crate shape:
+        # _mint_id returns an IRI entity_id verbatim), and the assay references it.
+        state = CrateState()
+        state.metadata.title = "Assay crate"
+        state.add_entity(
+            _ent(
+                "http://www.bioassayontology.org/bao#BAO_0010196",
+                "DefinedTerm",
+                name="uptake transporter inhibition assay",
+                term_code="BAO_0010196",
+            )
+        )
+        state.add_entity(
+            _ent(
+                "assay_1",
+                "Assay",
+                name="Uptake",
+                measurementMethod="http://www.bioassayontology.org/bao#BAO_0010196",
+            )
+        )
+        graph = _graph(state)
+        assay = _by_id(graph, "#Assay_assay_1")
+        assert assay is not None
+        assert assay.get("measurementMethod") == {
+            "@id": "http://www.bioassayontology.org/bao#BAO_0010196"
+        }, "measurementMethod must be an {@id} reference to the BAO DefinedTerm"
+
+    def test_measurement_method_iri_kept(self):
+        state = CrateState()
+        state.metadata.title = "Assay crate"
+        state.add_entity(
+            _ent(
+                "assay_1",
+                "Assay",
+                name="Uptake",
+                measurementMethod="http://www.bioassayontology.org/bao#BAO_0010196",
+            )
+        )
+        graph = _graph(state)
+        assay = _by_id(graph, "#Assay_assay_1")
+        assert assay is not None
+        assert assay.get("measurementMethod") == {
+            "@id": "http://www.bioassayontology.org/bao#BAO_0010196"
+        }
+
+    def test_no_raw_measurement_method_literal(self):
+        """measurementMethod must never leak onto the node as a bare string."""
+        state = CrateState()
+        state.metadata.title = "Assay crate"
+        state.add_entity(_ent("assay_1", "Assay", name="Uptake", measurementMethod="bao"))
+        # No DefinedTerm named "bao" exists -> unresolvable, non-IRI -> not emitted.
+        graph = _graph(state)
+        assay = _by_id(graph, "#Assay_assay_1")
+        assert assay is not None
+        assert assay.get("measurementMethod") != "bao"
+
+
+class TestAssayDataFilesAndResources:
+    def _state(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Assay file crate"
+        state.add_entity(
+            _ent("f_data", "File", name="raw.prism", dest_path="assays/a/dataset/raw.prism")
+        )
+        state.add_entity(
+            _ent("f_res", "File", name="README.txt", dest_path="assays/a/resources/README.txt")
+        )
+        state.add_entity(
+            _ent(
+                "assay_1",
+                "Assay",
+                name="Uptake",
+                dataFiles=["f_data"],
+                resources=["f_res"],
+            )
+        )
+        return state
+
+    def test_data_files_referenced_under_assay(self):
+        graph = _graph(self._state())
+        assay = _by_id(graph, "#Assay_assay_1")
+        assert assay is not None
+        assert _ids(assay.get("dataFiles")) == ["assays/a/dataset/raw.prism"]
+
+    def test_resources_referenced_under_assay(self):
+        graph = _graph(self._state())
+        assay = _by_id(graph, "#Assay_assay_1")
+        assert assay is not None
+        assert _ids(assay.get("resources")) == ["assays/a/resources/README.txt"]
+
+    def test_data_and_resource_files_stay_reachable_via_haspart(self):
+        """dataFiles/resources expand to schema:hasPart, so the Files stay
+        reachable from the assay and not dumped loose on the root."""
+        graph = _graph(self._state())
+        assay = _by_id(graph, "#Assay_assay_1")
+        root = _by_id(graph, "./")
+        assert assay is not None and root is not None
+        assay_parts = _ids(assay.get("hasPart")) + _ids(assay.get("dataFiles")) + _ids(
+            assay.get("resources")
+        )
+        assert "assays/a/dataset/raw.prism" in assay_parts
+        assert "assays/a/resources/README.txt" in assay_parts
+        # not orphaned loose on the root's hasPart
+        assert "assays/a/dataset/raw.prism" not in _ids(root.get("hasPart"))
+        assert "assays/a/resources/README.txt" not in _ids(root.get("hasPart"))
+
+
+class TestAssaysReverseAlias:
+    def test_study_assays_references_child_assays(self):
+        state = CrateState()
+        state.metadata.title = "Study/assay crate"
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        state.add_entity(_ent("assay_1", "Assay", name="A", study_id="study_1"))
+        graph = _graph(state)
+        study = _by_id(graph, "#Study_study_1")
+        assert study is not None
+        assert "#Assay_assay_1" in _ids(study.get("assays")) + _ids(study.get("hasPart"))
+
+    def test_root_assays_references_child_assays_without_study(self):
+        state = CrateState()
+        state.metadata.title = "Root/assay crate"
+        state.add_entity(_ent("inv_1", "Investigation", name="Inv"))
+        state.add_entity(_ent("assay_1", "Assay", name="A"))
+        graph = _graph(state)
+        root = _by_id(graph, "./")
+        assert root is not None
+        assert "#Assay_assay_1" in _ids(root.get("assays")) + _ids(root.get("hasPart"))


### PR DESCRIPTION
## What

Lane C of #180 — deterministic **build-path** reference-wiring (no new LLM tools), mirroring the #185 identifier-PropertyValue lane. Resolves references the build previously dropped so they round-trip exactly as the gold crate (`S-VHPS21`) emits them.

### Landed
- **Root `funder`** → Organization reference(s). Wired from the folded Investigation's `funder` field (in-crate Organization → ROR `{@id}`, or a bare ROR IRI kept as `{@id}`). Gold: `"funder":[{"@id":"https://ror.org/0254y9b08"}]`.
- **Root `about`** → the DataAnalysis LabProcess, mirroring the existing Assay `about`→LabProcess wiring but for the Investigation/root. Gold: `"about":[{"@id":"#report_analysis"}]`.
- **Assay `measurementMethod`** → BAO `DefinedTerm` `{@id}` reference. Gold: `{"@id":"http://www.bioassayontology.org/bao#BAO_0010196"}`.
- **Assay `dataFiles` / `resources`** → File references, re-emitted under their PageTab key **and** nested under the assay's `hasPart` (un-parented from the root). Both expand to `schema:hasPart` (`profiles/context.py`), so reachability/containment is preserved (File → Assay → Study → `./`).
- `funder`, `measurementMethod`, and the hasPart/about-family aliases (`studies`/`assays`/`resources`/`dataFiles`/`labProcesses`) joined `_REF_FIELDS` so `_scalar_props` strips them as resolver inputs instead of leaking the raw id/`{@id}` onto the node.

### Design
- New `_wire_dataset_aliases` + `_wire_references` helpers in `builder/tools/_crate_mapping.py`, running after `_add_structural`/`_add_processes` so every target (Organization, LabProcess, DefinedTerm, File) is already indexed. Reuses the merged `_wire_reference`/`_resolve_one`/`_resolve_many`/`_append_unique`/`_remove_child` primitives.
- **NEVER fabricates an id (D5):** every reference is resolved from a field already in state; an unresolvable, non-IRI value is dropped rather than guessed.
- Round-trip (`build → read_existing_crate → build`) verified idempotent and structure-preserving — all five wired references survive a rebuild.
- **No new LLM tool** → no four-place registration needed.

### Assays reverse alias
The `assays` (Study/root → Assay children) reverse alias was already satisfied by the existing `_add_structural` `hasPart` wiring (`assays` expands to `schema:hasPart`); regression tests assert it stays reachable. No new wiring was required, so it was not duplicated.

## Tests (TDD)
`tests/test_crate_mapping_references.py` (12 tests, graph-only, offline, no SHACL): root funder (org ref / IRI / absent), root about → DataAnalysis, assay measurementMethod (ref / IRI / no leak), dataFiles/resources (under-assay refs + hasPart reachability + not orphaned on root), and assays reverse-alias regression guards.

## Gate (full suite runs in CI)
```
uv run ruff check                  → All checks passed!
uv run --extra langchain ty check  → All checks passed!
uv run --extra langchain pytest tests/test_crate_mapping_references.py \
  tests/test_readers.py tests/test_builder_domain.py \
  tests/test_crate_mapping_identifiers.py
  → 55 passed (12 + 10 + 22 + 11)
```

## Docs
AGENTS.md §14.4 (lane marked done) + D13 (assay hasPart-family aliases) updated.

## Deferred
- Round-trip File `dest_path` drift (`assays/a/dataset/raw.prism` → `data/raw.prism` on rebuild) is **pre-existing** reader behavior (`read_existing_crate` does not reconstruct File `dest_path` from the node `@id`), orthogonal to this lane and internally consistent within each build.
- Remaining #180 lanes (per AGENTS.md §14.4): CSVW schema extensions (condition-table columns, `raw_measurements`); `set_crate_metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
