### PR TITLE
test: parallelize the suite with pytest-xdist (~2.4x on CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,9 @@ jobs:
         continue-on-error: true  # ty is a Rust-based type checker still evolving
 
       - name: Test (pytest)
-        run: uv run pytest --ignore=tests/test_validator_wiring.py --ignore=tests/test_lookups_contract.py --ignore=tests/test_dashboard.py --timeout=30 -x -v
+        # Run in parallel with pytest-xdist. `-n auto` uses every vCPU the runner
+        # has (ubuntu-latest = 4 vCPU at time of writing), and `--maxprocesses=4`
+        # caps worker count so memory-heavy build/validate tests do not exhaust
+        # RAM on larger runners. `timeout_method = thread` (pyproject) makes
+        # pytest-timeout fire inside xdist worker subprocesses.
+        run: uv run pytest --ignore=tests/test_validator_wiring.py --ignore=tests/test_lookups_contract.py --ignore=tests/test_dashboard.py --timeout=30 -n auto --maxprocesses=4 -x -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "nbformat>=5.10.4",
     "ruff>=0.15.18",
     "pytest-timeout>=2.4.0",
+    "pytest-xdist>=3.8.0",
 ]
 
 [tool.ruff]
@@ -53,3 +54,7 @@ select = ["E", "F", "I"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "eval/tests"]
 python_files = ["test_*.py"]
+# pytest-timeout's default `signal` method only fires on the main thread, so it
+# never triggers inside pytest-xdist worker subprocesses. `thread` works in both
+# serial and parallel runs, so set it globally for correct timeouts under xdist.
+timeout_method = "thread"

--- a/uv.lock
+++ b/uv.lock
@@ -1019,6 +1019,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4355,6 +4364,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -5905,6 +5927,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "responses" },
     { name = "ruff" },
     { name = "ty" },
@@ -5942,6 +5965,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "responses", specifier = ">=0.26.1" },
     { name = "ruff", specifier = ">=0.15.18" },
     { name = "ty", specifier = ">=0.0.51" },


### PR DESCRIPTION
## What

Run the test suite in parallel with **pytest-xdist**. The CI test step now uses
`-n auto --maxprocesses=4`, and `timeout_method = "thread"` is set in
`pyproject.toml` so `pytest-timeout` fires correctly inside xdist worker
subprocesses.

The suite (~891 tests) is dominated by heavy SHACL-validation and e2e
build/validate work — exactly the CPU-bound load that parallelizes well.

## Measured speedup (local, 10-core macOS, CI-equivalent command)

`uv run --extra langchain pytest <same --ignore set> --timeout=30`

| Config                | Wall-clock   | Speedup | Result |
|-----------------------|--------------|---------|--------|
| serial (today)        | 665s (11:05) | 1.00x   | 890 pass + 1 cold-cache flake* |
| `-n 2`                | 354s (5:54)  | 1.88x   | 891 passed |
| `-n 4`                | 274s (4:34)  | 2.42x   | 891 passed |
| `-n auto` (10 workers)| 220s (3:40)  | 3.02x   | **2 worker OOM crashes** |
| **`-n auto --maxprocesses=4`** (shipped) | 279s (4:38) | 2.38x | **891 passed** |

The plateau past `-n 4` is **tail-bound**: a cluster of ~25–75s tests
(`eval/tests/test_main*.py`, `eval/tests/test_runner.py`,
`tests/test_tools_repair.py`, `tests/test_e2e_agent_eval.py`) dominate the
critical path, so adding workers can't shrink wall-clock below the longest
serialized test. The slow tests are also inflated by each worker's first-import
of the torch/langchain stack.

## Why cap at `--maxprocesses=4` instead of raw `-n auto`

Raw `-n auto` (= 10 workers on this 10-core box) **OOM-crashed two workers**
(not assertion failures — `worker 'gwN' crashed`):
- `test_export_smoke.py::...test_exports_metadata_preview_and_validates_clean`
- `test_tools_build_and_validate.py::...test_none_args_fall_back_to_defaults`

Both are the most memory-hungry build_and_validate / SHACL-export tests; with 10
workers each loading torch+langchain+rocrate plus parallel rdflib graph
processing, RAM is exhausted. **Not an isolation bug** — the same tests pass
cleanly at `-n 2`/`-n 4`. `--maxprocesses=4` keeps `auto`'s portability (scales
to runner vCPUs) while bounding memory. On `ubuntu-latest` (4 vCPU) `-n auto`
already resolves to 4 workers, so the cap is a no-op there and matches the
verified-green `-n 4` run.

## Correctness under parallelism — isolation audit (all clean)

No per-worker fixture surgery was needed:
- **sessions/ & cwd writes** route through `monkeypatch.chdir(tmp_path)` (unique
  per test, auto-restored).
- **eval reports** write to `tmp_path`.
- **env mutations** (`test_agent_loop.py` etc.) are per-process — xdist workers
  are separate processes, so no cross-worker collision.
- **offline-context loader, `TOOL_REGISTRY`, lookup `lru_cache`s** are per-worker
  module-import state, built deterministically in each worker.
- **Validation is fully offline** (bundled RO-Crate contexts), so parallel SHACL
  never contends on the network or hits rate limits.
- **pytest-timeout under xdist**: default `signal` method only fires on the main
  thread → never triggers in worker subprocesses. Fixed via
  `timeout_method = "thread"` in `pyproject.toml`; verified timeouts still
  enforce across all parallel runs.

\* The single serial "failure" is a pre-existing, xdist-independent flake:
`test_agent_graph.py::test_returns_compiled_graph` timed out (30s) while
*first-importing* torch via `transformers`→`langchain_core` (cold `.pyc`
compile). It passes in ~5s once the cache is warm and never recurred under
parallelism. Not introduced or fixed here.

## CI projection (ubuntu-latest = 4 vCPU, ~16 GB RAM)

`-n auto` → 4 workers on the runner ≈ the verified-green `-n 4` ≈ **~4.5 min**,
down from ~11 min serial (**~2.4x**). 16 GB / 4 workers is ample, so the OOM seen
locally at 10 workers won't occur on CI.

### Optional follow-up — matrix sharding for further wall-clock

Runner minutes are not a constraint, so a future change could split the suite
into N parallel jobs to push CI wall-clock toward the tail floor (~1–2 min):
- (a) **single-job xdist** (this PR): ~4.5 min, simplest.
- (b) **matrix sharding** N jobs (`pytest-split` by stored timings, or path
  partition): wall ≈ tail floor (~1.5–2 min) given the long e2e/eval cluster.
- (c) **combined** shard×xdist: lowest wall-clock but more YAML.

Recommended next step if more speed is wanted: peel the heavy e2e/eval cluster
(`test_e2e_agent_eval.py`, `eval/tests/test_main*.py`, `test_tools_repair.py`)
into its own shard alongside an xdist'd "everything else" job. Left out of this
PR to keep it a small, reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)