### PR TITLE
feat(pipeline): bounded drafter-leaf for structured entity extraction (#179 task 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1329,12 +1329,41 @@ Study via `mentions`/`aop`). The only LLM-supplied input is the numeric `aop_id`
 ### 14.4 Migration tasks (each its own `jh-*` branch + PR, TDD)
 
 Pipeline (#179): (1) `fix_required_issues` deterministic repair loop — *the keystone*;
-(2) drafters as real LLM leaves; (3) composite meta-tools incl. `draft_process_chain`
+(2) drafters as real LLM leaves — **done** (see [the drafter-leaf](#the-drafter-leaf-leavespy)
+below); (3) composite meta-tools incl. `draft_process_chain`
 — **done**: it synthesizes the EndpointReadout/DataAnalysis outputs the build has no
 fallback for (closing the §14.3 Violation trap) and wires the whole chain in one
 idempotent call (see §5 Derivation Chain Tools); (4) pipeline spine replaces the
 `should_continue` ReAct loop; (5) shrink tail agent; (6) **A/B eval harness —
 decision gate**; (7) prompt + docs.
+
+#### The drafter-leaf (`leaves.py`)
+
+Task 2's "Leaves = cheap model" primitive (§14.2). `builder/agents/leaves.py`
+exposes a single pure function — **`draft_entity_fields(entity_type: str,
+context: str, *, model: str | None = None) -> dict`** — the smallest unit of LLM
+work in the pipeline: free-text/context in → a structured dict of one entity's
+fields out, in a **single bounded model call**. It is a **library leaf, not an
+LLM-callable tool** — the deterministic spine (task 4) imports and calls it; the
+ReAct agent never sees it, so it needs **no four-place tool registration**. It
+does **not** mutate `CrateState` and does **not** orchestrate; the spine feeds
+its result into the deterministic `draft_*` state mutators.
+
+Contract:
+- **Drafter tier.** The call goes through `_build_chat_model(role="drafter")`
+  (§4.4), so a cheap model does the extraction. With no drafter model configured
+  this resolves to the primary model — a strict no-op.
+- **Structured output.** The output is constrained by the entity's typed hint
+  schema `_crate_mapping.draft_hints_schema(entity_type)` via the model's
+  structured-output / function-calling, so the returned dict validates against
+  that schema. The schema gets a top-level `title` (`<EntityType>Fields`) so
+  langchain can use it directly as a function spec.
+- **D5 — no fabricated identifiers.** Identifier-bearing scalar fields (CAS /
+  InChIKey / SMILES / PubChem CID / ORCID / ROR / DOI / Cellosaurus accession /
+  ontology codes / IRIs) and all entity-reference fields (`_REF_FIELDS`) are
+  **removed from the schema the model sees** — it is never even asked for an
+  identifier — *and* defensively stripped from the result. Those fields are left
+  empty for a downstream **lookup** to fill, never guessed.
 
 Toolbox completion (companion issue, parallel disjoint lanes): `materialize_aop_subgraph`;
 ~~the identifier-PropertyValue family~~ **done (#180)** — landed as deterministic

--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -1,0 +1,166 @@
+"""Bounded drafter leaves for the deterministic pipeline (Issue #179, task 2).
+
+This module holds the cheap-model "bounded extraction" primitive the §14
+deterministic pipeline calls at its *leaves*. A leaf is the smallest unit of LLM
+work: free-text/context in -> a structured dict of one entity's fields out, in a
+SINGLE bounded model call. It does **not** mutate :class:`CrateState` and does
+**not** orchestrate — the spine (a separate PR) imports it and feeds the result
+to the deterministic ``draft_*`` state mutators.
+
+Design (AGENTS.md §4.4 Model Tiering, §14.2 "Leaves = cheap model"):
+
+- The call runs on the **drafter tier** — ``_build_chat_model(role="drafter")``
+  — so a cheap model does the extraction while a stronger model (if configured)
+  drives orchestration elsewhere. With no drafter model configured this resolves
+  to the primary model, a strict no-op.
+- The output is constrained by the entity's typed hint schema
+  (``_crate_mapping.draft_hints_schema(entity_type)``) via the model's
+  **structured-output / function-calling**, so it validates against that schema.
+- **D5 (Verify, Don't Trust).** Identifiers come from *lookups*, never
+  invention. Identifier-bearing fields (CAS / InChIKey / SMILES / PubChem CID /
+  ORCID / ROR / DOI / Cellosaurus accession / ontology codes / ...) and all
+  entity-reference fields are **removed from the schema the model sees** so it is
+  never even asked to produce one, and are defensively **stripped from the
+  output**. The leaf leaves those fields empty for a downstream lookup to fill.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from builder.agents.agent_loop import _build_chat_model
+from builder.tools._crate_mapping import _REF_FIELDS, draft_hints_schema
+
+# ---------------------------------------------------------------------------
+# D5: identifier-bearing scalar fields the leaf must NEVER let the model fill.
+#
+# These are the keys across ENTITY_DRAFT_SCHEMA whose values are identifiers /
+# accessions / ontology codes that MUST be resolved by a lookup service, never
+# guessed by the extractor. Entity-reference fields (``_REF_FIELDS``) are also
+# excluded — they are wired deterministically by ``link`` / the resolver, not
+# extracted as free text. Both sets are pruned from the structured-output schema
+# *and* stripped from the result.
+# ---------------------------------------------------------------------------
+_IDENTIFIER_SCALAR_FIELDS: frozenset[str] = frozenset(
+    {
+        # generic identifier slot (CAS / accession / DOI, per entity type)
+        "identifier",
+        "accession",
+        # MolecularEntity structure/registry identifiers
+        "inchikey",
+        "smiles",
+        "molecular_formula",
+        "pubchem_cid",
+        "cas",
+        "casrn",
+        "cas_number",
+        # Person / Organization / Publication external ids
+        "orcid",
+        "ror",
+        "doi",
+        # DefinedTerm / PropertyValue ontology identifiers + dereferenceable IRIs
+        "term_code",
+        "in_defined_term_set",
+        "property_id",
+        "unit_code",
+        "url",
+    }
+)
+
+# Fields removed from the schema the model sees AND stripped from its output (D5).
+_EXCLUDED_FIELDS: frozenset[str] = _IDENTIFIER_SCALAR_FIELDS | _REF_FIELDS
+
+_SYSTEM_PROMPT = (
+    "You are a bounded metadata extractor for ISA-Tox RO-Crates. Given an entity "
+    "type and some free-text context, return ONLY the entity's descriptive fields "
+    "(names, free-text descriptions) that are explicitly supported by the context. "
+    "Do NOT invent or guess. Critically, NEVER fabricate identifiers: CAS numbers, "
+    "InChIKeys, SMILES, PubChem CIDs, ORCIDs, RORs, DOIs, accessions, ontology "
+    "codes, or IRIs come from dedicated lookup services, never from you. Leave any "
+    "field you are unsure about empty rather than guessing."
+)
+
+
+def _structured_output_schema(entity_type: str) -> dict[str, Any]:
+    """Build the structured-output schema for the model, D5-pruned.
+
+    Starts from :func:`draft_hints_schema` and removes every identifier-bearing
+    and entity-reference field so the model is never asked to produce an
+    identifier (the strongest D5 guard). The schema stays open
+    (``additionalProperties: true``) so the long tail of descriptive fields is
+    still permitted. A top-level ``title`` is added so langchain can use the
+    schema directly as a structured-output function (a raw JSON-schema dict
+    without a ``title`` is rejected as a function spec).
+    """
+    schema = draft_hints_schema(entity_type)
+    props = schema.get("properties", {})
+    schema["properties"] = {
+        key: spec for key, spec in props.items() if key not in _EXCLUDED_FIELDS
+    }
+    # The function name langchain derives for the structured-output tool. Must be
+    # a valid identifier; ``entity_type`` is always a CamelCase type name.
+    schema["title"] = f"{entity_type}Fields"
+    return schema
+
+
+def _strip_identifiers(fields: dict[str, Any]) -> dict[str, Any]:
+    """Defensively drop any identifier/reference field from model output (D5)."""
+    return {
+        key: value for key, value in fields.items() if key not in _EXCLUDED_FIELDS
+    }
+
+
+def draft_entity_fields(
+    entity_type: str,
+    context: str,
+    *,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Extract one entity's descriptive fields from free-text ``context``.
+
+    A pure leaf: a SINGLE bounded LLM call on the drafter tier
+    (``_build_chat_model(role="drafter")``) whose output is constrained by the
+    entity type's typed hint schema (``draft_hints_schema(entity_type)``) via the
+    model's structured-output / function-calling. It does not mutate state and
+    does not orchestrate — context in, structured fields out.
+
+    D5: identifier-bearing fields and entity references are removed from the
+    schema the model sees and stripped from the result, so an identifier is never
+    fabricated — it is left empty for a downstream lookup to fill.
+
+    Args:
+        entity_type: The ISA-Tox entity type (e.g. ``"MolecularEntity"``,
+            ``"Study"``) keying :data:`ENTITY_DRAFT_SCHEMA`.
+        context: Free-text/context to extract from — a file excerpt, a brief,
+            or a conversation snippet.
+        model: Optional explicit model name override; when ``None`` the drafter
+            tier resolves the configured drafter (or primary) model.
+
+    Returns:
+        A dict of the entity's descriptive fields, validating against
+        ``draft_hints_schema(entity_type)`` and free of fabricated identifiers.
+    """
+    llm = _build_chat_model(model=model, role="drafter")
+    schema = _structured_output_schema(entity_type)
+    structured = llm.with_structured_output(schema)
+
+    messages = [
+        SystemMessage(content=_SYSTEM_PROMPT),
+        HumanMessage(
+            content=(
+                f"Entity type: {entity_type}\n\n"
+                f"Context:\n{context}\n\n"
+                "Extract the supported descriptive fields for this entity. "
+                "Leave identifier fields empty — they are filled by lookups."
+            )
+        ),
+    ]
+    result = structured.invoke(messages)
+
+    fields = dict(result) if isinstance(result, dict) else {}
+    return _strip_identifiers(fields)
+
+
+__all__ = ["draft_entity_fields"]

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -1,0 +1,271 @@
+"""Tests for the bounded drafter-leaf (Issue #179, task 2).
+
+`builder.agents.leaves.draft_entity_fields` is the cheap-model "bounded
+extraction" primitive the §14 deterministic pipeline calls at its leaves:
+free-text context in -> a structured dict of one entity's fields out, in a
+SINGLE LLM call on the drafter tier (`_build_chat_model(role="drafter")`),
+constrained by `_crate_mapping.draft_hints_schema(entity_type)` via the model's
+structured-output / function-calling.
+
+These tests are OFFLINE: the chat model is mocked with a fake that records the
+build call and returns canned structured output. No real model, no network.
+
+Contracts pinned here:
+  1. The leaf builds the chat model on the *drafter* tier (`role="drafter"`).
+  2. It calls structured output bound to the entity's hints schema, once.
+  3. The returned dict validates against `draft_hints_schema(entity_type)`.
+  4. It works for several entity types (MolecularEntity, Study, ...).
+  5. D5: identifier fields are never fabricated — a model that hallucinates a
+     CAS number / ORCID / DOI has those stripped from the result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jsonschema
+import pytest
+
+from builder.agents import leaves
+from builder.tools._crate_mapping import draft_hints_schema
+
+
+class _FakeStructuredRunnable:
+    """The runnable returned by `model.with_structured_output(schema)`.
+
+    Records the messages it was invoked with and returns canned output.
+    """
+
+    def __init__(self, parent: "FakeChatModel") -> None:
+        self._parent = parent
+
+    def invoke(self, messages: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        self._parent.invoke_calls.append(messages)
+        return self._parent.canned_output
+
+
+class FakeChatModel:
+    """A fake LangChain chat model recording structured-output usage.
+
+    `with_structured_output(schema)` records the schema and returns a runnable
+    whose `.invoke(...)` yields `canned_output`. This lets the tests assert the
+    leaf goes through structured output exactly once without any network call.
+    """
+
+    def __init__(self, canned_output: dict[str, Any]) -> None:
+        self.canned_output = canned_output
+        self.structured_schemas: list[Any] = []
+        self.invoke_calls: list[Any] = []
+
+    def with_structured_output(self, schema: Any, **kwargs: Any) -> _FakeStructuredRunnable:
+        self.structured_schemas.append(schema)
+        return _FakeStructuredRunnable(self)
+
+
+@pytest.fixture(autouse=True)
+def _patch_build_chat_model(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch `_build_chat_model` in the leaves module to capture its kwargs.
+
+    Returns a mutable record dict the test can read (the role requested, the
+    model passed) and write (`record["model"]` -> the FakeChatModel to return).
+    """
+    record: dict[str, Any] = {"calls": [], "model": FakeChatModel({})}
+
+    def _fake_build(*args: Any, **kwargs: Any) -> FakeChatModel:
+        record["calls"].append(kwargs)
+        return record["model"]
+
+    monkeypatch.setattr(leaves, "_build_chat_model", _fake_build)
+    return record
+
+
+class TestDrafterTier:
+    """The leaf must run on the cheap drafter tier."""
+
+    def test_requests_drafter_role(self, _patch_build_chat_model: dict[str, Any]) -> None:
+        rec = _patch_build_chat_model
+        rec["model"] = FakeChatModel({"name": "Acetaminophen"})
+
+        leaves.draft_entity_fields("MolecularEntity", "A study of acetaminophen.")
+
+        assert rec["calls"], "the leaf must build a chat model"
+        assert all(c.get("role") == "drafter" for c in rec["calls"]), (
+            "the leaf must build the chat model on the drafter tier (role='drafter')"
+        )
+
+    def test_explicit_model_is_forwarded(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        rec = _patch_build_chat_model
+        rec["model"] = FakeChatModel({"name": "Acetaminophen"})
+
+        leaves.draft_entity_fields(
+            "MolecularEntity", "context", model="gpt-4o-mini"
+        )
+
+        assert rec["calls"][0].get("model") == "gpt-4o-mini"
+
+
+class TestStructuredOutput:
+    """The leaf must use structured output bound once to the hints schema."""
+
+    def test_uses_structured_output_once(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"name": "Acetaminophen"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.draft_entity_fields("MolecularEntity", "context")
+
+        assert len(fake.structured_schemas) == 1, "exactly one structured-output bind"
+        assert len(fake.invoke_calls) == 1, "exactly one model invocation (a leaf)"
+
+    def test_single_model_invocation_for_study(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"name": "Toxicity study"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.draft_entity_fields("Study", "A study of liver toxicity.")
+
+        assert len(fake.invoke_calls) == 1
+
+
+class TestOutputValidatesAgainstSchema:
+    """The returned dict must validate against draft_hints_schema(entity_type)."""
+
+    def test_molecular_entity_output_validates(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"name": "Acetaminophen", "molecular_formula": "C8H9NO2"}
+        )
+
+        out = leaves.draft_entity_fields("MolecularEntity", "context")
+
+        assert isinstance(out, dict)
+        jsonschema.validate(out, draft_hints_schema("MolecularEntity"))
+        assert out["name"] == "Acetaminophen"
+
+    def test_study_output_validates(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"name": "Liver tox study", "description": "Hepatotoxicity assays."}
+        )
+
+        out = leaves.draft_entity_fields("Study", "context")
+
+        jsonschema.validate(out, draft_hints_schema("Study"))
+        assert out["name"] == "Liver tox study"
+
+
+class TestD5NoFabricatedIdentifiers:
+    """D5: identifiers come from lookups, never invention.
+
+    A model that hallucinates an identifier (CAS, ORCID, DOI, accession, ...)
+    must have those fields dropped — the leaf leaves them empty rather than
+    propagating a guessed id downstream.
+    """
+
+    def test_molecular_entity_strips_fabricated_identifier(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # The model fabricates a CAS number, InChIKey, SMILES and PubChem CID.
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {
+                "name": "Acetaminophen",
+                "identifier": "103-90-2",
+                "inchikey": "RZVAJINKPMORJF-UHFFFAOYSA-N",
+                "smiles": "CC(=O)Nc1ccc(O)cc1",
+                "pubchem_cid": "1983",
+            }
+        )
+
+        out = leaves.draft_entity_fields("MolecularEntity", "context")
+
+        assert out.get("name") == "Acetaminophen"
+        for ident in ("identifier", "inchikey", "smiles", "pubchem_cid"):
+            assert ident not in out or not out[ident], (
+                f"D5 violated: fabricated identifier field {ident!r} leaked through"
+            )
+
+    def test_person_strips_fabricated_orcid(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"name": "Jane Doe", "orcid": "0000-0002-1825-0097"}
+        )
+
+        out = leaves.draft_entity_fields("Person", "context")
+
+        assert out.get("name") == "Jane Doe"
+        assert not out.get("orcid"), "D5 violated: fabricated ORCID leaked through"
+
+    def test_publication_strips_fabricated_doi(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"name": "A paper", "doi": "10.1234/fake", "identifier": "10.1234/fake"}
+        )
+
+        out = leaves.draft_entity_fields("Publication", "context")
+
+        assert out.get("name") == "A paper"
+        assert not out.get("doi")
+        assert not out.get("identifier")
+
+
+class TestSchemaExclusion:
+    """The structured-output schema must not even offer identifier fields.
+
+    Pushing D5 into the schema (not just post-filtering) means the model is
+    never asked to produce an identifier, which is the strongest guard.
+    """
+
+    def test_identifier_fields_absent_from_structured_schema(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"name": "Acetaminophen"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.draft_entity_fields("MolecularEntity", "context")
+
+        schema = fake.structured_schemas[0]
+        props = schema.get("properties", {})
+        for ident in ("identifier", "inchikey", "smiles", "pubchem_cid"):
+            assert ident not in props, (
+                f"identifier field {ident!r} must not be offered to the model (D5)"
+            )
+        assert "name" in props, "non-identifier fields must still be offered"
+
+    def test_structured_schema_is_convertible_to_a_tool(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # A raw JSON-schema dict needs a top-level `title` to be usable as a
+        # function-calling tool name by langchain. Without it, the real model
+        # call raises ValueError("...must have a top-level 'title' key...").
+        from langchain_core.utils.function_calling import convert_to_openai_tool
+
+        fake = FakeChatModel({"name": "Acetaminophen"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.draft_entity_fields("MolecularEntity", "context")
+
+        schema = fake.structured_schemas[0]
+        assert schema.get("title"), "structured-output schema must carry a title"
+        tool = convert_to_openai_tool(schema)  # must not raise
+        assert tool["function"]["name"]
+
+
+class TestUnknownEntityType:
+    """An unknown entity type still returns a dict (open schema fallback)."""
+
+    def test_unknown_type_returns_dict(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel({"name": "x"})
+
+        out = leaves.draft_entity_fields("NotAType", "context")
+
+        assert isinstance(out, dict)


### PR DESCRIPTION
## What

Epic #179 task 2: the **drafter-as-leaf** — a bounded, cheap-model,
structured-output drafting primitive the deterministic §14 pipeline will call at
its leaves.

**ADDITIVE.** Does not change the ReAct loop or the existing `draft_*` tools.
It's a new library primitive the spine (task 4) adopts later.

## The leaf contract

```python
# builder/agents/leaves.py
def draft_entity_fields(entity_type: str, context: str, *, model: str | None = None) -> dict
```

A pure leaf: a **single bounded LLM call** — context in → a structured dict of
one entity's fields out. It does **not** mutate `CrateState` and does **not**
orchestrate.

- **Drafter tier.** Runs on `_build_chat_model(role="drafter")` (AGENTS.md §4.4),
  so a cheap model does the extraction. With no drafter model configured this
  resolves to the primary model — a strict no-op.
- **Structured output.** Output is constrained by
  `_crate_mapping.draft_hints_schema(entity_type)` via the model's
  structured-output / function-calling, so the returned dict validates against
  that schema. A top-level `title` (`<EntityType>Fields`) is added so langchain
  accepts the raw JSON-schema dict directly as a function spec.

## D5 handling (Verify, Don't Trust)

Identifiers come from lookups, never invention. Identifier-bearing scalar fields
(CAS / InChIKey / SMILES / PubChem CID / ORCID / ROR / DOI / Cellosaurus
accession / ontology codes / IRIs) **and** all entity-reference fields
(`_REF_FIELDS`) are:

1. **removed from the schema the model sees** — it is never even asked to produce
   an identifier (strongest guard), and
2. **defensively stripped from the result**.

The leaf leaves those fields empty for a downstream **lookup** to fill — never
guessed. Negative tests cover a hallucinated CAS/InChIKey/SMILES/PubChem CID
(MolecularEntity), ORCID (Person), and DOI (Publication).

## How the spine will use it

The deterministic spine (task 4) imports `draft_entity_fields`, runs it on a file
excerpt / brief to extract an entity's descriptive fields, then feeds the
returned dict into the deterministic `draft_*` state mutators. Identifier slots
come back empty and are filled by the lookup / `fix_required_issues` (task 1)
paths — not by the extractor.

## Library leaf, not a tool

This is **not** an LLM-callable tool — the ReAct agent never sees it. So **no
four-place tool registration** (`TOOL_REGISTRY` / `TOOL_SPECS` / system prompt /
§5). Documented instead in **AGENTS.md §14.4** as the §14 leaf primitive.

## Tests (offline — no live model)

Mocked chat model (a fake recording `with_structured_output` + `.invoke`), no
network. Asserts: drafter tier requested; structured output bound to the schema
exactly once / single invocation; output validates against `draft_hints_schema`
for MolecularEntity & Study; identifiers never fabricated (D5 negatives); the
schema excludes identifier fields; the schema is convertible to a tool.

## Checks

- `uv run ruff check .` → All checks passed!
- `uv run --extra langchain ty check` → All checks passed!
- `uv run --extra langchain pytest tests/agents/test_leaves.py` → 12 passed
- touched areas (`test_entity_draft_schema`, `test_config_drafter_model`,
  `test_agents_doc_toolbox`, `tests/agents/`) → green

## Files

- `builder/agents/leaves.py` (new)
- `tests/agents/test_leaves.py` (new)
- `AGENTS.md` §14.4 (doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)