### PR TITLE
fix(tools): rename draft_process_chain 'validate' arg to silence Pydantic shadow warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -642,7 +642,7 @@ orphaned.
 
 ### Derivation Chain Tools
 ```
-draft_process_chain(assay_id: str, chain: [{process_type, hints?, object?, result?}], validate=None) → {assay_id, process_ids, steps, synthesized}  # composite: create + wire the whole CellCulture→Exposure→EndpointReadout→DataAnalysis chain in one idempotent call, synthesizing the EndpointReadout/DataAnalysis outputs the build has no fallback for
+draft_process_chain(assay_id: str, chain: [{process_type, hints?, object?, result?}], validate_after=None) → {assay_id, process_ids, steps, synthesized}  # composite: create + wire the whole CellCulture→Exposure→EndpointReadout→DataAnalysis chain in one idempotent call, synthesizing the EndpointReadout/DataAnalysis outputs the build has no fallback for
 link(from_id: str, relation: str, to_id: str) → {from_id, relation, to_id}
 attach_files(to: str, name_contains=None, mime_contains=None, paths=None, role=None) → {attached, file_ids, to}
 check_provenance() → {ok, issues:[{entity_id, property, message, fix, severity, profile}]}

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -60,7 +60,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_process_chain",
-        "description": "Create and wire a whole LabProcess derivation chain in ONE idempotent call: Sample ->[CellCulture]-> Sample ->[Exposure]-> table ->[EndpointReadout]-> raw ->[DataAnalysis]-> figures. Pass the parent assay_id and an ordered chain of steps; each step is {process_type, hints?, object?, result?}. Steps are always wired in canonical order (CellCulture->Exposure->EndpointReadout->DataAnalysis) and a subset is fine (partial chains work). CRITICAL: it SYNTHESIZES the missing outputs that EndpointReadout/DataAnalysis require (they have no build-time fallback) so the chain never dangles into a validation error — placeholder File/Sample entities with NO fabricated data. Explicit object/result you pass win over synthesis. Set validate=true to also run build_and_validate. Prefer this over draft_process+link for the standard chain. Example: draft_process_chain(assay_id='assay_cell_viability_assay', chain=[{'process_type':'CellCulture','hints':{'name':'Seed MDCK'}},{'process_type':'Exposure','hints':{'duration':'24h'}},{'process_type':'EndpointReadout','hints':{}},{'process_type':'DataAnalysis','hints':{}}]).",
+        "description": "Create and wire a whole LabProcess derivation chain in ONE idempotent call: Sample ->[CellCulture]-> Sample ->[Exposure]-> table ->[EndpointReadout]-> raw ->[DataAnalysis]-> figures. Pass the parent assay_id and an ordered chain of steps; each step is {process_type, hints?, object?, result?}. Steps are always wired in canonical order (CellCulture->Exposure->EndpointReadout->DataAnalysis) and a subset is fine (partial chains work). CRITICAL: it SYNTHESIZES the missing outputs that EndpointReadout/DataAnalysis require (they have no build-time fallback) so the chain never dangles into a validation error — placeholder File/Sample entities with NO fabricated data. Explicit object/result you pass win over synthesis. Set validate_after=true to also run build_and_validate. Prefer this over draft_process+link for the standard chain. Example: draft_process_chain(assay_id='assay_cell_viability_assay', chain=[{'process_type':'CellCulture','hints':{'name':'Seed MDCK'}},{'process_type':'Exposure','hints':{'duration':'24h'}},{'process_type':'EndpointReadout','hints':{}},{'process_type':'DataAnalysis','hints':{}}]).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -83,7 +83,7 @@ TOOL_SPECS = [
                         "required": ["process_type"],
                     },
                 },
-                "validate": {"type": "boolean", "description": "Also run build_and_validate and return it under 'validation'."},
+                "validate_after": {"type": "boolean", "description": "Also run build_and_validate and return it under 'validation'."},
             },
             "required": ["assay_id", "chain"],
         },

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -157,7 +157,7 @@ def draft_process_chain(
     state: CrateState,
     assay_id: str,
     chain: list[dict[str, Any]] | None = None,
-    validate: bool | None = None,
+    validate_after: bool | None = None,
 ) -> dict[str, Any]:
     """Create and wire a LabProcess derivation chain in ONE idempotent call.
 
@@ -211,15 +211,20 @@ def draft_process_chain(
         state: The crate state to wire the chain into.
         assay_id: entity_id of the parent Assay every process belongs to.
         chain: Ordered list of step dicts (see above). ``None``/empty is a no-op.
-        validate: When true, also run a full ``build_and_validate`` and return it
-            under ``"validation"`` (weak models may pass ``None`` for this
-            optional arg; that is treated as false).
+        validate_after: When true, also run a full ``build_and_validate`` and
+            return it under ``"validation"`` (weak models may pass ``None`` for
+            this optional arg; that is treated as false). Named
+            ``validate_after`` (not ``validate``) to avoid shadowing
+            ``pydantic.BaseModel.validate`` in the generated arg schema; the
+            suffix differs from the sibling ``scaffold_isa_backbone`` whose
+            ``validate_base`` runs only the base profile, whereas this runs the
+            full three-pass ``build_and_validate``.
 
     Returns:
         ``{"assay_id", "process_ids", "steps", "synthesized"}`` — the ordered
         process entity ids, a per-step summary (``{process_id, process_type,
         object, result}``), and the list of placeholder entity ids synthesized.
-        ``"validation"`` is added when ``validate`` is true.
+        ``"validation"`` is added when ``validate_after`` is true.
 
     Raises:
         ValueError: If ``assay_id`` is missing/not an Assay, or a step has an
@@ -315,7 +320,7 @@ def draft_process_chain(
         "synthesized": synthesized,
     }
 
-    if validate:
+    if validate_after:
         from builder.tools.validation import build_and_validate
 
         result["validation"] = build_and_validate(state)

--- a/tests/test_tools_process_chain.py
+++ b/tests/test_tools_process_chain.py
@@ -14,6 +14,9 @@ The validation-heavy class carries a 120s timeout (the #184 lesson) because each
 
 from __future__ import annotations
 
+import inspect
+import warnings
+
 import pytest
 
 from builder.engine import AgentEngine
@@ -251,7 +254,70 @@ class TestChainPassesValidation:
     def test_optional_validate_flag_returns_report(self):
         state, assay_id = _scaffold()
         result = draft_process_chain(
-            state, assay_id, chain=_FULL_CHAIN, validate=True
+            state, assay_id, chain=_FULL_CHAIN, validate_after=True
         )
         assert "validation" in result
         assert result["validation"]["ok"] is True, result["validation"]
+
+    def test_validate_after_default_skips_validation(self):
+        """Omitting the flag (and passing None) must NOT run validation."""
+        state, assay_id = _scaffold()
+        result = draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+        assert "validation" not in result
+
+        state2, assay_id2 = _scaffold()
+        result2 = draft_process_chain(
+            state2, assay_id2, chain=_FULL_CHAIN, validate_after=None
+        )
+        assert "validation" not in result2
+
+
+class TestNoPydanticShadowWarning:
+    """The optional validation flag must not be named ``validate`` — that
+    shadows ``pydantic.BaseModel.validate`` and makes pydantic emit a
+    ``UserWarning`` on every run, for both the ``_build_args_schema`` model
+    and the ``StructuredTool.from_function`` model (#189)."""
+
+    def test_signature_has_no_validate_shadowing_param(self):
+        """The function must not expose a ``validate`` parameter."""
+        params = inspect.signature(draft_process_chain).parameters
+        assert "validate" not in params, (
+            "draft_process_chain still has a 'validate' param that shadows "
+            f"BaseModel.validate; params: {list(params)}"
+        )
+        assert "validate_after" in params
+
+    def test_args_schema_emits_no_shadow_warning(self):
+        """Building the LLM-facing pydantic args model must not warn."""
+        pytest.importorskip("pydantic")
+        from typing import Any, cast
+
+        from builder.agents.agent_loop import _build_args_schema
+        from builder.agents.tools_spec import TOOL_SPECS
+
+        spec = next(s for s in TOOL_SPECS if s["name"] == "draft_process_chain")
+        name = cast(str, spec["name"])
+        params = cast(dict[str, Any], spec["parameters"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            _build_args_schema(name, params)
+
+    def test_structured_tool_emits_no_shadow_warning(self):
+        """Introspecting the function signature for a tool must not warn."""
+        StructuredTool = pytest.importorskip(
+            "langchain_core.tools"
+        ).StructuredTool
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            StructuredTool.from_function(
+                func=draft_process_chain,
+                name="draft_process_chain",
+                description="wire a process chain",
+            )
+        shadow = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning) and "shadows" in str(w.message)
+        ]
+        assert not shadow, [str(w.message) for w in shadow]


### PR DESCRIPTION
## The warning

`draft_process_chain` exposed a parameter named `validate`, which shadows `pydantic.BaseModel.validate`. Pydantic emitted a `UserWarning` on **every run** — twice (#189):

```
UserWarning: Field name "validate" in "draft_process_chain_args" shadows an attribute in parent "BaseModel"
UserWarning: Field name "validate" in "draft_process_chain"      shadows an attribute in parent "BaseModel"
```

The first comes from the LLM-facing args model built by `_build_args_schema` (named `<tool>_args`); the second from the `StructuredTool.from_function` model built off the function signature.

## The rename

Renamed the parameter `validate` → **`validate_after`** in all four LLM-facing places, keeping the schema consistent:

- `builder/tools/composites.py` — the function signature, the `if validate:` guard, and the docstring.
- `builder/agents/tools_spec.py` — the `TOOL_SPECS` property name + its description, and the `Set validate_after=true …` text in the tool description.
- `AGENTS.md` §5 — the `draft_process_chain(... validate_after=None)` signature.

### Why `validate_after`, not `validate_base`

The sibling `scaffold_isa_backbone` uses `validate_base` because it runs `build_and_validate(profile="base")` — base profile only. `draft_process_chain` instead runs the **full three-pass** `build_and_validate`, so `validate_base` would be misleading. `validate_after` is non-shadowing and accurately describes "validate after wiring the chain".

## Behavior is unchanged

Only the name changes. Default / `None` still skips validation; an explicit truthy value still runs the full `build_and_validate` and returns it under `"validation"`.

## Tests (strict TDD — written failing first)

Added `TestNoPydanticShadowWarning` in `tests/test_tools_process_chain.py`:
- `test_signature_has_no_validate_shadowing_param` — asserts no `validate` param, and that `validate_after` exists.
- `test_args_schema_emits_no_shadow_warning` — builds the args model under `simplefilter("error", UserWarning)`; would re-raise the shadow warning if it returned.
- `test_structured_tool_emits_no_shadow_warning` — records warnings from `StructuredTool.from_function` and asserts none containing `"shadows"`.

Plus updated `test_optional_validate_flag_returns_report` to the new name and added `test_validate_after_default_skips_validation` (default + explicit `None` both skip). All confirmed red before the rename, green after. The existing parity tests in `test_tools_spec.py` / `test_agents_doc_toolbox.py` guard the cross-file rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)