### PR TITLE
feat(eval): A/B evaluation harness for the ReAct→pipeline decision gate (#179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ sessions/
 input/
 output/
 
+# A/B evaluation harness reports (live runs write here; never commit)
+eval_reports/
+
 .pytest_cache/
 .mypy_cache/
 .claude/CLAUDE.md

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,114 @@
+# `eval/` — A/B evaluation harness (the ReAct → pipeline decision gate)
+
+This package is **task 6** of the deterministic-pipeline migration (AGENTS.md §14.4).
+It is the in-repo A/B that AGENTS.md §14.1 says the full cutover is **gated on**: the
+defensible win for this system is *cost, latency, reproducibility, testability,
+predictability* — not blanket correctness — so we measure those directly instead of
+asserting them.
+
+The harness is **agent-agnostic**: it measures the current prose-prompt ReAct engine
+today and a future deterministic pipeline tomorrow, by swapping a single factory. The
+corpus, metrics, and report are unchanged across architectures, so two runs diff cleanly.
+
+> **Cost note.** A *live* harness run makes real LLM calls (your configured
+> DeepSeek-flash / OpenAI / Anthropic credentials) — that is its purpose. **CI and the
+> unit tests are strictly offline**: they exercise the runner / metrics / report /
+> determinism logic against a mock agent factory and never touch a model or the network.
+
+## The agent-agnostic factory
+
+The only thing the harness knows about an architecture is the
+[`BuildAgent`](agent_api.py) contract:
+
+```python
+class BuildAgent(Protocol):
+    def build(self, case: EvalCase) -> BuildOutcome: ...   # state + session_id + error
+```
+
+`run_eval(agent_factory, corpus, *, repeats=2)` takes a **zero-arg `agent_factory`**
+that returns a fresh `BuildAgent` per repeat (a fresh agent each time so no engine /
+session state leaks into the determinism signal). To A/B two architectures you change
+only the factory:
+
+| Architecture | Factory | Status |
+|--------------|---------|--------|
+| ReAct engine (as-built) | `eval.react_factory.make_react_agent_factory()` | implemented |
+| Deterministic pipeline | a future `make_pipeline_agent_factory()` (same shape) | when §14 tasks 1–5 land |
+| Offline tests | an in-memory mock returning canned `CrateState`s | tests only |
+
+`ReActBuildAgent` wraps the existing LangGraph ReAct loop: it creates a headless
+`AgentEngine` (`SimulatedHumanInterface`, so HITL auto-approves), `initialize()`s the
+case's input directory (which also assigns the `session_id` and opens this run's
+`profile.ndjson`), drives the graph once with the case's prompt, and returns the final
+`CrateState`. The model-driving step is injected so the wiring is unit-tested offline.
+
+## The corpus
+
+A small fixed set of crate-build cases ([`corpus.py`](corpus.py)), each declared as
+data — all inputs are in-repo and offline:
+
+| `case_id` | `kind` | What it exercises |
+|-----------|--------|-------------------|
+| `minimal-backbone` | `minimal` | Build a conformant ISA-Tox backbone from a short brief. |
+| `structured-svhps21` | `structured` | Scan the in-repo `tests/fixtures/svhps21_input` folder (README + raw/processed CSVs) and build from its structured metadata. |
+| `unstructured-conversation` | `unstructured` | No metadata files — the whole crate is elicited from the prompt. |
+
+**Success predicate** (shared, strict): a case succeeds when its crate reaches
+`{base, isa, tox}` REQUIRED conformance via `build_and_validate`
+(`reaches_isa_tox_conformance`).
+
+## The metrics
+
+Per case, across `repeats` runs ([`metrics.py`](metrics.py), [`runner.py`](runner.py)):
+
+- **success** (bool) + the per-layer **conformance** map;
+- **tokens** — input / output / total, summed from the run's `profile.ndjson`
+  (`node_end`/`model` events);
+- **latency** — wall-clock seconds for the build;
+- **iteration count** and **tool-call count** — also mined from `profile.ndjson`;
+- **determinism** — a stable SHA-256 hash of the assembled crate `@graph` (volatile
+  `datePublished`/`dateModified` stripped, nodes sorted by `@id`) compared across
+  repeats; identical ⇒ deterministic. With `repeats == 1`, determinism is `None`.
+
+The aggregate `EvalReport.summary()` reports **success rate**, **mean/median tokens**,
+**mean/median latency**, and the **determinism rate**.
+
+## Report format
+
+`write_report(report, path)` writes one labeled **ndjson** per run: a
+`{"record": "case", ...}` line per case carrying every metric, then one
+`{"record": "summary", ...}` line with the aggregates. `compare_reports(a, b, ...)`
+returns a side-by-side A/B diff (both summaries plus a per-case table keyed by
+`case_id`) so a ReAct report and a pipeline report compare field-for-field.
+
+## Running it
+
+### Live baseline (human-triggered, uses your credentials)
+
+```bash
+# Requires an LLM provider configured (VITRO_OPENAI_API_KEY / OPENAI_API_KEY, etc.).
+uv run --extra langchain python -m eval --label react-baseline
+# -> writes eval_reports/react-baseline.ndjson
+```
+
+Then **freeze the baseline** so future pipeline runs have a stable comparison point:
+
+```bash
+git tag react-baseline      # tags the pre-migration ReAct commit (AGENTS.md §14.4)
+git push origin react-baseline
+```
+
+Later, when the deterministic pipeline lands, run the harness with the pipeline factory
+under `--label pipeline` and compare the two reports with `compare_reports`.
+
+Options: `--repeats N` (builds per case), `--out PATH`, `--provider`, `--model`,
+`--api-base`. See `python -m eval --help`.
+
+### Offline tests (CI)
+
+```bash
+uv run --extra langchain pytest eval/tests
+```
+
+All `eval/tests` are mock-backed and offline. Tests that touch `build_and_validate`
+carry a module-level `pytest.mark.timeout(120)`.

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -1,0 +1,36 @@
+"""Agent-agnostic A/B evaluation harness for vitro-crate (Issue #179, task 6).
+
+This package measures a crate-building *agent* against a fixed corpus of cases,
+recording success, token cost, latency, iteration / tool-call counts, and a
+determinism signal. The same harness runs the current ReAct engine today and a
+future deterministic pipeline tomorrow — the only thing that changes is the
+zero-arg ``agent_factory`` passed to :func:`eval.runner.run_eval`.
+
+CI / unit tests stay strictly offline (mock agent factory); a *live* run makes
+real LLM calls and is triggered by a human with credentials (``python -m eval``).
+"""
+
+from __future__ import annotations
+
+from eval.agent_api import AgentFactory, BuildAgent, BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase, reaches_isa_tox_conformance
+from eval.metrics import ProfileMetrics, crate_graph_hash, mine_profile_metrics
+from eval.report import compare_reports, write_report
+from eval.runner import CaseResult, EvalReport, run_eval
+
+__all__ = [
+    "AgentFactory",
+    "BuildAgent",
+    "BuildOutcome",
+    "CaseResult",
+    "DEFAULT_CORPUS",
+    "EvalCase",
+    "EvalReport",
+    "ProfileMetrics",
+    "compare_reports",
+    "crate_graph_hash",
+    "mine_profile_metrics",
+    "reaches_isa_tox_conformance",
+    "run_eval",
+    "write_report",
+]

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -1,0 +1,139 @@
+"""``python -m eval`` — run the A/B harness and write a labeled report.
+
+Live by default: it runs the current ReAct engine over the corpus (real LLM calls,
+your configured DeepSeek-flash / OpenAI / Anthropic credentials) and writes a
+labeled ndjson report under ``eval_reports/``. Capture the baseline with::
+
+    python -m eval --label react-baseline
+
+then freeze the baseline at git tag ``react-baseline`` (see ``eval/README.md``).
+When the deterministic pipeline lands, run the same command with its factory under
+a ``--label pipeline`` and diff the two reports with :func:`eval.report.compare_reports`.
+
+The ``agent_factory`` / ``profile_reader`` parameters of :func:`run_main` exist so
+the offline tests drive the whole flow with a mock — they are never used live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from eval.agent_api import BuildAgent
+from eval.corpus import DEFAULT_CORPUS
+from eval.report import write_report
+from eval.runner import run_eval
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_OUT_DIR = "eval_reports"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser for ``python -m eval``."""
+    parser = argparse.ArgumentParser(
+        prog="python -m eval",
+        description="Run the agent-agnostic A/B evaluation harness over the corpus.",
+    )
+    parser.add_argument(
+        "--label",
+        default="react-baseline",
+        help="Run label recorded in the report (default: react-baseline).",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=2,
+        help="Builds per case; >1 enables the determinism signal (default: 2).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output ndjson path (default: <out-dir>/<label>.ndjson).",
+    )
+    parser.add_argument(
+        "--provider",
+        default=None,
+        help="LLM provider override (openai|anthropic); auto-detected if omitted.",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model name override for the live ReAct agent.",
+    )
+    parser.add_argument(
+        "--api-base",
+        dest="api_base",
+        default=None,
+        help="Custom OpenAI-compatible base URL for the live ReAct agent.",
+    )
+    return parser
+
+
+def run_main(
+    argv: list[str] | None = None,
+    *,
+    agent_factory: Callable[[], BuildAgent] | None = None,
+    profile_reader: Callable[[str], list[dict[str, Any]]] | None = None,
+    out_dir: str = _DEFAULT_OUT_DIR,
+) -> int:
+    """Run the harness and write a report; return a process exit code.
+
+    Args:
+        argv: CLI args (defaults to ``sys.argv[1:]``).
+        agent_factory: Override the agent factory (the tests inject a mock). When
+            ``None``, the **live** ReAct factory is used.
+        profile_reader: Override the profile reader (tests inject a canned one).
+        out_dir: Directory for the default ``<label>.ndjson`` output path.
+
+    Returns:
+        ``0`` on success, ``1`` on a configuration error (e.g. no LLM provider).
+    """
+    args = build_arg_parser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO)
+
+    if agent_factory is None:
+        from eval.react_factory import make_react_agent_factory
+
+        agent_factory = make_react_agent_factory(
+            provider=args.provider, model=args.model, base_url=args.api_base
+        )
+
+    out_path = Path(args.out) if args.out else Path(out_dir) / f"{args.label}.ndjson"
+
+    logger.info(
+        "Running eval: label=%s repeats=%s cases=%d",
+        args.label,
+        args.repeats,
+        len(DEFAULT_CORPUS),
+    )
+    try:
+        report = run_eval(
+            agent_factory,
+            DEFAULT_CORPUS,
+            repeats=args.repeats,
+            label=args.label,
+            profile_reader=profile_reader,
+        )
+    except RuntimeError as exc:
+        # e.g. no LLM provider configured for the live factory.
+        logger.error("Eval run failed: %s", exc)
+        return 1
+
+    write_report(report, out_path)
+    summary = report.summary()
+    logger.info(
+        "Done: success_rate=%.2f mean_tokens=%.0f determinism_rate=%.2f -> %s",
+        summary["success_rate"],
+        summary["mean_total_tokens"],
+        summary["determinism_rate"],
+        out_path,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    sys.exit(run_main())

--- a/eval/agent_api.py
+++ b/eval/agent_api.py
@@ -1,0 +1,56 @@
+"""The agent-agnostic build contract the harness measures against.
+
+The whole point of the harness is to compare *architectures* — today's prose-prompt
+ReAct engine vs the planned deterministic pipeline (AGENTS.md §14). It does that
+without knowing anything about either: it is handed a zero-arg ``agent_factory``
+that returns a :class:`BuildAgent`, and it calls ``agent.build(case)`` once per
+repeat. Swapping the factory swaps the architecture under test; the corpus, the
+metrics, and the report are unchanged.
+
+A :class:`BuildAgent` returns a :class:`BuildOutcome`: the finished
+:class:`~builder.state.CrateState` plus an optional ``session_id`` the runner uses
+to locate the run's ``profile.ndjson`` (the source of token / latency / iteration /
+tool-call metrics). A failed build sets ``error`` and may return a partial state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Protocol, runtime_checkable
+
+from builder.state import CrateState
+from eval.corpus import EvalCase
+
+
+@dataclass
+class BuildOutcome:
+    """The result of one agent build.
+
+    Attributes:
+        state: The crate state the agent produced (possibly partial on error).
+        session_id: The build's session id, used to find its ``profile.ndjson``.
+            ``None`` when the agent does not profile (e.g. a mock).
+        error: A short error string if the build raised / failed, else ``None``.
+    """
+
+    state: CrateState
+    session_id: str | None = None
+    error: str | None = None
+
+
+@runtime_checkable
+class BuildAgent(Protocol):
+    """A thing that builds a crate from an :class:`~eval.corpus.EvalCase`.
+
+    The single method the harness depends on. Implementations: the live ReAct
+    factory (:mod:`eval.react_factory`), a future deterministic-pipeline factory,
+    and the offline mock used by the tests.
+    """
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        """Build a crate for *case* and return its outcome."""
+        ...
+
+
+# An agent_factory is any zero-arg callable returning a fresh BuildAgent.
+AgentFactory = Callable[[], BuildAgent]

--- a/eval/corpus.py
+++ b/eval/corpus.py
@@ -1,0 +1,162 @@
+"""The evaluation corpus — a small fixed set of crate-build cases as data.
+
+Each :class:`EvalCase` declares:
+
+* a stable ``case_id`` and human ``description``;
+* a ``kind`` — one of the three input tiers from AGENTS.md §9
+  (``"minimal"`` / ``"structured"`` / ``"unstructured"``);
+* a ``prompt`` — the natural-language request handed to a *conversational* agent
+  (the ReAct engine / tail agent) to drive the build;
+* an optional ``input_path`` — an in-repo, offline directory the agent scans
+  (the structured-metadata case);
+* an optional ``build_state`` — a zero-arg factory returning a finished
+  :class:`CrateState`. The **mock** agent factory uses it to stand in for a real
+  build so the harness logic is unit-testable offline; live agents ignore it.
+
+The success predicate is shared and deliberately strict: a case succeeds when its
+crate reaches ``{base, isa, tox}`` REQUIRED conformance through ``build_and_validate``
+(see :func:`reaches_isa_tox_conformance`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from builder.state import CrateState
+
+CaseKind = Literal["minimal", "structured", "unstructured"]
+
+# The structured-metadata fixture is an in-repo, offline research folder (no real
+# experimental data) — the same one the #59 end-to-end quality test uses.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_STRUCTURED_INPUT = _REPO_ROOT / "tests" / "fixtures" / "svhps21_input"
+
+
+@dataclass(frozen=True)
+class EvalCase:
+    """One crate-build case in the corpus.
+
+    Attributes:
+        case_id: Stable identifier, unique within the corpus.
+        description: Human-readable summary of what the case exercises.
+        kind: The input tier — ``"minimal"`` / ``"structured"`` / ``"unstructured"``.
+        prompt: NL request driving a conversational agent's build.
+        input_path: Optional in-repo directory the agent scans (offline).
+        build_state: Optional factory of a finished state, used by the mock agent.
+    """
+
+    case_id: str
+    description: str
+    kind: CaseKind
+    prompt: str = ""
+    input_path: str | None = None
+    build_state: Callable[[], CrateState] | None = None
+
+
+def reaches_isa_tox_conformance(state: CrateState) -> dict[str, Any]:
+    """Success predicate: does *state* reach ``{base, isa, tox}`` conformance?
+
+    Runs ``build_and_validate`` at REQUIRED severity over all three layers and
+    returns ``{"success": bool, "conformance": {layer: bool}, "issues": [...]}``.
+    ``success`` is true only when every layer passes REQUIRED.
+
+    Args:
+        state: The crate state produced by an agent build.
+
+    Returns:
+        A dict with the boolean verdict, the per-layer conformance map, and the
+        list of routable issues (empty on success).
+    """
+    from eval.metrics import evaluate_success
+
+    result = evaluate_success(state, profile="all", severity="required")
+    conformance = result.get("conformance", {})
+    layers = ("base", "isa", "tox")
+    success = bool(conformance) and all(conformance.get(layer) for layer in layers)
+    return {
+        "success": success,
+        "conformance": conformance,
+        "issues": result.get("issues", []),
+    }
+
+
+# --- mock-build state factories (offline stand-ins for a real agent build) -----
+#
+# These let the harness's runner / report / determinism logic be exercised end to
+# end without a live model. A live agent never calls them; they exist so the
+# *mock* agent factory has a finished, REQUIRED-clean state to return per case.
+
+
+def _minimal_state() -> CrateState:
+    """A REQUIRED-clean S-VHPS21 backbone — the simplest passing crate."""
+    from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+    return vhps_fixture_state("S-VHPS21")
+
+
+def _structured_state() -> CrateState:
+    """Stand-in for building from the structured svhps21 input folder."""
+    from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+    return vhps_fixture_state("S-VHPS21")
+
+
+def _unstructured_state() -> CrateState:
+    """Stand-in for a conversation-driven build with no metadata files."""
+    from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+    return vhps_fixture_state("S-VHPS21")
+
+
+DEFAULT_CORPUS: tuple[EvalCase, ...] = (
+    EvalCase(
+        case_id="minimal-backbone",
+        description=(
+            "Minimal case: build a conformant ISA-Tox backbone "
+            "(Investigation -> Study -> Assay + one Exposure) from a short brief."
+        ),
+        kind="minimal",
+        prompt=(
+            "Build a minimal ISA-Tox RO-Crate for an in vitro assay named "
+            "'MCT8-MDCK1 cellular uptake assay' studying inhibition of MCT8-mediated "
+            "uptake of triiodothyronine. Use accession S-VHPS21. Scaffold the "
+            "Investigation/Study/Assay backbone and add the cell line, the compound "
+            "Triiodothyronine, and an Exposure process, then build and validate "
+            "until base, ISA, and ISA-Tox all pass."
+        ),
+        build_state=_minimal_state,
+    ),
+    EvalCase(
+        case_id="structured-svhps21",
+        description=(
+            "Structured-metadata directory: scan the in-repo S-VHPS21 research "
+            "folder (README + raw/processed CSVs) and build a conformant crate."
+        ),
+        kind="structured",
+        prompt=(
+            "Scan the provided input folder, read its README and data files, draft "
+            "the ISA-Tox entities for the S-VHPS21 MCT8 uptake study, attach the "
+            "data files, then build and validate until base, ISA, and ISA-Tox pass."
+        ),
+        input_path=str(_STRUCTURED_INPUT),
+        build_state=_structured_state,
+    ),
+    EvalCase(
+        case_id="unstructured-conversation",
+        description=(
+            "Unstructured / conversational: no metadata files; the whole crate is "
+            "elicited from the prompt and built from scratch."
+        ),
+        kind="unstructured",
+        prompt=(
+            "I ran an in vitro screen measuring whether test chemicals inhibit "
+            "triiodothyronine uptake via MCT8 in overexpressing MDCK1 cells "
+            "(study S-VHPS21, by Fabian Wagenaars at Universiteit Utrecht). There "
+            "are no metadata files. Please build a conformant ISA-Tox RO-Crate from "
+            "this description, validating until base, ISA, and ISA-Tox all pass."
+        ),
+        build_state=_unstructured_state,
+    ),
+)

--- a/eval/metrics.py
+++ b/eval/metrics.py
@@ -1,0 +1,179 @@
+"""Metric extraction for the evaluation harness.
+
+Three orthogonal concerns live here, all pure and offline:
+
+* :func:`mine_profile_metrics` — aggregate token / iteration / tool-call counts
+  from parsed ``profile.ndjson`` records (the schema written by
+  :class:`builder.tools.profiler.ProfilingLogger` and the LangGraph node wrappers
+  in :mod:`builder.agents.agent_loop`).
+* :func:`crate_graph_hash` — a stable content hash of the crate a state assembles
+  to, used as the determinism signal across repeated runs.
+* :func:`evaluate_success` — run ``build_and_validate`` and report the per-layer
+  conformance map (the corpus success predicate's building block).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from builder.state import CrateState
+
+logger = logging.getLogger(__name__)
+
+# Auto-generated, wall-clock-derived node properties that ro-crate-py stamps onto
+# the root Dataset at build time. They carry no agent-decision content, so they
+# are stripped before hashing — otherwise two identical builds run seconds apart
+# would falsely register as non-deterministic.
+_VOLATILE_NODE_KEYS: frozenset[str] = frozenset({"datePublished", "dateModified"})
+
+
+@dataclass(frozen=True)
+class ProfileMetrics:
+    """Token / iteration / tool-call counts mined from ``profile.ndjson``.
+
+    Attributes:
+        input_tokens: Sum of ``input_tokens`` across model ``node_end`` events.
+        output_tokens: Sum of ``output_tokens`` across model ``node_end`` events.
+        tool_calls: Number of ``tool_call`` events.
+        iterations: The highest ``iteration`` counter observed (0 if none).
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    tool_calls: int = 0
+    iterations: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        """Combined input + output token count."""
+        return self.input_tokens + self.output_tokens
+
+
+def _as_int(value: Any) -> int:
+    """Coerce a possibly-missing / null token field to a non-negative int."""
+    if value is None:
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def mine_profile_metrics(records: list[dict[str, Any]]) -> ProfileMetrics:
+    """Aggregate token, iteration, and tool-call counts from profile records.
+
+    Token usage is summed over ``node_end`` events for the ``"model"`` node only
+    (the ``"tools"`` node never carries token usage). The iteration count is the
+    maximum ``iteration`` seen across all events — robust to the per-event
+    ordering. ``records`` is the output of
+    :func:`builder.tools.dashboard.read_profile`.
+
+    Args:
+        records: Parsed ``profile.ndjson`` event dicts.
+
+    Returns:
+        A :class:`ProfileMetrics` with the aggregated counts.
+    """
+    input_tokens = 0
+    output_tokens = 0
+    tool_calls = 0
+    max_iteration = 0
+
+    for rec in records:
+        event = rec.get("event")
+        iteration = _as_int(rec.get("iteration"))
+        if iteration > max_iteration:
+            max_iteration = iteration
+        if event == "tool_call":
+            tool_calls += 1
+        elif event == "node_end" and rec.get("node") == "model":
+            input_tokens += _as_int(rec.get("input_tokens"))
+            output_tokens += _as_int(rec.get("output_tokens"))
+
+    return ProfileMetrics(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        tool_calls=tool_calls,
+        iterations=max_iteration,
+    )
+
+
+def crate_graph_hash(state: CrateState) -> str:
+    """Return a stable SHA-256 hash of the crate *state* assembles to.
+
+    The crate is assembled in memory (no disk write, no payload materialization)
+    and its JSON-LD ``@graph`` is canonicalized — each node sorted by ``@id`` and
+    the whole document dumped with ``sort_keys=True`` — before hashing. Two states
+    that produce the same crate therefore hash identically regardless of insertion
+    order, which is exactly the determinism signal the harness needs.
+
+    Falls back to hashing the serialized :class:`CrateState` if assembly fails, so
+    the determinism check degrades gracefully rather than raising into the runner.
+
+    Args:
+        state: The crate state to fingerprint.
+
+    Returns:
+        A 64-character hex SHA-256 digest.
+    """
+    try:
+        from builder.tools.builder import assemble_crate
+
+        crate = assemble_crate(
+            state,
+            output_dir=None,
+            materialize_payload=False,
+            include_all_scanned=False,
+        )
+        metadata_doc = crate.metadata.generate()
+        graph = metadata_doc.get("@graph", metadata_doc)
+        if isinstance(graph, list):
+            # Drop volatile build-time stamps, then sort nodes by @id so neither
+            # the build clock nor insertion order can perturb the hash.
+            scrubbed = [
+                {k: v for k, v in node.items() if k not in _VOLATILE_NODE_KEYS}
+                if isinstance(node, dict)
+                else node
+                for node in graph
+            ]
+            canonical: Any = sorted(
+                scrubbed,
+                key=lambda node: json.dumps(
+                    node.get("@id", "") if isinstance(node, dict) else node,
+                    sort_keys=True,
+                ),
+            )
+        else:
+            canonical = graph
+        payload = json.dumps(canonical, sort_keys=True, default=str)
+    except Exception as exc:  # noqa: BLE001 — never let hashing abort the run
+        logger.warning("crate_graph_hash: assembly failed (%s); hashing raw state", exc)
+        payload = json.dumps(state.to_dict(), sort_keys=True, default=str)
+
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def evaluate_success(
+    state: CrateState,
+    *,
+    profile: str = "all",
+    severity: str = "required",
+) -> dict[str, Any]:
+    """Run ``build_and_validate`` and return its conformance result.
+
+    Args:
+        state: The crate state produced by an agent build.
+        profile: Validation scope (``"all"`` runs base -> isa -> tox).
+        severity: Gate severity (``"required"`` is the conformance gate).
+
+    Returns:
+        ``{"ok": bool, "conformance": {layer: bool}, "issues": [...]}`` exactly as
+        :func:`builder.tools.validation.build_and_validate` returns it.
+    """
+    from builder.tools.validation import build_and_validate
+
+    return build_and_validate(state, severity=severity, profile=profile)

--- a/eval/react_factory.py
+++ b/eval/react_factory.py
@@ -1,0 +1,176 @@
+"""The live ReAct agent factory — the *current* architecture under test.
+
+This wraps the as-built prose-prompt ReAct StateGraph (AGENTS.md §4 / D1) behind
+the agent-agnostic :class:`~eval.agent_api.BuildAgent` contract. A future
+deterministic-pipeline factory (AGENTS.md §14) implements the same contract; the
+harness then A/B's the two by swapping factories.
+
+A build:
+
+1. creates a headless :class:`~builder.engine.AgentEngine`
+   (:class:`~builder.tools.hitl.SimulatedHumanInterface`, so HITL auto-approves);
+2. ``initialize(input_path)`` — scans the case's input dir if any, and (always)
+   assigns a ``session_id`` + opens the run's ``profile.ndjson``;
+3. drives the ReAct graph once with the case's prompt as a ``HumanMessage``;
+4. returns the engine's final :class:`~builder.state.CrateState` and ``session_id``
+   so the runner can mine that run's profile for tokens / latency / iterations.
+
+**This calls a real LLM** — it is the harness's whole purpose when run live, and is
+never exercised in CI. The model-driving step is injected (``graph_driver``) so the
+wiring is unit-testable offline with the network stubbed out.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from builder.engine import AgentEngine
+from builder.tools.hitl import SimulatedHumanInterface
+from eval.agent_api import BuildOutcome
+from eval.corpus import EvalCase
+
+logger = logging.getLogger(__name__)
+
+# A graph_driver runs the ReAct loop once for a prompt, mutating engine.state.
+GraphDriver = Callable[[AgentEngine, str], None]
+
+
+def _live_graph_driver(
+    engine: AgentEngine,
+    prompt: str,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+) -> None:
+    """Drive the existing LangGraph ReAct loop once for *prompt* (LIVE LLM call).
+
+    Mirrors the non-interactive core of
+    :func:`builder.agents.agent_loop.run_interactive_agent`: build the tools, the
+    chat model, and the compiled graph (passing the engine so node timing lands in
+    ``profile.ndjson``), then ``invoke`` it once with the prompt. The recursion
+    limit is derived from the engine's configured iteration cap.
+    """
+    from typing import cast
+
+    from langchain_core.messages import HumanMessage
+    from langchain_core.runnables import RunnableConfig
+
+    from builder.agents.agent_loop import (
+        _build_agent_graph,
+        _build_chat_model,
+        _build_langchain_tools,
+        _recursion_limit,
+    )
+    from builder.config import get_max_iterations
+
+    tools = _build_langchain_tools(engine)
+    llm = _build_chat_model(provider=provider, model=model, base_url=base_url)
+    app = _build_agent_graph(llm, tools, engine=engine)
+
+    max_iterations = get_max_iterations()
+    config = cast(
+        RunnableConfig,
+        {
+            "configurable": {"thread_id": engine.state.session_id},
+            "recursion_limit": _recursion_limit(max_iterations),
+        },
+    )
+    app.invoke({"messages": [HumanMessage(content=prompt)]}, config)
+
+
+class ReActBuildAgent:
+    """A :class:`~eval.agent_api.BuildAgent` backed by the live ReAct engine."""
+
+    def __init__(
+        self,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        graph_driver: GraphDriver | None = None,
+    ) -> None:
+        """Configure the agent's provider / model and (optional) driver override.
+
+        Args:
+            provider: LLM provider override (``"openai"`` / ``"anthropic"``); auto
+                -detected from env when ``None``.
+            model: Model name override.
+            base_url: Custom OpenAI-compatible base URL.
+            graph_driver: Injected driver (tests pass a stub). Defaults to the live
+                LLM-calling :func:`_live_graph_driver`.
+        """
+        self._provider = provider
+        self._model = model
+        self._base_url = base_url
+        self._graph_driver = graph_driver
+
+    def _make_engine(self) -> AgentEngine:
+        """Create a fresh headless engine with a simulated human interface."""
+        return AgentEngine(human_interface=SimulatedHumanInterface())
+
+    def _driver(self) -> GraphDriver:
+        """Return the configured driver, defaulting to the live LLM driver."""
+        if self._graph_driver is not None:
+            return self._graph_driver
+
+        def driver(engine: AgentEngine, prompt: str) -> None:
+            _live_graph_driver(
+                engine,
+                prompt,
+                provider=self._provider,
+                model=self._model,
+                base_url=self._base_url,
+            )
+
+        return driver
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        """Build the crate for *case* by driving the ReAct loop once.
+
+        Args:
+            case: The corpus case to build.
+
+        Returns:
+            A :class:`BuildOutcome` with the final state, the run's ``session_id``,
+            and an ``error`` string if the driver raised.
+        """
+        engine = self._make_engine()
+        # initialize() scans the input dir (if any) and always assigns a
+        # session_id + opens profile.ndjson — the source of this run's metrics.
+        engine.initialize(input_path=case.input_path)
+
+        error: str | None = None
+        try:
+            self._driver()(engine, case.prompt)
+        except Exception as exc:  # noqa: BLE001 — a failed build is a measured result
+            logger.warning("ReAct build failed for case %s: %s", case.case_id, exc)
+            error = str(exc)
+        finally:
+            engine.close_profiler()
+
+        return BuildOutcome(
+            state=engine.state,
+            session_id=engine.state.session_id,
+            error=error,
+        )
+
+
+def make_react_agent_factory(
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+) -> Callable[[], ReActBuildAgent]:
+    """Return a zero-arg factory producing fresh :class:`ReActBuildAgent` instances.
+
+    This is the callable handed to :func:`eval.runner.run_eval` for a live ReAct
+    baseline. A future pipeline ships its own ``make_*_agent_factory`` with the
+    same shape, and the harness compares them by swapping which factory it runs.
+    """
+
+    def factory() -> ReActBuildAgent:
+        return ReActBuildAgent(provider=provider, model=model, base_url=base_url)
+
+    return factory

--- a/eval/report.py
+++ b/eval/report.py
@@ -1,0 +1,83 @@
+"""Report serialization for the evaluation harness.
+
+Two outputs, both designed so a ReAct run and a later pipeline run **diff cleanly**:
+
+* :func:`write_report` — one labeled ndjson per harness run: a ``record: "case"``
+  line per case (carrying every metric) followed by one ``record: "summary"`` line
+  with the aggregates. ndjson keeps each run append-friendly and trivially loadable.
+* :func:`compare_reports` — a structured A/B diff of two labeled reports: both
+  summaries side by side plus a per-case success/token table keyed by ``case_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from eval.runner import EvalReport
+
+logger = logging.getLogger(__name__)
+
+
+def write_report(report: EvalReport, path: str | Path) -> Path:
+    """Write *report* to *path* as ndjson (case lines + a summary line).
+
+    Each case becomes one ``{"record": "case", "label": ..., ...metrics}`` line;
+    the run ends with one ``{"record": "summary", ...aggregates}`` line. Parent
+    directories are created as needed.
+
+    Args:
+        report: The harness report to serialize.
+        path: Destination ndjson file path.
+
+    Returns:
+        The resolved :class:`~pathlib.Path` written.
+    """
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    for result in report.results:
+        record: dict[str, Any] = {"record": "case", "label": report.label}
+        record.update(result.to_dict())
+        lines.append(json.dumps(record, default=str))
+
+    summary = {"record": "summary"}
+    summary.update(report.summary())
+    lines.append(json.dumps(summary, default=str))
+
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    logger.info("Wrote eval report (%d cases) to %s", len(report.results), out)
+    return out
+
+
+def compare_reports(*reports: EvalReport) -> dict[str, Any]:
+    """Diff two or more labeled reports into a comparison-ready dict.
+
+    Args:
+        *reports: The labeled reports to compare (typically a ReAct baseline and
+            a pipeline run).
+
+    Returns:
+        ``{"labels": [...], "summaries": {label: summary}, "cases": {case_id:
+        {label: {success, total_tokens, latency_seconds, deterministic}}}}``.
+    """
+    labels = [r.label for r in reports]
+    summaries = {r.label: r.summary() for r in reports}
+
+    cases: dict[str, dict[str, Any]] = {}
+    for report in reports:
+        for result in report.results:
+            per_label = cases.setdefault(result.case_id, {})
+            per_label[report.label] = {
+                "success": result.success,
+                "total_tokens": result.total_tokens,
+                "latency_seconds": round(result.latency_seconds, 4),
+                "iterations": result.iterations,
+                "tool_calls": result.tool_calls,
+                "deterministic": result.deterministic,
+            }
+
+    return {"labels": labels, "summaries": summaries, "cases": cases}

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -1,0 +1,241 @@
+"""The harness runner — runs an agent over the corpus and reports metrics.
+
+:func:`run_eval` is the single entry point. It is **agent-agnostic**: it takes a
+zero-arg ``agent_factory`` (returns a :class:`~eval.agent_api.BuildAgent`), runs
+each corpus case ``repeats`` times, and records per-case:
+
+* **success** (bool) + the per-layer ``conformance`` map (via ``build_and_validate``);
+* **tokens** (input / output / total) mined from the run's ``profile.ndjson``;
+* **latency** (wall-clock seconds for the build);
+* **iteration count** and **tool-call count** (also from ``profile.ndjson``);
+* a **determinism** signal — a stable hash of the resulting crate ``@graph`` across
+  repeats; identical hashes ⇒ deterministic.
+
+The same call shape runs today's ReAct engine and a future pipeline — only the
+factory changes — so a ReAct :class:`EvalReport` and a pipeline one diff cleanly.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from builder.state import CrateState
+from eval.agent_api import AgentFactory, BuildOutcome
+from eval.corpus import EvalCase, reaches_isa_tox_conformance
+from eval.metrics import crate_graph_hash, mine_profile_metrics
+
+logger = logging.getLogger(__name__)
+
+# A profile_reader maps a session_id to its parsed profile.ndjson records.
+ProfileReader = Callable[[str], list[dict[str, Any]]]
+
+
+def _default_profile_reader(session_id: str) -> list[dict[str, Any]]:
+    """Read ``sessions/<session_id>/profile.ndjson`` into records (offline-safe).
+
+    Returns an empty list when the file is absent — exactly what the mock-backed
+    tests expect when an agent does not profile.
+    """
+    from builder.tools.dashboard import read_profile
+    from builder.tools.profiler import SESSION_DIR
+
+    if not session_id:
+        return []
+    return read_profile(SESSION_DIR / session_id / "profile.ndjson")
+
+
+@dataclass
+class CaseResult:
+    """Per-case aggregated metrics across ``repeats`` runs.
+
+    The token / iteration / tool-call figures come from the **first** repeat's
+    profile (representative of one build); latency is the first repeat's wall
+    clock. ``crate_hashes`` holds one hash per repeat, and ``deterministic`` is
+    ``True``/``False`` when there is more than one repeat to compare, else ``None``.
+    """
+
+    case_id: str
+    kind: str
+    success: bool
+    conformance: dict[str, bool]
+    issues: list[dict[str, Any]]
+    input_tokens: int
+    output_tokens: int
+    tool_calls: int
+    iterations: int
+    latency_seconds: float
+    crate_hashes: list[str]
+    deterministic: bool | None
+    repeats: int
+    error: str | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        """Combined input + output token count for the representative run."""
+        return self.input_tokens + self.output_tokens
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (one ndjson line per case)."""
+        return {
+            "case_id": self.case_id,
+            "kind": self.kind,
+            "success": self.success,
+            "conformance": self.conformance,
+            "num_issues": len(self.issues),
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "tool_calls": self.tool_calls,
+            "iterations": self.iterations,
+            "latency_seconds": round(self.latency_seconds, 4),
+            "crate_hashes": self.crate_hashes,
+            "deterministic": self.deterministic,
+            "repeats": self.repeats,
+            "error": self.error,
+        }
+
+
+@dataclass
+class EvalReport:
+    """The full report for one harness run (one architecture, one label)."""
+
+    label: str
+    repeats: int
+    results: list[CaseResult] = field(default_factory=list)
+
+    def summary(self) -> dict[str, Any]:
+        """Aggregate the per-case results into a comparison-ready dict.
+
+        Keyed so a ReAct run and a pipeline run can be diffed field by field:
+        success rate, mean/median tokens and latency, and the determinism rate
+        (over cases where determinism is defined).
+        """
+        n = len(self.results)
+        successes = sum(1 for r in self.results if r.success)
+        totals = [r.total_tokens for r in self.results]
+        latencies = [r.latency_seconds for r in self.results]
+        decided = [r for r in self.results if r.deterministic is not None]
+        det_rate = (
+            sum(1 for r in decided if r.deterministic) / len(decided) if decided else None
+        )
+        return {
+            "label": self.label,
+            "repeats": self.repeats,
+            "num_cases": n,
+            "num_success": successes,
+            "success_rate": (successes / n) if n else 0.0,
+            "mean_total_tokens": statistics.mean(totals) if totals else 0.0,
+            "median_total_tokens": statistics.median(totals) if totals else 0.0,
+            "mean_latency_seconds": statistics.mean(latencies) if latencies else 0.0,
+            "median_latency_seconds": statistics.median(latencies) if latencies else 0.0,
+            "determinism_rate": det_rate if det_rate is not None else 0.0,
+        }
+
+
+def _safe_build(agent: Any, case: EvalCase) -> tuple[BuildOutcome, float]:
+    """Run one build, returning its outcome and wall-clock latency.
+
+    Any exception from the agent is captured into a failed ``BuildOutcome`` with an
+    empty state so one bad case never aborts the whole sweep.
+    """
+    start = time.perf_counter()
+    try:
+        outcome = agent.build(case)
+    except Exception as exc:  # noqa: BLE001 — a build crash is a measured failure
+        logger.warning("Build raised for case %s: %s", case.case_id, exc)
+        outcome = BuildOutcome(state=CrateState(), session_id=None, error=str(exc))
+    latency = time.perf_counter() - start
+    return outcome, latency
+
+
+def _run_case(
+    agent_factory: AgentFactory,
+    case: EvalCase,
+    *,
+    repeats: int,
+    profile_reader: ProfileReader,
+) -> CaseResult:
+    """Run a single case ``repeats`` times and aggregate its metrics."""
+    hashes: list[str] = []
+    first_outcome: BuildOutcome | None = None
+    first_latency = 0.0
+    error: str | None = None
+
+    for i in range(max(1, repeats)):
+        # A fresh agent per repeat — the determinism check must not be polluted by
+        # carried-over engine/session state.
+        agent = agent_factory()
+        outcome, latency = _safe_build(agent, case)
+        if i == 0:
+            first_outcome, first_latency = outcome, latency
+        if outcome.error and error is None:
+            error = outcome.error
+        hashes.append(crate_graph_hash(outcome.state))
+
+    assert first_outcome is not None  # repeats >= 1 guarantees this
+    state = first_outcome.state
+
+    predicate = reaches_isa_tox_conformance(state)
+
+    profile_records = (
+        profile_reader(first_outcome.session_id) if first_outcome.session_id else []
+    )
+    pm = mine_profile_metrics(profile_records)
+
+    deterministic: bool | None = None
+    if len(hashes) > 1:
+        deterministic = len(set(hashes)) == 1
+
+    return CaseResult(
+        case_id=case.case_id,
+        kind=case.kind,
+        success=predicate["success"],
+        conformance=predicate["conformance"],
+        issues=predicate["issues"],
+        input_tokens=pm.input_tokens,
+        output_tokens=pm.output_tokens,
+        tool_calls=pm.tool_calls,
+        iterations=pm.iterations,
+        latency_seconds=first_latency,
+        crate_hashes=hashes,
+        deterministic=deterministic,
+        repeats=max(1, repeats),
+        error=error,
+    )
+
+
+def run_eval(
+    agent_factory: AgentFactory,
+    corpus: tuple[EvalCase, ...] | list[EvalCase],
+    *,
+    repeats: int = 2,
+    label: str = "eval",
+    profile_reader: ProfileReader | None = None,
+) -> EvalReport:
+    """Run *agent_factory* over *corpus* and return an :class:`EvalReport`.
+
+    Args:
+        agent_factory: Zero-arg callable returning a fresh
+            :class:`~eval.agent_api.BuildAgent`. Called once per repeat per case
+            so no state leaks between runs (critical for the determinism signal).
+        corpus: The cases to evaluate (e.g. ``eval.corpus.DEFAULT_CORPUS``).
+        repeats: How many times to build each case (>= 1). With ``repeats == 1``
+            determinism is undefined and reported as ``None``.
+        label: A run label (e.g. ``"react-baseline"``) recorded in the report.
+        profile_reader: Override for reading a session's profile records (the
+            tests inject a canned reader); defaults to reading
+            ``sessions/<id>/profile.ndjson`` from disk.
+
+    Returns:
+        An :class:`EvalReport` with one :class:`CaseResult` per case.
+    """
+    reader = profile_reader or _default_profile_reader
+    results = [
+        _run_case(agent_factory, case, repeats=repeats, profile_reader=reader)
+        for case in corpus
+    ]
+    return EvalReport(label=label, repeats=repeats, results=results)

--- a/eval/tests/__init__.py
+++ b/eval/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Offline, mock-backed tests for the A/B evaluation harness (eval/)."""

--- a/eval/tests/test_agent_api.py
+++ b/eval/tests/test_agent_api.py
@@ -1,0 +1,56 @@
+"""Tests for the agent-agnostic build API (offline).
+
+The harness only ever talks to a :class:`~eval.agent_api.BuildAgent`: a zero-arg
+``agent_factory`` returns one, and the runner calls ``.build(case)``. This keeps
+the harness independent of *how* a crate is built (ReAct today, deterministic
+pipeline tomorrow). These tests pin the contract with an in-memory fake.
+"""
+
+from __future__ import annotations
+
+from builder.state import CrateState
+from eval.agent_api import BuildAgent, BuildOutcome
+from eval.corpus import EvalCase
+
+
+def _trivial_case() -> EvalCase:
+    return EvalCase(
+        case_id="trivial",
+        description="a case",
+        kind="minimal",
+        build_state=CrateState,
+    )
+
+
+class _FakeAgent:
+    """A minimal BuildAgent returning a fixed state and a session id."""
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id="fake-session")
+
+
+class TestBuildOutcome:
+    def test_carries_state_and_optional_session_id(self) -> None:
+        state = CrateState()
+        outcome = BuildOutcome(state=state, session_id="s1")
+        assert outcome.state is state
+        assert outcome.session_id == "s1"
+
+    def test_session_id_defaults_to_none(self) -> None:
+        outcome = BuildOutcome(state=CrateState())
+        assert outcome.session_id is None
+        assert outcome.error is None
+
+
+class TestBuildAgentProtocol:
+    def test_fake_agent_satisfies_the_protocol(self) -> None:
+        agent: BuildAgent = _FakeAgent()
+        outcome = agent.build(_trivial_case())
+        assert isinstance(outcome, BuildOutcome)
+        assert isinstance(outcome.state, CrateState)
+        assert outcome.session_id == "fake-session"
+
+    def test_isinstance_check_against_runtime_protocol(self) -> None:
+        # BuildAgent is a runtime_checkable Protocol, so duck typing is verifiable.
+        assert isinstance(_FakeAgent(), BuildAgent)

--- a/eval/tests/test_corpus.py
+++ b/eval/tests/test_corpus.py
@@ -1,0 +1,55 @@
+"""Tests for the evaluation corpus (offline, no validation runs here).
+
+The corpus is a small fixed set of crate-build cases described as data. Each case
+declares an input prompt, the kind of input it represents, and (for offline
+testing) an optional ``build_state`` factory the *mock* agent uses to stand in for
+a real build. These tests assert the corpus shape, not conformance — conformance
+is exercised in the runner test under a 120s timeout.
+"""
+
+from __future__ import annotations
+
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+
+
+class TestEvalCase:
+    def test_fields_are_accessible(self) -> None:
+        case = EvalCase(
+            case_id="c1",
+            description="desc",
+            kind="minimal",
+            prompt="build it",
+        )
+        assert case.case_id == "c1"
+        assert case.description == "desc"
+        assert case.kind == "minimal"
+        assert case.prompt == "build it"
+        # input_path / build_state are optional.
+        assert case.input_path is None
+        assert case.build_state is None
+
+
+class TestDefaultCorpus:
+    def test_is_non_empty_and_sized_three_to_four(self) -> None:
+        assert 3 <= len(DEFAULT_CORPUS) <= 4
+
+    def test_case_ids_are_unique(self) -> None:
+        ids = [c.case_id for c in DEFAULT_CORPUS]
+        assert len(ids) == len(set(ids))
+
+    def test_covers_the_three_input_kinds(self) -> None:
+        kinds = {c.kind for c in DEFAULT_CORPUS}
+        assert {"minimal", "structured", "unstructured"} <= kinds
+
+    def test_every_case_has_a_prompt(self) -> None:
+        for c in DEFAULT_CORPUS:
+            assert c.prompt, f"case {c.case_id} has no prompt"
+
+    def test_structured_case_points_at_an_existing_in_repo_input(self) -> None:
+        from pathlib import Path
+
+        structured = [c for c in DEFAULT_CORPUS if c.kind == "structured"]
+        assert structured, "expected a structured-metadata case"
+        for c in structured:
+            assert c.input_path is not None
+            assert Path(c.input_path).exists(), f"{c.input_path} must be in-repo"

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -1,0 +1,73 @@
+"""Tests for the ``python -m eval`` entry point — offline (mock factory).
+
+The CLI's default factory is the LIVE ReAct agent, so these inject a mock factory
+and a canned profile reader to drive the whole pipeline (parse args -> run -> write
+report) without a model. Only the wiring and the on-disk artifact are asserted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState
+from eval.__main__ import build_arg_parser, run_main
+from eval.agent_api import BuildOutcome
+from eval.corpus import EvalCase
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class _MockAgent:
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id=None)
+
+
+def _mock_factory() -> _MockAgent:
+    return _MockAgent()
+
+
+class TestArgParser:
+    def test_defaults(self) -> None:
+        args = build_arg_parser().parse_args([])
+        assert args.label == "react-baseline"
+        assert args.repeats == 2
+
+    def test_overrides(self) -> None:
+        args = build_arg_parser().parse_args(
+            ["--label", "pipeline", "--repeats", "3", "--out", "x.ndjson"]
+        )
+        assert args.label == "pipeline"
+        assert args.repeats == 3
+        assert args.out == "x.ndjson"
+
+
+class TestRunMain:
+    def test_writes_a_labeled_report_and_returns_zero(self, tmp_path: Path) -> None:
+        out = tmp_path / "report.ndjson"
+        rc = run_main(
+            ["--label", "mock-run", "--repeats", "2", "--out", str(out)],
+            agent_factory=_mock_factory,
+            profile_reader=lambda sid: [],
+        )
+        assert rc == 0
+        assert out.exists()
+        lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+        summary = next(line for line in lines if line.get("record") == "summary")
+        assert summary["label"] == "mock-run"
+        assert summary["success_rate"] == 1.0
+
+    def test_default_out_path_is_label_derived(self, tmp_path: Path) -> None:
+        rc = run_main(
+            ["--label", "mock-run"],
+            agent_factory=_mock_factory,
+            profile_reader=lambda sid: [],
+            out_dir=str(tmp_path),
+        )
+        assert rc == 0
+        produced = list(tmp_path.glob("*.ndjson"))
+        assert len(produced) == 1
+        assert "mock-run" in produced[0].name

--- a/eval/tests/test_metrics.py
+++ b/eval/tests/test_metrics.py
@@ -1,0 +1,136 @@
+"""Unit tests for the profile-mining / hashing metrics (offline, fast).
+
+These exercise the pure metric helpers against canned ``profile.ndjson`` records
+and small ``CrateState`` fixtures — never a live model or the network.
+"""
+
+from __future__ import annotations
+
+from builder.state import CrateState, Entity, EntityProvenance
+from eval.metrics import (
+    ProfileMetrics,
+    crate_graph_hash,
+    mine_profile_metrics,
+)
+
+
+class TestMineProfileMetrics:
+    """``mine_profile_metrics`` aggregates tokens / iterations / tool calls."""
+
+    def test_empty_records_yield_zeroed_metrics(self) -> None:
+        m = mine_profile_metrics([])
+        assert isinstance(m, ProfileMetrics)
+        assert m.input_tokens == 0
+        assert m.output_tokens == 0
+        assert m.total_tokens == 0
+        assert m.tool_calls == 0
+        assert m.iterations == 0
+
+    def test_sums_model_node_tokens_and_counts_tool_calls(self) -> None:
+        records = [
+            {"event": "node_start", "node": "model", "iteration": 1},
+            {
+                "event": "node_end",
+                "node": "model",
+                "iteration": 1,
+                "input_tokens": 100,
+                "output_tokens": 40,
+            },
+            {"event": "tool_call", "tool": "scan_files", "iteration": 1},
+            {
+                "event": "node_end",
+                "node": "model",
+                "iteration": 2,
+                "input_tokens": 200,
+                "output_tokens": 60,
+            },
+            {"event": "tool_call", "tool": "draft_investigation", "iteration": 2},
+            {"event": "tool_call", "tool": "build_and_validate", "iteration": 2},
+        ]
+        m = mine_profile_metrics(records)
+        assert m.input_tokens == 300
+        assert m.output_tokens == 100
+        assert m.total_tokens == 400
+        assert m.tool_calls == 3
+        # The highest observed iteration counter is the iteration count.
+        assert m.iterations == 2
+
+    def test_ignores_non_model_node_ends_for_tokens(self) -> None:
+        records = [
+            {
+                "event": "node_end",
+                "node": "tools",
+                "iteration": 1,
+                "input_tokens": 999,
+                "output_tokens": 999,
+            },
+            {
+                "event": "node_end",
+                "node": "model",
+                "iteration": 1,
+                "input_tokens": 10,
+                "output_tokens": 5,
+            },
+        ]
+        m = mine_profile_metrics(records)
+        assert m.input_tokens == 10
+        assert m.output_tokens == 5
+
+    def test_tolerates_missing_or_null_token_fields(self) -> None:
+        records = [
+            {"event": "node_end", "node": "model", "iteration": 1},
+            {
+                "event": "node_end",
+                "node": "model",
+                "iteration": 2,
+                "input_tokens": None,
+                "output_tokens": 7,
+            },
+        ]
+        m = mine_profile_metrics(records)
+        assert m.input_tokens == 0
+        assert m.output_tokens == 7
+        assert m.iterations == 2
+
+
+def _state_with(name: str) -> CrateState:
+    state = CrateState()
+    # The root Dataset name is driven by metadata.title, so vary that to get a
+    # crate whose @graph genuinely differs.
+    state.metadata.title = name
+    state.add_entity(
+        Entity(
+            entity_id="inv",
+            type="Investigation",
+            fields={"name": name, "description": "d", "identifier": "id"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    return state
+
+
+class TestCrateGraphHash:
+    """``crate_graph_hash`` is a stable content hash of the assembled crate."""
+
+    def test_identical_states_hash_identically(self) -> None:
+        assert crate_graph_hash(_state_with("X")) == crate_graph_hash(_state_with("X"))
+
+    def test_different_content_hashes_differently(self) -> None:
+        assert crate_graph_hash(_state_with("X")) != crate_graph_hash(_state_with("Y"))
+
+    def test_hash_ignores_the_build_timestamp(self) -> None:
+        # datePublished is auto-set to wall-clock now() by ro-crate-py; the
+        # determinism signal must not flip just because two runs happened at
+        # different times. Build twice with a forced clock gap and assert stable.
+        import time
+
+        a = crate_graph_hash(_state_with("Stable"))
+        time.sleep(0.01)
+        b = crate_graph_hash(_state_with("Stable"))
+        assert a == b
+
+    def test_hash_is_a_hex_string(self) -> None:
+        h = crate_graph_hash(_state_with("X"))
+        assert isinstance(h, str)
+        assert len(h) == 64  # sha256 hexdigest
+        int(h, 16)  # parses as hex

--- a/eval/tests/test_react_factory.py
+++ b/eval/tests/test_react_factory.py
@@ -1,0 +1,82 @@
+"""Tests for the live ReAct agent factory — offline (no LLM, no network).
+
+The factory wires a headless :class:`~builder.engine.AgentEngine` (with a
+:class:`~builder.tools.hitl.SimulatedHumanInterface`) and drives the existing
+LangGraph ReAct loop from a case's prompt. We never invoke a real model here: the
+graph-driving call is injected so the test can stub it, leaving only the wiring —
+engine creation, headless interface, input init, and outcome shaping — under test.
+"""
+
+from __future__ import annotations
+
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools.hitl import SimulatedHumanInterface
+from eval.agent_api import BuildAgent, BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.react_factory import ReActBuildAgent, make_react_agent_factory
+
+
+class TestReActAgentWiring:
+    def test_factory_returns_a_build_agent(self) -> None:
+        factory = make_react_agent_factory()
+        agent = factory()
+        assert isinstance(agent, BuildAgent)
+
+    def test_engine_uses_a_headless_human_interface(self) -> None:
+        agent = ReActBuildAgent()
+        engine = agent._make_engine()
+        assert isinstance(engine, AgentEngine)
+        assert isinstance(engine.human_interface, SimulatedHumanInterface)
+
+    def test_build_returns_outcome_with_state_and_session_id(self) -> None:
+        # Inject a fake graph-driver so no model is contacted: it just records the
+        # prompt and leaves the engine's state in place.
+        seen: dict[str, str] = {}
+
+        def fake_driver(engine: AgentEngine, prompt: str) -> None:
+            seen["prompt"] = prompt
+
+        agent = ReActBuildAgent(graph_driver=fake_driver)
+        case = DEFAULT_CORPUS[0]
+        outcome = agent.build(case)
+
+        assert isinstance(outcome, BuildOutcome)
+        assert isinstance(outcome.state, CrateState)
+        assert outcome.session_id  # initialize() sets a session id
+        assert seen["prompt"] == case.prompt
+
+    def test_structured_case_initializes_from_its_input_path(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_driver(engine: AgentEngine, prompt: str) -> None:
+            captured["input_path"] = engine.state.metadata.input_path
+
+        agent = ReActBuildAgent(graph_driver=fake_driver)
+        structured = next(c for c in DEFAULT_CORPUS if c.kind == "structured")
+        agent.build(structured)
+        assert captured["input_path"] == structured.input_path
+
+    def test_build_captures_a_driver_error_as_outcome_error(self) -> None:
+        def boom(engine: AgentEngine, prompt: str) -> None:
+            raise RuntimeError("model unreachable")
+
+        agent = ReActBuildAgent(graph_driver=boom)
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.error is not None
+        assert "model unreachable" in outcome.error
+        # Even on failure we still return the (partial) state for inspection.
+        assert isinstance(outcome.state, CrateState)
+
+    def test_minimal_case_has_no_input_path(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_driver(engine: AgentEngine, prompt: str) -> None:
+            captured["input_path"] = engine.state.metadata.input_path
+
+        agent = ReActBuildAgent(graph_driver=lambda e, p: captured.__setitem__(
+            "input_path", e.state.metadata.input_path
+        ))
+        minimal = next(c for c in DEFAULT_CORPUS if c.kind == "minimal")
+        agent.build(minimal)
+        assert captured["input_path"] is None

--- a/eval/tests/test_report.py
+++ b/eval/tests/test_report.py
@@ -1,0 +1,96 @@
+"""Tests for report serialization (ndjson + summary), fully offline.
+
+These build an :class:`~eval.runner.EvalReport` by hand (no agent, no validation)
+and assert the on-disk shape: one ndjson line per case plus a trailing summary
+line, and a comparison helper that diffs two labeled reports.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from eval.report import compare_reports, write_report
+from eval.runner import CaseResult, EvalReport
+
+
+def _case(case_id: str, *, success: bool, tokens: int, det: bool | None) -> CaseResult:
+    return CaseResult(
+        case_id=case_id,
+        kind="minimal",
+        success=success,
+        conformance={"base": True, "isa": success, "tox": success},
+        issues=[],
+        input_tokens=tokens,
+        output_tokens=tokens // 2,
+        tool_calls=5,
+        iterations=3,
+        latency_seconds=1.25,
+        crate_hashes=["abc", "abc"] if det else ["abc", "xyz"],
+        deterministic=det,
+        repeats=2,
+    )
+
+
+def _report(label: str) -> EvalReport:
+    return EvalReport(
+        label=label,
+        repeats=2,
+        results=[
+            _case("c1", success=True, tokens=100, det=True),
+            _case("c2", success=False, tokens=200, det=False),
+        ],
+    )
+
+
+class TestWriteReport:
+    def test_writes_one_ndjson_line_per_case_plus_summary(self, tmp_path: Path) -> None:
+        out = tmp_path / "react-baseline.ndjson"
+        write_report(_report("react-baseline"), out)
+
+        lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+        # 2 case lines + 1 summary line.
+        assert len(lines) == 3
+        records = [line for line in lines if line.get("record") == "case"]
+        summaries = [line for line in lines if line.get("record") == "summary"]
+        assert len(records) == 2
+        assert len(summaries) == 1
+
+    def test_case_lines_carry_metrics(self, tmp_path: Path) -> None:
+        out = tmp_path / "r.ndjson"
+        write_report(_report("r"), out)
+        lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+        c1 = next(line for line in lines if line.get("case_id") == "c1")
+        assert c1["success"] is True
+        assert c1["total_tokens"] == 150
+        assert c1["deterministic"] is True
+        assert c1["label"] == "r"
+
+    def test_summary_line_has_aggregate_fields(self, tmp_path: Path) -> None:
+        out = tmp_path / "r.ndjson"
+        write_report(_report("r"), out)
+        lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+        summary = next(line for line in lines if line.get("record") == "summary")
+        assert summary["label"] == "r"
+        assert summary["num_cases"] == 2
+        assert summary["success_rate"] == 0.5
+        assert "mean_total_tokens" in summary
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        out = tmp_path / "nested" / "deep" / "r.ndjson"
+        write_report(_report("r"), out)
+        assert out.exists()
+
+
+class TestCompareReports:
+    def test_diffs_two_labeled_reports_per_metric(self) -> None:
+        react = _report("react-baseline")
+        pipeline = _report("pipeline")
+        diff = compare_reports(react, pipeline)
+        assert diff["labels"] == ["react-baseline", "pipeline"]
+        # Per-metric side-by-side with both summaries present.
+        assert "react-baseline" in diff["summaries"]
+        assert "pipeline" in diff["summaries"]
+        # A per-case table keyed by case_id, success for both labels.
+        assert "cases" in diff
+        assert set(diff["cases"]) == {"c1", "c2"}

--- a/eval/tests/test_runner.py
+++ b/eval/tests/test_runner.py
@@ -1,0 +1,194 @@
+"""Runner tests — fully offline via a mock agent factory.
+
+The mock returns canned, REQUIRED-clean ``CrateState`` objects, so these exercise
+the runner / metrics / determinism / report-shaping logic end to end **without a
+live model or the network**. ``build_and_validate`` is heavy, so the module is
+under a 120s timeout per the harness conventions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.runner import CaseResult, EvalReport, run_eval
+
+pytestmark = pytest.mark.timeout(120)
+
+
+# --------------------------------------------------------------------------- #
+# Mock agents
+# --------------------------------------------------------------------------- #
+
+
+class _CleanMockAgent:
+    """Returns a REQUIRED-clean state per case (deterministic)."""
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id=None)
+
+
+def _clean_factory() -> _CleanMockAgent:
+    return _CleanMockAgent()
+
+
+class _FailingMockAgent:
+    """Returns an empty state that cannot reach conformance."""
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        return BuildOutcome(state=CrateState(), session_id=None)
+
+
+def _failing_factory() -> _FailingMockAgent:
+    return _FailingMockAgent()
+
+
+class _NonDeterministicMockAgent:
+    """Returns a *different* crate on each instance — a non-reproducible agent.
+
+    The runner builds a *fresh* agent per repeat (so per-instance state can't leak
+    into the determinism signal). To model genuine non-determinism the divergence
+    must therefore be per-instance, not per-call — here a unique title per build.
+    """
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        import uuid
+
+        tag = uuid.uuid4().hex
+        state = CrateState()
+        state.metadata.title = f"run-{tag}"
+        state.add_entity(
+            Entity(
+                entity_id="inv",
+                type="Investigation",
+                fields={"name": f"run-{tag}"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        return BuildOutcome(state=state, session_id=None)
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+class TestRunEvalShape:
+    def test_returns_report_with_one_result_per_case(self) -> None:
+        corpus = DEFAULT_CORPUS[:1]
+        report = run_eval(_clean_factory, corpus, repeats=2)
+        assert isinstance(report, EvalReport)
+        assert len(report.results) == 1
+        assert isinstance(report.results[0], CaseResult)
+
+    def test_records_label_and_repeats(self) -> None:
+        report = run_eval(_clean_factory, DEFAULT_CORPUS[:1], repeats=3, label="mock-x")
+        assert report.label == "mock-x"
+        assert report.repeats == 3
+        assert report.results[0].repeats == 3
+
+
+class TestSuccessAndConformance:
+    def test_clean_agent_succeeds_with_full_conformance(self) -> None:
+        report = run_eval(_clean_factory, DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert res.success is True
+        assert res.conformance == {"base": True, "isa": True, "tox": True}
+
+    def test_failing_agent_does_not_succeed(self) -> None:
+        report = run_eval(_failing_factory, DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert res.success is False
+        # An empty crate has no ISA backbone, so the ISA layer never conforms.
+        assert res.conformance.get("isa") is not True
+
+
+class TestDeterminism:
+    def test_identical_repeats_are_deterministic(self) -> None:
+        report = run_eval(_clean_factory, DEFAULT_CORPUS[:1], repeats=2)
+        res = report.results[0]
+        assert res.deterministic is True
+        assert len(set(res.crate_hashes)) == 1
+        assert len(res.crate_hashes) == 2
+
+    def test_single_repeat_reports_determinism_as_none(self) -> None:
+        # With one repeat there is nothing to compare; determinism is undefined.
+        report = run_eval(_clean_factory, DEFAULT_CORPUS[:1], repeats=1)
+        assert report.results[0].deterministic is None
+
+    def test_diverging_repeats_are_not_deterministic(self) -> None:
+        report = run_eval(_NonDeterministicMockAgent, DEFAULT_CORPUS[:1], repeats=2)
+        res = report.results[0]
+        assert res.deterministic is False
+        assert len(set(res.crate_hashes)) == 2
+
+
+class TestProfileBackedMetrics:
+    def test_metrics_are_mined_from_an_injected_profile_reader(self) -> None:
+        canned = {
+            "ignored": [
+                {"event": "node_end", "node": "model", "iteration": 4,
+                 "input_tokens": 1000, "output_tokens": 200},
+                {"event": "tool_call", "tool": "scan_files", "iteration": 1},
+                {"event": "tool_call", "tool": "draft_investigation", "iteration": 2},
+                {"event": "tool_call", "tool": "build_and_validate", "iteration": 4},
+            ]
+        }
+
+        class _ProfiledAgent:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                factory = case.build_state or CrateState
+                return BuildOutcome(state=factory(), session_id="ignored")
+
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=1,
+            profile_reader=lambda sid: canned.get(sid, []),
+        )
+        res = report.results[0]
+        assert res.input_tokens == 1000
+        assert res.output_tokens == 200
+        assert res.total_tokens == 1200
+        assert res.tool_calls == 3
+        assert res.iterations == 4
+
+    def test_no_session_id_yields_zero_token_metrics(self) -> None:
+        report = run_eval(_clean_factory, DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert res.input_tokens == 0
+        assert res.tool_calls == 0
+
+
+class TestLatency:
+    def test_latency_is_recorded_and_non_negative(self) -> None:
+        report = run_eval(_clean_factory, DEFAULT_CORPUS[:1], repeats=1)
+        assert report.results[0].latency_seconds >= 0.0
+
+
+class TestErrorHandling:
+    def test_a_raising_build_is_captured_as_a_failure_not_a_crash(self) -> None:
+        class _RaisingAgent:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                raise RuntimeError("boom")
+
+        report = run_eval(lambda: _RaisingAgent(), DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert res.success is False
+        assert res.error is not None
+        assert "boom" in res.error
+
+
+class TestAggregateSummary:
+    def test_summary_reports_success_rate_and_token_means(self) -> None:
+        report = run_eval(_clean_factory, DEFAULT_CORPUS, repeats=2)
+        summary = report.summary()
+        assert summary["label"] == report.label
+        assert summary["num_cases"] == len(DEFAULT_CORPUS)
+        assert summary["success_rate"] == 1.0
+        assert "mean_total_tokens" in summary
+        assert "median_latency_seconds" in summary
+        assert 0.0 <= summary["determinism_rate"] <= 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,5 @@ exclude = ["tests", "tests/*.py"]
 select = ["E", "F", "I"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["tests", "eval/tests"]
 python_files = ["test_*.py"]


### PR DESCRIPTION
## What & why

Task 6 of the deterministic-pipeline migration (AGENTS.md §14.4): a self-contained, **agent-agnostic** evaluation harness under a new top-level `eval/` package. It is the in-repo A/B that the §14.1 ReAct→pipeline cutover is **gated on** — measuring the defensible wins for this system (cost, latency, reproducibility, testability, predictability), not blanket correctness.

All changes are additive in **new files** under `eval/` (+ a one-line `pyproject.toml` `testpaths` edit and a `.gitignore` entry). **No changes** to `_crate_mapping.py`, `drafters.py`, or any tool-registration file — disjoint from the two sibling #180 PRs in flight.

## Agent-agnostic factory design

The harness only ever talks to a `BuildAgent` protocol:

```python
class BuildAgent(Protocol):
    def build(self, case: EvalCase) -> BuildOutcome: ...   # state + session_id + error
```

`run_eval(agent_factory, corpus, *, repeats=2)` takes a **zero-arg `agent_factory`** returning a fresh `BuildAgent` *per repeat* (so no engine/session state leaks into the determinism signal). To A/B two architectures you swap **only** the factory — corpus, metrics, and report are unchanged, so a ReAct report and a future pipeline report diff cleanly.

- `eval.react_factory.make_react_agent_factory()` — the **live** ReAct agent: wraps the existing LangGraph ReAct loop behind the contract (headless `AgentEngine` + `SimulatedHumanInterface`, `initialize()` the case input, drive the graph once with the prompt, return the final `CrateState` + `session_id`). The model-driving step is injected so the wiring is unit-tested offline.
- A future `make_pipeline_agent_factory()` ships with the same shape when §14 tasks 1–5 land.
- Tests use an in-memory mock factory returning canned `CrateState`s.

## Corpus (`eval/corpus.py`)

3 cases, all in-repo and offline:

| `case_id` | `kind` | Exercises |
|-----------|--------|-----------|
| `minimal-backbone` | minimal | Conformant ISA-Tox backbone from a short brief |
| `structured-svhps21` | structured | Scan the in-repo `tests/fixtures/svhps21_input` folder (README + raw/processed CSVs) |
| `unstructured-conversation` | unstructured | No metadata files; crate elicited from the prompt |

**Success predicate** (shared, strict): reaches `{base, isa, tox}` REQUIRED conformance via `build_and_validate`.

## Metrics (`eval/metrics.py`, `eval/runner.py`)

Per case across `repeats`: **success** + per-layer **conformance**; **tokens** (input/output/total, from `profile.ndjson` model `node_end` events); **latency** (wall-clock); **iteration count** and **tool-call count** (from `profile.ndjson`); **determinism** (stable SHA-256 of the assembled crate `@graph` across repeats — volatile `datePublished`/`dateModified` stripped, nodes sorted by `@id`; `None` when `repeats == 1`). Aggregate `summary()` reports success rate, mean/median tokens & latency, and determinism rate.

## Report (`eval/report.py`)

`write_report` → labeled **ndjson** (one `record:"case"` line per case + a `record:"summary"` line). `compare_reports` → side-by-side A/B diff (both summaries + per-case table keyed by `case_id`).

## Entry point

`python -m eval [--label react-baseline] [--repeats N] [--out PATH] [--provider/--model/--api-base]`.

### Capturing the react-baseline
```bash
uv run --extra langchain python -m eval --label react-baseline   # writes eval_reports/react-baseline.ndjson
git tag react-baseline && git push origin react-baseline         # freeze (AGENTS.md §14.4)
```
Later, run the pipeline factory under `--label pipeline` and diff with `compare_reports`.

## CI is mock-only / offline

A **live** run makes real LLM calls (DeepSeek-flash / configured provider) — that's its purpose, human-triggered. **CI and the unit tests are strictly offline**: the runner/metrics/report/determinism logic is exercised against a mock agent factory; no live model, no network. Validation-heavy tests carry module-level `pytest.mark.timeout(120)`. `eval/tests` added to pytest `testpaths` so CI runs the harness.

## Verification
- `uv run ruff check` — All checks passed!
- `uv run --extra langchain ty check` — All checks passed!
- `uv run --extra langchain pytest eval/tests` — 45 passed

## Open questions
- Whether to register a `[project.scripts]` console entry (deferred — the repo has no `[build-system]`, so `python -m eval` is the working entry point).
- The structured/unstructured cases currently share the S-VHPS21 success state in the offline mock; the live ReAct/pipeline factories drive genuinely different inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)