### PR TITLE
test(eval): add an entity-drafting corpus case for the A/B

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -51,17 +51,30 @@ data — all inputs are in-repo and offline:
 |-----------|--------|-------------------|
 | `minimal-backbone` | `minimal` | Build a conformant ISA-Tox backbone from a short brief. |
 | `structured-svhps21` | `structured` | Scan the in-repo `tests/fixtures/svhps21_input` folder (README + raw/processed CSVs) and build from its structured metadata. |
+| `structured-svhps22` | `structured` | **Entity-drafting** case: scan a *richer* `tests/fixtures/svhps22_input` folder (README naming a compound + cell line + protocol, plus raw/processed CSVs) and draft the full ISA-Tox domain set. Carries a `min_entities` content quota (below). |
 | `unstructured-conversation` | `unstructured` | No metadata files — the whole crate is elicited from the prompt. |
 
 **Success predicate** (shared, strict): a case succeeds when its crate reaches
 `{base, isa, tox}` REQUIRED conformance via `build_and_validate`
 (`reaches_isa_tox_conformance`).
 
+**Content-quality signal** (additive, per-case): conformance only measures whether
+the agent *acted* — an almost-empty backbone can pass it. A case may also declare
+`min_entities` (a minimum count of domain entities by `@type`); the harness then
+records `meets_quota` + `entity_counts` (`meets_entity_quota`) so the A/B can
+compare whether the drafted *content* is actually there, not just that the agent
+acted. `min_entities` never changes the success predicate — cases without it report
+`meets_quota = None`. The `structured-svhps22` case uses it to demand a compound, a
+cell line, and both attached data files; `structured-svhps21` (conformance-only)
+is deliberately kept as the looser baseline.
+
 ## The metrics
 
 Per case, across `repeats` runs ([`metrics.py`](metrics.py), [`runner.py`](runner.py)):
 
 - **success** (bool) + the per-layer **conformance** map;
+- **content quality** — `meets_quota` (bool / `None`) + `entity_counts`, recorded for
+  cases that declare a `min_entities` quota (see above); `None` otherwise;
 - **tokens** — input / output / total, summed from the run's `profile.ndjson`
   (`node_end`/`model` events);
 - **latency** — wall-clock seconds for the build;

--- a/eval/__init__.py
+++ b/eval/__init__.py
@@ -13,7 +13,12 @@ real LLM calls and is triggered by a human with credentials (``python -m eval``)
 from __future__ import annotations
 
 from eval.agent_api import AgentFactory, BuildAgent, BuildOutcome
-from eval.corpus import DEFAULT_CORPUS, EvalCase, reaches_isa_tox_conformance
+from eval.corpus import (
+    DEFAULT_CORPUS,
+    EvalCase,
+    meets_entity_quota,
+    reaches_isa_tox_conformance,
+)
 from eval.metrics import ProfileMetrics, crate_graph_hash, mine_profile_metrics
 from eval.report import compare_reports, write_report
 from eval.runner import CaseResult, EvalReport, run_eval
@@ -29,6 +34,7 @@ __all__ = [
     "ProfileMetrics",
     "compare_reports",
     "crate_graph_hash",
+    "meets_entity_quota",
     "mine_profile_metrics",
     "reaches_isa_tox_conformance",
     "run_eval",

--- a/eval/corpus.py
+++ b/eval/corpus.py
@@ -16,6 +16,13 @@ Each :class:`EvalCase` declares:
 The success predicate is shared and deliberately strict: a case succeeds when its
 crate reaches ``{base, isa, tox}`` REQUIRED conformance through ``build_and_validate``
 (see :func:`reaches_isa_tox_conformance`).
+
+A case may *additionally* declare ``min_entities`` — a minimum count of domain
+entities (by ``@type``) its build must produce. That gives the A/B a second,
+additive **content-quality** signal (:func:`meets_entity_quota`): conformance
+measures whether the agent *acted*; the quota measures whether what it drafted is
+actually there. ``min_entities`` never changes the success predicate; it is a
+separate, optional metric so cases that do not declare it are simply not assessed.
 """
 
 from __future__ import annotations
@@ -32,6 +39,10 @@ CaseKind = Literal["minimal", "structured", "unstructured"]
 # experimental data) — the same one the #59 end-to-end quality test uses.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _STRUCTURED_INPUT = _REPO_ROOT / "tests" / "fixtures" / "svhps21_input"
+# A richer structured fixture (Issue #179): a clear compound + cell line + a
+# protocol + a couple of data files + a README, so a build must draft several
+# distinct domain entities rather than just a backbone.
+_DRAFTING_INPUT = _REPO_ROOT / "tests" / "fixtures" / "svhps22_input"
 
 
 @dataclass(frozen=True)
@@ -45,6 +56,11 @@ class EvalCase:
         prompt: NL request driving a conversational agent's build.
         input_path: Optional in-repo directory the agent scans (offline).
         build_state: Optional factory of a finished state, used by the mock agent.
+        min_entities: Optional minimum domain-entity quota by ``@type`` (e.g.
+            ``{"MolecularEntity": 1, "CellLineSample": 1, "File": 2}``). When set,
+            the harness records an additive content-quality signal — whether the
+            build drafted at least that many of each type — *on top of* the strict
+            conformance success predicate. ``None`` ⇒ quality is not assessed.
     """
 
     case_id: str
@@ -53,6 +69,7 @@ class EvalCase:
     prompt: str = ""
     input_path: str | None = None
     build_state: Callable[[], CrateState] | None = None
+    min_entities: dict[str, int] | None = None
 
 
 def reaches_isa_tox_conformance(state: CrateState) -> dict[str, Any]:
@@ -82,6 +99,50 @@ def reaches_isa_tox_conformance(state: CrateState) -> dict[str, Any]:
     }
 
 
+def meets_entity_quota(
+    state: CrateState, min_entities: dict[str, int] | None
+) -> dict[str, Any]:
+    """Content-quality check: did *state* draft at least ``min_entities`` per type?
+
+    This is the second, *additive* signal the A/B uses alongside
+    :func:`reaches_isa_tox_conformance`. Conformance answers "did the agent act?";
+    the quota answers "is the drafted domain content actually there?" — a crate can
+    reach ``{base, isa, tox}`` with an almost-empty backbone, so a draft-quality
+    case demands a minimum set of domain entities (a compound, a cell line, files…).
+
+    Args:
+        state: The crate state produced by an agent build.
+        min_entities: Required minimum count per entity ``@type``. ``None`` means
+            the case does not assess content quality.
+
+    Returns:
+        A dict with:
+
+        * ``meets_quota`` — ``True``/``False`` when a quota is declared, else
+          ``None`` (quality not assessed);
+        * ``entity_counts`` — actual count of each *demanded* type in the state
+          (empty when no quota);
+        * ``missing`` — ``{type: shortfall}`` for every type below its minimum
+          (empty when the quota is met or undeclared).
+    """
+    if not min_entities:
+        return {"meets_quota": None, "entity_counts": {}, "missing": {}}
+
+    entity_counts: dict[str, int] = {}
+    missing: dict[str, int] = {}
+    for entity_type, required in min_entities.items():
+        count = len(state.list_entities(entity_type=entity_type))
+        entity_counts[entity_type] = count
+        if count < required:
+            missing[entity_type] = required - count
+
+    return {
+        "meets_quota": not missing,
+        "entity_counts": entity_counts,
+        "missing": missing,
+    }
+
+
 # --- mock-build state factories (offline stand-ins for a real agent build) -----
 #
 # These let the harness's runner / report / determinism logic be exercised end to
@@ -108,6 +169,105 @@ def _unstructured_state() -> CrateState:
     from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
     return vhps_fixture_state("S-VHPS21")
+
+
+def _drafting_state() -> CrateState:
+    """A *richly* drafted S-VHPS22 crate — the offline stand-in for a good build.
+
+    Unlike the backbone-only stand-ins above, this drafts the full domain set the
+    ``structured-svhps22`` case is designed to elicit: the ISA backbone, a
+    compound, a cell line, contributors, a lab protocol, the Exposure process, and
+    the two attached data files. It is REQUIRED-clean across base/ISA/ISA-Tox *and*
+    satisfies that case's ``min_entities`` quota, so the content-quality signal is
+    exercisable offline with a mock agent.
+    """
+    from builder.state import CrateState, Entity, EntityProvenance, EntityType
+
+    def _ent(entity_id: str, type_: EntityType, **fields: object) -> Entity:
+        return Entity(
+            entity_id=entity_id,
+            type=type_,
+            fields=fields,
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+
+    title = "Inhibition of thyroid peroxidase (TPO) activity dose-response screen"
+    description = (
+        "A cell-based in vitro assay screening a reference chemical for its "
+        "capacity to inhibit thyroid peroxidase (TPO) activity in a "
+        "TPO-overexpressing FRTL-5 follicular cell model."
+    )
+
+    state = CrateState()
+    state.metadata.title = title
+    state.metadata.description = description
+    state.metadata.accession = "S-VHPS22"
+
+    # ISA backbone.
+    state.add_entity(
+        _ent("inv", "Investigation", name=title, description=description, identifier="S-VHPS22")
+    )
+    state.add_entity(
+        _ent(
+            "study",
+            "Study",
+            name=title,
+            description=description,
+            identifier="S-VHPS22",
+            investigation_id="inv",
+            datePublished="2025-11-10",
+        )
+    )
+    state.add_entity(
+        _ent(
+            "assay",
+            "Assay",
+            name="TPO inhibition dose-response assay",
+            identifier="S-VHPS22-assay",
+            study_id="study",
+        )
+    )
+
+    # Contributors.
+    state.add_entity(
+        _ent(
+            "author",
+            "Person",
+            name="Marije Vonk",
+            givenName="Marije",
+            familyName="Vonk",
+            orcid="0000-0002-1825-0097",
+        )
+    )
+    state.add_entity(_ent("org", "Organization", name="Universiteit Utrecht"))
+
+    # Domain entities: compound, cell line, protocol, and the Exposure process.
+    state.add_entity(_ent("cell", "CellLineSample", name="FRTL-5 TPO-overexpressing cells"))
+    state.add_entity(_ent("compound", "MolecularEntity", name="Methimazole"))
+    state.add_entity(
+        _ent("protocol", "LabProtocol", name="Amplex Red fluorometric TPO activity readout")
+    )
+    state.add_entity(
+        _ent(
+            "exposure",
+            "LabProcess",
+            name="Methimazole TPO inhibition exposure",
+            process_type="Exposure",
+            assay_id="assay",
+            samples="cell",
+            chemicals="compound",
+            protocol_id="protocol",
+        )
+    )
+
+    # The two attached data files from the fixture folder.
+    state.add_entity(
+        _ent("raw", "File", name="dose_response_raw.csv", path="raw_data/dose_response_raw.csv")
+    )
+    state.add_entity(
+        _ent("proc", "File", name="ic50_results.csv", path="processed_data/ic50_results.csv")
+    )
+    return state
 
 
 DEFAULT_CORPUS: tuple[EvalCase, ...] = (
@@ -142,6 +302,33 @@ DEFAULT_CORPUS: tuple[EvalCase, ...] = (
         ),
         input_path=str(_STRUCTURED_INPUT),
         build_state=_structured_state,
+    ),
+    EvalCase(
+        case_id="structured-svhps22",
+        description=(
+            "Entity-drafting case: scan a richer in-repo S-VHPS22 research folder "
+            "(README naming a compound + cell line + protocol, plus raw/processed "
+            "CSVs) and draft the full ISA-Tox domain set. Success is the strict "
+            "{base, isa, tox} conformance gate; the additive min_entities quota "
+            "measures whether the build actually drafted the domain content "
+            "(compound, cell line, the two files) — so the A/B can compare draft "
+            "QUALITY, not just that the agent acted (Issue #179)."
+        ),
+        kind="structured",
+        prompt=(
+            "Scan the provided input folder. Read its README and both data files, "
+            "then draft the ISA-Tox entities for this TPO-inhibition dose-response "
+            "study (S-VHPS22): the Investigation/Study/Assay backbone, the test "
+            "compound Methimazole, the FRTL-5 TPO-overexpressing cell line, the "
+            "Amplex Red protocol, an Exposure process, the contributors, and attach "
+            "the raw and processed data files. Then build and validate until base, "
+            "ISA, and ISA-Tox all pass."
+        ),
+        input_path=str(_DRAFTING_INPUT),
+        build_state=_drafting_state,
+        # Content-quality quota: a real draft must carry the compound, the cell
+        # line, and both attached data files — not merely a conformant backbone.
+        min_entities={"MolecularEntity": 1, "CellLineSample": 1, "File": 2},
     ),
     EvalCase(
         case_id="unstructured-conversation",

--- a/eval/report.py
+++ b/eval/report.py
@@ -78,6 +78,9 @@ def compare_reports(*reports: EvalReport) -> dict[str, Any]:
                 "iterations": result.iterations,
                 "tool_calls": result.tool_calls,
                 "deterministic": result.deterministic,
+                # Additive content-quality signal — ``None`` for cases that do not
+                # declare a min_entities quota.
+                "meets_quota": result.meets_quota,
             }
 
     return {"labels": labels, "summaries": summaries, "cases": cases}

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -25,7 +25,7 @@ from typing import Any, Callable
 
 from builder.state import CrateState
 from eval.agent_api import AgentFactory, BuildOutcome
-from eval.corpus import EvalCase, reaches_isa_tox_conformance
+from eval.corpus import EvalCase, meets_entity_quota, reaches_isa_tox_conformance
 from eval.metrics import crate_graph_hash, mine_profile_metrics
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,12 @@ class CaseResult:
     profile (representative of one build); latency is the first repeat's wall
     clock. ``crate_hashes`` holds one hash per repeat, and ``deterministic`` is
     ``True``/``False`` when there is more than one repeat to compare, else ``None``.
+
+    ``meets_quota`` / ``entity_counts`` are the additive content-quality signal:
+    for cases that declare ``min_entities`` they say whether the build drafted the
+    demanded domain content (and how much of each demanded type it drafted). For
+    cases without a quota, ``meets_quota`` is ``None`` and ``entity_counts`` empty
+    — the signal is purely additive and never affects ``success``.
     """
 
     case_id: str
@@ -72,6 +78,8 @@ class CaseResult:
     deterministic: bool | None
     repeats: int
     error: str | None = None
+    meets_quota: bool | None = None
+    entity_counts: dict[str, int] = field(default_factory=dict)
 
     @property
     def total_tokens(self) -> int:
@@ -96,6 +104,8 @@ class CaseResult:
             "deterministic": self.deterministic,
             "repeats": self.repeats,
             "error": self.error,
+            "meets_quota": self.meets_quota,
+            "entity_counts": self.entity_counts,
         }
 
 
@@ -180,6 +190,7 @@ def _run_case(
     state = first_outcome.state
 
     predicate = reaches_isa_tox_conformance(state)
+    quota = meets_entity_quota(state, case.min_entities)
 
     profile_records = (
         profile_reader(first_outcome.session_id) if first_outcome.session_id else []
@@ -205,6 +216,8 @@ def _run_case(
         deterministic=deterministic,
         repeats=max(1, repeats),
         error=error,
+        meets_quota=quota["meets_quota"],
+        entity_counts=quota["entity_counts"],
     )
 
 

--- a/eval/tests/test_corpus_entity_drafting.py
+++ b/eval/tests/test_corpus_entity_drafting.py
@@ -1,0 +1,133 @@
+"""Tests for the entity-drafting corpus case + its content-quality metric.
+
+The original corpus measures *reliability of acting* — its success predicate is
+purely ``{base, isa, tox}`` conformance, which an empty-ish backbone can reach.
+This adds one richer structured case (Issue #179) designed so an agent must draft
+several distinct domain entities, plus an **additive** content-quality signal
+(``min_entities`` on the case + ``meets_quota`` on the result) that measures
+whether the drafted *content* is there — not just that the agent acted.
+
+These tests are offline. The conformance-touching test carries the harness 120s
+timeout; the corpus/metric-shape tests are pure and fast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eval.corpus import (
+    DEFAULT_CORPUS,
+    EvalCase,
+    meets_entity_quota,
+)
+
+
+class TestEntityDraftingCaseRegistered:
+    """The richer entity-drafting case is present and well-formed."""
+
+    CASE_ID = "structured-svhps22"
+
+    def _case(self) -> EvalCase:
+        match = [c for c in DEFAULT_CORPUS if c.case_id == self.CASE_ID]
+        assert match, f"expected a {self.CASE_ID!r} case in the corpus"
+        return match[0]
+
+    def test_case_is_in_the_corpus(self) -> None:
+        case = self._case()
+        assert case.kind == "structured"
+        assert case.prompt, "the entity-drafting case must carry a prompt"
+
+    def test_case_points_at_an_existing_offline_fixture(self) -> None:
+        case = self._case()
+        assert case.input_path is not None
+        root = Path(case.input_path)
+        assert root.is_dir(), f"{case.input_path} must be an in-repo directory"
+        # A README plus at least two data files — enough that an agent must draft
+        # several entities (compound, cell line, files, backbone).
+        assert (root / "README.md").is_file()
+        data_files = [p for p in root.rglob("*.csv") if p.is_file()]
+        assert len(data_files) >= 2, "fixture should ship a couple of data files"
+
+    def test_case_declares_a_minimum_entity_quota(self) -> None:
+        case = self._case()
+        assert case.min_entities is not None, (
+            "the entity-drafting case must declare min_entities so the A/B can "
+            "measure draft quality, not just that the agent acted"
+        )
+        # The quota must demand the domain content that distinguishes a real draft
+        # from an empty backbone: a compound, a cell line, and at least one file.
+        assert case.min_entities.get("MolecularEntity", 0) >= 1
+        assert case.min_entities.get("CellLineSample", 0) >= 1
+        assert case.min_entities.get("File", 0) >= 2
+
+
+class TestMeetsEntityQuota:
+    """``meets_entity_quota`` is a pure content-quality check over a state."""
+
+    def test_none_quota_is_undefined_quality(self) -> None:
+        from builder.state import CrateState
+
+        result = meets_entity_quota(CrateState(), None)
+        # No quota declared -> quality is not assessed (None), counts still given.
+        assert result["meets_quota"] is None
+        assert result["entity_counts"] == {}
+        assert result["missing"] == {}
+
+    def test_empty_state_misses_a_real_quota(self) -> None:
+        from builder.state import CrateState
+
+        quota = {"MolecularEntity": 1, "CellLineSample": 1, "File": 2}
+        result = meets_entity_quota(CrateState(), quota)
+        assert result["meets_quota"] is False
+        # Everything is missing, by exactly the demanded amount.
+        assert result["missing"] == {"MolecularEntity": 1, "CellLineSample": 1, "File": 2}
+
+    def test_state_meeting_quota_passes(self) -> None:
+        from builder.state import CrateState, Entity, EntityProvenance, EntityType
+
+        def _ent(eid: str, t: EntityType, **f: object) -> Entity:
+            return Entity(
+                entity_id=eid,
+                type=t,
+                fields=f,
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+
+        state = CrateState()
+        state.add_entity(_ent("c", "MolecularEntity", name="Methimazole"))
+        state.add_entity(_ent("cell", "CellLineSample", name="FRTL-5"))
+        state.add_entity(_ent("f1", "File", name="raw.csv", path="raw.csv"))
+        state.add_entity(_ent("f2", "File", name="ic50.csv", path="ic50.csv"))
+
+        quota = {"MolecularEntity": 1, "CellLineSample": 1, "File": 2}
+        result = meets_entity_quota(state, quota)
+        assert result["meets_quota"] is True
+        assert result["missing"] == {}
+        assert result["entity_counts"]["File"] == 2
+        assert result["entity_counts"]["MolecularEntity"] == 1
+
+
+@pytest.mark.timeout(120)
+class TestEntityDraftingCaseBuildState:
+    """The case's mock build_state both conforms AND meets its own quota.
+
+    This is the offline stand-in a *good* agent would produce: it must satisfy
+    BOTH the strict ``{base, isa, tox}`` predicate and the content quota, so the
+    quality signal is exercised end to end without a live model.
+    """
+
+    def test_build_state_reaches_conformance_and_meets_quota(self) -> None:
+        from eval.corpus import reaches_isa_tox_conformance
+
+        case = next(c for c in DEFAULT_CORPUS if c.case_id == "structured-svhps22")
+        assert case.build_state is not None
+        state = case.build_state()
+
+        predicate = reaches_isa_tox_conformance(state)
+        assert predicate["success"] is True, predicate["issues"]
+        assert predicate["conformance"] == {"base": True, "isa": True, "tox": True}
+
+        quota = meets_entity_quota(state, case.min_entities)
+        assert quota["meets_quota"] is True, quota["missing"]

--- a/eval/tests/test_runner_entity_quota.py
+++ b/eval/tests/test_runner_entity_quota.py
@@ -1,0 +1,84 @@
+"""Runner tests for the additive content-quality (entity-quota) metric.
+
+The harness's success predicate stays unchanged (``{base, isa, tox}`` conformance).
+On top of it, for cases that declare ``min_entities``, the runner now records a
+per-case content-quality signal — ``entity_counts`` (what was drafted) and
+``meets_quota`` (did the draft contain the demanded domain entities). This lets
+the ReAct→pipeline A/B compare *draft content*, not just "did the agent act".
+
+Fully offline via mock agents; ``build_and_validate`` runs, so the module carries
+the harness 120s timeout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.runner import run_eval
+
+pytestmark = pytest.mark.timeout(120)
+
+_DRAFTING_CASE = next(c for c in DEFAULT_CORPUS if c.case_id == "structured-svhps22")
+
+
+class _QuotaMeetingAgent:
+    """Returns the case's own canned, quota-meeting state."""
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id=None)
+
+
+class _EmptyBackboneAgent:
+    """Conformance-shaped state with NO domain content — misses the quota.
+
+    Models the failure mode the new case is designed to catch: an agent that
+    *acts* (reaches conformance) but drafts no real domain entities.
+    """
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        return BuildOutcome(state=CrateState(), session_id=None)
+
+
+class TestQuotaRecorded:
+    def test_quota_meeting_build_records_meets_quota_true(self) -> None:
+        report = run_eval(lambda: _QuotaMeetingAgent(), [_DRAFTING_CASE], repeats=1)
+        res = report.results[0]
+        assert res.success is True
+        assert res.meets_quota is True
+        assert res.entity_counts.get("MolecularEntity", 0) >= 1
+        assert res.entity_counts.get("File", 0) >= 2
+
+    def test_empty_backbone_misses_quota(self) -> None:
+        report = run_eval(lambda: _EmptyBackboneAgent(), [_DRAFTING_CASE], repeats=1)
+        res = report.results[0]
+        # An empty crate cannot meet the domain-entity quota.
+        assert res.meets_quota is False
+        assert res.entity_counts.get("MolecularEntity", 0) == 0
+
+    def test_case_without_quota_reports_meets_quota_none(self) -> None:
+        # The pre-existing minimal case declares no min_entities, so its quality
+        # is undefined (None) — the metric is purely additive.
+        minimal = next(c for c in DEFAULT_CORPUS if c.case_id == "minimal-backbone")
+        assert minimal.min_entities is None
+
+        class _CleanAgent:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                factory = case.build_state or CrateState
+                return BuildOutcome(state=factory(), session_id=None)
+
+        report = run_eval(lambda: _CleanAgent(), [minimal], repeats=1)
+        res = report.results[0]
+        assert res.meets_quota is None
+
+
+class TestQuotaInSerializedReport:
+    def test_to_dict_carries_the_quality_signal(self) -> None:
+        report = run_eval(lambda: _QuotaMeetingAgent(), [_DRAFTING_CASE], repeats=1)
+        row = report.results[0].to_dict()
+        assert row["meets_quota"] is True
+        assert "entity_counts" in row
+        assert isinstance(row["entity_counts"], dict)

--- a/tests/fixtures/svhps22_input/README.md
+++ b/tests/fixtures/svhps22_input/README.md
@@ -1,0 +1,25 @@
+# S-VHPS22 — TPO inhibition dose-response screen
+
+A cell-based in vitro assay screening a reference chemical for its capacity to
+inhibit thyroid peroxidase (TPO) activity, using a TPO-overexpressing follicular
+cell model. This folder is a richer structured-metadata input than S-VHPS21: it
+names a clear compound, a clear cell line, a protocol, and ships both raw and
+processed data so an agent must draft several distinct domain entities.
+
+- Accession: S-VHPS22
+- DOI: 10.6019/S-VHPS22
+- Author: Marije Vonk (ORCID 0000-0002-1825-0097), Universiteit Utrecht
+- Organization: Universiteit Utrecht
+- Assay: TPO inhibition dose-response assay
+- Cell line: FRTL-5 TPO-overexpressing rat thyroid follicular cells
+- Compound: Methimazole (reference TPO inhibitor)
+- Protocol: Amplex Red fluorometric TPO activity readout
+
+## Files
+
+- `raw_data/dose_response_raw.csv` — per-well fluorescence at each dose.
+- `processed_data/ic50_results.csv` — fitted IC50 for the compound.
+
+This is a minimal, synthetic research folder used as a deterministic, offline
+input fixture for the A/B evaluation harness (Issue #179). No real experimental
+data is committed.

--- a/tests/fixtures/svhps22_input/processed_data/ic50_results.csv
+++ b/tests/fixtures/svhps22_input/processed_data/ic50_results.csv
@@ -1,0 +1,2 @@
+compound,cell_line,endpoint,value,unit
+Methimazole,FRTL-5 TPO-overexpressing cells,IC50,2.7,uM

--- a/tests/fixtures/svhps22_input/raw_data/dose_response_raw.csv
+++ b/tests/fixtures/svhps22_input/raw_data/dose_response_raw.csv
@@ -1,0 +1,5 @@
+well,compound,cell_line,concentration_uM,tpo_activity_rfu
+A1,Methimazole,FRTL-5 TPO-overexpressing cells,0.0,18420
+A2,Methimazole,FRTL-5 TPO-overexpressing cells,0.3,15110
+A3,Methimazole,FRTL-5 TPO-overexpressing cells,3.0,8260
+A4,Methimazole,FRTL-5 TPO-overexpressing cells,30.0,2140


### PR DESCRIPTION
## Why

The captured react-baseline showed the corpus mostly measures **reliability of acting**: a weak model that did almost nothing (0–1 tool calls, identical empty crate) still reached `{base, isa, tox}` conformance from a near-empty backbone. So the ReAct→pipeline A/B could not compare **draft QUALITY** — whether the content an engine drafts is actually there.

## The new case — `structured-svhps22` (entity-drafting)

A richer **structured** case backed by a new in-repo, offline fixture `tests/fixtures/svhps22_input/`:

- `README.md` naming a clear compound (Methimazole), a clear cell line (FRTL-5 TPO-overexpressing), and a protocol (Amplex Red TPO readout);
- `raw_data/dose_response_raw.csv` + `processed_data/ic50_results.csv`.

It is designed so a build must draft several distinct domain entities (backbone + compound + cell line + protocol + Exposure + contributors + the two files), not just a conformant shell. Its mock `build_state` (`_drafting_state`) is REQUIRED-clean across base/ISA/ISA-Tox **and** drafts that full set, so the new signal is exercisable offline.

## The additive content-quality metric

Conformance answers "did the agent act?"; this answers "is the drafted content there?":

- `EvalCase.min_entities` — optional minimum domain-entity quota by `@type`;
- `meets_entity_quota(state, min_entities)` — pure check → `{meets_quota, entity_counts, missing}`;
- `CaseResult.meets_quota` + `.entity_counts` — computed in the runner, serialized in `to_dict`, surfaced in `compare_reports`.

The success predicate is **unchanged** (`{base, isa, tox}` conformance). The quota is purely additive — cases that don't declare it report `meets_quota = None`. The new case demands `{MolecularEntity: 1, CellLineSample: 1, File: 2}`.

## On the existing `structured-svhps21`

It is **conformance-only** — it asserts no content. Its golden backbone reaches `{base,isa,tox}` with minimal domain content and **no attached files**, which is exactly the under-elicitation this PR addresses. Kept intact as the looser baseline; the new case is the stricter, content-asserting one.

## TDD / checks

Failing tests added first (corpus registration + fixture scannability + an end-to-end mock-agent runner recording the quota), then the implementation. Offline & deterministic; conformance-touching modules carry `timeout(120)`.

- `uv run ruff check eval/ tests/fixtures/` → **All checks passed!**
- `uv run --extra langchain ty check eval/` → **All checks passed!**
- `uv run --extra langchain pytest eval/tests` → **58 passed** (incl. 11 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)