### PR TITLE
ci: fix setup-uv@v8 → @v8.2.0 (unblock red main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
           enable-cache: true
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
           enable-cache: true


### PR DESCRIPTION
`main` went red after #205: `astral-sh/setup-uv@v8` does not resolve — setup-uv has no floating `v8` major tag (only full releases like `v8.2.0`, plus a `v7` major). Every job failed at *Set up job*. This pins `setup-uv@v8.2.0` (2 occurrences in ci.yml). `checkout@v7`/`setup-python@v6` are unaffected (they have valid major tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)