### PR TITLE
fix(eval): hydrate config.toml → env so live runs find creds (#179)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
+from builder.config import load_config, merge_with_env
 from eval.agent_api import BuildAgent
 from eval.corpus import DEFAULT_CORPUS
 from eval.report import write_report
@@ -96,6 +97,15 @@ def run_main(
     logging.basicConfig(level=logging.INFO)
 
     if agent_factory is None:
+        # LIVE path only: the ReAct factory reads provider/api_key/base_url/model
+        # from the environment (builder.agents.agent_loop), so bridge any creds
+        # kept solely in ~/.config/vitro-crate/config.toml into os.environ first —
+        # mirroring how the interactive CLI hydrates via merge_with_env(). Without
+        # this a live run with creds only in config.toml raises "No LLM provider
+        # configured" (#179). The offline/mock path (injected agent_factory) skips
+        # this entirely so its tests stay config-free.
+        merge_with_env(load_config())
+
         from eval.react_factory import make_react_agent_factory
 
         agent_factory = make_react_agent_factory(

--- a/eval/tests/test_main_config.py
+++ b/eval/tests/test_main_config.py
@@ -1,0 +1,101 @@
+"""Config -> env hydration for the LIVE ``python -m eval`` path (#179).
+
+The live ReAct factory reads provider/api_key/base_url/model from the
+environment only (``builder.agents.agent_loop``). Credentials kept solely in
+``~/.config/vitro-crate/config.toml`` must therefore be bridged into ``os.environ``
+before the live run — exactly as the normal CLI does via
+``merge_with_env(load_config())`` — otherwise a live run raises
+"No LLM provider configured" despite valid creds on disk.
+
+These tests assert the harness performs that hydration on the live path and that
+the offline (injected ``agent_factory``) path stays config-free.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pytest
+
+import eval.__main__ as eval_main
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import EvalCase
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class _MockAgent:
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id=None)
+
+
+def _mock_factory() -> _MockAgent:
+    return _MockAgent()
+
+
+class TestLiveConfigHydration:
+    def test_live_path_hydrates_config_into_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """On the live path (no injected factory) the harness must bridge
+        config.toml -> env via ``merge_with_env(load_config())`` before running,
+        so a live run finds creds that live only in the config file."""
+        calls: dict[str, int] = {"load": 0, "merge": 0}
+
+        def fake_load_config() -> dict[str, Any]:
+            calls["load"] += 1
+            return {"openai": {"api_key": "sk-from-config"}}
+
+        def fake_merge_with_env(cfg: dict[str, Any]) -> dict[str, Any]:
+            calls["merge"] += 1
+            return cfg
+
+        monkeypatch.setattr(eval_main, "load_config", fake_load_config, raising=False)
+        monkeypatch.setattr(eval_main, "merge_with_env", fake_merge_with_env, raising=False)
+
+        # Stub the live factory so no real LLM/network is contacted: it returns a
+        # mock agent that builds an empty state. We are only asserting hydration.
+        def fake_make_react_agent_factory(**_: Any) -> Callable[[], _MockAgent]:
+            return _mock_factory
+
+        import eval.react_factory as react_factory
+
+        monkeypatch.setattr(
+            react_factory, "make_react_agent_factory", fake_make_react_agent_factory
+        )
+
+        rc = eval_main.run_main(
+            ["--label", "live-hydration", "--repeats", "1"],
+            profile_reader=lambda sid: [],
+            out_dir=str(tmp_path),
+        )
+
+        assert rc == 0
+        assert calls["load"] == 1, "live path must load config.toml exactly once"
+        assert calls["merge"] == 1, "live path must merge config into env exactly once"
+
+    def test_offline_path_does_not_require_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """When a caller injects an ``agent_factory`` (the offline/mock path), the
+        harness must NOT load or merge config — offline tests stay config-free."""
+
+        def boom_load_config() -> dict[str, Any]:
+            raise AssertionError("offline path must not load config.toml")
+
+        def boom_merge_with_env(cfg: dict[str, Any]) -> dict[str, Any]:
+            raise AssertionError("offline path must not merge config into env")
+
+        monkeypatch.setattr(eval_main, "load_config", boom_load_config, raising=False)
+        monkeypatch.setattr(eval_main, "merge_with_env", boom_merge_with_env, raising=False)
+
+        rc = eval_main.run_main(
+            ["--label", "offline-run", "--repeats", "1"],
+            agent_factory=_mock_factory,
+            profile_reader=lambda sid: [],
+            out_dir=str(tmp_path),
+        )
+
+        assert rc == 0


### PR DESCRIPTION
## Root cause

A live `python -m eval` run fails with **"No LLM provider configured"** even when valid credentials exist in `~/.config/vitro-crate/config.toml`.

The live path builds the ReAct factory, whose model construction (`builder/agents/agent_loop.py::_detect_provider` / `_build_chat_model`) reads `provider` / `api_key` / `base_url` / `model` from **environment variables only**. The interactive CLI bridges `config.toml` into the environment via `merge_with_env(load_config())` (`main.py::_ensure_configured`), but the eval harness (`eval/__main__.py::run_main`) never did. So a live run with creds kept solely in the config file saw no provider and raised the error.

## Fix

Minimal and pattern-consistent with the CLI: on the **LIVE path only** (`agent_factory is None`), call `merge_with_env(load_config())` before constructing the live ReAct factory. `merge_with_env` sets each mapped env var from config when that env var is unset (env always wins), so this is a no-op-safe bridge.

The **offline/mock path** (an injected `agent_factory`, used by the offline tests) skips hydration entirely — offline tests stay config-free and require no network/LLM. `agent_loop.py` is untouched; the fix lives in the harness, mirroring how the CLI hydrates.

## Tests (TDD)

New `eval/tests/test_main_config.py`:
- `test_live_path_hydrates_config_into_env` — patches `load_config` / `merge_with_env` on `eval.__main__`, stubs the live factory (no LLM/network), and asserts both are called exactly once on the live path. **Red before the fix, green after.**
- `test_offline_path_does_not_require_config` — injects an `agent_factory`, makes `load_config` / `merge_with_env` raise if touched, and asserts the run still returns 0 — proving the offline path remains config-free.

Existing `eval/tests/test_main.py` offline tests stay green.

## Gates

- `uv run ruff check` → All checks passed!
- `uv run --extra langchain ty check` → All checks passed!
- `uv run --extra langchain pytest eval/tests` → 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)