### PR TITLE
fix(readers): preserve File path on round-trip (#180)

### DIFF
--- a/builder/readers/existing_crate.py
+++ b/builder/readers/existing_crate.py
@@ -65,6 +65,25 @@ def _crate_type(node: dict) -> EntityType | None:
     return None
 
 
+def _relative_path_id(node_id: str) -> str | None:
+    """The node @id as a crate-relative path, or None if it isn't one.
+
+    A File node's @id IS its crate-relative location (ro-crate-1.2.0.md
+    §Data-Entities: a File's @id is a path relative to the crate root). To make
+    build → read → build idempotent for file placement (AGENTS.md §D13), the
+    reader feeds this path back as the reconstructed File's ``dest_path`` — the
+    field ``_file_dest`` consumes first when re-placing a File.
+
+    Returns None for ids that are not usable relative paths — ``#``-fragments,
+    absolute URIs (``http(s)://``, any ``scheme://``) and root-absolute paths —
+    so the builder falls back to its ``data/<name>`` default rather than inventing
+    a path from a non-path id (D5: derive only from the node's own @id).
+    """
+    if not node_id or node_id.startswith(("#", "/")) or "://" in node_id:
+        return None
+    return node_id
+
+
 def _ref_ids(value: object) -> list[str]:
     """The @id strings under a reference property (id, {"@id": …}, or list)."""
     if value is None:
@@ -169,6 +188,18 @@ def read_existing_crate(crate_dir: str) -> CrateState:
             if node_id.startswith("#") and entity_id.startswith(prefix):
                 entity_id = entity_id[len(prefix):]
             fields = {k: v for k, v in node.items() if not k.startswith("@")}
+            # Preserve a File's in-crate location: its @id is the crate-relative
+            # path, which the builder re-reads from ``dest_path`` to re-place it.
+            # Without this the rebuild defaults to ``data/<name>``, drifting the
+            # File's path every cycle (Issue #180). Only set it when the @id is a
+            # usable relative path and the node didn't already carry an explicit
+            # placement field (D5: derive from the node's own @id, never invent).
+            if ctype == "File" and not any(
+                fields.get(k) for k in ("dest_path", "path", "contentUrl")
+            ):
+                rel = _relative_path_id(node_id)
+                if rel is not None:
+                    fields["dest_path"] = rel
             entity = Entity(
                 entity_id=entity_id,
                 type=ctype,

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -93,6 +93,110 @@ class TestRoundTrip:
         assert len(investigations) == 1
         assert investigations[0]["@id"] == "./"
 
+    def _state_nested_file(self):
+        """A state whose File lives at a NESTED in-crate path (not data/<name>)."""
+        state = CrateState()
+        state.metadata.accession = "FAB-2026"
+        state.add_entity(_ent("inv_1", "Investigation", name="Inv"))
+        state.add_entity(_ent("study_1", "Study", name="S", investigation_id="inv_1"))
+        state.add_entity(_ent("assay_1", "Assay", name="A", study_id="study_1"))
+        state.add_entity(
+            _ent(
+                "raw",
+                "File",
+                name="raw.prism",
+                dest_path="assays/assay_1/dataset/raw_data/raw.prism",
+            )
+        )
+        state.add_entity(
+            _ent("er", "LabProcess", process_type="EndpointReadout", name="R",
+                 assay_id="assay_1", result=["raw"])
+        )
+        return state
+
+    def test_nested_file_path_preserved_after_roundtrip(self, tmp_path):
+        """A File at a nested in-crate path keeps that path across build→read→build.
+
+        Regression for #180: the reader used to drop the File's location, so a
+        rebuild re-placed it at the default ``data/<name>`` — non-idempotent file
+        placement. The File's @id (its crate-relative path) must survive verbatim.
+        """
+        nested = "assays/assay_1/dataset/raw_data/raw.prism"
+        build_crate(self._state_nested_file(), str(tmp_path / "c1"))
+        by1 = _graph(tmp_path / "c1")
+        assert nested in by1  # sanity: the build itself places it there
+
+        restored = read_existing_crate(str(tmp_path / "c1"))
+        build_crate(restored, str(tmp_path / "c2"))
+        by2 = _graph(tmp_path / "c2")
+
+        # The File's @id (path) is STABLE — no drift to data/raw.prism.
+        assert nested in by2
+        assert "data/raw.prism" not in by2
+        # And it stays nested under its Assay, not orphaned onto the root.
+        assert nested in _ids(by2["#Assay_assay_1"].get("hasPart"))
+        assert nested not in _ids(by2["./"].get("hasPart"))
+
+
+class TestReaderFileDestPath:
+    """read_existing_crate must feed the builder the File's original path (#180)."""
+
+    def test_reader_sets_dest_path_from_node_id(self, tmp_path):
+        """A File node's relative @id becomes the reconstructed File's dest_path.
+
+        ``_file_dest`` (the crate-mapping) places a File from ``dest_path`` first;
+        if the reader leaves it unset, a rebuild defaults to ``data/<name>``.
+        """
+        from builder.state import Entity, EntityProvenance
+
+        state = CrateState()
+        state.metadata.title = "Test"
+        state.add_entity(
+            Entity(
+                entity_id="raw",
+                type="File",
+                fields={"name": "raw.prism", "dest_path": "results/run1/raw.prism"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        build_crate(state, str(tmp_path / "c1"))
+
+        restored = read_existing_crate(str(tmp_path / "c1"))
+        files = restored.list_entities("File")
+        raw = next(f for f in files if f.fields.get("name") == "raw.prism")
+        assert raw.fields.get("dest_path") == "results/run1/raw.prism"
+
+    def test_reader_does_not_set_dest_path_for_fragment_id(self, tmp_path):
+        """A path-less File (a ``#``-fragment @id) gets no dest_path — default applies.
+
+        We don't invent a path from a non-relative @id (D5); the builder then
+        falls back to its ``data/<name>`` default, the prior behaviour.
+        """
+        crate_dir = tmp_path / "crate"
+        crate_dir.mkdir()
+        (crate_dir / "ro-crate-metadata.json").write_text(
+            json.dumps(
+                {
+                    "@context": "https://w3id.org/ro/crate/1.2/context",
+                    "@graph": [
+                        {
+                            "@id": "ro-crate-metadata.json",
+                            "@type": "CreativeWork",
+                            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+                            "about": {"@id": "./"},
+                        },
+                        {"@id": "./", "@type": "Dataset", "name": "X"},
+                        {"@id": "#File_floating", "@type": "File", "name": "ghost.bin"},
+                    ],
+                }
+            )
+        )
+        restored = read_existing_crate(str(crate_dir))
+        ghost = next(
+            f for f in restored.list_entities("File") if f.fields.get("name") == "ghost.bin"
+        )
+        assert "dest_path" not in ghost.fields
+
 
 class TestReadDirectory:
     """Tests for read_directory."""


### PR DESCRIPTION
## The drift (#180)

On `build → read_existing_crate → build`, a File's path drifted. A File built at e.g. `assays/<a>/dataset/raw_data/raw.prism` came back from the reader and re-built at the default `data/<name>` (e.g. `data/raw.prism`), making the round-trip non-idempotent for file placement.

**Root cause.** A File node's `@id` *is* its crate-relative location (ro-crate-1.2 §Data-Entities). But `read_existing_crate` strips every `@`-prefixed key (including `@id`) into the entity's `fields` and never set a placement field. On rebuild, `_file_dest` (`builder/tools/_crate_mapping.py`) reads `dest_path` → `path` → `contentUrl`, finds none, and falls back to `data/<slug(name)>`.

## The fix

In `read_existing_crate`, when reconstructing a `File` entity, set its **`dest_path`** from the node `@id` when the `@id` is a usable crate-relative path (not a `#`-fragment, not an absolute/`scheme://` URI, not root-absolute) and the node carries no explicit placement field. `dest_path` is the field the builder consumes first to re-place a File, so the path now survives the round-trip verbatim — restoring AGENTS.md §D13 round-trip symmetry.

Path-less Files (a `#`-fragment `@id`) get no `dest_path` and still fall back to the prior `data/<name>` default — no path is invented (D5: derive only from the node's own `@id`).

## Field the builder consumes

`_file_dest(fe)` in `builder/tools/_crate_mapping.py`: `dest_path` (preferred) → `path` → `contentUrl` → `data/<slug(name)>`. The fix feeds `dest_path`.

## Tests (TDD)

- `TestRoundTrip::test_nested_file_path_preserved_after_roundtrip` — build a File at a nested path, round-trip, assert the `@id` is stable (no `data/` drift) and the File stays nested under its Assay. (Was red.)
- `TestReaderFileDestPath::test_reader_sets_dest_path_from_node_id` — reader unit: a relative `@id` becomes the File's `dest_path`. (Was red.)
- `TestReaderFileDestPath::test_reader_does_not_set_dest_path_for_fragment_id` — a `#`-fragment File `@id` gets no `dest_path`, so the default applies. (Guards the fallback.)

Scope: reader + its tests only. `tests/test_readers.py` (13) and the existing AOP round-trip test stay green; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)