### PR TITLE
feat(crate): full condition-table CSVW schema + raw_measurements table (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -654,14 +654,33 @@ with `profile="data"`.
 
 `populate_condition_table` (Issue #144) writes the per-well rows into an
 Exposure's CSVW condition table — replacing the header-only placeholder #94
-materialises — either from a list of row dicts (keyed by the column titles
-`cell_line`/`compound`/`concentration`/`unit`/`duration`) or by attaching a
-user-supplied plate-map CSV. It targets the exact path the build wires
-(`_crate_mapping._condition_table_rel`), so the #94 CSVW typing (`tableSchema`)
-stays attached to the populated table. The companion bridge
-`data_content.csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)` converts those CSVW
-column descriptors into the Frictionless `{fields:[...]}` shape, so `validate_table`
-needs no hand-authored schema for the populated table.
+materialises — either from a list of row dicts (keyed by the condition-table
+column titles) or by attaching a user-supplied plate-map CSV. The condition
+table's typed schema is the gold S-VHPS21 crate's full **10 columns** (#180,
+Lane D): `well_id`, `assay`, `cell_line`, `compound`, `concentration_value`,
+`concentration_unit`, `exposure_duration`, `experiment`, `technical_replicate`,
+`control` — each with a `datatype` + ontology `propertyUrl` (and a `valueUrl`
+resolving the cell-line/compound columns to their in-crate Sample /
+MolecularEntity id). Population fills whatever columns the data provides; the
+schema describes all 10 and missing cells are written empty. It targets the
+exact path the build wires (`_crate_mapping._condition_table_rel`), so the #94
+CSVW typing (`tableSchema`) stays attached to the populated table. The companion
+bridge `data_content.csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)` converts
+those CSVW column descriptors into the Frictionless `{fields:[...]}` shape (the
+single source of truth — `_CONDITION_TABLE_HEADER` is also derived from the
+column constant, so the placeholder header and the typed schema cannot drift),
+so `validate_table` needs no hand-authored schema for the populated table.
+
+An `EndpointReadout` that already emits result file(s) additionally emits a typed
+`raw_measurements.csv` `csvw:Table` (#180, Lane D) — 3 columns (`well_id`,
+`measured_value`, `measured_unit`), typed the same way the condition table is
+(`datatype` + `propertyUrl`). It is **appended** to the readout's results, never
+substituted, so a resultless readout still fires the "MUST have a result" issue
+for `fix_required_issues`. The CSV is header-only — no measurement rows are
+fabricated (D5). Both tables emit `propertyUrl`/`valueUrl` as `{@id}` references
+(not bare strings): RO-Crate 1.2's base profile flags an IRI value used as a
+string when that IRI is also a described entity (e.g. the cell-line `NCIT_C16403`,
+which a `CellLineSample` materialises as a `cell line` `DefinedTerm`).
 
 `build_and_validate` is the agent's primary build/fix loop: it assembles the
 crate from `CrateState` **in memory** and validates the generated JSON-LD
@@ -1248,9 +1267,21 @@ the assay's `hasPart` (un-parented from the root). All five new alias keys
 (`funder`, `measurementMethod`, `studies`, `assays`, `resources`, `dataFiles`,
 `labProcesses`) joined `_REF_FIELDS` so `_scalar_props` strips them as resolver
 inputs rather than leaking the raw id onto the node (D5: an unresolvable, non-IRI
-value is dropped, never guessed). Remaining lanes: CSVW schema extensions
-(condition-table columns, `raw_measurements`); `set_crate_metadata` (fidelity, **not** a
-validity blocker — `datePublished` is auto-set by ro-crate-py).
+value is dropped, never guessed). The **CSVW payload** lane is also **done (#180
+Lane D)** — deterministic build-path wiring, **not** new LLM tools: the Exposure
+condition table grows from 5 to the gold crate's full **10 typed columns**
+(`_crate_mapping._CONDITION_TABLE_COLUMNS`), and an EndpointReadout that already
+emits result file(s) additionally emits a typed `raw_measurements.csv`
+`csvw:Table` (3 columns, `_crate_mapping._synth_raw_measurements`), appended (never
+substituted) so the "MUST have a result" repair contract is untouched. Both
+schemas are built by a shared `_build_csvw_schema` and emit `propertyUrl`/`valueUrl`
+as `{@id}` references (RO-Crate 1.2 flags an IRI-as-string when it is also a
+described entity, e.g. the cell-line `NCIT_C16403` `DefinedTerm`). The header-only
+placeholders never fabricate measurement/well rows (D5). Deferred from Lane D:
+`extend_draft_file_for_source_code` (`@type: [File, SoftwareSourceCode]` +
+`programmingLanguage`). Remaining lanes: `set_crate_metadata` (fidelity, **not** a
+validity blocker — `datePublished` is auto-set by ro-crate-py); Lane E
+characteristics/properties fidelity.
 
 > **Tool-registration contract:** every new LLM tool must be registered in **four**
 > lockstep places — `TOOL_REGISTRY`, `TOOL_SPECS`, the system-prompt "## Your Tools"

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1147,7 +1147,54 @@ def _synth_sample(crate: ROCrate, sid: str, name: str, derives_from: Any = None)
     return Sample(crate, identifier=ident, name=name, properties=props or None)
 
 
-_CONDITION_TABLE_HEADER = "cell_line,compound,concentration,unit,duration\n"
+# Typed CSVW columns for the condition table: each maps a CSV column to an
+# ontology property (propertyUrl) with a declared datatype. The cell-line and
+# compound columns additionally resolve to in-crate entity ids (valueUrl, filled
+# at build time), so the per-well design table is machine-readable rather than a
+# header-only placeholder. The 10-column contract mirrors the gold S-VHPS21 crate
+# (Issue #180, Lane D — extends the original 5-column schema from #94).
+_CONDITION_TABLE_COLUMNS: tuple[dict[str, str], ...] = (
+    {"titles": "well_id", "datatype": "string",
+     "propertyUrl": "http://purl.org/dc/terms/identifier"},
+    {"titles": "assay", "datatype": "string",
+     "propertyUrl": "http://purl.obolibrary.org/obo/NCIT_C60819"},
+    {"titles": "cell_line", "datatype": "string",
+     "propertyUrl": "http://purl.obolibrary.org/obo/NCIT_C16403"},
+    {"titles": "compound", "datatype": "string",
+     "propertyUrl": "http://purl.obolibrary.org/obo/CHEBI_23367"},
+    {"titles": "concentration_value", "datatype": "double",
+     "propertyUrl": "http://purl.obolibrary.org/obo/PATO_0000033"},
+    {"titles": "concentration_unit", "datatype": "string",
+     "propertyUrl": "http://purl.obolibrary.org/obo/IAO_0000039"},
+    {"titles": "exposure_duration", "datatype": "string",
+     "propertyUrl": "https://bioregistry.io/NCIT:C83280"},
+    {"titles": "experiment", "datatype": "string",
+     "propertyUrl": "https://bioregistry.io/EFO:0002091"},
+    {"titles": "technical_replicate", "datatype": "string",
+     "propertyUrl": "https://bioregistry.io/EFO:0002090"},
+    {"titles": "control", "datatype": "string",
+     "propertyUrl": "http://purl.obolibrary.org/obo/NCIT_C28143"},
+)
+
+# Header line (column titles, in order) for the materialised condition-table CSV.
+# Derived from _CONDITION_TABLE_COLUMNS so the placeholder header and the typed
+# CSVW schema can never drift apart.
+_CONDITION_TABLE_HEADER = ",".join(c["titles"] for c in _CONDITION_TABLE_COLUMNS) + "\n"
+
+# Typed CSVW columns for the per-well raw-measurements table emitted as the
+# EndpointReadout's result (Issue #180, Lane D). Typed exactly the way the
+# condition table is (datatype + propertyUrl); the cell-content (measurement
+# rows) is never fabricated — D5 — so the materialised CSV is header-only.
+_RAW_MEASUREMENTS_COLUMNS: tuple[dict[str, str], ...] = (
+    {"titles": "well_id", "datatype": "string",
+     "propertyUrl": "http://purl.org/dc/terms/identifier"},
+    {"titles": "measured_value", "datatype": "double",
+     "propertyUrl": "http://purl.obolibrary.org/obo/IAO_0000109"},
+    {"titles": "measured_unit", "datatype": "string",
+     "propertyUrl": "http://purl.obolibrary.org/obo/IAO_0000039"},
+)
+
+_RAW_MEASUREMENTS_HEADER = ",".join(c["titles"] for c in _RAW_MEASUREMENTS_COLUMNS) + "\n"
 
 
 def _condition_table_rel(exp_pid: str) -> str:
@@ -1158,18 +1205,10 @@ def _condition_table_rel(exp_pid: str) -> str:
     """
     return f"data/{_slug(exp_pid)}_condition_table.csv"
 
-# Typed CSVW columns for the condition table: each maps a CSV column to an
-# ontology property (propertyUrl) with a declared datatype. The cell-line and
-# compound columns additionally resolve to in-crate entity ids (valueUrl, filled
-# at build time), so the per-well design table is machine-readable rather than a
-# header-only placeholder. Issue #94.
-_CONDITION_TABLE_COLUMNS: tuple[dict[str, str], ...] = (
-    {"titles": "cell_line", "datatype": "string", "propertyUrl": "http://schema.org/name"},
-    {"titles": "compound", "datatype": "string", "propertyUrl": "http://schema.org/mentions"},
-    {"titles": "concentration", "datatype": "double", "propertyUrl": "http://schema.org/value"},
-    {"titles": "unit", "datatype": "string", "propertyUrl": "http://schema.org/unitText"},
-    {"titles": "duration", "datatype": "string", "propertyUrl": "http://schema.org/duration"},
-)
+
+def _raw_measurements_rel(er_pid: str) -> str:
+    """Crate-relative path of an EndpointReadout's raw-measurements CSV."""
+    return f"data/{_slug(er_pid)}_raw_measurements.csv"
 
 
 def _node_id(node: Any) -> str | None:
@@ -1177,43 +1216,76 @@ def _node_id(node: Any) -> str | None:
     return getattr(node, "id", None)
 
 
+def _build_csvw_schema(
+    crate: ROCrate,
+    *,
+    schema_id: str,
+    schema_name: str,
+    id_prefix: str,
+    columns: tuple[dict[str, str], ...],
+    value_urls: dict[str, str | None] | None = None,
+) -> ContextEntity:
+    """Build a ``csvw:Schema`` entity from a tuple of typed column descriptors.
+
+    Each column is emitted as a ``csvw:Column`` graph node (ro-crate-py requires
+    nested objects to be referenceable entities, not inline dicts) carrying its
+    ``datatype`` and ``propertyUrl``. Columns named in ``value_urls`` additionally
+    get a ``valueUrl`` resolving to an in-crate entity id (emitted as an ``{@id}``
+    reference). Shared by the condition table and the raw-measurements table so
+    both are typed the same way (Issue #180, Lane D).
+    """
+    value_urls = value_urls or {}
+    schema = crate.add(
+        ContextEntity(
+            crate,
+            schema_id,
+            properties={
+                "@type": ["csvw:Schema", "CreativeWork"],
+                "name": schema_name,
+            },
+        )
+    )
+    for col in columns:
+        title = col["titles"]
+        props: dict[str, Any] = {"@type": "csvw:Column", **col}
+        # Emit propertyUrl as an {@id} reference rather than a bare string:
+        # RO-Crate 1.2's base profile flags an IRI value used as a string when
+        # that IRI is also a described entity (e.g. the cell-line NCIT_C16403,
+        # which a CellLineSample materialises as a `cell line` DefinedTerm). The
+        # CSVW range of propertyUrl is a URI, so an {@id} is the faithful form.
+        if col.get("propertyUrl"):
+            props["propertyUrl"] = {"@id": col["propertyUrl"]}
+        if value_urls.get(title):
+            # Same rule for valueUrl: emit the resolved Sample / MolecularEntity
+            # link as an {@id} reference, never a bare string @id.
+            props["valueUrl"] = {"@id": value_urls[title]}
+        column = crate.add(
+            ContextEntity(crate, f"{id_prefix}_col_{title}", properties=props)
+        )
+        schema.append_to("columns", column)
+    return schema
+
+
 def _build_condition_table_schema(
     crate: ROCrate, exp_slug: str, cells: list[Any], chems: list[Any]
 ) -> ContextEntity:
     """The csvw:Schema entity describing the condition table's typed columns.
 
-    Each column is a ``csvw:Column`` graph node (ro-crate-py requires nested
-    objects to be referenceable entities, not inline dicts) carrying a datatype
-    and propertyUrl. The cell-line and compound columns additionally carry a
-    ``valueUrl`` resolving to the in-crate Sample / MolecularEntity id, so a
-    row's value maps to its entity.
+    The cell-line and compound columns resolve their ``valueUrl`` to the in-crate
+    Sample / MolecularEntity id, so a row's value maps to its entity (#94, #180).
     """
-    value_urls = {
+    value_urls: dict[str, str | None] = {
         "cell_line": _node_id(cells[0]) if cells else None,
         "compound": _node_id(chems[0]) if chems else None,
     }
-    schema = crate.add(
-        ContextEntity(
-            crate,
-            f"#{exp_slug}_condition_table_schema",
-            properties={
-                "@type": ["csvw:Schema", "CreativeWork"],
-                "name": "Condition table schema",
-            },
-        )
+    return _build_csvw_schema(
+        crate,
+        schema_id=f"#{exp_slug}_condition_table_schema",
+        schema_name="Condition table schema",
+        id_prefix=f"#{exp_slug}",
+        columns=_CONDITION_TABLE_COLUMNS,
+        value_urls=value_urls,
     )
-    for col in _CONDITION_TABLE_COLUMNS:
-        title = col["titles"]
-        props: dict[str, Any] = {"@type": "csvw:Column", **col}
-        if value_urls.get(title):
-            # Emit valueUrl as an {@id} reference (not a bare string): RO-Crate 1.2
-            # REQUIRES entity links be reference objects, and flags string @ids.
-            props["valueUrl"] = {"@id": value_urls[title]}
-        column = crate.add(
-            ContextEntity(crate, f"#{exp_slug}_col_{title}", properties=props)
-        )
-        schema.append_to("columns", column)
-    return schema
 
 
 def _synth_condition_table(
@@ -1269,6 +1341,78 @@ def _synth_condition_table(
     # conformsTo (RO-Crate conformance — not a bare inline tableSchema dict).
     # Issue #94.
     schema = _build_condition_table_schema(crate, _slug(exp_pid), cells, chems)
+    table["tableSchema"] = {"@id": schema.id}
+    table.append_to("conformsTo", schema)
+    return table
+
+
+def _add_csvw_table_file(
+    crate: ROCrate,
+    output_dir: Path | None,
+    *,
+    rel: str,
+    name: str,
+    header: str,
+    materialize_payload: bool,
+) -> File:
+    """Add a ``File`` that is also a ``csvw:Table``, materialising a header-only CSV.
+
+    Shared by the condition table and the raw-measurements table: a bare
+    ``csvw:Table`` is rejected by the ISA shape, so the node is a ``File`` (a valid
+    process result) carrying only its header row in-payload — measurement / well
+    rows are never fabricated (D5). The in-memory validate path skips the write.
+    """
+    source: str | None = None
+    if materialize_payload and output_dir is not None:
+        dest = output_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if not dest.exists():
+            dest.write_text(header, encoding="utf-8")
+        # Point source at the file we just wrote so ro-crate-py records it as
+        # payload (its _copy_file no-ops when source and dest are the same file).
+        source = str(dest)
+    return crate.add(
+        File(
+            crate,
+            source,
+            dest_path=rel,
+            properties={"@type": ["File", "csvw:Table"], "name": name},
+        )
+    )
+
+
+def _synth_raw_measurements(
+    crate: ROCrate,
+    output_dir: Path | None,
+    er_pid: str,
+    *,
+    materialize_payload: bool = True,
+) -> File:
+    """An EndpointReadout's typed per-well raw-measurements ``csvw:Table``.
+
+    Emitted *alongside* the process's explicit result file(s) — never as a
+    substitute — so the "EndpointReadout MUST have a result" repair contract
+    (resultless readouts still fire the issue) is untouched. Typed the same way as
+    the condition table: a ``File``/``csvw:Table`` linked to a ``csvw:Schema``
+    whose 3 columns carry datatype + propertyUrl. The CSV is header-only; no
+    measurement rows are fabricated (D5). Issue #180, Lane D.
+    """
+    rel = _raw_measurements_rel(er_pid)
+    table = _add_csvw_table_file(
+        crate,
+        output_dir,
+        rel=rel,
+        name="Raw measurements",
+        header=_RAW_MEASUREMENTS_HEADER,
+        materialize_payload=materialize_payload,
+    )
+    schema = _build_csvw_schema(
+        crate,
+        schema_id=f"#{_slug(er_pid)}_raw_measurements_schema",
+        schema_name="Raw measurements schema",
+        id_prefix=f"#{_slug(er_pid)}_raw",
+        columns=_RAW_MEASUREMENTS_COLUMNS,
+    )
     table["tableSchema"] = {"@id": schema.id}
     table.append_to("conformsTo", schema)
     return table
@@ -1384,13 +1528,25 @@ def _build_process(
         )
 
     if ptype == "EndpointReadout":
+        # When the readout already emits result file(s), additionally synthesize a
+        # typed raw-measurements csvw:Table alongside them (mirroring the gold
+        # crate's EndpointReadout → raw_measurements.csv; Issue #180, Lane D). It
+        # is appended, never substituted, so a resultless readout still fires the
+        # "MUST have a result" issue for the deterministic repair loop (#179).
+        er_result = list(result)
+        if er_result:
+            er_result.append(
+                _synth_raw_measurements(
+                    crate, output_dir, pid, materialize_payload=materialize_payload
+                )
+            )
         return LabProcessEndpointReadout(
             crate,
             identifier=pid,
             name=name,
             samples=(samples or obj or None),
             labprotocol=protocol,
-            result=result,
+            result=er_result,
             detection_instrument=f.get("detection_instrument", "unknown"),
             instrument_manufacturer=f.get("instrument_manufacturer", "unknown"),
             measured_entity=f.get("measured_entity", "unknown"),

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -208,9 +208,10 @@ class TestLabProcessSubtypes:
         assert "#MolecularEntity_chem_1" in _ids(table.get("about"))
 
     def test_exposure_condition_table_is_typed_csvw(self, tmp_path):
-        # Issue #94: the condition table must be typed CSVW — a linked schema
-        # entity with per-column datatype + propertyUrl, the cell-line/compound
-        # columns resolving to their entity ids (valueUrl).
+        # Issue #94 / #180: the condition table must be typed CSVW — a linked
+        # schema entity with the gold crate's full 10-column schema, each column
+        # carrying datatype + propertyUrl, the cell-line/compound columns
+        # resolving to their entity ids (valueUrl).
         state = self._state_with_process(
             "Exposure",
             samples="sample_cult",
@@ -232,7 +233,18 @@ class TestLabProcessSubtypes:
 
         cols = [by_id[cid] for cid in _ids(schema.get("columns"))]
         by_title = {c["titles"]: c for c in cols}
-        assert set(by_title) == {"cell_line", "compound", "concentration", "unit", "duration"}
+        assert set(by_title) == {
+            "well_id",
+            "assay",
+            "cell_line",
+            "compound",
+            "concentration_value",
+            "concentration_unit",
+            "exposure_duration",
+            "experiment",
+            "technical_replicate",
+            "control",
+        }
         # every column is typed: datatype + propertyUrl
         for col in by_title.values():
             assert col["datatype"]

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -37,20 +37,36 @@ def test_csvw_to_frictionless_maps_columns():
     schema = csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)
     assert "fields" in schema
     names = [f["name"] for f in schema["fields"]]
-    assert names == ["cell_line", "compound", "concentration", "unit", "duration"]
+    # The full 10-column condition-table schema (Issue #180, Lane D).
+    assert names == [
+        "well_id",
+        "assay",
+        "cell_line",
+        "compound",
+        "concentration_value",
+        "concentration_unit",
+        "exposure_duration",
+        "experiment",
+        "technical_replicate",
+        "control",
+    ]
     by_name = {f["name"]: f for f in schema["fields"]}
     # double -> number, string -> string (Frictionless types)
-    assert by_name["concentration"]["type"] == "number"
+    assert by_name["concentration_value"]["type"] == "number"
     assert by_name["cell_line"]["type"] == "string"
 
 
 def test_populate_condition_table_writes_rows(tmp_path):
     state = _exposure_state()
+    # Population fills whatever columns the data provides; the schema describes
+    # all 10, missing columns are written empty (extrasaction="ignore").
     rows = [
-        {"cell_line": "HepG2", "compound": "Aspirin", "concentration": "10",
-         "unit": "uM", "duration": "24h"},
-        {"cell_line": "HepG2", "compound": "Aspirin", "concentration": "100",
-         "unit": "uM", "duration": "24h"},
+        {"well_id": "A1", "cell_line": "HepG2", "compound": "Aspirin",
+         "concentration_value": "10", "concentration_unit": "uM",
+         "exposure_duration": "24h"},
+        {"well_id": "A2", "cell_line": "HepG2", "compound": "Aspirin",
+         "concentration_value": "100", "concentration_unit": "uM",
+         "exposure_duration": "24h"},
     ]
     result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
     assert result["ok"] is True
@@ -58,15 +74,17 @@ def test_populate_condition_table_writes_rows(tmp_path):
     with open(csv_path, newline="", encoding="utf-8") as fh:
         reader = list(csv.DictReader(fh))
     assert len(reader) == 2
-    assert reader[0]["concentration"] == "10"
-    assert reader[1]["concentration"] == "100"
+    assert reader[0]["concentration_value"] == "10"
+    assert reader[1]["concentration_value"] == "100"
+    assert reader[0]["well_id"] == "A1"
 
 
 def test_populated_table_validates_with_inferred_schema(tmp_path):
     state = _exposure_state()
     rows = [
-        {"cell_line": "HepG2", "compound": "Aspirin", "concentration": "10",
-         "unit": "uM", "duration": "24h"},
+        {"well_id": "A1", "cell_line": "HepG2", "compound": "Aspirin",
+         "concentration_value": "10", "concentration_unit": "uM",
+         "exposure_duration": "24h"},
     ]
     result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
     schema = csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)

--- a/tests/test_csvw_payload.py
+++ b/tests/test_csvw_payload.py
@@ -1,0 +1,279 @@
+"""Tests for the CSVW payload lane (Issue #180, Lane D).
+
+Two deterministic build-path enhancements (no new LLM tools):
+
+(a) The Exposure condition table grows from the original 5 columns to the gold
+    crate's full 10-column typed CSVW schema (``well_id``, ``assay``,
+    ``cell_line``, ``compound``, ``concentration_value``, ``concentration_unit``,
+    ``exposure_duration``, ``experiment``, ``technical_replicate``, ``control``),
+    each carrying ``datatype`` + ``propertyUrl`` (and ``valueUrl`` for the
+    cell-line / compound columns).
+
+(b) An EndpointReadout that already emits result file(s) additionally emits a
+    typed ``raw_measurements.csv`` ``csvw:Table`` (3 columns: ``well_id``,
+    ``measured_value``, ``measured_unit``) — typed the same way the condition
+    table is. No measurement rows are fabricated (D5): the CSV is a header-only
+    placeholder carrying its machine-readable schema.
+
+Graph-only assertions (no ``build_and_validate``) so the suite stays fast.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rocrate.rocrate import ROCrate
+
+from builder.state import CrateState, Entity, EntityProvenance, EntityType
+from builder.tools._crate_mapping import (
+    _CONDITION_TABLE_COLUMNS,
+    _RAW_MEASUREMENTS_COLUMNS,
+    populate_crate,
+)
+from builder.tools.validation import build_and_validate
+from profiles.context import ISA_TOX_CONTEXT
+
+# Only the build-and-validate test below is heavy; mark the module so it cannot
+# hang CI.
+pytestmark = pytest.mark.timeout(120)
+
+
+def _ent(entity_id: str, type_: EntityType, **fields: object) -> Entity:
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+def _assemble(state: CrateState) -> list[dict]:
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, None, materialize_payload=False)
+    return crate.metadata.generate()["@graph"]
+
+
+def _by_id(graph: list[dict]) -> dict[str, dict]:
+    return {str(e.get("@id", "")): e for e in graph}
+
+
+def _ids(value: object) -> list[str]:
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [str(v.get("@id")) if isinstance(v, dict) else str(v) for v in items]
+
+
+def _iri(value: object) -> object:
+    """Unwrap a possibly-{@id} value to its IRI string."""
+    if isinstance(value, dict):
+        return value.get("@id")
+    return value
+
+
+# --- Expected gold-crate column contracts -----------------------------------
+
+_EXPECTED_CONDITION_COLUMNS = [
+    ("well_id", "string", "http://purl.org/dc/terms/identifier", None),
+    ("assay", "string", "http://purl.obolibrary.org/obo/NCIT_C60819", None),
+    ("cell_line", "string", "http://purl.obolibrary.org/obo/NCIT_C16403", "cell_line"),
+    ("compound", "string", "http://purl.obolibrary.org/obo/CHEBI_23367", "compound"),
+    ("concentration_value", "double", "http://purl.obolibrary.org/obo/PATO_0000033", None),
+    ("concentration_unit", "string", "http://purl.obolibrary.org/obo/IAO_0000039", None),
+    ("exposure_duration", "string", "https://bioregistry.io/NCIT:C83280", None),
+    ("experiment", "string", "https://bioregistry.io/EFO:0002091", None),
+    ("technical_replicate", "string", "https://bioregistry.io/EFO:0002090", None),
+    ("control", "string", "http://purl.obolibrary.org/obo/NCIT_C28143", None),
+]
+
+_EXPECTED_RAW_COLUMNS = [
+    ("well_id", "string", "http://purl.org/dc/terms/identifier"),
+    ("measured_value", "double", "http://purl.obolibrary.org/obo/IAO_0000109"),
+    ("measured_unit", "string", "http://purl.obolibrary.org/obo/IAO_0000039"),
+]
+
+
+# --- (a) Condition-table 10-column schema -----------------------------------
+
+
+def test_condition_table_columns_constant_matches_gold():
+    """The hardcoded column constant is the gold crate's 10-column contract."""
+    got = [
+        (
+            c["titles"],
+            c["datatype"],
+            c["propertyUrl"],
+        )
+        for c in _CONDITION_TABLE_COLUMNS
+    ]
+    want = [(t, d, p) for (t, d, p, _v) in _EXPECTED_CONDITION_COLUMNS]
+    assert got == want
+
+
+def _exposure_state() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Exposure crate"
+    state.add_entity(_ent("assay_1", "Assay", name="A"))
+    state.add_entity(
+        _ent(
+            "proc_exp",
+            "LabProcess",
+            name="Exposure step",
+            process_type="Exposure",
+            assay_id="assay_1",
+            samples="sample_cult",
+            chemicals="chem_1",
+        )
+    )
+    state.add_entity(_ent("sample_cult", "Sample", name="cultured"))
+    state.add_entity(_ent("chem_1", "MolecularEntity", name="Silychristin A"))
+    return state
+
+
+def test_condition_table_emits_ten_typed_csvw_columns():
+    by_id = _by_id(_assemble(_exposure_state()))
+    table = next(
+        e for e in by_id.values()
+        if str(e.get("@id", "")).endswith("condition_table.csv")
+    )
+    schema_ids = [s for s in _ids(table.get("conformsTo")) if "schema" in str(s)]
+    assert schema_ids
+    schema = by_id[schema_ids[0]]
+    cols = [by_id[cid] for cid in _ids(schema.get("columns"))]
+    by_title = {c["titles"]: c for c in cols}
+
+    assert [c["titles"] for c in cols] == [
+        t for (t, _d, _p, _v) in _EXPECTED_CONDITION_COLUMNS
+    ]
+    for title, datatype, prop, _vt in _EXPECTED_CONDITION_COLUMNS:
+        col = by_title[title]
+        assert col["@type"] == "csvw:Column"
+        assert col["datatype"] == datatype
+        # propertyUrl is emitted as an {@id} reference (RO-Crate 1.2).
+        assert _iri(col["propertyUrl"]) == prop
+
+
+def test_condition_table_value_urls_resolve_to_entities():
+    """cell_line / compound columns still resolve their valueUrl to entity ids."""
+    by_id = _by_id(_assemble(_exposure_state()))
+    table = next(
+        e for e in by_id.values()
+        if str(e.get("@id", "")).endswith("condition_table.csv")
+    )
+    schema = by_id[[s for s in _ids(table.get("conformsTo")) if "schema" in str(s)][0]]
+    cols = {by_id[cid]["titles"]: by_id[cid] for cid in _ids(schema.get("columns"))}
+    assert "#MolecularEntity_chem_1" in str(cols["compound"].get("valueUrl"))
+    assert "#Sample_sample_cult" in str(cols["cell_line"].get("valueUrl"))
+
+
+# --- (b) raw_measurements typed csvw:Table ----------------------------------
+
+
+def test_raw_measurements_columns_constant_matches_gold():
+    got = [(c["titles"], c["datatype"], c["propertyUrl"]) for c in _RAW_MEASUREMENTS_COLUMNS]
+    assert got == _EXPECTED_RAW_COLUMNS
+
+
+def _endpoint_readout_state() -> CrateState:
+    state = CrateState()
+    state.add_entity(_ent("assay_1", "Assay", name="A"))
+    state.add_entity(
+        _ent(
+            "proc_er",
+            "LabProcess",
+            name="Endpoint Readout",
+            process_type="EndpointReadout",
+            assay_id="assay_1",
+            samples="sample_x",
+            result="file_raw",
+            endpoint="viability",
+        )
+    )
+    state.add_entity(_ent("sample_x", "Sample", name="exposed"))
+    state.add_entity(
+        _ent("file_raw", "File", name="raw.csv", dest_path="data/raw.csv")
+    )
+    return state
+
+
+def test_endpoint_readout_emits_typed_raw_measurements_table():
+    by_id = _by_id(_assemble(_endpoint_readout_state()))
+    proc = by_id["#LabProcess_proc_er"]
+    out_ids = _ids(proc.get("output"))
+    # Explicit result file is preserved …
+    assert "data/raw.csv" in out_ids
+    # … and a typed raw_measurements table is emitted alongside it.
+    rm_ids = [i for i in out_ids if str(i).endswith("raw_measurements.csv")]
+    assert rm_ids, f"expected a raw_measurements.csv output, got {out_ids}"
+    rm = by_id[rm_ids[0]]
+    tt = rm["@type"] if isinstance(rm["@type"], list) else [rm["@type"]]
+    assert "File" in tt and "csvw:Table" in tt
+
+
+def test_raw_measurements_schema_has_three_typed_columns():
+    by_id = _by_id(_assemble(_endpoint_readout_state()))
+    proc = by_id["#LabProcess_proc_er"]
+    rm_id = next(
+        i for i in _ids(proc.get("output")) if str(i).endswith("raw_measurements.csv")
+    )
+    rm = by_id[rm_id]
+    schema_ids = [s for s in _ids(rm.get("conformsTo")) if "schema" in str(s)]
+    assert schema_ids, "raw_measurements must conformTo a schema entity"
+    schema = by_id[schema_ids[0]]
+    stype = schema["@type"] if isinstance(schema["@type"], list) else [schema["@type"]]
+    assert "csvw:Schema" in stype
+    cols = [by_id[cid] for cid in _ids(schema.get("columns"))]
+    got = [(c["titles"], c["datatype"], _iri(c["propertyUrl"])) for c in cols]
+    assert got == _EXPECTED_RAW_COLUMNS
+    for c in cols:
+        assert c["@type"] == "csvw:Column"
+
+
+def test_endpoint_readout_with_raw_measurements_validates_clean():
+    """The synthesized raw_measurements csvw:Table passes full ISA-Tox SHACL."""
+    state = CrateState()
+    state.metadata.title = "Readout crate"
+    state.add_entity(_ent("inv_1", "Investigation", name="Inv"))
+    state.add_entity(_ent("study_1", "Study", name="Study", investigation_id="inv_1"))
+    state.add_entity(_ent("assay_1", "Assay", name="Assay", study_id="study_1"))
+    state.add_entity(
+        _ent(
+            "proc_er",
+            "LabProcess",
+            name="Endpoint Readout",
+            process_type="EndpointReadout",
+            assay_id="assay_1",
+            samples="sample_x",
+            result="file_raw",
+            endpoint="viability",
+            detection_instrument="plate reader",
+        )
+    )
+    state.add_entity(_ent("sample_x", "Sample", name="exposed"))
+    state.add_entity(_ent("file_raw", "File", name="raw.csv", dest_path="data/raw.csv"))
+
+    result = build_and_validate(state, severity="required")
+    assert result["ok"] is True, result["issues"]
+    assert result["conformance"] == {"base": True, "isa": True, "tox": True}
+
+
+def test_endpoint_readout_without_result_emits_no_raw_measurements():
+    """No explicit result => no synthesized table (D5; preserves repair contract)."""
+    state = CrateState()
+    state.add_entity(_ent("assay_1", "Assay", name="A"))
+    state.add_entity(
+        _ent(
+            "proc_er",
+            "LabProcess",
+            name="Endpoint Readout",
+            process_type="EndpointReadout",
+            assay_id="assay_1",
+            samples="sample_x",
+            endpoint="viability",
+        )
+    )
+    state.add_entity(_ent("sample_x", "Sample", name="exposed"))
+    by_id = _by_id(_assemble(state))
+    proc = by_id["#LabProcess_proc_er"]
+    out_ids = _ids(proc.get("output"))
+    assert not any(str(i).endswith("raw_measurements.csv") for i in out_ids), out_ids


### PR DESCRIPTION
Lane D of the #180 toolbox-completion track — a deterministic **build-path** enhancement (no new LLM tools), bringing the crate's CSVW payload typing in line with the gold S-VHPS21 crate.

## Changes
- **Condition table: 5 → 10 typed CSVW columns** (`builder/tools/_crate_mapping.py::_CONDITION_TABLE_COLUMNS`). The gold crate's full schema — `well_id`, `assay`, `cell_line`, `compound`, `concentration_value`, `concentration_unit`, `exposure_duration`, `experiment`, `technical_replicate`, `control` — each carrying `datatype` + ontology `propertyUrl` (and a `valueUrl` resolving the cell-line/compound columns to their in-crate Sample / MolecularEntity id). `_CONDITION_TABLE_HEADER` is now **derived** from the column constant, so the placeholder header, the Frictionless bridge (`csvw_to_frictionless`), and the typed schema are a single source of truth and cannot drift.
- **`raw_measurements.csv` typed `csvw:Table`** (`_synth_raw_measurements`). An EndpointReadout that already emits result file(s) additionally emits a 3-column (`well_id`, `measured_value`, `measured_unit`) typed table, **appended** to its results — never substituted — so the "EndpointReadout MUST have a result" `fix_required_issues` repair contract (#179) is untouched. Header-only: **no measurement rows are fabricated (D5)**.
- **Shared `_build_csvw_schema` / `_add_csvw_table_file`** so both tables are typed identically.
- **`propertyUrl`/`valueUrl` emitted as `{@id}` references.** RO-Crate 1.2's base profile flags an IRI value used as a string when that IRI is also a *described entity* — the new `cell_line` propertyUrl `NCIT_C16403` collides with the `cell line` `DefinedTerm` a `CellLineSample` materialises. Emitting the URI-valued CSVW terms as `{@id}` is both the validator-clean and CSVW-faithful form. Verified: full crate validates `{base, isa, tox}` all true, zero issues.

## Tests
- New `tests/test_csvw_payload.py`: graph-only column-contract assertions (10 condition columns, 3 raw-measurements columns, datatype/propertyUrl/valueUrl), the appended-not-substituted + resultless-emits-nothing contracts, and one timeout-marked `build_and_validate` clean-conformance check.
- Updated existing 5-column assertions to the 10-column reality: `tests/test_builder_domain.py::test_exposure_condition_table_is_typed_csvw`, `tests/test_condition_table.py` (`csvw_to_frictionless` map + `populate_condition_table` rows).

## Gate (all green)
- `uv run ruff check` — All checks passed!
- `uv run --extra langchain ty check` — All checks passed!
- `uv run --extra langchain pytest` over every touched condition-table / data-content / payload / process / graph test (198 passed), incl. the `test_vhps_fixtures` golden-crate full-validation gate.

## Build-path, not a new tool
Per §14's "prefer the deterministic build path" and the prompt's "prefer NO new LLM tools" — zero changes to the tool registry / TOOL_SPECS / system prompt.

## Deferred
- `extend_draft_file_for_source_code` (`@type: [File, SoftwareSourceCode]` + `programmingLanguage`) — the third Lane D item, out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)