### PR TITLE
feat(tools): draft_publication_with_authors with ORCID harmonization + HITL (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,7 @@ format only (D7); the ARC folder tree is materialised at export time by
 ```
 scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=False) → dict  # composite: linked Investigation→Study→Assay in one call (idempotent), the fast path to a BASE-passing crate
 materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
+draft_publication_with_authors(doi: str) → {publication_id, doi, authors:[{name, person_id, orcid, resolution}], hitl}  # composite (engine-routed, HITL-capable): publication + every author wired as a Person, each author's @id harmonized to their ORCID via a verify-first cascade
 draft_investigation(hints: dict) → Entity
 draft_study(investigation_id: str, hints: dict) → Entity
 draft_assay(study_id: str, hints: dict) → Entity
@@ -515,6 +516,33 @@ These three types live in the shared `aop_entities` CrateState collection and
 build via `_crate_mapping` as `ContextEntity` nodes typed by their own AOP class.
 With `study_id`, the AOP is wired onto that Study via the `aop` reference (an
 alias of `schema:mentions`), closing the largest gold-crate fidelity gap.
+
+`draft_publication_with_authors` (Issue #180, deferred item) is the citation
+counterpart of the composites above and the **only engine-routed, HITL-capable
+drafter** (registered `takes_human=True`; the engine injects the active
+`HumanInterface` as a `human_interface` kwarg). It calls `lookup_doi`, ensures the
+`ScholarlyArticle` exists in state, and for EACH author creates/reuses a `Person`
+wired as the article's `author`, harmonizing the author's `@id` to their **ORCID**
+via a verify-first cascade (stop at first success): **(a)** the Crossref ORCID on
+the author; **(b)** an in-crate `Person` with a *verified* ORCID matching the
+author's family name + given/initial (affiliation-preferred) — this resolves the
+gold case where citation `Fabian Wagenaars` reuses root `F.M.A. Wagenaars`'s ORCID
+`0000-0003-4766-7358`; **(c)** a public ORCID search
+(`lookups.orcid.lookup_orcid_by_name`, the `/v3.0/expanded-search` endpoint via the
+shared rate-limited HTTP layer); **(d)** fallback to a synthesized
+`#CitationAuthor_<Given>_<Family>` Person (the legacy behavior). **Confidence rule
+for (c):** auto-accept **only** a *single* candidate that is a STRONG match (family
++ full — not initial-only — given name) and that passes name verification;
+*anything else* — multiple candidates, a weak / initial-only match, or a sole
+strong match that fails verification — **escalates to HITL** (`present` the ranked
+candidates plus a none/skip option, then optionally `request_input` for a pasted
+ORCID). **D5:** an ORCID from (a) or (c), and an HITL-chosen one, is attached only
+after `lookup_orcid` resolves it and the family name matches; (b) is already
+verified; an ORCID-resolved Person also carries its ORCID `identifier`
+PropertyValue at build via the shared `_identifier_pv` path. HITL fires **only** on
+genuine ambiguity — never when an author is confidently resolved or confidently
+absent — and when no `human_interface` is available an ambiguous author falls back
+to a synthesized id rather than guessing.
 The `hints` parameter is **typed per entity type** (Issue #90). Each `draft_*`
 tool advertises a JSON-Schema built by `_crate_mapping.draft_hints_schema(type)`
 from the single source of truth `_crate_mapping.ENTITY_DRAFT_SCHEMA` — allowed

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -34,6 +34,7 @@ Entity drafting:
 - draft_person: Create a Person entity
 - draft_organization: Create an Organization entity
 - draft_publication: Create a Publication entity
+- draft_publication_with_authors: Create a publication from a DOI AND wire every author as a Person in one call, harmonizing each author's @id to their ORCID via a verify-first cascade (Crossref ORCID -> in-crate Person match -> public ORCID search, escalating to you only on genuine ambiguity); never attaches an unverified ORCID
 - draft_defined_term: Persist a looked-up ontology/AOP/Key-Event term as a DefinedTerm entity
 - draft_property_value: Create a typed PropertyValue (key/value with optional unit and ontology id)
 - draft_file: Create a File data entity (raw measurements, processed results, figures); pass additional_types=['SoftwareSourceCode'] + programming_language for an analysis script

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -101,6 +101,17 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "draft_publication_with_authors",
+        "description": "Create a publication (from a DOI) AND wire every author as a Person in ONE call, harmonizing each author's @id to their ORCID when it can be determined. Resolution cascade per author (first hit wins): (1) the Crossref ORCID on the author (verified before use); (2) an in-crate Person with a verified ORCID matching the author's family + given/initial (e.g. citation 'Fabian Wagenaars' -> root 'F.M.A. Wagenaars'); (3) a public ORCID search — a single strong (family + full given) match is auto-used, anything ambiguous (multiple candidates or an initial-only match) asks YOU via present_to_human/request_input; (4) fallback to a synthesized #CitationAuthor_<Given>_<Family> Person. NEVER attaches an unverified or guessed ORCID (D5). Prefer this over draft_publication when you want the authors resolved too. Example: draft_publication_with_authors(doi='10.1016/j.tox.2021.152898').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "doi": {"type": "string", "description": "DOI of the publication (with or without a URL prefix)."},
+            },
+            "required": ["doi"],
+        },
+    },
+    {
         "name": "draft_molecular_entity",
         "description": "Create a MolecularEntity from a compound name. Look the compound up first (lookup_compound) so you can pass a verified pubchem_cid. Example: draft_molecular_entity(name='Silychristin A', hints={'pubchem_cid': '443515', 'identifier': '33889-69-9'}).",
         "parameters": {

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -317,10 +317,15 @@ class AgentEngine:
             spec = registry.get_spec(tool_name)
             if spec is None:
                 raise ValueError(f"Unknown tool: {tool_name!r}")
+            call_kwargs = dict(kwargs)
+            # Inject the active HITL adapter for tools that escalate ambiguous
+            # decisions to the human (e.g. draft_publication_with_authors, #180).
+            if spec.takes_human:
+                call_kwargs["human_interface"] = self.human_interface
             if spec.takes_state:
-                result = spec.fn(self.state, **kwargs)
+                result = spec.fn(self.state, **call_kwargs)
             else:
-                result = spec.fn(**kwargs)
+                result = spec.fn(**call_kwargs)
 
         # Memoize a fresh, non-error build_and_validate result for the debounce
         # above (#155). Bounded so a long session cannot grow the cache without

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -15,6 +15,7 @@ consistent with the "Toolbox, Not Graph" design (AGENTS.md §1).
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
@@ -23,9 +24,13 @@ from builder.tools.drafters import (
     draft_assay,
     draft_investigation,
     draft_process,
+    draft_publication,
     draft_sample,
     draft_study,
 )
+from builder.tools.hitl import HumanInterface
+from builder.tools.lookups import lookup_doi, lookup_orcid
+from lookups.orcid import lookup_orcid_by_name
 
 logger = logging.getLogger(__name__)
 
@@ -515,6 +520,421 @@ def materialize_aop_subgraph(
 
 
 # ---------------------------------------------------------------------------
+# Publication authors + ORCID harmonization (Issue #180, deferred item)
+#
+# A citation author who is not already an in-crate Person used to get a
+# synthesized blank id (#CitationAuthor_<Given>_<Family>). This composite
+# resolves each author's @id to their ORCID when it can be determined — with
+# strict verification (D5) and bounded HITL only on genuine ambiguity.
+# ---------------------------------------------------------------------------
+
+
+def _norm(text: Any) -> str:
+    """Lowercase + collapse whitespace + drop trailing dots (for name matching)."""
+    return " ".join(str(text or "").lower().replace(".", " ").split())
+
+
+def _given_tokens(given: Any) -> list[str]:
+    """Tokenise a given name into comparable parts ('F.M.A.' -> ['f','m','a'])."""
+    return [t for t in _norm(given).split() if t]
+
+
+def _is_initial(token: str) -> bool:
+    return len(token) == 1
+
+
+def _given_match(a: Any, b: Any) -> str:
+    """Strength of a given-name match: 'full', 'initial', or '' (no match).
+
+    'full' requires the leading given tokens to share a non-initial first name
+    (e.g. 'Fabian' vs 'Fabian Marinus'); 'initial' requires only the first
+    initial to agree (e.g. 'F.' / 'F.M.A.' vs 'Fabian'). An empty given on
+    either side is treated as an initial-strength match (family-only signal).
+    """
+    ta, tb = _given_tokens(a), _given_tokens(b)
+    if not ta or not tb:
+        return "initial"
+    fa, fb = ta[0], tb[0]
+    if not _is_initial(fa) and not _is_initial(fb):
+        return "full" if fa == fb else ""
+    # At least one side is an initial — compare first letters.
+    return "initial" if fa[0] == fb[0] else ""
+
+
+def _names_match(given_a: Any, family_a: Any, given_b: Any, family_b: Any) -> str:
+    """Match strength between two (given, family) names: 'full' | 'initial' | ''."""
+    if not _norm(family_a) or _norm(family_a) != _norm(family_b):
+        return ""
+    return _given_match(given_a, given_b)
+
+
+def _bare_orcid(value: Any) -> str:
+    """Strip any URL prefix from an ORCID, returning the bare 0000-... id."""
+    return str(value or "").strip().rstrip("/").rsplit("/", 1)[-1]
+
+
+def _verify_orcid(orcid_id: str, family: str, lookup_orcid_fn: Any) -> dict | None:
+    """Resolve an ORCID and return its record IFF the family name roughly matches.
+
+    D5: an ORCID is only trusted once :func:`lookup_orcid` resolves it AND the
+    resolved family name matches the author's. Returns the resolved data dict on
+    success, else ``None`` (a transient outage also yields ``None`` — we never
+    attach an unverified ORCID).
+    """
+    bare = _bare_orcid(orcid_id)
+    if not bare:
+        return None
+    result = lookup_orcid_fn(bare)
+    if not result.get("found"):
+        return None
+    data = result.get("data") or {}
+    resolved_family = data.get("familyName", "")
+    if _norm(resolved_family) and _norm(resolved_family) == _norm(family):
+        return data
+    return None
+
+
+def _find_in_crate_person(
+    state: CrateState, given: str, family: str, affiliation: str | None
+) -> Entity | None:
+    """An in-crate Person with a VERIFIED ORCID matching this author, or None.
+
+    Family must match and the given name must match at least at initial strength
+    (this resolves 'Fabian Wagenaars' -> root 'F.M.A. Wagenaars'). When several
+    qualify, an affiliation match is preferred, then a full-given match.
+    """
+    candidates: list[tuple[int, Entity]] = []
+    aff_norm = _norm(affiliation)
+    for person in state.list_entities("Person"):
+        if not person.fields.get("orcid"):
+            continue
+        status = person.get_field_status("orcid")
+        if status is None or status.status != "verified":
+            continue
+        strength = _names_match(
+            given, family, person.fields.get("givenName"), person.fields.get("familyName")
+        )
+        if not strength:
+            continue
+        score = 0
+        if strength == "full":
+            score += 1
+        if aff_norm and aff_norm == _norm(person.fields.get("affiliation")):
+            score += 2
+        candidates.append((score, person))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda sc: sc[0], reverse=True)
+    return candidates[0][1]
+
+
+def _pick_from_human(
+    response: Mapping[str, Any] | None, candidates: list[dict], options: list[str]
+) -> str | None:
+    """Extract a chosen bare ORCID from a HITL ``present`` response, or None.
+
+    Accepts a pick expressed as an explicit ORCID in ``comments``/``edits`` or as
+    an option label/index. A ``skipped``/``rejected`` action yields ``None``.
+    """
+    if not response or response.get("action") in ("skipped", "rejected"):
+        return None
+    by_orcid = {_bare_orcid(c["orcid"]): c for c in candidates}
+    # 1. An edits dict naming the orcid.
+    edits = response.get("edits") or {}
+    for value in edits.values():
+        bare = _bare_orcid(value)
+        if bare in by_orcid:
+            return bare
+    # 2. Free-text comments containing an orcid or an option label.
+    comments = str(response.get("comments") or "").strip()
+    if comments:
+        bare = _bare_orcid(comments)
+        if bare in by_orcid:
+            return bare
+        for idx, label in enumerate(options):
+            if comments == label or comments == str(idx) or comments == str(idx + 1):
+                if idx < len(candidates):
+                    return _bare_orcid(candidates[idx]["orcid"])
+    return None
+
+
+def _resolve_via_search(
+    given: str,
+    family: str,
+    affiliation: str | None,
+    human: HumanInterface | None,
+    lookup_orcid_fn: Any,
+    lookup_by_name_fn: Any,
+) -> str | None:
+    """Search ORCID and resolve to a verified bare ORCID, escalating if ambiguous.
+
+    Auto-accepts iff there is exactly ONE candidate that is a STRONG match
+    (family + full given name). Anything else — multiple candidates, a weak /
+    initial-only match, or a single match that fails name verification — is
+    escalated to HITL (``present`` the candidates + a none/skip option, then
+    optionally ``request_input`` for a pasted ORCID). Returns a verified bare
+    ORCID, or ``None`` (no confident answer; caller falls back to synthesis).
+    """
+    candidates = list(lookup_by_name_fn(given, family, affiliation) or [])
+    if not candidates:
+        return None
+
+    strong = [
+        c
+        for c in candidates
+        if _names_match(given, family, c.get("given"), c.get("family")) == "full"
+    ]
+
+    # Auto-accept ONLY a single, strong, name-verified candidate.
+    if len(candidates) == 1 and len(strong) == 1:
+        verified = _verify_orcid(strong[0]["orcid"], family, lookup_orcid_fn)
+        if verified is not None:
+            return _bare_orcid(strong[0]["orcid"])
+        # Fall through to HITL — a sole strong match that fails verification is
+        # ambiguous, not confidently absent.
+
+    # Genuine ambiguity (or a single weak / unverifiable match): escalate.
+    if human is None:
+        return None
+
+    options = [
+        f"{c.get('given', '')} {c.get('family', '')} — {c.get('orcid')}"
+        + (f" ({c['affiliation']})" if c.get("affiliation") else "")
+        for c in candidates
+    ]
+    options.append("None of these / skip")
+    context = (
+        f"Multiple ORCID candidates for citation author '{given} {family}'. "
+        "Pick the correct one (or skip to leave it unresolved):"
+    )
+    chosen = _pick_from_human(human.present(context, options), candidates, options)
+    if chosen is None:
+        # Last chance: let the user paste an ORCID directly.
+        resp = human.request_input(
+            f"Paste the ORCID for '{given} {family}' (or skip):", "identifier"
+        )
+        if not resp.get("skipped"):
+            chosen = _bare_orcid(resp.get("value"))
+    if not chosen:
+        return None
+
+    # An HITL-chosen ORCID is still verified before use (D5).
+    verified = _verify_orcid(chosen, family, lookup_orcid_fn)
+    return _bare_orcid(chosen) if verified is not None else None
+
+
+def _ensure_person_for_orcid(state: CrateState, orcid: str, data: dict) -> Entity:
+    """Find-or-create a Person whose @id is the ORCID URL, with a verified ORCID."""
+    bare = _bare_orcid(orcid)
+    orcid_url = f"https://orcid.org/{bare}"
+    existing = state.get_entity(orcid_url) or state.get_entity(bare)
+    if existing is not None and existing.type == "Person":
+        person = existing
+    else:
+        person = Entity(
+            entity_id=orcid_url,
+            type="Person",
+            _provenance=EntityProvenance(created_by="lookup"),
+        )
+        state.add_entity(person)
+    fields: dict[str, Any] = {"orcid": bare}
+    given = data.get("givenName")
+    family = data.get("familyName")
+    name = data.get("name") or (f"{given or ''} {family or ''}".strip())
+    if name:
+        fields["name"] = name
+    if given:
+        fields["givenName"] = given
+    if family:
+        fields["familyName"] = family
+    affiliation = data.get("affiliation_name")
+    if affiliation:
+        fields["affiliation"] = affiliation
+    person.set_fields_from_dict(fields, source="lookup")
+    person.set_field_status("orcid", "verified", "lookup")
+    return person
+
+
+def _synthesize_citation_author(state: CrateState, given: str, family: str) -> Entity:
+    """Create (or reuse) the fallback #CitationAuthor_<Given>_<Family> Person."""
+    parts = [p for p in (str(given or "").strip(), str(family or "").strip()) if p]
+    label = "_".join(parts).replace(" ", "_") or "Unknown"
+    entity_id = f"#CitationAuthor_{label}"
+    existing = state.get_entity(entity_id)
+    if existing is not None:
+        return existing
+    person = Entity(
+        entity_id=entity_id,
+        type="Person",
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+    person.set_fields_from_dict(
+        {
+            "name": " ".join(parts) or "Unknown Author",
+            **({"givenName": given} if given else {}),
+            **({"familyName": family} if family else {}),
+        },
+        source="llm",
+    )
+    state.add_entity(person)
+    return person
+
+
+def _ensure_publication(state: CrateState, doi: str, data: dict) -> Entity:
+    """Find-or-create the ScholarlyArticle Publication for a DOI (no author wiring)."""
+    bare_doi = data.get("identifier") or doi
+    for pub in state.list_entities("Publication"):
+        ident = str(pub.fields.get("identifier") or "")
+        if ident and (ident == str(bare_doi) or _bare_orcid(ident) == _bare_orcid(doi)):
+            return pub
+        if pub.fields.get("doi") and _norm(pub.fields["doi"]) == _norm(doi):
+            return pub
+    hints: dict[str, Any] = {}
+    if data.get("name"):
+        hints["name"] = data["name"]
+    if data.get("headline"):
+        hints["headline"] = data["headline"]
+    if data.get("datePublished"):
+        hints["datePublished"] = data["datePublished"]
+    if data.get("url"):
+        hints["url"] = data["url"]
+    return draft_publication(state, str(bare_doi), hints)
+
+
+def _wire_author(pub: Entity, person: Entity) -> None:
+    """Append a Person reference onto the publication's ``author`` list (deduped)."""
+    refs = pub.fields.get("author") or []
+    if not isinstance(refs, list):
+        refs = [refs]
+    ids = {(r.get("@id") if isinstance(r, dict) else r) for r in refs}
+    if person.entity_id not in ids:
+        refs = [*refs, {"@id": person.entity_id}]
+    pub.fields["author"] = refs
+    pub.set_field_status("author", "filled", "lookup")
+
+
+def draft_publication_with_authors(
+    state: CrateState,
+    doi: str,
+    human_interface: HumanInterface | None = None,
+) -> dict[str, Any]:
+    """Draft a publication and wire each author, harmonizing @ids to ORCIDs (#180).
+
+    Looks the DOI up via Crossref, ensures the ``ScholarlyArticle`` exists in
+    state, and for EACH author creates/reuses a ``Person`` wired as the article's
+    ``author``. Each author's ``@id`` is resolved by this cascade (first hit wins):
+
+    1. **Crossref ORCID** on the author — verified via :func:`lookup_orcid`
+       (resolved family name must match) — used as ``https://orcid.org/<id>``.
+    2. **In-crate Person** with a verified ORCID matching the author's family +
+       given/initial (affiliation-preferred) — reused (e.g. citation
+       'Fabian Wagenaars' → root 'F.M.A. Wagenaars').
+    3. **Public ORCID search** (:func:`lookups.orcid.lookup_orcid_by_name`): a
+       single STRONG (family + full given) match is verified and used; anything
+       ambiguous (multiple candidates, or a weak/initial-only match) is escalated
+       to HITL via ``human_interface`` (pick a candidate / paste an ORCID / skip).
+    4. **Fallback**: a synthesized ``#CitationAuthor_<Given>_<Family>`` Person.
+
+    D5: an ORCID from (1) or (3) — and an HITL-chosen one — is only attached after
+    it resolves and the name roughly matches; (2) is already verified. HITL fires
+    ONLY on genuine ambiguity, never when an author is confidently resolved or
+    confidently absent.
+
+    Args:
+        state: The crate state to draft into.
+        doi: The DOI to resolve (with or without a URL prefix).
+        human_interface: HITL adapter injected by the engine; when ``None`` the
+            search step cannot escalate, so an ambiguous author falls back to a
+            synthesized id rather than guessing (D5).
+
+    Returns:
+        On success ``{"publication_id", "doi", "authors": [{name, person_id,
+        orcid, resolution}], "hitl": int}``. On a DOI miss
+        ``{"ok": False, "error": ...}``.
+    """
+    lookup = lookup_doi(doi)
+    if not lookup.get("found"):
+        return {"ok": False, "error": lookup.get("error", f"DOI '{doi}' not found")}
+
+    data = lookup.get("data") or {}
+    pub = _ensure_publication(state, doi, data)
+
+    authors_out: list[dict[str, Any]] = []
+    hitl_count = 0
+    for author in data.get("author", []):
+        given = author.get("givenName", "")
+        family = author.get("familyName", "")
+        affiliation = author.get("affiliation")
+        resolution = "synthesized"
+        person: Entity | None = None
+
+        # (a) Crossref ORCID on the author.
+        crossref_orcid = author.get("identifier")
+        if crossref_orcid:
+            verified = _verify_orcid(crossref_orcid, family, lookup_orcid)
+            if verified is not None:
+                person = _ensure_person_for_orcid(state, crossref_orcid, verified)
+                resolution = "crossref_orcid"
+
+        # (b) In-crate Person with a verified ORCID.
+        if person is None:
+            match = _find_in_crate_person(state, given, family, affiliation)
+            if match is not None:
+                person = match
+                resolution = "in_crate"
+
+        # (c) Public ORCID search (auto-accept ONE strong match; else HITL).
+        if person is None:
+            prompts_before = _hitl_prompt_count(human_interface)
+            searched = _resolve_via_search(
+                given,
+                family,
+                affiliation,
+                human_interface,
+                lookup_orcid,
+                lookup_orcid_by_name,
+            )
+            if _hitl_prompt_count(human_interface) > prompts_before:
+                hitl_count += 1
+            if searched:
+                verified = _verify_orcid(searched, family, lookup_orcid)
+                if verified is not None:
+                    person = _ensure_person_for_orcid(state, searched, verified)
+                    resolution = "orcid_search"
+
+        # (d) Fallback synthesized author.
+        if person is None:
+            person = _synthesize_citation_author(state, given, family)
+            resolution = "synthesized"
+
+        _wire_author(pub, person)
+        authors_out.append(
+            {
+                "name": f"{given} {family}".strip(),
+                "person_id": person.entity_id,
+                "orcid": _bare_orcid(person.fields.get("orcid")) or None,
+                "resolution": resolution,
+            }
+        )
+
+    return {
+        "publication_id": pub.entity_id,
+        "doi": data.get("identifier") or doi,
+        "authors": authors_out,
+        "hitl": hitl_count,
+    }
+
+
+def _hitl_prompt_count(human: HumanInterface | None) -> int:
+    """Best-effort count of prompts a recording interface has made (for hitl stat)."""
+    if human is None:
+        return 0
+    return len(getattr(human, "present_calls", []) or []) + len(
+        getattr(human, "input_calls", []) or []
+    )
+
+
+# ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
@@ -523,4 +943,10 @@ TOOL_REGISTRY.register("scaffold_isa_backbone", scaffold_isa_backbone, takes_sta
 TOOL_REGISTRY.register("draft_process_chain", draft_process_chain, takes_state=True)
 TOOL_REGISTRY.register(
     "materialize_aop_subgraph", materialize_aop_subgraph, takes_state=True
+)
+TOOL_REGISTRY.register(
+    "draft_publication_with_authors",
+    draft_publication_with_authors,
+    takes_state=True,
+    takes_human=True,
 )

--- a/builder/tools/registry.py
+++ b/builder/tools/registry.py
@@ -26,12 +26,17 @@ class ToolSpec:
         description: Optional human-readable description.
         takes_state: Whether the engine must pass ``CrateState`` as the first
             positional argument when invoking ``fn``.
+        takes_human: Whether the engine must inject the active
+            :class:`~builder.tools.hitl.HumanInterface` as a ``human_interface``
+            keyword argument so the tool can escalate to HITL on genuine
+            ambiguity (e.g. ``draft_publication_with_authors``, #180).
     """
 
     name: str
     fn: Callable[..., Any]
     description: str = ""
     takes_state: bool = False
+    takes_human: bool = False
 
 
 class ToolRegistry:
@@ -46,8 +51,13 @@ class ToolRegistry:
         fn: Callable[..., Any],
         description: str = "",
         takes_state: bool = False,
+        takes_human: bool = False,
     ) -> None:
         """Register ``fn`` under ``name`` (overwrites any existing entry).
+
+        Set ``takes_human=True`` for a tool that needs to escalate to HITL: the
+        engine then injects the active ``HumanInterface`` as a ``human_interface``
+        keyword when it invokes the tool.
 
         Hint for developers: after adding a new tool here, also add an entry
         in ``builder.tools.dashboard._TOOL_CATEGORIES`` so it appears under
@@ -55,7 +65,11 @@ class ToolRegistry:
         show up in a highlighted "Other" row with a logger warning.
         """
         self._tools[name] = ToolSpec(
-            name=name, fn=fn, description=description, takes_state=takes_state
+            name=name,
+            fn=fn,
+            description=description,
+            takes_state=takes_state,
+            takes_human=takes_human,
         )
 
     def get(self, name: str) -> Callable[..., Any]:

--- a/lookups/orcid.py
+++ b/lookups/orcid.py
@@ -79,3 +79,90 @@ def lookup_orcid(orcid_id: str) -> dict:
         raise
     except Exception:
         return {}
+
+
+@functools.lru_cache(maxsize=256)
+def _search_orcid_by_name(
+    given: str, family: str, affiliation: str | None
+) -> tuple[tuple[tuple[str, str], ...], ...]:
+    """Cached ORCID expanded-search returning hashable candidate tuples.
+
+    Returns a tuple of candidates, each a tuple of ``(key, value)`` pairs, so the
+    cached value is immutable and never shared-mutated. :func:`lookup_orcid_by_name`
+    rehydrates these into fresh dicts for callers.
+    """
+    family = (family or "").strip()
+    given = (given or "").strip()
+    if not family:
+        return ()
+
+    # Lucene query against ORCID's indexed name fields. Family name is the
+    # strongest signal; given name and affiliation narrow it when present.
+    terms = [f'family-name:"{family}"']
+    if given:
+        terms.append(f'given-names:"{given}"')
+    if affiliation:
+        terms.append(f'affiliation-org-name:"{affiliation.strip()}"')
+    query = " AND ".join(terms)
+
+    try:
+        time.sleep(0.1)
+        data = http_get_json(
+            f"{_BASE}/expanded-search/",
+            params={"q": query, "rows": "10"},
+            headers=_HEADERS,
+        )
+        if data is NOT_FOUND:
+            return ()
+
+        out: list[tuple[tuple[str, str], ...]] = []
+        for row in data.get("expanded-result") or []:
+            orcid_id = row.get("orcid-id")
+            if not orcid_id:
+                continue
+            institutions = row.get("institution-name") or []
+            out.append(
+                (
+                    ("orcid", str(orcid_id)),
+                    ("given", row.get("given-names") or ""),
+                    ("family", row.get("family-names") or ""),
+                    ("affiliation", institutions[0] if institutions else ""),
+                )
+            )
+        return tuple(out)
+    except TransientLookupError:
+        raise
+    except Exception:
+        return ()
+
+
+def lookup_orcid_by_name(
+    given: str, family: str, affiliation: str | None = None
+) -> list[dict]:
+    """Search the ORCID public registry for people matching a name.
+
+    Uses the ORCID public ``/v3.0/expanded-search`` endpoint (no auth) via the
+    shared rate-limited HTTP layer, so candidate ORCID iDs can be discovered for
+    a citation author who is not already in the crate. The caller is responsible
+    for disambiguating and verifying any candidate before use (D5: never attach
+    an unverified ORCID).
+
+    Args:
+        given: The author's given (first) name. May be an initial.
+        family: The author's family (last) name. Required — a blank family name
+            returns no candidates without issuing a request.
+        affiliation: Optional institution name; when given it is added to the
+            query to bias the search, but candidates from any affiliation are
+            still returned (ranking/filtering is left to the caller).
+
+    Returns:
+        A list of candidate dicts, each ``{orcid, given, family, affiliation}``
+        in the order ORCID returned them. Empty when nothing matched. Raises
+        :class:`TransientLookupError` on a transient API failure so a momentary
+        outage is never mistaken for "no such person".
+    """
+    return [dict(candidate) for candidate in _search_orcid_by_name(given, family, affiliation)]
+
+
+# Expose the underlying cache so tests can clear it like the other lookups.
+lookup_orcid_by_name.cache_clear = _search_orcid_by_name.cache_clear  # ty: ignore[unresolved-attribute]

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -643,6 +643,124 @@ class TestORCIDContract:
 
 
 # ===========================================================================
+# ORCID expanded-search (lookup_orcid_by_name)
+# ===========================================================================
+
+
+class TestORCIDByNameContract:
+    """Contract tests for lookups.orcid.lookup_orcid_by_name (#180)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear(self):
+        from lookups.orcid import lookup_orcid_by_name
+
+        lookup_orcid_by_name.cache_clear()  # ty: ignore[unresolved-attribute]
+        yield
+
+    def _result(self, *entries: dict) -> dict:
+        return {"expanded-result": list(entries), "num-found": len(entries)}
+
+    @responses.activate
+    def test_single_match_parses_candidate(self):
+        """One expanded-result row → one ranked candidate dict."""
+        from lookups.orcid import lookup_orcid_by_name
+
+        responses.add(
+            responses.GET,
+            "https://pub.orcid.org/v3.0/expanded-search/",
+            json=self._result(
+                {
+                    "orcid-id": "0000-0003-4766-7358",
+                    "given-names": "Fabian",
+                    "family-names": "Wagenaars",
+                    "institution-name": ["Utrecht University"],
+                }
+            ),
+            status=200,
+        )
+
+        candidates = lookup_orcid_by_name("Fabian", "Wagenaars")
+
+        assert candidates == [
+            {
+                "orcid": "0000-0003-4766-7358",
+                "given": "Fabian",
+                "family": "Wagenaars",
+                "affiliation": "Utrecht University",
+            }
+        ]
+
+    @responses.activate
+    def test_multiple_matches_returns_all(self):
+        """Several rows → all candidates, order preserved."""
+        from lookups.orcid import lookup_orcid_by_name
+
+        responses.add(
+            responses.GET,
+            "https://pub.orcid.org/v3.0/expanded-search/",
+            json=self._result(
+                {
+                    "orcid-id": "0000-0001-1111-1111",
+                    "given-names": "Jane",
+                    "family-names": "Smith",
+                    "institution-name": ["University A"],
+                },
+                {
+                    "orcid-id": "0000-0002-2222-2222",
+                    "given-names": "Jane",
+                    "family-names": "Smith",
+                    "institution-name": [],
+                },
+            ),
+            status=200,
+        )
+
+        candidates = lookup_orcid_by_name("Jane", "Smith")
+
+        assert [c["orcid"] for c in candidates] == [
+            "0000-0001-1111-1111",
+            "0000-0002-2222-2222",
+        ]
+        assert candidates[1]["affiliation"] == ""
+
+    @responses.activate
+    def test_no_matches_returns_empty_list(self):
+        """Empty expanded-result → []."""
+        from lookups.orcid import lookup_orcid_by_name
+
+        responses.add(
+            responses.GET,
+            "https://pub.orcid.org/v3.0/expanded-search/",
+            json=self._result(),
+            status=200,
+        )
+
+        assert lookup_orcid_by_name("Nemo", "Nobody") == []
+
+    @responses.activate
+    def test_empty_family_no_http_returns_empty(self):
+        """A blank family name short-circuits with no HTTP call."""
+        from lookups.orcid import lookup_orcid_by_name
+
+        assert lookup_orcid_by_name("Given", "") == []
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_timeout_raises_transient(self):
+        """A timeout raises TransientLookupError (not a silent empty)."""
+        from lookups.orcid import lookup_orcid_by_name
+
+        responses.add(
+            responses.GET,
+            "https://pub.orcid.org/v3.0/expanded-search/",
+            body=Timeout("timed out"),
+        )
+
+        with pytest.raises(TransientLookupError):
+            lookup_orcid_by_name("Fabian", "Wagenaars")
+
+
+# ===========================================================================
 # ROR
 # ===========================================================================
 

--- a/tests/test_tools_publication_authors.py
+++ b/tests/test_tools_publication_authors.py
@@ -1,0 +1,562 @@
+"""Tests for ``draft_publication_with_authors`` — ORCID harmonization (#180).
+
+The composite resolves a citation author's ``@id`` to their **ORCID** (with safe
+fallbacks) so authors stop getting synthesized blank ids like
+``#CitationAuthor_Fabian_Wagenaars``. The resolution cascade (stop at first
+success) is:
+
+    (a) Crossref ORCID on the author       -> verify -> https://orcid.org/<id>
+    (b) in-crate Person with a verified ORCID matching family + given/initial
+    (c) public ORCID search:
+          - exactly ONE strong match       -> verify -> use it
+          - multiple / weak / initial-only -> escalate to HITL
+    (d) fallback: synthesized #CitationAuthor_<Given>_<Family> Person
+
+D5: an ORCID from (a) or (c) is only attached after :func:`lookup_orcid` resolves
+it and the name roughly matches; (b) is already verified; an HITL-chosen ORCID is
+verified before use. HITL fires ONLY on genuine ambiguity.
+
+All lookups + HITL are mocked, so these run fully offline (graph-only assertions).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.composites import draft_publication_with_authors
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class RecordingHumanInterface:
+    """A HumanInterface double that returns scripted responses and records calls."""
+
+    def __init__(self, present_response=None, input_response=None) -> None:
+        self.present_response = present_response or {
+            "action": "skipped",
+            "comments": None,
+            "edits": None,
+        }
+        self.input_response = input_response or {"value": None, "skipped": True}
+        self.present_calls: list[tuple[str, list[str] | None]] = []
+        self.input_calls: list[tuple[str, str]] = []
+
+    def present(self, context, options=None):
+        self.present_calls.append((context, options))
+        return self.present_response
+
+    def request_input(self, prompt, field_type="text"):
+        self.input_calls.append((prompt, field_type))
+        return self.input_response
+
+
+def _doi_result(*authors: dict, name: str = "A nephrotoxicity study") -> dict:
+    """A Crossref-shaped lookup result (the `{found, data}` wrapper)."""
+    return {
+        "found": True,
+        "data": {
+            "@id": "https://doi.org/10.1234/example",
+            "@type": "ScholarlyArticle",
+            "identifier": "https://doi.org/10.1234/example",
+            "name": name,
+            "headline": name,
+            "author": list(authors),
+            "datePublished": "2021",
+            "url": "https://doi.org/10.1234/example",
+        },
+        "error": None,
+    }
+
+
+def _orcid_record(orcid: str, given: str, family: str, affiliation: str = "") -> dict:
+    """A `lookup_orcid` `{found, data}` result for verification."""
+    return {
+        "found": True,
+        "data": {
+            "@id": f"https://orcid.org/{orcid}",
+            "@type": "Person",
+            "identifier": f"https://orcid.org/{orcid}",
+            "givenName": given,
+            "familyName": family,
+            "name": f"{given} {family}".strip(),
+            "affiliation_name": affiliation,
+            "affiliation_ror": "",
+        },
+        "error": None,
+    }
+
+
+def _patch(monkeypatch, *, doi=None, orcid=None, by_name=None):
+    """Patch the three external lookups the tool consumes (offline)."""
+    if doi is not None:
+        monkeypatch.setattr("builder.tools.composites.lookup_doi", doi)
+    if orcid is not None:
+        monkeypatch.setattr("builder.tools.composites.lookup_orcid", orcid)
+    if by_name is not None:
+        monkeypatch.setattr("builder.tools.composites.lookup_orcid_by_name", by_name)
+
+
+def _person_nodes(state: CrateState) -> list[Entity]:
+    return [e for e in state.list_entities() if e.type == "Person"]
+
+
+def _author_ids(state: CrateState, pub: Entity) -> set[str]:
+    refs = pub.fields.get("author") or []
+    if not isinstance(refs, list):
+        refs = [refs]
+    out: set[str] = set()
+    for r in refs:
+        out.add(r.get("@id") if isinstance(r, dict) else r)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# (a) Crossref ORCID
+# ---------------------------------------------------------------------------
+
+
+class TestCrossrefOrcid:
+    def test_uses_crossref_orcid_when_present_and_verified(self, monkeypatch):
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: _orcid_record("0000-0002-1825-0097", "Jane", "Doe"),
+        )
+
+        result = draft_publication_with_authors(state, "10.1234/example")
+
+        persons = _person_nodes(state)
+        assert len(persons) == 1
+        person = persons[0]
+        # The ORCID became the @id source (orcid field) and is verified.
+        assert person.fields.get("orcid") in (
+            "0000-0002-1825-0097",
+            "https://orcid.org/0000-0002-1825-0097",
+        )
+        status = person.get_field_status("orcid")
+        assert status is not None and status.status == "verified"
+        # No synthesized CitationAuthor id was used.
+        assert not person.entity_id.startswith("#CitationAuthor")
+        # The author is wired onto the publication.
+        pub = next(e for e in state.list_entities() if e.type == "Publication")
+        assert person.entity_id in {a.lstrip("#") for a in _author_ids(state, pub)} or (
+            f"https://orcid.org/0000-0002-1825-0097" in _author_ids(state, pub)
+        )
+        assert "0000-0002-1825-0097" in str(result)
+
+    def test_crossref_orcid_rejected_when_name_mismatches(self, monkeypatch):
+        """D5: a Crossref ORCID whose resolved name does not match is NOT used."""
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            # ORCID resolves to a completely different person.
+            orcid=lambda o: _orcid_record("0000-0002-1825-0097", "Carlos", "Santana"),
+            by_name=lambda g, f, affiliation=None: [],
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        person = _person_nodes(state)[0]
+        # Mismatch -> no ORCID attached; falls back to synthesized author.
+        assert not person.fields.get("orcid")
+        assert person.entity_id.startswith("#CitationAuthor")
+
+
+# ---------------------------------------------------------------------------
+# (b) In-crate Person match (incl. the F.M.A. <-> Fabian initial case)
+# ---------------------------------------------------------------------------
+
+
+class TestInCratePersonMatch:
+    def _seed_root_person(self, state: CrateState) -> Entity:
+        """A root Person 'F.M.A. Wagenaars' with a verified ORCID."""
+        person = Entity(
+            entity_id="https://orcid.org/0000-0003-4766-7358",
+            type="Person",
+            _provenance=EntityProvenance(created_by="lookup"),
+        )
+        person.set_fields_from_dict(
+            {
+                "name": "F.M.A. Wagenaars",
+                "givenName": "F.M.A.",
+                "familyName": "Wagenaars",
+                "orcid": "0000-0003-4766-7358",
+                "affiliation": "Utrecht University",
+            },
+            source="lookup",
+        )
+        person.set_field_status("orcid", "verified", "lookup")
+        state.add_entity(person)
+        return person
+
+    def test_reuses_in_crate_person_via_initial_match(self, monkeypatch):
+        """Citation 'Fabian Wagenaars' resolves to root 'F.M.A. Wagenaars' ORCID."""
+        state = CrateState()
+        root = self._seed_root_person(state)
+
+        # No Crossref ORCID; search must NOT be consulted (in-crate wins first).
+        def _no_search(*a, **k):
+            raise AssertionError("ORCID search should not be called for an in-crate hit")
+
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {"givenName": "Fabian", "familyName": "Wagenaars"}
+            ),
+            orcid=lambda o: _orcid_record(
+                "0000-0003-4766-7358", "F.M.A.", "Wagenaars"
+            ),
+            by_name=_no_search,
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        # No NEW Person was created — the root Person is reused as the author.
+        assert len(_person_nodes(state)) == 1
+        pub = next(e for e in state.list_entities() if e.type == "Publication")
+        assert root.entity_id in _author_ids(state, pub)
+
+    def test_in_crate_match_requires_verified_orcid(self, monkeypatch):
+        """An in-crate Person whose ORCID is only 'filled' (unverified) is not reused."""
+        state = CrateState()
+        person = Entity(entity_id="person_x", type="Person")
+        person.set_fields_from_dict(
+            {"name": "Fabian Wagenaars", "familyName": "Wagenaars", "givenName": "Fabian"}
+        )  # no orcid at all
+        state.add_entity(person)
+
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {"givenName": "Fabian", "familyName": "Wagenaars"}
+            ),
+            orcid=lambda o: {"found": False, "data": {}, "error": "x"},
+            by_name=lambda g, f, affiliation=None: [],  # no search hit -> fallback
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        # A synthesized CitationAuthor was created (the unverified person not reused).
+        synth = [p for p in _person_nodes(state) if p.entity_id.startswith("#CitationAuthor")]
+        assert len(synth) == 1
+
+
+# ---------------------------------------------------------------------------
+# (c-auto) unambiguous public search
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAutoAccept:
+    def test_single_strong_search_match_auto_accepted(self, monkeypatch):
+        state = CrateState()
+        human = RecordingHumanInterface()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {"givenName": "Fabian", "familyName": "Wagenaars"}
+            ),
+            by_name=lambda g, f, affiliation=None: [
+                {
+                    "orcid": "0000-0003-4766-7358",
+                    "given": "Fabian",
+                    "family": "Wagenaars",
+                    "affiliation": "Utrecht University",
+                }
+            ],
+            orcid=lambda o: _orcid_record(
+                "0000-0003-4766-7358", "Fabian", "Wagenaars"
+            ),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example", human_interface=human)
+
+        person = _person_nodes(state)[0]
+        assert person.fields.get("orcid") in (
+            "0000-0003-4766-7358",
+            "https://orcid.org/0000-0003-4766-7358",
+        )
+        # Confidently resolved -> no HITL prompt.
+        assert human.present_calls == []
+        assert human.input_calls == []
+
+    def test_initial_only_search_match_is_not_auto_accepted(self, monkeypatch):
+        """A weak (initial-only given) match escalates rather than auto-accepting."""
+        state = CrateState()
+        human = RecordingHumanInterface()  # default: skip
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result({"givenName": "F.", "familyName": "Wagenaars"}),
+            by_name=lambda g, f, affiliation=None: [
+                {
+                    "orcid": "0000-0003-4766-7358",
+                    "given": "Fabian",
+                    "family": "Wagenaars",
+                    "affiliation": "Utrecht University",
+                }
+            ],
+            orcid=lambda o: _orcid_record(
+                "0000-0003-4766-7358", "Fabian", "Wagenaars"
+            ),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example", human_interface=human)
+
+        # Weak match -> a HITL escalation happened.
+        assert human.present_calls, "expected a HITL prompt for the weak/initial match"
+
+
+# ---------------------------------------------------------------------------
+# (c-HITL) ambiguous -> simulated human picks
+# ---------------------------------------------------------------------------
+
+
+class TestSearchHitlPick:
+    def test_multiple_candidates_escalate_and_human_picks(self, monkeypatch):
+        state = CrateState()
+        candidates = [
+            {
+                "orcid": "0000-0001-1111-1111",
+                "given": "Jane",
+                "family": "Smith",
+                "affiliation": "University A",
+            },
+            {
+                "orcid": "0000-0002-2222-2222",
+                "given": "Jane",
+                "family": "Smith",
+                "affiliation": "University B",
+            },
+        ]
+        # Human approves option index 1 (the second candidate) via comments/edits.
+        human = RecordingHumanInterface(
+            present_response={
+                "action": "approved",
+                "comments": "0000-0002-2222-2222",
+                "edits": {"orcid": "0000-0002-2222-2222"},
+            }
+        )
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result({"givenName": "Jane", "familyName": "Smith"}),
+            by_name=lambda g, f, affiliation=None: candidates,
+            orcid=lambda o: _orcid_record(
+                o.rsplit("/", 1)[-1], "Jane", "Smith"
+            ),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example", human_interface=human)
+
+        assert human.present_calls, "expected a HITL prompt with the candidate options"
+        person = _person_nodes(state)[0]
+        assert person.fields.get("orcid") in (
+            "0000-0002-2222-2222",
+            "https://orcid.org/0000-0002-2222-2222",
+        )
+
+    def test_human_pastes_orcid_via_request_input(self, monkeypatch):
+        state = CrateState()
+        # present() returns no usable pick -> tool asks request_input; user pastes.
+        human = RecordingHumanInterface(
+            present_response={"action": "approved", "comments": None, "edits": None},
+            input_response={"value": "0000-0002-2222-2222", "skipped": False},
+        )
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result({"givenName": "Jane", "familyName": "Smith"}),
+            by_name=lambda g, f, affiliation=None: [
+                {"orcid": "0000-0001-1111-1111", "given": "Jane", "family": "Smith", "affiliation": "A"},
+                {"orcid": "0000-0009-9999-9999", "given": "Jane", "family": "Smith", "affiliation": "B"},
+            ],
+            orcid=lambda o: _orcid_record(o.rsplit("/", 1)[-1], "Jane", "Smith"),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example", human_interface=human)
+
+        person = _person_nodes(state)[0]
+        assert person.fields.get("orcid") in (
+            "0000-0002-2222-2222",
+            "https://orcid.org/0000-0002-2222-2222",
+        )
+
+
+# ---------------------------------------------------------------------------
+# (d) fallback synthesized + D5 negative
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackAndD5:
+    def test_no_signal_synthesizes_citation_author(self, monkeypatch):
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {"givenName": "Fabian", "familyName": "Wagenaars"}
+            ),
+            by_name=lambda g, f, affiliation=None: [],  # no search hit
+            orcid=lambda o: {"found": False, "data": {}, "error": "x"},
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        person = _person_nodes(state)[0]
+        assert person.entity_id == "#CitationAuthor_Fabian_Wagenaars"
+        assert not person.fields.get("orcid")
+
+    def test_d5_uncertain_and_human_skip_attaches_no_orcid(self, monkeypatch):
+        """Ambiguous candidates + human SKIP => no ORCID, synthesized fallback used."""
+        state = CrateState()
+        human = RecordingHumanInterface(
+            present_response={"action": "skipped", "comments": None, "edits": None},
+            input_response={"value": None, "skipped": True},
+        )
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result({"givenName": "Jane", "familyName": "Smith"}),
+            by_name=lambda g, f, affiliation=None: [
+                {"orcid": "0000-0001-1111-1111", "given": "Jane", "family": "Smith", "affiliation": "A"},
+                {"orcid": "0000-0002-2222-2222", "given": "Jane", "family": "Smith", "affiliation": "B"},
+            ],
+            orcid=lambda o: _orcid_record(o.rsplit("/", 1)[-1], "Jane", "Smith"),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example", human_interface=human)
+
+        assert human.present_calls, "expected a HITL prompt"
+        person = _person_nodes(state)[0]
+        assert not person.fields.get("orcid"), "no ORCID may be attached after a skip (D5)"
+        assert person.entity_id.startswith("#CitationAuthor")
+
+    def test_returns_summary_and_reuses_existing_publication(self, monkeypatch):
+        """Re-running with an already-present ScholarlyArticle does not duplicate it."""
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: _orcid_record("0000-0002-1825-0097", "Jane", "Doe"),
+        )
+
+        r1 = draft_publication_with_authors(state, "10.1234/example")
+        r2 = draft_publication_with_authors(state, "10.1234/example")
+
+        pubs = [e for e in state.list_entities() if e.type == "Publication"]
+        assert len(pubs) == 1
+        assert r1["publication_id"] == r2["publication_id"]
+        assert "authors" in r1
+
+    def test_doi_not_found_returns_error(self, monkeypatch):
+        state = CrateState()
+        _patch(monkeypatch, doi=lambda d: {"found": False, "data": {}, "error": "nope"})
+
+        result = draft_publication_with_authors(state, "10.0000/missing")
+
+        assert result.get("ok") is False
+        assert not [e for e in state.list_entities() if e.type == "Publication"]
+
+
+# ---------------------------------------------------------------------------
+# Registration & engine routing
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_registered_with_takes_human(self):
+        from builder.tools.registry import TOOL_REGISTRY
+
+        import builder.tools.composites  # noqa: F401  (triggers registration)
+
+        spec = TOOL_REGISTRY.get_spec("draft_publication_with_authors")
+        assert spec is not None
+        assert spec.takes_state is True
+        assert spec.takes_human is True
+
+    def test_orcid_person_round_trips_with_identifier_pv(self, monkeypatch):
+        """An ORCID-resolved author builds with the ORCID @id + ORCID PropertyValue."""
+        from rocrate.rocrate import ROCrate
+
+        from builder.tools._crate_mapping import populate_crate
+        from profiles.context import ISA_TOX_CONTEXT
+
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: _orcid_record("0000-0002-1825-0097", "Jane", "Doe"),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        crate = ROCrate()
+        crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+        populate_crate(state, crate, None, materialize_payload=False)
+        graph = crate.metadata.generate()["@graph"]
+
+        # The Person node @id is the ORCID URL.
+        person_node = next(
+            n for n in graph if n.get("@id") == "https://orcid.org/0000-0002-1825-0097"
+        )
+        # It carries an ORCID identifier PropertyValue (#185's _identifier_pv path).
+        pv_nodes = [n for n in graph if n.get("name") == "ORCID"]
+        assert pv_nodes, "expected an ORCID PropertyValue identifier node"
+        assert any("0000-0002-1825-0097" in str(n.get("value")) for n in pv_nodes)
+        # The ScholarlyArticle's author references the ORCID Person.
+        article = next(
+            n for n in graph if "ScholarlyArticle" in (
+                n.get("@type") if isinstance(n.get("@type"), list) else [n.get("@type")]
+            )
+        )
+        authors = article.get("author")
+        author_ids = {
+            (a.get("@id") if isinstance(a, dict) else a)
+            for a in (authors if isinstance(authors, list) else [authors])
+        }
+        assert person_node["@id"] in author_ids
+
+    def test_engine_injects_human_interface(self, monkeypatch):
+        from builder.engine import AgentEngine
+
+        human = RecordingHumanInterface()
+        engine = AgentEngine(human_interface=human)
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result({"givenName": "Jane", "familyName": "Smith"}),
+            by_name=lambda g, f, affiliation=None: [
+                {"orcid": "0000-0001-1111-1111", "given": "Jane", "family": "Smith", "affiliation": "A"},
+                {"orcid": "0000-0002-2222-2222", "given": "Jane", "family": "Smith", "affiliation": "B"},
+            ],
+            orcid=lambda o: _orcid_record(o.rsplit("/", 1)[-1], "Jane", "Smith"),
+        )
+
+        engine.run_tool("draft_publication_with_authors", doi="10.1234/example")
+
+        # The engine routed the injected interface through to the tool.
+        assert human.present_calls, "engine should have injected the HITL adapter"


### PR DESCRIPTION
## What

Adds `draft_publication_with_authors(doi)` — a state-mutating, engine-routed composite that drafts a publication from a DOI **and** wires every author as a `Person`, harmonizing each author's `@id` to their **ORCID** when it can be determined. This closes the #180 deferred item: citation authors that aren't already in-crate Persons used to get synthesized blank ids like `#CitationAuthor_Fabian_Wagenaars`; now they get a real ORCID `@id` whenever one can be safely resolved.

## Resolution cascade (per author, first hit wins)

1. **Crossref ORCID** on the author → verified via `lookup_orcid` (resolved family name must match) → `https://orcid.org/<id>`.
2. **In-crate Person** with a *verified* ORCID matching the author's family name + given/initial (affiliation-preferred) → reused. Resolves the gold case where citation `Fabian Wagenaars` reuses root `F.M.A. Wagenaars`'s ORCID `0000-0003-4766-7358`.
3. **Public ORCID search** — new library helper `lookups.orcid.lookup_orcid_by_name(given, family, affiliation=None)` hitting the ORCID public `/v3.0/expanded-search` endpoint through the shared rate-limited HTTP layer (`lru_cache`d, returns ranked `[{orcid, given, family, affiliation}]`).
4. **Fallback** → synthesized `#CitationAuthor_<Given>_<Family>` Person (legacy behavior).

## Confidence rule: auto-accept vs HITL

Auto-accept **only** a *single* search candidate that is a **STRONG** match (family + **full**, not initial-only, given name) **and** passes name verification. *Everything else* — multiple candidates, a weak / initial-only match, or a sole strong match that fails verification — **escalates to HITL**: `present` the ranked candidates plus a "none/skip" option, then optionally `request_input` for a pasted ORCID. HITL fires **only** on genuine ambiguity — never when an author is confidently resolved or confidently absent.

## D5 — never attach an unverified/guessed ORCID

An ORCID from (a) or (c), and an HITL-chosen one, is attached **only** after `lookup_orcid` resolves it and the family name roughly matches; (b) is already verified. With no `human_interface` available, an ambiguous author falls back to a synthesized id rather than guessing. An ORCID-resolved Person round-trips with its ORCID `identifier` PropertyValue via #185's `_identifier_pv` build path (verified by a graph-level test).

## Engine routing

`ToolSpec`/`ToolRegistry.register` gain a `takes_human` flag; the engine injects the active `HumanInterface` as a `human_interface` kwarg when invoking such a tool. This is the first HITL-capable registered drafter (others go through the special-cased `present_to_human`/`request_input` routing).

## Four-place registration

`TOOL_REGISTRY` (composites.py), `TOOL_SPECS` (tools_spec.py), system-prompt "## Your Tools", and `AGENTS.md §5`. The bidirectional source-of-truth tests (`test_tools_spec.py`, `test_agents_doc_toolbox.py`) stay green.

## Tests (TDD, fully offline)

- `tests/test_tools_publication_authors.py` (new): every cascade branch — (a) Crossref ORCID, (a-negative) name-mismatch rejection, (b) in-crate match incl. the F.M.A.↔Fabian initial case, (b) unverified-ORCID not reused, (c-auto) single strong match, (c) initial-only is **not** auto-accepted, (c-HITL) ambiguous → human picks / pastes via `request_input`, (d) fallback synthesized, **D5 negative** (uncertain + human-skip ⇒ no ORCID), DOI-not-found, idempotent publication reuse, ORCID-PropertyValue round-trip, and registration/engine-injection.
- `tests/test_lookups_contract.py`: 5 new `responses`-replayed contract tests for `lookup_orcid_by_name` (single/multiple/none matches, empty-family short-circuit, transient raises).

## Open questions worth a human's eye

- The ORCID expanded-search Lucene query uses `family-name`/`given-names`/`affiliation-org-name` fields and `rows=10`; field names and ranking were not validated against a live ORCID response (tests mock the HTTP layer per repo offline policy). Worth a one-off live smoke check before relying on the auto-accept path in production.
- `hitl` count in the result dict is best-effort metadata (reads a recording double's call lists); it stays 0 with the production `SimulatedHumanInterface`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)