### PR TITLE
fix(security): pin Actions to commit SHAs + scope @claude trigger (#171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "latest"
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: .python-version
 
@@ -54,16 +54,16 @@ jobs:
         group: [1, 2, 3, 4]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "latest"
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: .python-version
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,18 @@ on:
 
 jobs:
   claude:
+    # Gate every trigger on a trusted author_association so only OWNER / MEMBER /
+    # COLLABORATOR can invoke billed Claude runs — outside contributors mentioning
+    # @claude no longer trigger this job (security #171).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,13 +33,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Closes #171.

Hardens the three GitHub Actions workflows per the issue's two-part remediation. No job logic, step order, matrix sharding, or action **versions** were changed — only the ref (mutable tag → commit SHA) and the `@claude` trigger gate.

## 1. Pin third-party actions to commit SHAs
Every external `uses:` is now pinned to the full 40-char commit SHA the **current** tag points to, with the human-readable version kept in a trailing comment. SHAs resolved via the GitHub git-refs API (annotated tag for `claude-code-action` dereferenced to its commit) and each re-verified against `…/commits/<sha>`.

| Action | SHA | Version | Files |
| --- | --- | --- | --- |
| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | v7 | ci.yml, claude.yml, claude-code-review.yml |
| `astral-sh/setup-uv` | `fac544c07dec837d0ccb6301d7b5580bf5edae39` | v8.2.0 | ci.yml |
| `actions/setup-python` | `ece7cb06caefa5fff74198d8649806c4678c61a1` | v6 | ci.yml |
| `anthropics/claude-code-action` | `428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d` | v1 | claude.yml, claude-code-review.yml |

No local `./` action references exist, so nothing first-party to pin.

## 2. Scope the `@claude` trigger (`claude.yml`)
Each branch of the `claude` job `if:` now additionally requires a trusted `author_association`:

```
contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.<scope>.author_association)
```

- `issue_comment` → `github.event.comment.author_association`
- `pull_request_review_comment` → `github.event.comment.author_association`
- `pull_request_review` → `github.event.review.author_association`
- `issues` → `github.event.issue.author_association`

Outside contributors mentioning `@claude` can no longer trigger billed runs. `claude-code-review.yml` fires on `pull_request` events (not a user `@claude` mention), so the issue's author-association gate does not apply there; its actions are SHA-pinned only.

## Validation
- All four SHAs re-resolve via `gh api repos/<owner>/<repo>/commits/<sha>` (returns the same SHA).
- YAML parses: `uv run python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('yaml ok')"` → `yaml ok`.
- No remaining unpinned external `uses:` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)