### PR TITLE
feat(crate): cell-line characteristics, DataAnalysis property & SoftwareSourceCode typing (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,7 +491,7 @@ draft_organization(name: str, hints: dict) → Entity
 draft_publication(doi: str, hints: dict) → Entity
 draft_defined_term(name: str, hints: dict) → Entity
 draft_property_value(name: str, hints: dict) → Entity
-draft_file(name: str, path=None, role=None, encoding_format=None) → Entity
+draft_file(name: str, path=None, role=None, encoding_format=None, additional_types=None, programming_language=None) → Entity
 ```
 `draft_defined_term` persists a looked-up ontology / AOP / Key-Event term as a
 `schema:DefinedTerm` contextual entity (Issue #141): pass the looked-up IRI as the
@@ -529,9 +529,15 @@ subtype parameters (`assay_kit`/`substrate` for EndpointReadout,
 `_build_process` threads `units=f.get('units')` into the Exposure /
 EndpointReadout / DataAnalysis constructors so each `ParameterValue` carries its
 `unitText`, and threads the optional params into the matching subtype. A
-`CellLineSample`'s `passage` / `growth` hints are promoted to ISA Sample
-Characteristics — `schema:additionalProperty` PropertyValue nodes carrying the
-value and, when known, the property's ontology IRI.
+`CellLineSample`'s `passage` / `growth` / `organ` / `tissue` hints are promoted to
+ISA Sample Characteristics — `schema:additionalProperty` PropertyValue nodes
+carrying the value and, when known, the property's ontology IRI (`organ` / `tissue`
+mirror the gold crate's `Organ` / `Tissue` characteristics with the ISA-Tox
+`param/{organ,tissue}` `propertyID`; Issue #180). A `LabProcess`'s
+`additionalProperty` field is likewise resolved to its in-state PropertyValue
+reference(s) at build time (gold `#report_analysis` → `[#pv_repro_score]`) — only
+PropertyValues already present in state (or bare IRIs) are wired; a score is never
+computed or fabricated here (D5).
 
 **Looked-up identifiers round-trip as `schema:PropertyValue` nodes** (Issue #180,
 deterministic build path — no new LLM tools). `_crate_mapping._identifier_pv(name,
@@ -559,7 +565,12 @@ DOI/PubMedID PropertyValue passes the tox pass instead of silently failing.
 MIME registry the scanner uses — so `run.mzML` becomes `application/x-mzml` and
 `acquisition.fcs` becomes `application/vnd.isac.fcs` rather than being left blank
 or mislabeled `text/plain`. An explicit `encoding_format` always wins; an
-extensionless name leaves the field unset.
+extensionless name leaves the field unset. `additional_types` co-types the node
+beyond plain `File` (Issue #180) — passing `["SoftwareSourceCode"]` plus
+`programming_language="Python"` makes an analysis script a `@type:[File,
+SoftwareSourceCode]` data entity with `schema:programmingLanguage` (gold
+`plot.py`); both are consumed structurally (`File` is always the leading type and
+duplicates are dropped), and a plain File keeps its scalar `@type`.
 
 ### Entity Management Tools
 ```
@@ -1277,11 +1288,24 @@ substituted) so the "MUST have a result" repair contract is untouched. Both
 schemas are built by a shared `_build_csvw_schema` and emit `propertyUrl`/`valueUrl`
 as `{@id}` references (RO-Crate 1.2 flags an IRI-as-string when it is also a
 described entity, e.g. the cell-line `NCIT_C16403` `DefinedTerm`). The header-only
-placeholders never fabricate measurement/well rows (D5). Deferred from Lane D:
-`extend_draft_file_for_source_code` (`@type: [File, SoftwareSourceCode]` +
-`programmingLanguage`). Remaining lanes: `set_crate_metadata` (fidelity, **not** a
-validity blocker — `datePublished` is auto-set by ro-crate-py); Lane E
-characteristics/properties fidelity.
+placeholders never fabricate measurement/well rows (D5). The
+**characteristics/properties fidelity** lane is also **done (#180 Lane E)** —
+deterministic build-path enhancements (no new LLM tools, plus one existing-tool
+signature extension): (1) a `CellLineSample`'s `organ` / `tissue` hints join
+`passage` / `growth` as `schema:additionalProperty` PropertyValue characteristics,
+carrying the ISA-Tox `param/{organ,tissue}` `propertyID` (gold
+`#SampleCell_MDCK1`); (2) a `LabProcess`'s `additionalProperty` field is resolved
+to its in-state PropertyValue reference(s) (gold `#report_analysis` →
+`[#pv_repro_score]`) via `_wire_references` — only PropertyValues already in state
+(or bare IRIs) are wired, never a fabricated score (D5); (3)
+`extend_draft_file_for_source_code` landed as new `draft_file` params
+`additional_types` + `programming_language`, co-typing an analysis script as
+`@type:[File, SoftwareSourceCode]` with `schema:programmingLanguage` (gold
+`plot.py`). **Deferred:** `set_crate_metadata` (`releaseDate` / `dateModified` on
+the root) — it requires new `CrateState.metadata` fields **and** a new four-place
+LLM tool, and it is a fidelity nicety, **not** a validity blocker
+(`datePublished` is auto-set by ro-crate-py); deferred to keep this a cohesive,
+build-path-only change.
 
 > **Tool-registration contract:** every new LLM tool must be registered in **four**
 > lockstep places — `TOOL_REGISTRY`, `TOOL_SPECS`, the system-prompt "## Your Tools"

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -35,7 +35,7 @@ Entity drafting:
 - draft_publication: Create a Publication entity
 - draft_defined_term: Persist a looked-up ontology/AOP/Key-Event term as a DefinedTerm entity
 - draft_property_value: Create a typed PropertyValue (key/value with optional unit and ontology id)
-- draft_file: Create a File data entity (raw measurements, processed results, figures)
+- draft_file: Create a File data entity (raw measurements, processed results, figures); pass additional_types=['SoftwareSourceCode'] + programming_language for an analysis script
 
 Entity management & provenance:
 - set_fields: Set one or more fields on an existing entity (the single mutation tool)

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -118,7 +118,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_file",
-        "description": "Create a File data entity (raw measurements, processed results, figures). Use this so a process can take the file as input/output via `link` — the agent had no other way to create a File. Returns the File entity.",
+        "description": "Create a File data entity (raw measurements, processed results, figures, analysis scripts). Use this so a process can take the file as input/output via `link` — the agent had no other way to create a File. For a source-code file pass additional_types=['SoftwareSourceCode'] and programming_language (e.g. 'Python') so it is typed @type:[File, SoftwareSourceCode]. Returns the File entity.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -126,6 +126,8 @@ TOOL_SPECS = [
                 "path": {"type": "string", "description": "Crate-relative path (dest_path), e.g. 'data/raw.csv' (optional)"},
                 "role": {"type": "string", "description": "Role label, e.g. 'raw_data' or 'figure' (optional)"},
                 "encoding_format": {"type": "string", "description": "IANA media type, e.g. 'text/csv' (optional)"},
+                "additional_types": {"type": "array", "items": {"type": "string"}, "description": "Extra @type term(s) alongside File, e.g. ['SoftwareSourceCode'] for an analysis script (optional)"},
+                "programming_language": {"type": "string", "description": "schema:programmingLanguage for a source-code file, e.g. 'Python' (optional)"},
             },
             "required": ["name"],
         },

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -76,6 +76,11 @@ _REF_FIELDS = frozenset(
         "about",
         # schema:about alias for a Study/Assay's LabProcess list (PageTab-aligned).
         "labProcesses",
+        # schema:additionalProperty — PropertyValue reference(s) wired onto a
+        # LabProcess (#180, gold #report_analysis). Held here so _scalar_props
+        # strips the raw id/{@id} rather than leaking it onto the node; it is
+        # re-emitted as a resolved reference by _add_processes.
+        "additionalProperty",
         # schema:funder — root/Investigation funding Organization reference(s).
         "funder",
         # schema:measurementMethod — the Assay's BAO method DefinedTerm reference.
@@ -344,9 +349,16 @@ _STRUCT_FIELDS = frozenset(
         "substrate",
         "acceptance_criteria",
         "evaluation_criteria",
-        # CellLineSample characteristics promoted to additionalProperty (#143).
+        # CellLineSample characteristics promoted to additionalProperty PropertyValue
+        # nodes (#143 passage/growth, #180 organ/tissue) — consumed structurally,
+        # never emitted as raw literals on the Sample node.
         "passage",
         "growth",
+        "organ",
+        "tissue",
+        # draft_file's extra @type term(s) — consumed to co-type the File node
+        # (#180, e.g. SoftwareSourceCode), never emitted as a literal property.
+        "additional_types",
     }
 )
 
@@ -664,34 +676,59 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
 
 
 # CellLineSample fields promoted to schema:additionalProperty Characteristic
-# PropertyValue nodes (ISA Sample Characteristics): name -> propertyID IRI (#143).
-_CELL_LINE_CHARACTERISTICS: dict[str, str | None] = {
-    "passage": "https://bioregistry.io/EFO:0007061",  # passage number
-    "growth": "http://www.bioassayontology.org/bao#BAO_0002648",  # growth properties
-}
+# PropertyValue nodes (ISA Sample Characteristics; #143, #180).
+#
+# Each entry maps the recognised state field (plus any drafter aliases) to the
+# PropertyValue's display ``name`` and its ``propertyID`` ontology IRI. ``organ``
+# and ``tissue`` mirror the gold crate's #SampleCell_MDCK1 characteristics
+# (PropertyValue "Organ"/"Tissue" with the ISA-Tox ``param/{organ,tissue}``
+# propertyID); ``passage``/``growth`` keep their lower-case ISA names (#143).
+@dataclass(frozen=True)
+class _Characteristic:
+    aliases: tuple[str, ...]  # candidate state field names (first non-empty wins)
+    name: str  # PropertyValue display name
+    property_id: str | None  # ontology IRI for propertyID, or None
+
+
+_CELL_LINE_CHARACTERISTICS: tuple[_Characteristic, ...] = (
+    _Characteristic(("passage",), "passage", "https://bioregistry.io/EFO:0007061"),
+    _Characteristic(
+        ("growth",), "growth", "http://www.bioassayontology.org/bao#BAO_0002648"
+    ),
+    _Characteristic(
+        ("organ",), "Organ", f"{PROFILE_ISATOX}/param/organ"
+    ),
+    _Characteristic(
+        ("tissue",), "Tissue", f"{PROFILE_ISATOX}/param/tissue"
+    ),
+)
+# NB: the field names above (passage/growth/organ/tissue) are also listed in
+# _STRUCT_FIELDS so _scalar_props strips them from the Sample node — they round-trip
+# only as additionalProperty PropertyValue characteristics, never as raw literals.
 
 
 def _cell_line_characteristics(crate: ROCrate, cl: Entity) -> list[Any]:
     """Build CharacteristicValue (PropertyValue) nodes for a CellLineSample.
 
-    Promotes recognised culture-characteristic fields (``passage``, ``growth``)
-    to ISA Sample Characteristics — schema:additionalProperty PropertyValue nodes
-    carrying the value and, when known, the property's ontology IRI as
-    ``propertyID``. Returns an empty list when none are present.
+    Promotes recognised culture-characteristic fields (``passage``, ``growth``,
+    ``organ``, ``tissue``) to ISA Sample Characteristics — schema:additionalProperty
+    PropertyValue nodes carrying the value and, when known, the property's ontology
+    IRI as ``propertyID``. Returns an empty list when none are present (D5: a field
+    that is absent is never fabricated).
     """
     out: list[Any] = []
-    for field_name, property_id in _CELL_LINE_CHARACTERISTICS.items():
-        value = cl.fields.get(field_name)
+    for char in _CELL_LINE_CHARACTERISTICS:
+        value = _first_field(cl, char.aliases)
         if value in (None, ""):
             continue
         props: dict[str, Any] = {}
-        if property_id:
-            props["propertyID"] = {"@id": property_id}
+        if char.property_id:
+            props["propertyID"] = {"@id": char.property_id}
         out.append(
             CharacteristicValue(
                 crate,
-                param_id(field_name, str(value)),
-                name=field_name,
+                param_id(char.name, str(value)),
+                name=char.name,
                 value=str(value),
                 properties=props or None,
             )
@@ -841,6 +878,19 @@ def _add_leaves(
         source = (
             _file_source(fe, state.metadata.input_path) if materialize_payload else None
         )
+        # Co-type a source-code (or otherwise extra-typed) File as a @type list,
+        # e.g. ["File", "SoftwareSourceCode"] for an analysis script (#180, gold
+        # plot.py). A plain File keeps its scalar @type. additional_types is
+        # consumed here, never emitted as a stray literal (see _STRUCT_FIELDS).
+        file_type: Any = "File"
+        extra_types = fe.fields.get("additional_types")
+        if extra_types:
+            seen: set[str] = set()
+            file_type = []
+            for t in ["File", *extra_types]:
+                if t and t not in seen:
+                    seen.add(t)
+                    file_type.append(t)
         _idx_add(
             idx,
             fe,
@@ -849,7 +899,7 @@ def _add_leaves(
                     crate,
                     source,
                     dest_path=_file_dest(fe),
-                    properties={"@type": "File", **_scalar_props(fe)},
+                    properties={"@type": file_type, **_scalar_props(fe)},
                 )
             ),
         )
@@ -1440,6 +1490,12 @@ def _add_processes(
             materialize_payload=materialize_payload,
         )
         _idx_add(idx, proc, node)
+        # Wire any additionalProperty references onto the process (gold
+        # #report_analysis -> [#pv_repro_score]). Mirrors the root/assay reference
+        # wiring: only PropertyValues already present in state (or bare IRIs) are
+        # referenced; an unresolvable, non-IRI value is dropped, never fabricated
+        # (D5 — the score itself is computed elsewhere, not here).
+        _wire_references(node, "additionalProperty", f.get("additionalProperty"), idx)
         assay = _resolve_one(idx, f.get("assay_id"))
         if assay is not None:
             assay.append_to("about", node)

--- a/builder/tools/provenance.py
+++ b/builder/tools/provenance.py
@@ -52,6 +52,8 @@ def draft_file(
     path: str | None = None,
     role: str | None = None,
     encoding_format: str | None = None,
+    additional_types: list[str] | None = None,
+    programming_language: str | None = None,
 ) -> Entity:
     """Create a File data entity in the state.
 
@@ -66,6 +68,12 @@ def draft_file(
             then ``path``) via the scientific-format-aware registry (Issue #148),
             so e.g. ``run.mzML`` becomes ``application/x-mzml`` rather than being
             left blank or mislabeled text/plain. An explicit value always wins.
+        additional_types: Optional extra ``@type`` term(s) to co-type the node
+            alongside ``File`` (Issue #180). e.g. ``["SoftwareSourceCode"]`` makes
+            an analysis script a ``@type:[File, SoftwareSourceCode]`` data entity
+            (gold ``plot.py``). When omitted the node stays a plain ``File``.
+        programming_language: Optional schema:programmingLanguage (e.g. "Python")
+            — for a source-code File. Left unset when omitted.
 
     Returns:
         The newly created File Entity.
@@ -84,6 +92,14 @@ def draft_file(
         )
     if encoding_format:
         fields["encodingFormat"] = encoding_format
+    # Drop blanks/dupes/the implicit File type so a clean term list reaches the
+    # mapping (which co-types the node @type:[File, *additional_types]).
+    if additional_types:
+        extra = [t for t in additional_types if t and t != "File"]
+        if extra:
+            fields["additional_types"] = extra
+    if programming_language:
+        fields["programmingLanguage"] = programming_language
     entity = Entity(
         entity_id=_make_entity_id("file", name, {}),
         type="File",

--- a/tests/test_crate_mapping_references.py
+++ b/tests/test_crate_mapping_references.py
@@ -256,3 +256,107 @@ class TestAssaysReverseAlias:
         root = _by_id(graph, "./")
         assert root is not None
         assert "#Assay_assay_1" in _ids(root.get("assays")) + _ids(root.get("hasPart"))
+
+
+class TestProcessAdditionalProperty:
+    """A LabProcess's additionalProperty references resolve to in-state
+    PropertyValue nodes (gold #report_analysis -> [#pv_repro_score])."""
+
+    def _state(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Analysis crate"
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        state.add_entity(_ent("assay_1", "Assay", name="A", study_id="study_1"))
+        state.add_entity(
+            _ent(
+                "pv_repro",
+                "PropertyValue",
+                name="reproducibility score",
+                value=100,
+                unitText="percent",
+            )
+        )
+        state.add_entity(
+            _ent(
+                "report",
+                "LabProcess",
+                name="Crate quality & reproducibility report",
+                process_type="DataAnalysis",
+                assay_id="assay_1",
+                additionalProperty="pv_repro",
+            )
+        )
+        return state
+
+    def test_dataanalysis_additional_property_references_property_value(self):
+        graph = _graph(self._state())
+        proc = _by_id(graph, "#LabProcess_report")
+        assert proc is not None, "DataAnalysis LabProcess node should exist"
+        pv = _by_id(graph, "#PropertyValue_pv_repro")
+        assert pv is not None, "the PropertyValue must round-trip into the graph"
+        assert pv["@id"] in _ids(proc.get("additionalProperty")), (
+            "DataAnalysis additionalProperty must reference the in-state PropertyValue"
+        )
+
+    def test_no_additional_property_fabricated_when_unresolvable(self):
+        """An additionalProperty pointing at no in-state entity (and no IRI) is
+        dropped, never fabricated (D5)."""
+        state = CrateState()
+        state.metadata.title = "Analysis crate"
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        state.add_entity(_ent("assay_1", "Assay", name="A", study_id="study_1"))
+        state.add_entity(
+            _ent(
+                "report",
+                "LabProcess",
+                name="Report",
+                process_type="DataAnalysis",
+                assay_id="assay_1",
+                additionalProperty="does_not_exist",
+            )
+        )
+        graph = _graph(state)
+        proc = _by_id(graph, "#LabProcess_report")
+        assert proc is not None
+        assert _ids(proc.get("additionalProperty")) == []
+
+
+class TestSourceCodeFileTyping:
+    """draft_file gains additional_types + programming_language so a script
+    round-trips as @type:[File, SoftwareSourceCode] (gold plot.py)."""
+
+    def test_source_code_file_emits_typed_node(self):
+        state = CrateState()
+        state.metadata.title = "Code crate"
+        from builder.tools.provenance import draft_file
+
+        draft_file(
+            state,
+            "plot.py",
+            additional_types=["SoftwareSourceCode"],
+            programming_language="Python",
+        )
+        graph = _graph(state)
+        node = next(
+            (n for n in graph if n.get("@id", "").endswith("plot.py")), None
+        )
+        assert node is not None, "plot.py File node should exist"
+        types = node["@type"] if isinstance(node.get("@type"), list) else [node.get("@type")]
+        assert "File" in types and "SoftwareSourceCode" in types, (
+            f"@type should be [File, SoftwareSourceCode]; got {node.get('@type')}"
+        )
+        assert node.get("programmingLanguage") == "Python"
+        # encodingFormat is still auto-derived from the extension.
+        assert node.get("encodingFormat") == "text/x-python"
+
+    def test_plain_file_stays_single_typed(self):
+        state = CrateState()
+        state.metadata.title = "Code crate"
+        from builder.tools.provenance import draft_file
+
+        draft_file(state, "raw.csv")
+        graph = _graph(state)
+        node = next((n for n in graph if n.get("@id", "").endswith("raw.csv")), None)
+        assert node is not None
+        assert node.get("@type") == "File", "plain File keeps scalar @type"
+        assert "programmingLanguage" not in node

--- a/tests/test_tools_drafters.py
+++ b/tests/test_tools_drafters.py
@@ -559,3 +559,50 @@ class TestUnitsThreadedIntoProcesses:
         assert cell_nodes, "CellLineSample node should exist"
         addl = cell_nodes[0].get("additionalProperty")
         assert addl is not None, "CellLineSample should carry additionalProperty"
+
+    def test_cell_line_organ_tissue_become_additional_properties(self):
+        """CellLineSample organ/tissue -> additionalProperty PropertyValue nodes
+        carrying the ISA-Tox param/{organ,tissue} propertyID (gold #SampleCell_MDCK1).
+        """
+        state = CrateState()
+        draft_cell_line_sample(
+            state,
+            "MDCK-I",
+            {"accession": "CVCL_0592", "organ": "Brain", "tissue": "Neural tissue"},
+        )
+        graph = _graph(state)
+        pv_nodes = [
+            n
+            for n in graph
+            if "PropertyValue"
+            in (n["@type"] if isinstance(n.get("@type"), list) else [n.get("@type")])
+        ]
+        by_name = {n.get("name"): n for n in pv_nodes}
+        assert "Organ" in by_name, f"Organ PropertyValue expected; got {set(by_name)}"
+        assert "Tissue" in by_name, f"Tissue PropertyValue expected; got {set(by_name)}"
+        assert by_name["Organ"].get("value") == "Brain"
+        assert by_name["Tissue"].get("value") == "Neural tissue"
+        assert by_name["Organ"].get("propertyID") == {
+            "@id": "https://w3id.org/ro/crate/isa-tox/1.0/param/organ"
+        }, "Organ PV must carry the ISA-Tox param/organ propertyID as an @id node"
+        assert by_name["Tissue"].get("propertyID") == {
+            "@id": "https://w3id.org/ro/crate/isa-tox/1.0/param/tissue"
+        }, "Tissue PV must carry the ISA-Tox param/tissue propertyID as an @id node"
+        # The CellLineSample must reference both via additionalProperty.
+        cell_nodes = [n for n in graph if n.get("additionalType") == "CellLine"]
+        assert cell_nodes, "CellLineSample node should exist"
+        addl_ids = {
+            (it.get("@id") if isinstance(it, dict) else it)
+            for it in (cell_nodes[0].get("additionalProperty") or [])
+        }
+        assert by_name["Organ"]["@id"] in addl_ids
+        assert by_name["Tissue"]["@id"] in addl_ids
+
+    def test_cell_line_organ_tissue_absent_emits_nothing(self):
+        """No organ/tissue field -> no Organ/Tissue PropertyValue fabricated (D5)."""
+        state = CrateState()
+        draft_cell_line_sample(state, "HepG2", {"accession": "CVCL_0027"})
+        graph = _graph(state)
+        names = {n.get("name") for n in graph}
+        assert "Organ" not in names
+        assert "Tissue" not in names


### PR DESCRIPTION
Final toolbox-completion lane (#180 Lane E). Deterministic BUILD-PATH/drafter enhancements — **no new LLM tools**, plus one existing-tool signature extension. Strict TDD (failing tests first).

## Landed
- **(a) Cell-line Organ/Tissue characteristics.** A `CellLineSample`'s `organ`/`tissue` hints join `passage`/`growth` as `schema:additionalProperty` PropertyValue characteristics, carrying the ISA-Tox `param/{organ,tissue}` `propertyID` as `{@id}` nodes (gold `#SampleCell_MDCK1`: PropertyValue "Organ"/"Tissue"). Mapping refactored to a `tuple[_Characteristic(...)]` (aliases → display name → propertyID); the source fields are stripped from the Sample node via `_STRUCT_FIELDS`.
- **(b) DataAnalysis `additionalProperty`.** A `LabProcess`'s `additionalProperty` field is resolved to its in-state PropertyValue reference(s) at build time via `_wire_references` (gold `#report_analysis` → `[#pv_repro_score]`). Only PropertyValues already in state (or bare IRIs) are wired — **no score is computed or fabricated** (D5). `additionalProperty` added to `_REF_FIELDS` so the raw id never leaks onto the node.
- **(c) `extend_draft_file_for_source_code`.** `draft_file` gains `additional_types` + `programming_language`, co-typing an analysis script as `@type:[File, SoftwareSourceCode]` with `schema:programmingLanguage` (gold `plot.py`). `File` is always the leading type, dupes dropped; a plain File keeps its scalar `@type`. Existing-tool signature change propagated in lockstep: `TOOL_SPECS`, the system-prompt "## Your Tools" line, and `AGENTS.md §5` signature + prose.

## Deferred
- **(d) `set_crate_metadata`** (root `releaseDate`/`dateModified`). `CrateState.metadata` has no such fields, so this needs **both** a state-schema change **and** a new four-place LLM tool. It is a fidelity nicety, **not** a validity blocker (`datePublished` is auto-set by ro-crate-py), so it's deferred to keep this a cohesive build-path-only PR (per the lane brief's lowest-priority guidance).

## Files changed
- `builder/tools/_crate_mapping.py` — cell-line organ/tissue mapping, process `additionalProperty` wiring, File `@type` list emission, `_REF_FIELDS`/`_STRUCT_FIELDS` updates.
- `builder/tools/provenance.py` — `draft_file` `additional_types`/`programming_language` params.
- `builder/agents/tools_spec.py`, `builder/agents/system_prompt.py` — `draft_file` spec + catalogue parity.
- `AGENTS.md` — §5 `draft_file` signature/prose, cell-line + process-property prose, §14 lane status (Lane E done, deferral noted).
- `tests/test_tools_drafters.py`, `tests/test_crate_mapping_references.py` — new failing-first tests (organ/tissue + absent guard, DataAnalysis additionalProperty + D5 guard, SoftwareSourceCode typing + plain-File guard).

## Verification (offline, graph-only)
- `uv run ruff check` → All checks passed!
- `uv run --extra langchain ty check builder/tools/_crate_mapping.py builder/tools/provenance.py` → All checks passed!
- `uv run --extra langchain pytest tests/test_crate_mapping_references.py tests/test_tools_drafters.py tests/test_provenance_tools.py tests/test_tools_spec.py tests/test_agents_doc_toolbox.py` → 86 passed
- Tool-spec/doc parity (`test_tools_spec.py`, `test_agents_doc_toolbox.py`) green — `draft_file` keeps its name, so name-level parity is unaffected.

Full suite runs in CI (not run locally, per lane brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)