### PR TITLE
feat(tools): draft_process_chain composite with output synthesis (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -601,10 +601,35 @@ orphaned.
 
 ### Derivation Chain Tools
 ```
+draft_process_chain(assay_id: str, chain: [{process_type, hints?, object?, result?}], validate=None) → {assay_id, process_ids, steps, synthesized}  # composite: create + wire the whole CellCulture→Exposure→EndpointReadout→DataAnalysis chain in one idempotent call, synthesizing the EndpointReadout/DataAnalysis outputs the build has no fallback for
 link(from_id: str, relation: str, to_id: str) → {from_id, relation, to_id}
 attach_files(to: str, name_contains=None, mime_contains=None, paths=None, role=None) → {attached, file_ids, to}
 check_provenance() → {ok, issues:[{entity_id, property, message, fix, severity, profile}]}
 ```
+`draft_process_chain` (Issue #179, task 3) is the `link` composite — the
+proactive counterpart of `fix_required_issues`' missing-output repair rule. It
+fuses the recurring `draft_process` + `link` sequence that wires the gold
+S-VHPS21 derivation chain into ONE idempotent call. `chain` is an ordered list of
+step dicts (`process_type` + optional `hints` + optional explicit `object` /
+`result` ids); any **subset** of the four subtypes is allowed (partial chains
+work) and steps are always wired in the canonical order regardless of input order,
+so a weak model cannot mis-sequence the provenance. Each producing step's output
+is threaded into the next step's input, so the chain is fully connected and
+referenceable. **Its load-bearing job (§14.3):** `EndpointReadout`/`DataAnalysis`
+have **no build-time output fallback**, so a process with no explicit `result`
+(and, for DataAnalysis, no `object`) fires a tox REQUIRED Violation. The composite
+**synthesizes** the missing output — a placeholder `Sample` (via `draft_sample`)
+for a material producer (CellCulture) or a placeholder `File` (via `draft_file`)
+for a data producer (Exposure/EndpointReadout/DataAnalysis) — and `link`s it, so
+the chain never dangles. **Requires:** an existing `assay_id` + each step's
+`process_type`. **Synthesizes (only when not supplied/derivable):** the produced
+output entity (and a DataAnalysis input `File` when it has no upstream step).
+**Respects:** any explicit `object`/`result` you pass — those win over synthesis.
+Placeholders carry only structural metadata (name, crate path, role); they
+**never fabricate measurement values or identifiers** (D5) — they are header-less
+stubs to be filled with `populate_condition_table` / `set_fields`. Idempotent:
+placeholder/process ids are derived deterministically from the step, so re-running
+reuses them rather than duplicating.
 `attach_files` is the bulk *placement* verb (#177): it associates a **group** of
 scanned files with a Study or Assay in one call (select by `name_contains` /
 `mime_contains` / explicit `paths`, stamp an optional `role`). For each match it
@@ -1255,9 +1280,11 @@ Study via `mentions`/`aop`). The only LLM-supplied input is the numeric `aop_id`
 
 Pipeline (#179): (1) `fix_required_issues` deterministic repair loop — *the keystone*;
 (2) drafters as real LLM leaves; (3) composite meta-tools incl. `draft_process_chain`
-(must synthesize EndpointReadout/DataAnalysis outputs to earn its keep); (4) pipeline
-spine replaces the `should_continue` ReAct loop; (5) shrink tail agent; (6) **A/B eval
-harness — decision gate**; (7) prompt + docs.
+— **done**: it synthesizes the EndpointReadout/DataAnalysis outputs the build has no
+fallback for (closing the §14.3 Violation trap) and wires the whole chain in one
+idempotent call (see §5 Derivation Chain Tools); (4) pipeline spine replaces the
+`should_continue` ReAct loop; (5) shrink tail agent; (6) **A/B eval harness —
+decision gate**; (7) prompt + docs.
 
 Toolbox completion (companion issue, parallel disjoint lanes): `materialize_aop_subgraph`;
 ~~the identifier-PropertyValue family~~ **done (#180)** — landed as deterministic

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -21,6 +21,7 @@ File scanning & reading:
 
 Entity drafting:
 - scaffold_isa_backbone: Create a linked Investigation+Study+Assay backbone in one call (idempotent) — the fastest path to a BASE-passing crate
+- draft_process_chain: Create and wire a whole LabProcess derivation chain (CellCulture->Exposure->EndpointReadout->DataAnalysis, any subset) in one idempotent call — synthesizes the outputs EndpointReadout/DataAnalysis require so the chain never dangles into a validation error
 - materialize_aop_subgraph: Turn one AOP-Wiki id into the full subgraph (AdverseOutcomePathway + KeyEvents + KeyEventRelationships, cross-linked) and optionally wire it onto a Study
 - draft_investigation: Create an Investigation entity
 - draft_study: Create a Study entity

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -59,6 +59,36 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "draft_process_chain",
+        "description": "Create and wire a whole LabProcess derivation chain in ONE idempotent call: Sample ->[CellCulture]-> Sample ->[Exposure]-> table ->[EndpointReadout]-> raw ->[DataAnalysis]-> figures. Pass the parent assay_id and an ordered chain of steps; each step is {process_type, hints?, object?, result?}. Steps are always wired in canonical order (CellCulture->Exposure->EndpointReadout->DataAnalysis) and a subset is fine (partial chains work). CRITICAL: it SYNTHESIZES the missing outputs that EndpointReadout/DataAnalysis require (they have no build-time fallback) so the chain never dangles into a validation error — placeholder File/Sample entities with NO fabricated data. Explicit object/result you pass win over synthesis. Set validate=true to also run build_and_validate. Prefer this over draft_process+link for the standard chain. Example: draft_process_chain(assay_id='assay_cell_viability_assay', chain=[{'process_type':'CellCulture','hints':{'name':'Seed MDCK'}},{'process_type':'Exposure','hints':{'duration':'24h'}},{'process_type':'EndpointReadout','hints':{}},{'process_type':'DataAnalysis','hints':{}}]).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "assay_id": {"type": "string", "description": "entity_id of the parent Assay every process belongs to."},
+                "chain": {
+                    "type": "array",
+                    "description": "Ordered list of process steps to create and wire.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "process_type": {
+                                "type": "string",
+                                "enum": ["CellCulture", "Exposure", "EndpointReadout", "DataAnalysis"],
+                                "description": "Which domain LabProcess subtype this step is.",
+                            },
+                            "hints": draft_hints_schema("LabProcess"),
+                            "object": {"type": ["array", "string"], "description": "Explicit input entity id(s) the process consumes (overrides the inherited upstream output)."},
+                            "result": {"type": ["array", "string"], "description": "Explicit output entity id(s) the process produces (overrides synthesis)."},
+                        },
+                        "required": ["process_type"],
+                    },
+                },
+                "validate": {"type": "boolean", "description": "Also run build_and_validate and return it under 'validation'."},
+            },
+            "required": ["assay_id", "chain"],
+        },
+    },
+    {
         "name": "materialize_aop_subgraph",
         "description": "Turn ONE AOP-Wiki id into the full crate subgraph in one call: an AdverseOutcomePathway node plus every KeyEvent (MIE/KE/AO, discriminated by eventType) and KeyEventRelationship, all cross-linked deterministically from AOP-Wiki (never fabricated). Pass only the numeric aop_id; optionally pass study_id to wire the AOP onto that Study (schema:mentions). Idempotent (keyed by AOP-Wiki IRI). Prefer this over lookup_aop + manual drafting when you want the whole pathway in the crate. Example: materialize_aop_subgraph(aop_id='610', study_id='study_silychristin_exposure').",
         "parameters": {

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -359,6 +359,10 @@ _STRUCT_FIELDS = frozenset(
         # draft_file's extra @type term(s) — consumed to co-type the File node
         # (#180, e.g. SoftwareSourceCode), never emitted as a literal property.
         "additional_types",
+        # draft_file / attach_files' state-tracking placement label — not a
+        # crate property and absent from the RO-Crate @context, so emitting it
+        # raw fails the base context check (ro-crate-1.2_2.1). Strip it here.
+        "role",
     }
 )
 

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -14,10 +14,20 @@ consistent with the "Toolbox, Not Graph" design (AGENTS.md §1).
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
-from builder.tools.drafters import draft_assay, draft_investigation, draft_study
+from builder.tools.drafters import (
+    VALID_PROCESS_TYPES,
+    draft_assay,
+    draft_investigation,
+    draft_process,
+    draft_sample,
+    draft_study,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def _first_of_type(state: CrateState, type_name: str) -> Entity | None:
@@ -87,6 +97,293 @@ def scaffold_isa_backbone(
         result["validation"] = build_and_validate(state, profile="base")
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# LabProcess derivation chain (Issue #179, task 3)
+# ---------------------------------------------------------------------------
+
+# The canonical order of the gold S-VHPS21 derivation chain. A supplied chain may
+# be any *subset* of these (partial chains work) but is always wired in this
+# order so the provenance flows the right way.
+_CHAIN_ORDER: tuple[str, ...] = (
+    "CellCulture",
+    "Exposure",
+    "EndpointReadout",
+    "DataAnalysis",
+)
+
+# Subtypes that produce *material* (a Sample) vs *data* (a File). Determines
+# which kind of placeholder entity is synthesized to carry a step's output so the
+# next step has something concrete to consume. EndpointReadout / DataAnalysis are
+# the two subtypes with NO build-time output fallback (AGENTS.md §14.3); a missing
+# schema:result on them fires a tox Violation — closing that trap is this tool's
+# load-bearing job, and synthesizing an output for *every* producing step keeps
+# the whole derivation chain connected and referenceable.
+_SAMPLE_PRODUCERS = frozenset({"CellCulture"})
+
+
+def _ref_ids(value: Any) -> set[str]:
+    """Normalize a reference value (id / {@id} / list thereof) to bare ids."""
+    if value is None:
+        return set()
+    items = value if isinstance(value, list) else [value]
+    out: set[str] = set()
+    for v in items:
+        key = v.get("@id") if isinstance(v, dict) else v
+        if key:
+            out.add(str(key).lstrip("#"))
+    return out
+
+
+def _explicit_ids(step: dict[str, Any], *keys: str) -> list[str]:
+    """Collect the union of caller-supplied reference ids under ``keys``."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in keys:
+        for rid in _ref_ids(step.get(key)):
+            if rid not in seen:
+                seen.add(rid)
+                out.append(rid)
+    return out
+
+
+def draft_process_chain(
+    state: CrateState,
+    assay_id: str,
+    chain: list[dict[str, Any]] | None = None,
+    validate: bool | None = None,
+) -> dict[str, Any]:
+    """Create and wire a LabProcess derivation chain in ONE idempotent call.
+
+    Fuses the recurring ``draft_process`` + ``link`` sequence that wires the gold
+    S-VHPS21 chain::
+
+        Sample →[CellCulture]→ Sample →[Exposure]→ condition_table
+               →[EndpointReadout]→ raw/result →[DataAnalysis]→ figures
+
+    into a single call. ``chain`` is an ordered list of step dicts; each step has
+    a ``process_type`` (a subset of CellCulture / Exposure / EndpointReadout /
+    DataAnalysis — **partial chains are allowed**), optional ``hints`` (passed
+    straight to :func:`draft_process`), and optional explicit ``object`` /
+    ``result`` reference id(s) (or their ``input`` / ``output`` aliases). Steps
+    are always wired in the canonical chain order regardless of input order, so a
+    weak model cannot mis-sequence the provenance.
+
+    **The load-bearing job — output synthesis (AGENTS.md §14.3).** Unlike
+    CellCulture / Exposure, ``EndpointReadout`` and ``DataAnalysis`` have **no
+    build-time output fallback**: a process with no explicit ``result`` (and, for
+    DataAnalysis, no ``object``) fires a tox REQUIRED Violation and the chain
+    dangles. This composite closes that trap:
+
+    - It threads each producing step's output into the next step's input, so a
+      downstream process always *consumes* what the previous step produced.
+    - For any step that still lacks a required output (``result`` for both,
+      ``object`` for DataAnalysis), it **synthesizes an explicit placeholder data
+      entity** — a :func:`~builder.tools.drafters.draft_sample` Sample for a
+      material producer (CellCulture) or a
+      :func:`~builder.tools.provenance.draft_file` File for a data producer — and
+      wires it with :func:`~builder.tools.provenance.link`.
+
+    Synthesized placeholders carry **only** structural metadata (a name, a crate
+    path, a role); they NEVER fabricate measurement values or identifiers (D5).
+    They are intentionally header-less stubs — use ``populate_condition_table`` /
+    ``attach_files`` / ``set_fields`` to fill real content. What this tool
+    **requires vs synthesizes**:
+
+    - **Requires:** an existing ``assay_id``; the per-step ``process_type``.
+    - **Synthesizes (only when needed):** the produced output entity for a step
+      whose output is required but neither supplied nor derivable from the chain.
+    - **Respects:** any explicit ``object`` / ``result`` you pass — those win over
+      synthesis, and the build still appends the typed CSVW condition table
+      (Exposure) / raw-measurements table (EndpointReadout) on top.
+
+    It is **idempotent**: process / placeholder ids are derived deterministically
+    from the step, so re-running reuses (overwrites in place) the same entities
+    rather than minting duplicates.
+
+    Args:
+        state: The crate state to wire the chain into.
+        assay_id: entity_id of the parent Assay every process belongs to.
+        chain: Ordered list of step dicts (see above). ``None``/empty is a no-op.
+        validate: When true, also run a full ``build_and_validate`` and return it
+            under ``"validation"`` (weak models may pass ``None`` for this
+            optional arg; that is treated as false).
+
+    Returns:
+        ``{"assay_id", "process_ids", "steps", "synthesized"}`` — the ordered
+        process entity ids, a per-step summary (``{process_id, process_type,
+        object, result}``), and the list of placeholder entity ids synthesized.
+        ``"validation"`` is added when ``validate`` is true.
+
+    Raises:
+        ValueError: If ``assay_id`` is missing/not an Assay, or a step has an
+            invalid ``process_type``.
+    """
+    from builder.tools.provenance import draft_file, link
+
+    assay = state.get_entity(assay_id)
+    if assay is None:
+        raise ValueError(f"draft_process_chain assay not found: {assay_id!r}.")
+    if assay.type != "Assay":
+        raise ValueError(
+            f"draft_process_chain assay_id must be an Assay; {assay_id!r} is a "
+            f"{assay.type}."
+        )
+
+    steps_in = list(chain or [])
+    for step in steps_in:
+        ptype = step.get("process_type")
+        if ptype not in VALID_PROCESS_TYPES:
+            raise ValueError(
+                f"Invalid process_type {ptype!r} in chain step. Must be one of: "
+                f"{', '.join(sorted(VALID_PROCESS_TYPES))}."
+            )
+
+    # Wire in canonical order regardless of input order so the model cannot
+    # mis-sequence the provenance. Within a type, preserve the caller's order.
+    ordered = sorted(steps_in, key=lambda s: _CHAIN_ORDER.index(s["process_type"]))
+
+    process_ids: list[str] = []
+    step_summaries: list[dict[str, Any]] = []
+    synthesized: list[str] = []
+    # The most recent step's produced output id(s) — fed to the next step's input.
+    upstream_output: list[str] = []
+
+    for step in ordered:
+        ptype = str(step["process_type"])
+        hints = dict(step.get("hints") or {})
+        proc = draft_process(state, assay_id, ptype, hints)
+
+        # --- inputs: explicit wins; otherwise inherit the upstream output ---
+        inputs = _explicit_ids(step, "object", "input", "samples")
+        if not inputs and upstream_output:
+            inputs = list(upstream_output)
+        for tid in inputs:
+            if state.get_entity(tid) is not None:
+                link(state, proc.entity_id, "object", tid)
+
+        # --- outputs: explicit wins; else synthesize a concrete, referenceable
+        # output so the chain connects AND the §14.3 "no output fallback" trap is
+        # closed. Every producing step gets a real output entity in state (a
+        # Sample for a material producer, a File for a data producer) — so the
+        # next step can consume it by id and EndpointReadout / DataAnalysis never
+        # dangle into a tox Violation. ---
+        outputs = _explicit_ids(step, "result", "output")
+        if not outputs:
+            placeholder = _synthesize_output(
+                state, proc, ptype, draft_sample, draft_file
+            )
+            synthesized.append(placeholder.entity_id)
+            outputs = [placeholder.entity_id]
+        for tid in outputs:
+            if state.get_entity(tid) is not None:
+                link(state, proc.entity_id, "result", tid)
+
+        # DataAnalysis MUST also carry schema:object (its raw/condition input).
+        # If nothing was wired as input, synthesize a placeholder input File too.
+        if ptype == "DataAnalysis" and not inputs:
+            placeholder_in = _synthesize_input(state, proc, draft_file)
+            synthesized.append(placeholder_in.entity_id)
+            link(state, proc.entity_id, "object", placeholder_in.entity_id)
+            inputs = [placeholder_in.entity_id]
+
+        process_ids.append(proc.entity_id)
+        step_summaries.append(
+            {
+                "process_id": proc.entity_id,
+                "process_type": ptype,
+                "object": inputs,
+                "result": outputs,
+            }
+        )
+        # The next step consumes what this one produced (its explicit/synthesized
+        # output), falling back to this step's inputs so a no-output step (e.g. a
+        # bare Exposure relying on the build's typed-table fallback) still hands
+        # the material flow downstream.
+        upstream_output = outputs or inputs
+
+    result: dict[str, Any] = {
+        "assay_id": assay_id,
+        "process_ids": process_ids,
+        "steps": step_summaries,
+        "synthesized": synthesized,
+    }
+
+    if validate:
+        from builder.tools.validation import build_and_validate
+
+        result["validation"] = build_and_validate(state)
+
+    return result
+
+
+def _synthesize_output(
+    state: CrateState,
+    proc: Entity,
+    ptype: str,
+    draft_sample_fn: Any,
+    draft_file_fn: Any,
+) -> Entity:
+    """Create (deterministically) the placeholder output entity for ``proc``.
+
+    A material producer (CellCulture) yields a placeholder Sample; a data
+    producer (EndpointReadout / DataAnalysis) yields a placeholder File. The id
+    is derived from the process so re-running reuses it (idempotent). The
+    placeholder carries only structural metadata — never a fabricated value (D5).
+    """
+    if ptype in _SAMPLE_PRODUCERS:
+        name = f"{proc.entity_id} output sample"
+        existing = state.get_entity(f"sample_{_slug(name)}")
+        if existing is not None:
+            return existing
+        sample_hints: dict[str, Any] = {"name": name}
+        upstream = _input_ref(proc)
+        if upstream is not None:
+            sample_hints["derives_from"] = upstream
+        return draft_sample_fn(state, sample_hints)
+    # Data producer: a placeholder result File.
+    name = f"{proc.entity_id}_result.csv"
+    file_id = f"file_{_slug(name)}"
+    existing = state.get_entity(file_id)
+    if existing is not None:
+        return existing
+    return draft_file_fn(
+        state,
+        name=name,
+        path=f"data/{name}",
+        role="processed_data",
+    )
+
+
+def _synthesize_input(state: CrateState, proc: Entity, draft_file_fn: Any) -> Entity:
+    """Create the placeholder *input* File a DataAnalysis needs (schema:object).
+
+    Only used when a DataAnalysis has no upstream output and no explicit object —
+    it must still declare its analysed input, so we mint a header-less stub.
+    """
+    name = f"{proc.entity_id}_input.csv"
+    file_id = f"file_{_slug(name)}"
+    existing = state.get_entity(file_id)
+    if existing is not None:
+        return existing
+    return draft_file_fn(state, name=name, path=f"data/{name}", role="raw_data")
+
+
+def _input_ref(proc: Entity) -> Any:
+    """First wired input of a process (for a Sample's derives_from), or None."""
+    for fld in ("object", "input", "samples", "cell_line"):
+        ids = _ref_ids(proc.fields.get(fld))
+        if ids:
+            return next(iter(ids))
+    return None
+
+
+def _slug(text: str) -> str:
+    """Mirror drafters._make_entity_id's name normalization for stable ids."""
+    base = text.lower().replace(" ", "_").replace("-", "_")
+    base = "".join(c for c in base if c.isalnum() or c == "_")
+    return base or "unnamed"
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +520,7 @@ def materialize_aop_subgraph(
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
 TOOL_REGISTRY.register("scaffold_isa_backbone", scaffold_isa_backbone, takes_state=True)
+TOOL_REGISTRY.register("draft_process_chain", draft_process_chain, takes_state=True)
 TOOL_REGISTRY.register(
     "materialize_aop_subgraph", materialize_aop_subgraph, takes_state=True
 )

--- a/tests/test_tools_process_chain.py
+++ b/tests/test_tools_process_chain.py
@@ -1,0 +1,257 @@
+"""Tests for the ``draft_process_chain`` composite (Issue #179, task 3).
+
+``draft_process_chain`` fuses the recurring
+``draft_process`` + ``link`` sequence that wires the gold S-VHPS21 derivation
+chain — ``Sample →[CellCulture]→ Sample →[Exposure]→ condition_table
+→[EndpointReadout]→ raw/result →[DataAnalysis]→ figures`` — into ONE
+idempotent call. Its keystone job is to **synthesize the missing outputs** for
+EndpointReadout / DataAnalysis (the two subtypes with no build-time output
+fallback, AGENTS.md §14.3) so the chain never dangles into a tox Violation.
+
+The validation-heavy class carries a 120s timeout (the #184 lesson) because each
+``build_and_validate`` runs the full three-pass SHACL sweep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools.composites import draft_process_chain, scaffold_isa_backbone
+from builder.tools.validation import build_and_validate
+
+
+def _by_type(state: CrateState, type_name: str) -> list:
+    return [e for e in state.list_entities() if e.type == type_name]
+
+
+def _processes_by_subtype(state: CrateState) -> dict[str, list]:
+    out: dict[str, list] = {}
+    for p in _by_type(state, "LabProcess"):
+        out.setdefault(p.fields.get("process_type", ""), []).append(p)
+    return out
+
+
+def _ref_ids(value) -> set[str]:
+    if value is None:
+        return set()
+    items = value if isinstance(value, list) else [value]
+    out: set[str] = set()
+    for v in items:
+        key = v.get("@id") if isinstance(v, dict) else v
+        if key:
+            out.add(str(key).lstrip("#"))
+    return out
+
+
+def _scaffold() -> tuple[CrateState, str]:
+    """A BASE/ISA-passing backbone; returns (state, assay_id)."""
+    state = CrateState()
+    state.metadata.title = "Chain test crate"
+    ids = scaffold_isa_backbone(
+        state,
+        investigation={"name": "Inv", "description": "d", "identifier": "INV-1"},
+        study={"name": "Study", "description": "d"},
+        assay={"name": "Assay", "description": "d"},
+    )
+    return state, ids["assay_id"]
+
+
+_FULL_CHAIN = [
+    {"process_type": "CellCulture", "hints": {"name": "Seed"}},
+    {"process_type": "Exposure", "hints": {"name": "Dose"}},
+    {"process_type": "EndpointReadout", "hints": {"name": "Read"}},
+    {"process_type": "DataAnalysis", "hints": {"name": "Analyse"}},
+]
+
+
+class TestChainCreation:
+    def test_creates_all_four_processes(self):
+        state, assay_id = _scaffold()
+        result = draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+
+        by_subtype = _processes_by_subtype(state)
+        for t in ("CellCulture", "Exposure", "EndpointReadout", "DataAnalysis"):
+            assert len(by_subtype.get(t, [])) == 1, f"missing {t}: {by_subtype}"
+
+        # Result reports one process id per step, in order.
+        assert len(result["process_ids"]) == 4
+        assert result["assay_id"] == assay_id
+
+    def test_processes_carry_assay_id(self):
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        for p in _by_type(state, "LabProcess"):
+            assert p.fields.get("assay_id") == assay_id
+
+    def test_wires_sequential_provenance_edges(self):
+        """Each step's output feeds the next step's input (object/input)."""
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        by = _processes_by_subtype(state)
+        cc = by["CellCulture"][0]
+        exp = by["Exposure"][0]
+        er = by["EndpointReadout"][0]
+        da = by["DataAnalysis"][0]
+
+        # CellCulture produces a Sample that the Exposure consumes.
+        cc_out = _ref_ids(cc.fields.get("result")) | _ref_ids(cc.fields.get("output"))
+        exp_in = (
+            _ref_ids(exp.fields.get("object"))
+            | _ref_ids(exp.fields.get("input"))
+            | _ref_ids(exp.fields.get("samples"))
+        )
+        assert cc_out, "CellCulture must have an output to feed the Exposure"
+        assert cc_out & exp_in, "Exposure must consume the CellCulture output"
+
+        # Exposure output feeds the EndpointReadout input.
+        exp_out = _ref_ids(exp.fields.get("result")) | _ref_ids(exp.fields.get("output"))
+        er_in = (
+            _ref_ids(er.fields.get("object"))
+            | _ref_ids(er.fields.get("input"))
+            | _ref_ids(er.fields.get("samples"))
+        )
+        assert exp_out & er_in, "EndpointReadout must consume the Exposure output"
+
+        # EndpointReadout output feeds the DataAnalysis object.
+        er_out = _ref_ids(er.fields.get("result")) | _ref_ids(er.fields.get("output"))
+        da_in = _ref_ids(da.fields.get("object")) | _ref_ids(da.fields.get("input"))
+        assert er_out & da_in, "DataAnalysis must consume the EndpointReadout output"
+
+
+class TestOutputSynthesis:
+    def test_endpoint_readout_gets_a_result(self):
+        """EndpointReadout (no build-time fallback) must end with a result."""
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        er = _processes_by_subtype(state)["EndpointReadout"][0]
+        assert _ref_ids(er.fields.get("result")) | _ref_ids(er.fields.get("output"))
+
+    def test_data_analysis_gets_object_and_result(self):
+        """DataAnalysis must end with BOTH an object and a result."""
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        da = _processes_by_subtype(state)["DataAnalysis"][0]
+        assert _ref_ids(da.fields.get("object")) | _ref_ids(da.fields.get("input"))
+        assert _ref_ids(da.fields.get("result")) | _ref_ids(da.fields.get("output"))
+
+    def test_synthesized_outputs_are_real_file_entities(self):
+        """Any synthesized output id resolves to a real File entity (no dangling ref)."""
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        for p in _by_type(state, "LabProcess"):
+            for fld in ("object", "input", "result", "output"):
+                for tid in _ref_ids(p.fields.get(fld)):
+                    assert state.get_entity(tid) is not None, (
+                        f"{p.entity_id}.{fld} -> {tid} dangles"
+                    )
+
+    def test_no_fabricated_identifiers(self):
+        """Synthesized placeholder Files carry NO measurement value / identifier (D5).
+
+        A placeholder may carry a name/path/role/encodingFormat, but must not
+        invent a CAS/accession/DOI/measured value etc.
+        """
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        forbidden = {
+            "identifier", "cas", "casrn", "cas_number", "pubchem_cid",
+            "accession", "doi", "value", "measured_value", "inchikey",
+        }
+        for f in _by_type(state, "File"):
+            leaked = forbidden & set(f.fields)
+            assert not leaked, f"placeholder File {f.entity_id} fabricated {leaked}"
+
+
+class TestPartialChains:
+    def test_subset_chain_just_readout(self):
+        """A chain may be a subset of the four types (partial chains work)."""
+        state, assay_id = _scaffold()
+        result = draft_process_chain(
+            state, assay_id, chain=[{"process_type": "EndpointReadout", "hints": {}}]
+        )
+        assert len(result["process_ids"]) == 1
+        er = _processes_by_subtype(state)["EndpointReadout"][0]
+        # Even a lone EndpointReadout must get a synthesized result.
+        assert _ref_ids(er.fields.get("result")) | _ref_ids(er.fields.get("output"))
+
+    def test_explicit_outputs_are_respected(self):
+        """An explicit result on a step is used instead of a synthesized one."""
+        from builder.tools.provenance import draft_file
+
+        state, assay_id = _scaffold()
+        existing = draft_file(state, name="my_results.csv")
+        draft_process_chain(
+            state,
+            assay_id,
+            chain=[
+                {
+                    "process_type": "EndpointReadout",
+                    "hints": {},
+                    "result": [existing.entity_id],
+                }
+            ],
+        )
+        er = _processes_by_subtype(state)["EndpointReadout"][0]
+        wired = _ref_ids(er.fields.get("result")) | _ref_ids(er.fields.get("output"))
+        assert existing.entity_id in wired
+
+
+class TestIdempotency:
+    def test_rerun_does_not_duplicate(self):
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        n_proc = len(_by_type(state, "LabProcess"))
+        n_file = len(_by_type(state, "File"))
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        assert len(_by_type(state, "LabProcess")) == n_proc
+        assert len(_by_type(state, "File")) == n_file
+
+
+class TestViaEngine:
+    def test_callable_through_run_tool(self):
+        engine = AgentEngine()
+        engine.initialize()
+        ids = engine.run_tool("scaffold_isa_backbone")
+        result = engine.run_tool(
+            "draft_process_chain",
+            assay_id=ids["assay_id"],
+            chain=_FULL_CHAIN,
+        )
+        assert result["process_ids"]
+
+
+@pytest.mark.timeout(120)
+class TestChainPassesValidation:
+    """The KEY assertion: after one chain call there are NO EndpointReadout /
+    DataAnalysis missing-result/object tox Violations (§14.3 trap closed)."""
+
+    def test_no_dangling_output_violations(self):
+        state, assay_id = _scaffold()
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+
+        report = build_and_validate(state)  # full 3-pass sweep at REQUIRED
+        assert "error" not in report, report
+
+        # Specifically: no missing-result / missing-object Violation on any
+        # EndpointReadout / DataAnalysis process.
+        offending = [
+            iss
+            for iss in report.get("issues", [])
+            if (iss.get("property") or "").rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+            in ("result", "object")
+        ]
+        assert not offending, offending
+
+        # The chain produces a tox-conformant crate end to end.
+        assert report["conformance"]["tox"] is True, report
+        assert report["ok"] is True, report
+
+    def test_optional_validate_flag_returns_report(self):
+        state, assay_id = _scaffold()
+        result = draft_process_chain(
+            state, assay_id, chain=_FULL_CHAIN, validate=True
+        )
+        assert "validation" in result
+        assert result["validation"]["ok"] is True, result["validation"]


### PR DESCRIPTION
## What

Adds `draft_process_chain` — the `link`-composite meta-tool from epic #179 (task 3). It creates and wires a whole LabProcess derivation chain in **one idempotent call**, reusing the pure `draft_process` + `link` tools under the hood (no new build machinery), mirroring the gold S-VHPS21 chain:

```
Sample →[CellCulture]→ Sample →[Exposure]→ table →[EndpointReadout]→ raw →[DataAnalysis]→ figures
```

## The chain API

```python
draft_process_chain(assay_id: str, chain=[{process_type, hints?, object?, result?}], validate=None)
  → {assay_id, process_ids, steps, synthesized}
```

- `chain` is an **ordered list of step dicts**; each has a `process_type` (a subset of CellCulture / Exposure / EndpointReadout / DataAnalysis — **partial chains are allowed**), optional `hints` (passed straight to `draft_process`), and optional explicit `object` / `result` reference id(s).
- Steps are always wired in the **canonical order** regardless of input order, so a weak model cannot mis-sequence the provenance.
- Each producing step's output is threaded into the next step's input, so the chain is **fully connected and referenceable**.
- `validate=true` also runs `build_and_validate` and returns it under `"validation"`.

## What it synthesizes vs requires (the load-bearing part)

This closes the **AGENTS.md §14.3 Violation trap**: `EndpointReadout` and `DataAnalysis` have **no build-time output fallback** (unlike CellCulture/Exposure), so a process with no explicit `result` (and, for DataAnalysis, no `object`) fires a tox REQUIRED Violation and the chain dangles.

- **Requires:** an existing `assay_id`; each step's `process_type`.
- **Synthesizes (only when not supplied/derivable):** the produced output entity for each step — a placeholder **Sample** (via `draft_sample`) for a material producer (CellCulture) or a placeholder **File** (via `draft_file`) for a data producer (Exposure/EndpointReadout/DataAnalysis), `link`ed as `result`; plus a DataAnalysis input **File** when it has no upstream step (it MUST carry `schema:object`).
- **Respects:** any explicit `object`/`result` the caller passes — those win over synthesis.
- Placeholders carry **only structural metadata** (name, crate path, role); they **never fabricate measurement values or identifiers** (D5) — they are header-less stubs to be filled with `populate_condition_table` / `set_fields`.
- **Idempotent:** placeholder/process ids are derived deterministically from the step, so re-running reuses (overwrites in place) the same entities rather than duplicating.

This is the proactive counterpart of the `fix_required_issues` missing-output repair rule.

## Incidental fix

The File `role` state-tracking label was emitted raw onto the built node but is absent from the RO-Crate `@context`, so **any** File with a role failed the base pass (`ro-crate-1.1_2.1`). Added `role` to `_STRUCT_FIELDS` so it is stripped at build time (the state field is untouched). This is a latent bug `draft_file(role=...)` / `attach_files(role=...)` already triggered.

## Four-place tool registration

Registered in lockstep: `TOOL_REGISTRY` (composites.py), `TOOL_SPECS` (tools_spec.py), the system-prompt "## Your Tools" catalogue, and AGENTS.md §5 (Derivation Chain Tools), plus §14.4 task-3 status. Parity is enforced by `tests/test_tools_spec.py` and `tests/test_agents_doc_toolbox.py`.

## TDD

New `tests/test_tools_process_chain.py` (failing-first) asserts:
- one call produces all four linked processes with correct sequential provenance edges;
- output synthesis for the no-fallback subtypes (EndpointReadout gets a `result`; DataAnalysis gets both `object` and `result`); synthesized refs resolve to real entities;
- **D5** — no fabricated identifiers on placeholders;
- idempotency, partial chains, explicit-output passthrough, engine dispatch;
- **the key assertion** — after one call + `build_and_validate`, there are NO EndpointReadout/DataAnalysis missing-`result`/`object` tox Violations, and `{base, isa, tox}` all pass with `ok=True` (module carries `pytest.mark.timeout(120)`, the #184 lesson).

## Gate (green)

- `uv run ruff check` → All checks passed!
- `uv run --extra langchain ty check` → All checks passed!
- `uv run --extra langchain pytest tests/test_tools_process_chain.py tests/test_tools_spec.py tests/test_agents_doc_toolbox.py tests/test_tools_composites.py tests/test_tools_repair.py` → **42 passed**

(The full suite is left to CI per the repo's pre-push convention.)

## Open question for review

The composite synthesizes an **explicit** condition-table File as the Exposure's `result` (so the EndpointReadout can consume it by id) rather than letting the build auto-emit the typed CSVW condition table (#180 Lane D). This trades the auto-typed table for a fully-connected, referenceable chain; the typed table is recoverable via `populate_condition_table`. Worth a sanity check that this tradeoff matches the intended fidelity priority.

Closes part of #179 (task 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)