### PR TITLE
fix(security): chmod 0600 secret-at-rest + percent-encode lookup URLs (#170)

### DIFF
--- a/builder/config.py
+++ b/builder/config.py
@@ -147,8 +147,20 @@ def get_max_history_tokens() -> int:
 
 
 def ensure_config_dir() -> Path:
-    """Create the config directory if it doesn't exist."""
+    """Create the config directory if it doesn't exist.
+
+    The directory holds the LLM provider API key, so it is created (and, if it
+    already exists, tightened) to owner-only ``0o700`` permissions so the secret
+    is never group/world-readable (Issue #170). Permission tightening is a no-op
+    on platforms (e.g. Windows) that ignore POSIX modes.
+    """
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        CONFIG_DIR.chmod(0o700)
+    except OSError:
+        # Best-effort on platforms without POSIX permissions; the secret is
+        # still written below with the most restrictive mode the OS honours.
+        pass
     return CONFIG_DIR
 
 
@@ -187,12 +199,28 @@ def save_config(config: dict[str, Any]) -> None:
     """Save configuration to ``~/.config/vitro-crate/config.toml``.
 
     Preserves keys not present in ``config`` (only overwrites what's given).
+
+    The file stores the LLM provider API key in plaintext, so it is written
+    with owner-only ``0o600`` permissions (Issue #170): the file is opened with
+    that mode when created, and an explicit ``chmod`` afterwards tightens any
+    pre-existing, loosely-permissioned file. The TOML format is unchanged, so
+    existing readers keep working. Permission handling is best-effort on
+    platforms (e.g. Windows) that ignore POSIX modes.
     """
     ensure_config_dir()
     existing = load_config()
     existing.update(config)
-    with open(CONFIG_PATH, "w") as f:
+    # ``os.open`` with mode 0o600 creates a new file owner-read/write only; the
+    # process umask can only further *restrict* it, never loosen it.
+    fd = os.open(CONFIG_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
         f.write(_format_toml(existing))
+    try:
+        # Covers the already-exists case: O_CREAT does not change the mode of a
+        # file that was already on disk with looser permissions.
+        CONFIG_PATH.chmod(0o600)
+    except OSError:
+        pass
 
 
 def merge_with_env(config: dict[str, Any]) -> dict[str, Any]:

--- a/lookups/aopwiki.py
+++ b/lookups/aopwiki.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import functools
 from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
@@ -31,11 +32,13 @@ _EVENT_TYPE_LABEL = {
 
 
 def _event_url(eid) -> str:
-    return f"{_BASE}/events/{eid}"
+    # Percent-encode the id segment so a "/" or ".." can't escape the path or
+    # inject query params (Issue #170). ``safe=""`` encodes every reserved char.
+    return f"{_BASE}/events/{quote(str(eid), safe='')}"
 
 
 def _rel_url(rid) -> str:
-    return f"{_BASE}/relationships/{rid}"
+    return f"{_BASE}/relationships/{quote(str(rid), safe='')}"
 
 
 @functools.lru_cache(maxsize=2048)
@@ -81,7 +84,9 @@ def lookup_aop(aop_id: str) -> dict:
           linking its upstream and downstream events by @id.
     """
     aop_id = str(aop_id).strip()
-    aop_url = f"{_BASE}/aops/{aop_id}"
+    # Percent-encode the caller-supplied id for the request path so a "/" or
+    # ".." cannot break out of the aops path or inject query params (Issue #170).
+    aop_url = f"{_BASE}/aops/{quote(aop_id, safe='')}"
     try:
         data = http_get_json(f"{aop_url}.json", timeout=15)
         if data is NOT_FOUND:

--- a/lookups/cellosaurus.py
+++ b/lookups/cellosaurus.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import functools
 import time
+from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
@@ -45,7 +46,10 @@ def lookup_cellosaurus(accession: str) -> dict:
     """
     try:
         time.sleep(0.1)
-        data = http_get_json(f"{_BASE}/{accession}?format=json")
+        # Percent-encode the caller-supplied accession so a value containing a
+        # "/" or ".." cannot break out of the cell-line path or inject query
+        # params (Issue #170). ``safe=""`` encodes every reserved char.
+        data = http_get_json(f"{_BASE}/{quote(accession, safe='')}?format=json")
         if data is NOT_FOUND:
             return {}
         # API wraps result: {"Cellosaurus": {"cell-line-list": [...]}}

--- a/lookups/crossref.py
+++ b/lookups/crossref.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import time
+from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
@@ -39,7 +40,10 @@ def lookup_doi(doi: str) -> dict:
     doi_url = f"https://doi.org/{doi}"
     try:
         time.sleep(0.1)
-        data = http_get_json(f"{_BASE}/{doi}", headers=_HEADERS)
+        # A DOI's "/" is structural (e.g. "10.1016/j.tox..."), so keep slashes
+        # but percent-encode spaces, "#", "?", "&", etc. so a malformed value
+        # can't inject extra query params into the Crossref request (Issue #170).
+        data = http_get_json(f"{_BASE}/{quote(doi, safe='/')}", headers=_HEADERS)
         if data is NOT_FOUND:
             return {}
 

--- a/lookups/orcid.py
+++ b/lookups/orcid.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import functools
 import time
+from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
@@ -34,7 +35,9 @@ def lookup_orcid(orcid_id: str) -> dict:
     orcid_url = f"https://orcid.org/{orcid_id}"
     try:
         time.sleep(0.1)
-        data = http_get_json(f"{_BASE}/{orcid_id}/record", headers=_HEADERS)
+        # Percent-encode the caller-supplied iD for the request path so a "/" or
+        # ".." cannot escape the /record path or inject query params (Issue #170).
+        data = http_get_json(f"{_BASE}/{quote(orcid_id, safe='')}/record", headers=_HEADERS)
         if data is NOT_FOUND:
             return {}
 

--- a/tests/test_secret_url_hardening.py
+++ b/tests/test_secret_url_hardening.py
@@ -1,0 +1,200 @@
+"""Security hardening tests for Issue #170 (LOW).
+
+Two independent hardening fixes:
+
+1. **Secret-at-rest.** ``builder.config.save_config`` writes the LLM provider
+   API key to disk in plaintext. The file must be created with owner-only
+   permissions (``0o600``) so the key is not group/world-readable, and the
+   parent config directory must be ``0o700``.
+
+2. **Lookup URL encoding.** User/lookup-derived values interpolated into a URL
+   *path segment* must be percent-encoded so a value containing ``/``, spaces,
+   ``#``, ``?``, ``&``, or ``..`` cannot break out of the intended path or
+   inject extra query parameters. This pins the built request URL for each raw
+   lookup client that interpolates a caller-supplied segment.
+
+All HTTP is captured via the ``responses`` library — no network is touched.
+"""
+
+from __future__ import annotations
+
+import stat
+from urllib.parse import urlsplit
+
+import responses
+
+from builder import config
+from lookups.aopwiki import lookup_aop
+from lookups.cellosaurus import lookup_cellosaurus
+from lookups.crossref import lookup_doi
+from lookups.orcid import lookup_orcid
+
+
+# ===========================================================================
+# Part 1 — secret-at-rest: config file mode is 0o600
+# ===========================================================================
+
+
+class TestSecretAtRest:
+    """``save_config`` must persist the secret with restrictive permissions."""
+
+    def test_config_file_mode_is_0600_on_create(self, tmp_path, monkeypatch) -> None:
+        """A freshly written config must be owner read/write only (0o600)."""
+        cfg_dir = tmp_path / "vitro-crate"
+        cfg_path = cfg_dir / "config.toml"
+        monkeypatch.setattr(config, "CONFIG_DIR", cfg_dir)
+        monkeypatch.setattr(config, "CONFIG_PATH", cfg_path)
+
+        config.save_config({"openai": {"api_key": "sk-super-secret"}})
+
+        assert cfg_path.exists()
+        mode = stat.S_IMODE(cfg_path.stat().st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+    def test_config_dir_mode_is_0700(self, tmp_path, monkeypatch) -> None:
+        """The parent config dir must be owner-only too (no group/world)."""
+        cfg_dir = tmp_path / "vitro-crate"
+        cfg_path = cfg_dir / "config.toml"
+        monkeypatch.setattr(config, "CONFIG_DIR", cfg_dir)
+        monkeypatch.setattr(config, "CONFIG_PATH", cfg_path)
+
+        config.save_config({"openai": {"api_key": "sk-super-secret"}})
+
+        mode = stat.S_IMODE(cfg_dir.stat().st_mode)
+        assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+
+    def test_config_file_mode_is_0600_on_overwrite(self, tmp_path, monkeypatch) -> None:
+        """An already-existing (loosely-permissioned) file is tightened on save."""
+        cfg_dir = tmp_path / "vitro-crate"
+        cfg_path = cfg_dir / "config.toml"
+        cfg_dir.mkdir(parents=True)
+        cfg_path.write_text('[openai]\napi_key = "old"\n')
+        cfg_path.chmod(0o644)  # simulate a world-readable secret already on disk
+        monkeypatch.setattr(config, "CONFIG_DIR", cfg_dir)
+        monkeypatch.setattr(config, "CONFIG_PATH", cfg_path)
+
+        config.save_config({"openai": {"api_key": "sk-new-secret"}})
+
+        mode = stat.S_IMODE(cfg_path.stat().st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+        # Format/readers must still work — the new value round-trips.
+        assert config.load_config()["openai"]["api_key"] == "sk-new-secret"
+
+
+# ===========================================================================
+# Part 2 — lookup URL encoding: reserved chars in path segments are encoded
+# ===========================================================================
+
+
+def _captured_url() -> str:
+    """Return the URL of the single captured outbound request."""
+    assert len(responses.calls) >= 1, "no HTTP request was captured"
+    url = responses.calls[0].request.url
+    assert url is not None, "captured request has no URL"
+    return url
+
+
+class TestCellosaurusURLEncoding:
+    """A path-traversal-y accession must be percent-encoded into the path."""
+
+    def setup_method(self) -> None:
+        lookup_cellosaurus.cache_clear()
+
+    @responses.activate
+    def test_slash_and_dotdot_are_encoded(self) -> None:
+        # Match any URL on the host; capture what was actually requested.
+        responses.add(
+            responses.GET,
+            "https://api.cellosaurus.org/cell-line/CVCL_0027%2F..%2Fadmin",
+            json={"Cellosaurus": {"cell-line-list": []}},
+            status=200,
+        )
+        lookup_cellosaurus("CVCL_0027/../admin")
+
+        url = _captured_url()
+        # The slash must be percent-encoded, not left as a path separator.
+        assert "/../" not in url
+        assert "%2F" in url.upper()
+        # The query must still be the single intended format param.
+        assert urlsplit(url).query == "format=json"
+
+
+class TestAOPWikiURLEncoding:
+    """A non-numeric / reserved aop_id must not break out of the path."""
+
+    def setup_method(self) -> None:
+        lookup_aop.cache_clear()
+
+    @responses.activate
+    def test_reserved_aop_id_is_encoded(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://aopwiki.org/aops/610%2F..%2Fsecret.json",
+            json={},
+            status=200,
+        )
+        lookup_aop("610/../secret")
+
+        url = _captured_url()
+        assert "/../" not in url
+        assert "%2F" in url.upper()
+        assert url.endswith(".json")
+
+
+class TestCrossrefURLEncoding:
+    """DOIs keep their structural slashes but encode injection chars."""
+
+    def setup_method(self) -> None:
+        lookup_doi.cache_clear()
+
+    @responses.activate
+    def test_well_formed_doi_unchanged(self) -> None:
+        # A normal DOI's slashes/dots are structural and must survive verbatim.
+        responses.add(
+            responses.GET,
+            "https://api.crossref.org/works/10.1016/j.tox.2021.152898",
+            json={"message": {"title": ["X"]}},
+            status=200,
+        )
+        lookup_doi("10.1016/j.tox.2021.152898")
+
+        url = _captured_url()
+        assert url == "https://api.crossref.org/works/10.1016/j.tox.2021.152898"
+
+    @responses.activate
+    def test_query_injection_chars_are_encoded(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://api.crossref.org/works/10.1016/evil%3Fmailto%3Dx%40y.com",
+            json={"message": {"title": ["X"]}},
+            status=200,
+        )
+        lookup_doi("10.1016/evil?mailto=x@y.com")
+
+        url = _captured_url()
+        # No extra query param may be injected via the path segment.
+        assert urlsplit(url).query == ""
+        assert "?mailto" not in url
+        assert "%3F" in url.upper()
+
+
+class TestOrcidURLEncoding:
+    """An ORCID iD with reserved chars must stay inside the /record path."""
+
+    def setup_method(self) -> None:
+        lookup_orcid.cache_clear()
+
+    @responses.activate
+    def test_reserved_orcid_id_is_encoded(self) -> None:
+        responses.add(
+            responses.GET,
+            "https://pub.orcid.org/v3.0/0000%2F..%2Fadmin/record",
+            json={"person": {}},
+            status=200,
+        )
+        lookup_orcid("0000/../admin")
+
+        url = _captured_url()
+        assert "/../" not in url.replace("/record", "")
+        assert "%2F" in url.upper()
+        assert url.endswith("/record")


### PR DESCRIPTION
Closes #170 — **LOW-severity** pre-public hardening (two small, independent fixes).

## 1. Secret-at-rest: config file mode `0o600`
`builder/config.py` persists the LLM provider API key in plaintext to `~/.config/vitro-crate/config.toml`. Previously the file was written with default (world/group-readable) permissions.

- `save_config` now creates the file via `os.open(..., 0o600)` and `chmod`s it to `0o600` afterwards, which also tightens a **pre-existing** loosely-permissioned secret already on disk.
- `ensure_config_dir` now creates/tightens the parent dir to `0o700`.
- TOML **format is unchanged** so existing readers keep working. Permission handling is best-effort on non-POSIX platforms (e.g. Windows).

## 2. Lookup URL path-segment encoding
Caller/lookup-derived values interpolated into a URL **path segment** are now percent-encoded (`urllib.parse.quote`) so a value containing `/`, `..`, spaces, `#`, `?`, or `&` cannot break out of the intended path or inject extra query params (the host stays fixed — no SSRF, but path traversal / odd requests within the trusted host were possible):

| file | fix |
|------|-----|
| `lookups/cellosaurus.py` | `quote(accession, safe="")` |
| `lookups/aopwiki.py` | `quote` on `aop_id` + event/relationship ids |
| `lookups/crossref.py` | `quote(doi, safe="/")` — DOI slashes are structural |
| `lookups/orcid.py` | `quote(orcid_id, safe="")` |

`pubchem.py`/`comptox.py` already encoded their segments (pattern followed here). Query-param lookups (OLS/BAO/UO, ROR, ORCID expanded-search) route through `requests`' `params=`, which encodes automatically — left unchanged. **Endpoints and semantics for well-formed inputs are identical.**

## Tests (TDD, no network)
New `tests/test_secret_url_hardening.py`:
- Secret: asserts config file mode is `0o600` on create **and** overwrite, and the dir is `0o700` (uses `pytest tmp_path`, monkeypatches `CONFIG_DIR`/`CONFIG_PATH`).
- URL encoding: captures the **built request URL** via the `responses` library and asserts reserved chars are encoded with no injected query params; a well-formed DOI is asserted to pass through verbatim.

## Quality gates (all green)
- `uv run ruff check` ✅
- `uv run --extra langchain ty check` ✅
- `uv run --extra langchain pytest tests/test_secret_url_hardening.py tests/test_tools_lookups.py tests/test_lookups_contract.py tests/test_config_drafter_model.py` → **95 passed** ✅ (incl. the CI-ignored contract test, kept green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)