### PR TITLE
fix(security): fail closed on scan-root guard, deny filesystem-root scans (#197)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,11 +68,12 @@ One step is **always** run as fixed initialization before the agent loop:
 This inventory is the only precondition. The agent uses it during entity drafting to bind files to `LabProcess` instances as annotations emerge. The ARC folder structure is not scaffolded upfront — it is produced as an output by `arc_writer.py` once entity annotations are complete.
 
 ### Guard Rails: Approved Scan Roots
-The agent's `scan_files` tool is restricted to directories the user has explicitly approved. Every session has a `CrateState.approved_scan_roots` set that records user-confirmed paths. When the agent calls `scan_files(path)`:
+The agent's `scan_files` tool is restricted to directories the user has explicitly approved. Every session has a `CrateState.approved_scan_roots` set that records user-confirmed paths. The guard **fails closed** (#197): with no approved roots, *nothing* is scannable. When the agent calls `scan_files(path)`:
 1. The path is resolved to an absolute canonical form
-2. It is checked against the approved set — if not found, scanning is denied
-3. If it is a subdirectory of an approved root, scanning is allowed
-4. The user can approve new paths through HITL review (via `present_to_human` or the CLI) — this is the only way new roots get added
+2. If `approved_scan_roots` is empty (or the scanner receives `None`/empty `approved_roots`), the scan is **refused without walking** — the agent's own scan call never auto-approves a new root
+3. It is checked against the approved set — if the target is not equal to, nor a subdirectory of, an approved root, scanning is denied
+4. A hard denylist (`_is_forbidden_root`) refuses the filesystem root `/`, the user's home directory itself, and OS/system trees (`/System`, `/Library`, `/private`, `/var`, `/etc`, `/usr`, bare `/Users`, `/Volumes`) **even if such a path appears in `approved_scan_roots`**. Legitimate *subdirectories* (e.g. `~/Desktop/project`) are still allowed — only the bare roots are blocked
+5. New roots are added **only** from a user-provided input path (`AgentEngine.initialize()` / `read_directory()`) or an explicit real approval — never from the agent's own scan call. The non-interactive `SimulatedHumanInterface` **denies** any `present(..., purpose="scan_root")` escalation, so it can never widen filesystem access on its own
 
 This prevents the LLM agent from reaching into arbitrary locations on the user's filesystem and provides a clear audit trail of which directories the system has ever accessed.
 
@@ -1076,7 +1077,14 @@ Every tool call, state change, and reasoning step is recorded in `CrateState.che
 The reasoning log is persisted with the session and survives resume. A future web UI can tail or stream this log without changing the builder's internals — the data structure is already there.
 
 ### D9: Approved Scan Roots (Security Guard Rail)
-The `scan_files` tool is restricted to directories the user has explicitly approved. Every session has a `CrateState.approved_scan_roots` set. When the agent calls `scan_files(path)`, the path is resolved to an absolute canonical form and checked against approved roots — if not found or within a subdirectory of one, scanning is denied. New roots are added only through user approval (HITL or CLI prompt at the `present_to_human` checkpoint). This prevents the LLM agent from accessing arbitrary filesystem locations and provides a clear audit trail. On macOS, this same mechanism protects user files. On Linux, it prevents scanning into `/proc`, `/sys`, or other system paths.
+The `scan_files` tool is restricted to directories the user has explicitly approved. Every session has a `CrateState.approved_scan_roots` set. When the agent calls `scan_files(path)`, the path is resolved to an absolute canonical form and checked against approved roots — if not found or within a subdirectory of one, scanning is denied. New roots are added only through user approval (a user-provided input path at `initialize()`/`read_directory()`, or a real HITL approval). This prevents the LLM agent from accessing arbitrary filesystem locations and provides a clear audit trail. On macOS, this same mechanism protects user files. On Linux, it prevents scanning into `/proc`, `/sys`, or other system paths.
+
+**Fail-closed (#197).** The guard previously failed *open*: when `approved_scan_roots` was empty the engine passed `approved_roots=None`, which the scanner treated as "no guard", and the first path the agent scanned was auto-approved. The agent could therefore scan the entire filesystem by naming any path. The guard now fails **closed**:
+- The engine always passes a concrete allowlist (an empty `set()`, never `None`); the scanner refuses (returns `[]` without walking) whenever `approved_roots` is `None` or empty.
+- The auto-approve-of-first-scan was removed: the agent's own `scan_files` call can never add a root. Roots enter the allowlist only from a user-provided input path or a real approval.
+- A hard denylist (`scanner._is_forbidden_root`) refuses `/`, the user's home directory itself, `/System`, `/Library`, `/private`, `/var`, `/etc`, `/usr`, bare `/Users`, and `/Volumes` even if explicitly present in `approved_roots`; it is also enforced in `engine._directory_to_approve` so a forbidden directory can never *become* an approved root. Legitimate subdirectories are unaffected.
+- `SimulatedHumanInterface.present(..., purpose="scan_root")` returns a `rejected` action, so the non-interactive default can never approve a new scan root (benign checkpoints still auto-approve).
+- Follow-up: sandboxing the eval harness so it cannot scan outside its fixtures is tracked separately.
 
 ### D10: State Brief Injected via System Prompt, Not Message History
 The per-turn state brief (session id, file/entity/iteration counts) is **not** appended to user

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _directory_to_approve(scanned_path: str) -> str:
+def _directory_to_approve(scanned_path: str) -> str | None:
     """Return the directory to add to ``approved_scan_roots`` for *scanned_path*.
 
     The approved root must be a *directory*: the guard treats roots as
@@ -36,16 +36,26 @@ def _directory_to_approve(scanned_path: str) -> str:
       the archive's parent — approving the parent would expose unrelated
       sibling files, weakening the D9 approved-roots guard rail;
     - any other file -> its parent directory.
+
+    Returns ``None`` when the resulting directory is a forbidden root (the
+    filesystem root, the user's home directory, or an OS/system tree). A
+    forbidden directory can never become an approved scan root (#197).
     """
-    from builder.tools.scanner import _is_archive
+    from builder.tools.scanner import _is_archive, _is_forbidden_root
 
     p = Path(scanned_path).resolve()
     if p.is_dir():
-        return str(p)
-    if _is_archive(p):
+        candidate = p
+    elif _is_archive(p):
         # Mirror unzip_file's extraction layout: <parent>/<stem>_extracted
-        return str(p.parent / f"{p.stem}_extracted")
-    return str(p.parent)
+        candidate = p.parent / f"{p.stem}_extracted"
+    else:
+        candidate = p.parent
+
+    if _is_forbidden_root(candidate):
+        logger.warning("Refusing to approve forbidden scan root: %s", candidate)
+        return None
+    return str(candidate)
 
 
 # Validation layers stack as a pyramid (BASE -> ISA -> TOX); ordering REQUIRED
@@ -149,13 +159,25 @@ class AgentEngine:
         from builder.tools.scanner import scan_files
 
         if input_path:
-            scanned = scan_files(input_path)
-            self.state.scanned_files = scanned
+            # Approve the directory whose contents we inventory (the extraction
+            # dir for an archive), not the raw input path — see
+            # _directory_to_approve. This is a user-provided input path, the
+            # only legitimate way (besides a real approval) for a root to enter
+            # the allowlist (#197). A forbidden root yields None and is refused.
             self.state.metadata.input_path = input_path
-            # Approve the directory whose contents we inventoried (the
-            # extraction dir for an archive), not the raw input path — see
-            # _directory_to_approve. Locks the guard even on an empty scan.
-            self.state.approved_scan_roots.add(_directory_to_approve(input_path))
+            approved = _directory_to_approve(input_path)
+            if approved is not None:
+                self.state.approved_scan_roots.add(approved)
+                # The scanner fails closed, so it must receive a concrete
+                # allowlist. For an archive the literal input path differs from
+                # its extraction dir, so approve the input path for this one
+                # scan too; the persistent root remains the extraction dir.
+                scan_roots = self.state.approved_scan_roots | {str(Path(input_path).resolve())}
+                self.state.scanned_files = scan_files(input_path, approved_roots=scan_roots)
+            else:
+                logger.warning(
+                    "Refusing to initialize scan on forbidden input path: %s", input_path
+                )
 
         if not self.state.session_id:
             self.state.session_id = _config.now().strftime("%Y%m%d_%H%M%S")
@@ -284,26 +306,19 @@ class AgentEngine:
             )
         elif tool_name in scanner_tools:
             tool_fn = scanner_tools[tool_name]
-            # Inject approved roots for scan_files
+            # Inject approved roots for scan_files. Fail closed (#197): always
+            # pass a concrete allowlist — an EMPTY set, never None — so the
+            # scanner refuses when nothing has been approved. The agent's own
+            # scan call must NEVER auto-approve a new root; roots are added only
+            # by initialize() (a user-provided input path) or a real approval.
             tool_kwargs = dict(kwargs)
             if tool_name == "scan_files":
-                tool_kwargs["approved_roots"] = (
-                    self.state.approved_scan_roots.copy()
-                    if self.state.approved_scan_roots
-                    else None
-                )
+                tool_kwargs["approved_roots"] = self.state.approved_scan_roots.copy()
             result = tool_fn(**tool_kwargs)
-            # Auto-store scan results in state, and register the scanned
-            # path as an approved root if none were set yet.
+            # Auto-store scan results in state. Do NOT register the scanned path
+            # as an approved root here — that fail-open auto-approve (#197) let
+            # the agent scan arbitrary locations by simply naming them.
             if tool_name == "scan_files" and isinstance(result, list):
-                # Lock the guard to the scanned area on the first scan, even if
-                # it returned nothing — otherwise approved_scan_roots stays
-                # empty, run_tool keeps passing approved_roots=None, and the
-                # guard is effectively disabled (any path becomes scannable).
-                if not self.state.approved_scan_roots:
-                    self.state.approved_scan_roots.add(
-                        _directory_to_approve(kwargs.get("path", ""))
-                    )
                 if result:
                     self.state.scanned_files = result
                     self.state.log_reasoning(

--- a/builder/readers/directory.py
+++ b/builder/readers/directory.py
@@ -27,15 +27,25 @@ def read_directory(path: str) -> CrateState:
     Returns:
         A CrateState seeded with scanned file information.
     """
-    from builder.tools.scanner import scan_files
+    from builder.tools.scanner import _is_forbidden_root, scan_files
 
     state = CrateState()
 
     dir_path = Path(path)
-    state.metadata.input_path = str(dir_path.resolve())
+    resolved = dir_path.resolve()
+    state.metadata.input_path = str(resolved)
     state.metadata.title = dir_path.name
 
-    scanned = scan_files(path)
+    # A user-provided input directory is a legitimate scan root. Approve it and
+    # pass the allowlist to the now fail-closed scanner (#197). A forbidden root
+    # (filesystem root, home dir, system tree) is refused outright.
+    if _is_forbidden_root(resolved):
+        logger.warning("Refusing to read forbidden directory: %s", resolved)
+        scanned: list = []
+    else:
+        approved = {str(resolved)}
+        state.approved_scan_roots.add(str(resolved))
+        scanned = scan_files(path, approved_roots=approved)
     state.scanned_files = scanned
 
     state.session_id = _config.now().strftime("%Y%m%d_%H%M%S")

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -42,6 +42,12 @@ class InputResponse(TypedDict):
     skipped: bool
 
 
+# Sentinel ``purpose`` value marking a request to approve a NEW filesystem
+# scan root. The default/simulated interface must DENY these — it can never be
+# the approver for filesystem access (fail-closed, #197).
+SCAN_ROOT_PURPOSE = "scan_root"
+
+
 @runtime_checkable
 class HumanInterface(Protocol):
     """Dependency-injection point for human-in-the-loop interaction.
@@ -50,8 +56,18 @@ class HumanInterface(Protocol):
     (CLI prompt, Streamlit widget, FastAPI round-trip, test double, …).
     """
 
-    def present(self, context: str, options: list[str] | None = None) -> HumanResponse:
-        """Present content to the human and return their decision."""
+    def present(
+        self,
+        context: str,
+        options: list[str] | None = None,
+        purpose: str | None = None,
+    ) -> HumanResponse:
+        """Present content to the human and return their decision.
+
+        *purpose* optionally classifies the request (e.g. ``"scan_root"`` for a
+        request to approve a new filesystem scan root). Implementations may use
+        it to apply stricter handling to security-sensitive escalations.
+        """
         ...
 
     def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
@@ -63,14 +79,32 @@ class SimulatedHumanInterface:
     """Default non-interactive interface: auto-approves and skips input.
 
     Reproduces the previous stub behaviour so headless/batch runs proceed
-    without blocking on a real user.
+    without blocking on a real user — EXCEPT for scan-root escalations, which
+    it denies: the simulator can never be the approver for filesystem access
+    (fail-closed, #197).
     """
 
-    def present(self, context: str, options: list[str] | None = None) -> HumanResponse:
-        """Log the presentation and return a simulated-approved response."""
+    def present(
+        self,
+        context: str,
+        options: list[str] | None = None,
+        purpose: str | None = None,
+    ) -> HumanResponse:
+        """Log the presentation and return a simulated decision.
+
+        Benign checkpoints (entity review, etc.) auto-approve as before. A
+        scan-root escalation (``purpose == "scan_root"``) is DENIED — the
+        non-interactive default must not silently widen filesystem access.
+        """
         logger.info("HITL presentation: %s", context)
         if options:
             logger.info("HITL options: %s", options)
+        if purpose == SCAN_ROOT_PURPOSE:
+            logger.warning(
+                "Denying simulated approval of a new scan root (fail-closed): %s",
+                context,
+            )
+            return {"action": "rejected", "comments": None, "edits": None}
         return {"action": "approved", "comments": None, "edits": None}
 
     def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
@@ -86,13 +120,14 @@ _default_interface: HumanInterface = SimulatedHumanInterface()
 def present_to_human(
     context: str,
     options: list[str] | None = None,
+    purpose: str | None = None,
 ) -> HumanResponse:
     """Present content to the human via the default simulated interface.
 
     Backward-compatible wrapper; new code should inject a
     :class:`HumanInterface` into :class:`~builder.engine.AgentEngine` instead.
     """
-    return _default_interface.present(context, options)
+    return _default_interface.present(context, options, purpose)
 
 
 def request_input(
@@ -108,6 +143,7 @@ def request_input(
 
 
 __all__ = [
+    "SCAN_ROOT_PURPOSE",
     "HumanInterface",
     "HumanResponse",
     "InputResponse",

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -39,6 +39,50 @@ class _UnsafeArchiveError(Exception):
     uncompressed-size cap (zip-bomb)."""
 
 
+# Directories that must NEVER be scanned, even if somehow present in
+# ``approved_roots`` (D9 hard denylist, #197). These are filesystem roots,
+# the user's home directory itself, and OS/system trees. Legitimate
+# *subdirectories* (e.g. ``~/Desktop/project``) are still allowed — only the
+# bare roots themselves are forbidden.
+_FORBIDDEN_STATIC_ROOTS = frozenset(
+    {
+        "/",
+        "/System",
+        "/Library",
+        "/private",
+        "/var",
+        "/etc",
+        "/usr",
+        "/Users",
+        "/Volumes",
+    }
+)
+
+
+def _is_forbidden_root(path: Path) -> bool:
+    """Return True if *path* is a forbidden scan root (hard denylist, #197).
+
+    Refuses the filesystem root, the user's home directory itself, and known
+    OS/system trees regardless of whether they appear in ``approved_roots``.
+    A path that merely *descends* from one of these (e.g. a project folder
+    under the home directory) is allowed — only the bare roots are blocked.
+    """
+    try:
+        resolved = path.resolve()
+    except OSError:
+        # If we cannot even resolve it, treat it as forbidden (fail closed).
+        return True
+    if str(resolved) in _FORBIDDEN_STATIC_ROOTS:
+        return True
+    try:
+        if resolved == Path.home().resolve():
+            return True
+    except (OSError, RuntimeError):
+        # Path.home() can raise if HOME is unset; fail closed on the home check.
+        return True
+    return False
+
+
 def _is_within(dest: Path, target: Path) -> bool:
     """Return True if *target* resolves inside *dest* (Zip-Slip guard)."""
     try:
@@ -371,35 +415,54 @@ def scan_files(
 
     .. security::
 
-       The scanner **only** accepts paths that descend from one of the
-       *approved_roots* — directories the user has explicitly permitted.
-       If *approved_roots* is ``None`` (the default) the first path scanned
-       is auto-approved and becomes the sole root for subsequent calls.
+       The scanner fails **closed** (#197): it only accepts paths that descend
+       from one of the *approved_roots* — directories the user has explicitly
+       permitted. If *approved_roots* is ``None`` or empty, **nothing** is
+       approved and the scan is refused without walking. A hard denylist
+       (filesystem root, the user's home directory, OS/system trees) is always
+       refused even if such a path appears in *approved_roots*. There is no
+       auto-approval of the first scanned path — roots are added only through an
+       explicit user-provided input path or a real approval.
 
     Args:
         path: Path to the directory **or** archive to inspect.
         approved_roots: Set of resolved absolute directory paths that are
-            allowed for scanning.  Pass ``None`` on the first call to
-            auto-approve the target.
+            allowed for scanning. ``None`` or an empty set means *nothing is
+            approved* and the scan is refused.
         max_files: Maximum number of files to return. 0 means unlimited.
             When exceeded, the list is truncated and a warning is logged.
         max_line_length: Maximum length for each ``first_rows`` line.
             0 means unlimited. Longer lines are truncated.
 
     Returns:
-        A list of ``FileClassification`` records.
+        A list of ``FileClassification`` records (empty when refused).
     """
     target = Path(path).resolve()
 
-    # -- Security guard: approved-roots check -----------------------------------
-    if approved_roots is not None:
-        if not any(str(target) == r or str(target).startswith(r + "/") for r in approved_roots):
-            logger.warning(
-                "Refusing to scan %s — not in approved roots: %s",
-                target,
-                approved_roots,
-            )
-            return []
+    # -- Security guard: fail closed on approved-roots --------------------------
+    # No approved roots (None or empty) => nothing is approved => REFUSE. Never
+    # walk a target that is not inside an explicitly approved root (#197).
+    if not approved_roots:
+        logger.warning(
+            "Refusing to scan %s — not in approved roots: %s",
+            target,
+            approved_roots,
+        )
+        return []
+    if not any(str(target) == r or str(target).startswith(r + "/") for r in approved_roots):
+        logger.warning(
+            "Refusing to scan %s — not in approved roots: %s",
+            target,
+            approved_roots,
+        )
+        return []
+
+    # -- Security guard: hard denylist (forbidden roots) ------------------------
+    # Refuse filesystem root, the home directory, and OS/system trees even if
+    # they were somehow added to approved_roots (#197).
+    if _is_forbidden_root(target):
+        logger.warning("Refusing to scan forbidden root: %s", target)
+        return []
 
     # -- Security guard: don't follow symlinks out of the resolved path ---------
     _follows_symlinks = False
@@ -426,8 +489,15 @@ def scan_files(
             logger.warning("Could not extract archive: %s", result["error"])
             return []
         extracted_dir = result["extracted_to"]
-        # Scan extracted directory recursively
-        return scan_files(extracted_dir)
+        # Scan extracted directory recursively. The extraction dir is derived
+        # from an already-approved archive, so add it to the allowlist for the
+        # recursive call — otherwise the fail-closed guard would refuse it.
+        return scan_files(
+            extracted_dir,
+            approved_roots=set(approved_roots) | {str(Path(extracted_dir).resolve())},
+            max_files=max_files,
+            max_line_length=max_line_length,
+        )
 
     # -- Directory case --------------------------------------------------------
     if not target.is_dir():

--- a/tests/test_e2e_agent_eval.py
+++ b/tests/test_e2e_agent_eval.py
@@ -169,7 +169,11 @@ class ScriptedRun:
 def scripted_run() -> ScriptedRun:
     """A fresh engine that has run the full scripted scan->draft sequence."""
     engine = AgentEngine()
-    engine.initialize()  # establish session_id (no input scan; we scan via run_tool)
+    # initialize() with the fixture dir seeds approved_scan_roots the legitimate
+    # way (a user-provided input path), so the later run_tool("scan_files", ...)
+    # is allowed by the now fail-closed guard (#197). We re-scan via run_tool
+    # below to exercise the real approved-roots path.
+    engine.initialize(input_path=str(FIXTURE_INPUT_DIR))
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         result = _scripted_build(engine)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from pathlib import Path
 
 from builder.engine import AgentEngine
 from builder.state import CrateState
@@ -164,9 +165,12 @@ def _make_zip(tmp_path, name="study.zip", with_sibling=False):
 
 
 class TestScanApprovedRoots:
-    """The approved-roots guard must (a) not be wiped by an empty scan,
-    (b) allow follow-up scans of extracted contents, and (c) NOT over-broaden
-    to expose unrelated sibling files (D9)."""
+    """Fail-closed approved-roots guard (#197). The agent's own scan_files
+    call must NEVER auto-approve a new root: with no approved roots the scan
+    is refused and the set stays empty. Roots are added only by initialize()
+    (a user-provided input path) or an explicit real approval. The guard must
+    (a) not be wiped by an empty scan, (b) allow follow-up scans of extracted
+    contents, and (c) NOT over-broaden to expose unrelated sibling files (D9)."""
 
     def test_empty_scan_result_does_not_overwrite_state(self, monkeypatch):
         """A denied/empty scan must NOT wipe a populated inventory with zero."""
@@ -180,8 +184,24 @@ class TestScanApprovedRoots:
         assert result == []
         assert engine.state.scanned_files == ["existing1", "existing2"]
 
-    def test_directory_scan_approves_that_directory(self, tmp_path):
-        """Scanning a directory approves that directory; a subdir is allowed."""
+    def test_agent_scan_with_no_roots_refuses_and_does_not_autoapprove(self, tmp_path):
+        """Fail-closed: with no approved roots, the agent's scan is refused and
+        no root is added (the set stays empty)."""
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "a.txt").write_text("a")
+
+        engine = AgentEngine()
+        assert engine.state.approved_scan_roots == set()
+
+        r = engine.run_tool("scan_files", path=str(d))
+
+        assert r == []  # refused
+        assert engine.state.approved_scan_roots == set(), "agent scan must not auto-approve"
+        assert engine.state.scanned_files == []  # nothing stored
+
+    def test_directory_scan_after_initialize_allows_subdir(self, tmp_path):
+        """initialize() approves the input dir; a subdir is then scannable."""
         d = tmp_path / "data"
         d.mkdir()
         (d / "a.txt").write_text("a")
@@ -190,19 +210,19 @@ class TestScanApprovedRoots:
         (sub / "c.txt").write_text("c")
 
         engine = AgentEngine()
-        engine.run_tool("scan_files", path=str(d))
+        engine.initialize(str(d))
         assert str(d.resolve()) in engine.state.approved_scan_roots
 
         r = engine.run_tool("scan_files", path=str(sub))
         assert len(r) == 1  # subdir of an approved root is allowed
 
-    def test_zip_scan_approves_extracted_dir_not_parent(self, tmp_path):
-        """A zip approves its extraction dir, NOT the archive's parent — so a
-        sibling file next to the zip stays out of reach (security)."""
+    def test_initialize_zip_approves_extracted_dir_not_parent(self, tmp_path):
+        """initialize(zip) approves the extraction dir, NOT the archive's parent
+        — so a sibling file next to the zip stays out of reach (security)."""
         zpath = _make_zip(tmp_path, with_sibling=True)
 
         engine = AgentEngine()
-        engine.run_tool("scan_files", path=str(zpath))
+        engine.initialize(str(zpath))
 
         extracted = str((tmp_path / "study_extracted").resolve())
         assert extracted in engine.state.approved_scan_roots
@@ -215,12 +235,12 @@ class TestScanApprovedRoots:
         assert len(engine.state.scanned_files) >= 2
 
     def test_followup_scan_of_extracted_dir_is_not_denied(self, tmp_path):
-        """run_tool path: scan a zip, then scan its extracted dir — allowed."""
+        """initialize a zip, then the agent scans its extracted dir — allowed."""
         zpath = _make_zip(tmp_path, name="d.zip")
 
         engine = AgentEngine()
-        r1 = engine.run_tool("scan_files", path=str(zpath))
-        assert len(r1) >= 2
+        engine.initialize(str(zpath))
+        assert len(engine.state.scanned_files) >= 2
 
         extracted = zpath.parent / "d_extracted"
         r2 = engine.run_tool("scan_files", path=str(extracted))
@@ -239,24 +259,25 @@ class TestScanApprovedRoots:
         r = engine.run_tool("scan_files", path=str(extracted))
         assert len(r) >= 2, "extracted dir denied on the initialize() entry path"
 
-    def test_empty_first_scan_locks_guard(self, tmp_path):
-        """An empty first scan must still lock the guard, not leave it open."""
+    def test_empty_first_scan_does_not_open_guard(self, tmp_path):
+        """An agent scan of an unapproved (even empty) dir leaves the guard
+        closed: nothing is approved and a later scan is still denied."""
         empty = tmp_path / "empty"
         empty.mkdir()
 
         engine = AgentEngine()
         r1 = engine.run_tool("scan_files", path=str(empty))
         assert r1 == []
-        assert engine.state.approved_scan_roots, "guard left wide open after empty scan"
+        assert engine.state.approved_scan_roots == set(), "guard must stay closed"
 
-        # An unrelated path must now be denied (guard is active).
+        # An unrelated path must remain denied (guard never opened).
         other = tmp_path / "other"
         other.mkdir()
         (other / "f.txt").write_text("x")
         r2 = engine.run_tool("scan_files", path=str(other))
         assert r2 == []
 
-    def test_unrelated_dir_scan_denied_after_first(self, tmp_path):
+    def test_unrelated_dir_scan_denied_after_initialize(self, tmp_path):
         """The agent cannot wander into an unrelated directory unprompted."""
         d1 = tmp_path / "d1"
         d1.mkdir()
@@ -266,9 +287,17 @@ class TestScanApprovedRoots:
         (d2 / "b.txt").write_text("b")
 
         engine = AgentEngine()
-        r1 = engine.run_tool("scan_files", path=str(d1))
-        assert len(r1) == 1
+        engine.initialize(str(d1))
+        assert len(engine.state.scanned_files) == 1
 
         r2 = engine.run_tool("scan_files", path=str(d2))
         assert r2 == []  # d2 is not under the approved root (d1)
         assert len(engine.state.scanned_files) == 1  # inventory preserved
+
+    def test_initialize_does_not_approve_forbidden_root(self, tmp_path, monkeypatch):
+        """A forbidden dir (e.g. the user's home) can never become an approved
+        root, even when handed to initialize()."""
+        engine = AgentEngine()
+        engine.initialize(str(Path.home()))
+        assert str(Path.home()) not in engine.state.approved_scan_roots
+        assert engine.state.approved_scan_roots == set()

--- a/tests/test_scan_loop_fix.py
+++ b/tests/test_scan_loop_fix.py
@@ -50,7 +50,8 @@ class TestBinarySamplingSkip:
 
     def test_scan_files_leaves_xlsx_first_rows_none(self, tmp_path):
         _make_xlsx(tmp_path / "book.xlsx")
-        results = scan_files(str(tmp_path))
+        # The scanner fails closed (#197): approve the temp dir so the scan runs.
+        results = scan_files(str(tmp_path), approved_roots={str(tmp_path.resolve())})
         xlsx = next(r for r in results if r.filename == "book.xlsx")
         assert xlsx.first_rows is None
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -14,12 +14,30 @@ from builder.tools.scanner import (
 )
 
 
+def _scan(path, **kwargs):
+    """Test helper: scan *path* with it pre-approved.
+
+    The scanner now fails CLOSED (#197): a scan is refused unless the target is
+    inside an approved root. These unit tests exercise pure scanning/classification
+    behaviour, so we approve the target itself. For an archive we also approve its
+    extraction dir (``<stem>_extracted``) so the post-extract recursion is allowed.
+    Tests that specifically exercise the guard pass ``approved_roots`` explicitly.
+    """
+    if "approved_roots" in kwargs:
+        return scan_files(path, **kwargs)
+    p = Path(path).resolve()
+    approved = {str(p)}
+    # Archives extract next to themselves; approve that dir too.
+    approved.add(str(p.parent / f"{p.stem}_extracted"))
+    return scan_files(path, approved_roots=approved, **kwargs)
+
+
 class TestScanFiles:
     """Tests for the scan_files function."""
 
     def test_empty_directory_returns_empty_list(self, tmp_path):
         """scan_files on an empty directory should return an empty list."""
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
         assert result == []
 
     def test_single_text_file_returns_one_classification(self, tmp_path):
@@ -28,7 +46,7 @@ class TestScanFiles:
         data_file = tmp_path / "readme.txt"
         data_file.write_text("hello world\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 1
         fc = result[0]
@@ -44,7 +62,7 @@ class TestScanFiles:
         # Create a hidden file
         (tmp_path / ".hidden").write_text("shh\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 1
         assert result[0].filename == "visible.txt"
@@ -54,7 +72,7 @@ class TestScanFiles:
         csv_file = tmp_path / "data.csv"
         csv_file.write_text("col1,col2,col3\n1,2,3\n4,5,6\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 1
         fc = result[0]
@@ -66,7 +84,7 @@ class TestScanFiles:
         csv_file = tmp_path / "data.csv"
         csv_file.write_text("col1,col2,col3\n1,2,3\n4,5,6\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         fc = result[0]
         assert fc.first_rows is not None
@@ -77,7 +95,7 @@ class TestScanFiles:
         """scan_files does not populate first_rows for plain text files."""
         (tmp_path / "readme.txt").write_text("hello world\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert result[0].first_rows is None
 
@@ -86,7 +104,7 @@ class TestScanFiles:
         tsv_file = tmp_path / "data.tsv"
         tsv_file.write_text("col1\tcol2\n1\t2\n3\t4\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         fc = result[0]
         assert fc.first_rows is not None
@@ -95,7 +113,7 @@ class TestScanFiles:
     def test_nonexistent_directory_returns_empty_list(self, tmp_path):
         """scan_files on a non-existent directory should return [] gracefully."""
         nonexistent = tmp_path / "does_not_exist"
-        result = scan_files(str(nonexistent))
+        result = _scan(str(nonexistent))
         assert result == []
 
     def test_unreadable_directory_returns_empty_list(self, tmp_path):
@@ -108,7 +126,7 @@ class TestScanFiles:
         # Remove read permission for all
         unreadable.chmod(stat.S_IRUSR)
 
-        result = scan_files(str(unreadable))
+        result = _scan(str(unreadable))
         assert result == []
 
         # Restore so cleanup works
@@ -127,7 +145,7 @@ class TestScanFilesArchive:
             zf.writestr("file1.txt", "hello\n")
             zf.writestr("file2.txt", "world\n")
 
-        result = scan_files(str(zip_path))
+        result = _scan(str(zip_path))
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -142,7 +160,7 @@ class TestScanFilesArchive:
         with zipfile.ZipFile(zip_path, "w") as zf:
             zf.writestr("a.txt", "content\n")
 
-        result = scan_files(str(zip_path))
+        result = _scan(str(zip_path))
 
         assert isinstance(result, list)
         assert len(result) == 1
@@ -157,7 +175,7 @@ class TestScanFilesArchive:
             zf.writestr("subdir/", b"")
             zf.writestr("subdir/data.csv", "a,b\n1,2\n")
 
-        result = scan_files(str(zip_path))
+        result = _scan(str(zip_path))
 
         assert isinstance(result, list)
         assert len(result) == 1  # only the file, not the dir entry
@@ -168,7 +186,7 @@ class TestScanFilesArchive:
         zip_path = tmp_path / "corrupt.zip"
         zip_path.write_bytes(b"this is not a zip file")
 
-        result = scan_files(str(zip_path))
+        result = _scan(str(zip_path))
 
         assert isinstance(result, list)
         assert result == []
@@ -183,7 +201,7 @@ class TestScanFilesArchive:
             zf.writestr("__MACOSX/subdir/._notes.txt", b"\x00\x02")
             zf.writestr("data.csv", "a,b\n1,2\n")
 
-        result = scan_files(str(zip_path))
+        result = _scan(str(zip_path))
 
         assert isinstance(result, list)
         filenames = [f.filename for f in result]
@@ -544,7 +562,7 @@ class TestScannerTiming:
         for i in range(250):
             (tmp_path / f"file_{i:03d}.txt").write_text(f"content {i}\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 250
         # Should have at least "Progress: 100/..." and "Progress: 200/..."
@@ -568,7 +586,7 @@ class TestScannerTiming:
         for i in range(3):
             (tmp_path / f"file_{i}.txt").write_text(f"content {i}\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 3
         progress_messages = [r for r in caplog.records if "Progress" in r.getMessage()]
@@ -632,6 +650,65 @@ class TestApprovedRoots:
         assert result[0].filename == "file.csv"
 
 
+class TestApprovedRootsFailClosed:
+    """Fail-closed contract for the approved-scan-roots guard (#197).
+
+    With NO approved roots (None or empty) the scanner must REFUSE and never
+    walk the target. Forbidden system/home roots must be denied even when
+    explicitly present in *approved_roots*.
+    """
+
+    def test_none_approved_roots_refuses_and_does_not_walk(self, tmp_path, caplog):
+        """None approved_roots ⇒ refuse, return [], and never descend."""
+        (tmp_path / "data.csv").write_text("a,b\n1,2\n")
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "nested.txt").write_text("nested")
+
+        with mock.patch("builder.tools.scanner._safe_walk") as walk:
+            result = scan_files(str(tmp_path), approved_roots=None)
+
+        assert result == []
+        walk.assert_not_called()  # never traversed
+        assert any("not in approved roots" in r.getMessage() for r in caplog.records)
+
+    def test_empty_approved_roots_refuses_and_does_not_walk(self, tmp_path):
+        """An empty set ⇒ nothing approved ⇒ refuse without walking."""
+        (tmp_path / "data.csv").write_text("a,b\n1,2\n")
+
+        with mock.patch("builder.tools.scanner._safe_walk") as walk:
+            result = scan_files(str(tmp_path), approved_roots=set())
+
+        assert result == []
+        walk.assert_not_called()
+
+    def test_filesystem_root_refused_regardless_of_approved_roots(self):
+        """scan_files('/') is refused even with an approved root present."""
+        with mock.patch("builder.tools.scanner._safe_walk") as walk:
+            assert scan_files("/", approved_roots={"/"}) == []
+            assert scan_files("/", approved_roots={"/some/dir"}) == []
+        walk.assert_not_called()
+
+    def test_denylisted_roots_refused_even_when_explicitly_approved(self, tmp_path):
+        """Forbidden roots cannot be scanned even if passed in approved_roots."""
+        home = str(Path.home())
+        for forbidden in ("/", home, "/System", "/usr", "/etc", "/Users"):
+            with mock.patch("builder.tools.scanner._safe_walk") as walk:
+                result = scan_files(forbidden, approved_roots={forbidden})
+            assert result == [], f"{forbidden} should be refused"
+            walk.assert_not_called()
+
+    def test_normal_subdir_under_temp_root_is_allowed(self, tmp_path):
+        """A legitimate subdir under an approved (non-forbidden) root scans."""
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / "data.csv").write_text("a,b\n1,2\n")
+
+        result = scan_files(str(root), approved_roots={str(root.resolve())})
+
+        assert len(result) == 1
+        assert result[0].filename == "data.csv"
+
+
 class TestPruneHiddenDirs:
     """Tests for Issue #69: prune hidden/.git/__MACOSX subtrees during walk."""
 
@@ -642,7 +719,7 @@ class TestPruneHiddenDirs:
         (tmp_path / ".git" / "objects" / "abc123").write_text("fake pack\n")
         (tmp_path / "data.txt").write_text("real data\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         filenames = [f.filename for f in result]
         assert "data.txt" in filenames
@@ -655,7 +732,7 @@ class TestPruneHiddenDirs:
         (tmp_path / ".hidden_dir" / "secret.csv").write_text("a,b\n1,2\n")
         (tmp_path / "visible.csv").write_text("c,d\n3,4\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         filenames = [f.filename for f in result]
         assert "visible.csv" in filenames
@@ -668,7 +745,7 @@ class TestPruneHiddenDirs:
         (tmp_path / "__MACOSX" / "._junk.txt").write_text("junk\n")
         (tmp_path / "real.csv").write_text("x,y\n1,2\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         filenames = [f.filename for f in result]
         assert "real.csv" in filenames
@@ -683,7 +760,7 @@ class TestPruneHiddenDirs:
         (sub / ".cache" / "deep.txt").write_text("hidden\n")
         (sub / "good.txt").write_text("visible\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert all(".cache" not in f.path for f in result)
         assert len(result) == 1
@@ -694,7 +771,7 @@ class TestPruneHiddenDirs:
         (tmp_path / "visible.txt").write_text("hello\n")
         (tmp_path / ".hidden.txt").write_text("shh\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 1
         assert result[0].filename == "visible.txt"
@@ -708,7 +785,7 @@ class TestMaxFilesCap:
         for i in range(150):
             (tmp_path / f"file_{i:03d}.txt").write_text(f"content {i}\n")
 
-        result = scan_files(str(tmp_path), max_files=50)
+        result = _scan(str(tmp_path), max_files=50)
 
         assert len(result) == 50
 
@@ -717,7 +794,7 @@ class TestMaxFilesCap:
         for i in range(50):
             (tmp_path / f"file_{i:03d}.txt").write_text(f"content {i}\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         assert len(result) == 50
 
@@ -730,7 +807,7 @@ class TestMaxFilesCap:
         for i in range(150):
             (tmp_path / f"file_{i:03d}.txt").write_text(f"content {i}\n")
 
-        scan_files(str(tmp_path), max_files=50)
+        _scan(str(tmp_path), max_files=50)
 
         warning_messages = [r for r in caplog.records if "max_files" in r.getMessage().lower()]
         assert len(warning_messages) == 1
@@ -741,7 +818,7 @@ class TestMaxFilesCap:
         csv_content = f"{long_line}\ncol1,col2\n1,2\n"
         (tmp_path / "long.csv").write_text(csv_content)
 
-        result = scan_files(str(tmp_path), max_line_length=100)
+        result = _scan(str(tmp_path), max_line_length=100)
 
         fc = result[0]
         assert fc.first_rows is not None
@@ -752,7 +829,7 @@ class TestMaxFilesCap:
         line = "x" * 300
         (tmp_path / "data.csv").write_text(f"{line}\na,b\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         fc = result[0]
         assert fc.first_rows is not None
@@ -762,7 +839,7 @@ class TestMaxFilesCap:
         """scan_files with max_line_length does not affect shorter lines."""
         (tmp_path / "data.csv").write_text("a,b\n1,2\n3,4\n")
 
-        result = scan_files(str(tmp_path), max_line_length=100)
+        result = _scan(str(tmp_path), max_line_length=100)
 
         fc = result[0]
         assert fc.first_rows is not None
@@ -782,7 +859,7 @@ class TestReducedStats:
             "builder.tools.scanner._detect_mime_type",
             wraps=_detect_mime_type,
         ) as mock_mime:
-            result = scan_files(str(tmp_path), max_files=100)
+            result = _scan(str(tmp_path), max_files=100)
 
         assert len(result) == 1
         assert result[0].mime_type == "text/csv"
@@ -795,7 +872,7 @@ class TestReducedStats:
         csv_file = tmp_path / "data.csv"
         csv_file.write_text("col1,col2\n1,2\n3,4\n")
 
-        result = scan_files(str(tmp_path))
+        result = _scan(str(tmp_path))
 
         fc = result[0]
         assert fc.first_rows is not None

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -19,7 +19,7 @@ class MockHumanInterface:
         self.present_calls: list[tuple[str, list[str] | None]] = []
         self.input_calls: list[tuple[str, str]] = []
 
-    def present(self, context, options=None):
+    def present(self, context, options=None, purpose=None):
         self.present_calls.append((context, options))
         return {"action": "edited", "comments": "fix it", "edits": {"name": "X"}}
 
@@ -41,6 +41,19 @@ class TestSimulatedHumanInterface:
     def test_request_input_returns_skipped_input_response(self):
         resp = SimulatedHumanInterface().request_input("DOI?", "identifier")
         assert resp == {"value": None, "skipped": True}
+
+    def test_present_denies_scan_root_escalation(self):
+        """Fail-closed (#197): the simulator must NOT auto-approve a request to
+        add a new scan root — it cannot be the approver for filesystem access."""
+        resp = SimulatedHumanInterface().present(
+            "Approve scanning /etc?", options=["Approve", "Deny"], purpose="scan_root"
+        )
+        assert resp["action"] == "rejected"
+
+    def test_present_still_approves_benign_checkpoints(self):
+        """Non-scan-root checkpoints keep the convenient auto-approve behaviour."""
+        resp = SimulatedHumanInterface().present("Review investigation", purpose="entity_review")
+        assert resp["action"] == "approved"
 
 
 class TestBackwardCompatibleFunctions:

--- a/tests/test_tools_publication_authors.py
+++ b/tests/test_tools_publication_authors.py
@@ -45,7 +45,7 @@ class RecordingHumanInterface:
         self.present_calls: list[tuple[str, list[str] | None]] = []
         self.input_calls: list[tuple[str, str]] = []
 
-    def present(self, context, options=None):
+    def present(self, context, options=None, purpose=None):
         self.present_calls.append((context, options))
         return self.present_response
 


### PR DESCRIPTION
Fixes #197.

## Root cause (fail-open)
The D9 approved-scan-roots guard failed **open**. When `CrateState.approved_scan_roots` was empty, `AgentEngine.run_tool` passed `approved_roots=None` to `scan_files`, which the scanner treated as "no guard at all". On top of that, the engine **auto-approved the first path the agent scanned**. The net effect: the LLM agent could scan **any** location on the filesystem — including the user's home directory — simply by naming a path. (The previous test run proved this: the denylist test walked all of `~/Library/Preferences` before the fix.)

## The fix (fail-closed)
1. **Engine never disables the guard.** `run_tool` always injects a concrete allowlist for `scan_files` — an empty `set()`, never `None` (`builder/engine.py`).
2. **Scanner fails closed.** `scan_files` refuses (logs the existing "Refusing to scan … not in approved roots" warning and returns `[]` **without walking**) whenever `approved_roots` is `None` or empty. The archive recursion now propagates `approved_roots` (plus the extraction dir) instead of calling with no allowlist. Docstring updated to drop the "first path auto-approved" behavior (`builder/tools/scanner.py`).
3. **Removed auto-approve-of-first-scan.** Deleted the engine block that added the agent's scanned path to `approved_scan_roots`. Roots now enter the allowlist **only** from a user-provided input path (`initialize()` / `read_directory()`) or a real approval — never from the agent's own scan call.
4. **Hard denylist.** New `scanner._is_forbidden_root` refuses `/`, the user's home dir itself, `/System`, `/Library`, `/private`, `/var`, `/etc`, `/usr`, bare `/Users`, `/Volumes` — even if explicitly present in `approved_roots`. Enforced in the scanner guard **and** in `engine._directory_to_approve` (a forbidden dir can never *become* an approved root). Legitimate subdirectories (e.g. `~/Desktop/project`) are unaffected.
5. **`SimulatedHumanInterface` fail-closed for scan-root escalation.** `present(..., purpose="scan_root")` now returns a `rejected` action, so the non-interactive default can never widen filesystem access on its own; benign checkpoints (entity review, etc.) still auto-approve. Investigation confirmed **no distinct HITL path approved a new scan root** — the only escalation was the now-removed auto-first-scan; the simulator simply cannot be the approver for scan roots.

`initialize()` now approves the input dir **before** scanning (the scanner requires a concrete allowlist) and passes it through; for archives it approves the extraction dir as the persistent root and the archive path only for the one initial scan, so a sibling file next to the archive stays out of reach.

## New fail-closed contract
- No approved roots (None or empty) ⇒ **nothing** is scannable; the scan is refused without walking.
- The agent's own `scan_files` call can never add a root or widen access.
- Forbidden roots are always denied, regardless of `approved_roots`.

## Tests (TDD: red → green)
- Scanner: None/empty `approved_roots` ⇒ refuse + never traverse (`_safe_walk` not called); `scan_files("/")` refused; denylist (`/`, `Path.home()`, `/System`, …) refused even when explicitly approved; a normal subdir under a temp root is allowed.
- Engine: agent `scan_files` with empty roots refuses and the set stays **empty** (no auto-approve); an unapproved empty scan does not open the guard; `initialize()` refuses to approve a forbidden input path; normal flow preserved (`initialize(tempdir)` approves it, subdir scans, sibling/outside refused; zip approves extraction dir not parent).
- HITL: `SimulatedHumanInterface` denies a `scan_root` escalation; still approves benign checkpoints.
- Updated existing tests that encoded the old fail-open / auto-approve-first-scan contract (`test_engine.py::TestScanApprovedRoots`, `test_scanner.py` pure-scan tests via a `_scan` helper that pre-approves the target, two `present` test doubles to match the new protocol signature, `read_directory` reader tests).

## Gate
- `uv run ruff check` → All checks passed!
- `uv run --extra langchain ty check` → All checks passed!
- `uv run --extra langchain pytest tests/test_scanner.py tests/test_engine.py tests/test_tools_hitl.py tests/test_readers.py tests/test_tools_publication_authors.py` → 130 passed

## Follow-up (out of scope)
Sandboxing the eval harness so it cannot scan outside its fixtures is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)