### PR TITLE
feat(tools): resolve_compound composite (lookup→draft→verify) (#179 task 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,6 +498,7 @@ format only (D7); the ARC folder tree is materialised at export time by
 ```
 scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=False) → dict  # composite: linked Investigation→Study→Assay in one call (idempotent), the fast path to a BASE-passing crate
 materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
+resolve_compound(name: str, hints: dict | None = None, verify=None) → {entity_id, name, identifiers, verifications, verified, source}  # composite: chemical name → lookup_compound → draft_molecular_entity → verify_identifier, in one idempotent call; carries the looked-up CAS + PubChem CID and never keeps an unverified id (D5)
 draft_publication_with_authors(doi: str) → {publication_id, doi, authors:[{name, person_id, orcid, resolution}], hitl}  # composite (engine-routed, HITL-capable): publication + every author wired as a Person, each author's @id harmonized to their ORCID via a verify-first cascade
 draft_investigation(hints: dict) → Entity
 draft_study(investigation_id: str, hints: dict) → Entity
@@ -536,6 +537,23 @@ These three types live in the shared `aop_entities` CrateState collection and
 build via `_crate_mapping` as `ContextEntity` nodes typed by their own AOP class.
 With `study_id`, the AOP is wired onto that Study via the `aop` reference (an
 alias of `schema:mentions`), closing the largest gold-crate fidelity gap.
+
+`resolve_compound` (Issue #179, task 3) is the chemistry counterpart of
+`scaffold_isa_backbone`: from the single model-supplied compound `name` it fuses
+the recurring `lookup_compound` → `draft_molecular_entity` → `verify_identifier`
+chain into ONE deterministic call. (1) `lookup_compound` resolves the chemical
+(PubChem, then a ChEBI fallback) — a miss returns `{ok: False, error}` and creates
+no entity; (2) `draft_molecular_entity` mints (or, idempotently, reuses) the
+`MolecularEntity` carrying the looked-up `cas` / `pubchem_cid` (and `smiles` /
+`inchikey` / …) — the build's shared `_identifier_pv` path turns `cas` +
+`pubchem_cid` into the `[CAS, PubChem CID]` identifier PropertyValues, so this
+composite never hand-rolls that wiring; (3) `verify_identifier` confirms each
+minted identifier against source. **D5:** `verify_identifier` *clears* any value
+that does not resolve, so a failed identifier never lingers as a fabricated id —
+the per-field verdicts are surfaced in `verifications` and `verified` is the AND of
+them. Looked-up identifier fields win over same-named caller `hints`, and the
+entity id is derived deterministically from the name so re-running reuses the
+entity rather than duplicating it.
 
 `draft_publication_with_authors` (Issue #180, deferred item) is the citation
 counterpart of the composites above and the **only engine-routed, HITL-capable

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -23,6 +23,7 @@ Entity drafting:
 - scaffold_isa_backbone: Create a linked Investigation+Study+Assay backbone in one call (idempotent) — the fastest path to a BASE-passing crate
 - draft_process_chain: Create and wire a whole LabProcess derivation chain (CellCulture->Exposure->EndpointReadout->DataAnalysis, any subset) in one idempotent call — synthesizes the outputs EndpointReadout/DataAnalysis require so the chain never dangles into a validation error
 - materialize_aop_subgraph: Turn one AOP-Wiki id into the full subgraph (AdverseOutcomePathway + KeyEvents + KeyEventRelationships, cross-linked) and optionally wire it onto a Study
+- resolve_compound: Resolve a chemical name to a verified MolecularEntity in one call (lookup_compound -> draft_molecular_entity -> verify_identifier), carrying the looked-up CAS + PubChem CID; idempotent and never keeps an unverified identifier (D5)
 - draft_investigation: Create an Investigation entity
 - draft_study: Create a Study entity
 - draft_assay: Create an Assay entity

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -89,6 +89,19 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "resolve_compound",
+        "description": "Resolve a chemical NAME to a verified MolecularEntity in ONE call (the chemistry counterpart of scaffold_isa_backbone): it looks the compound up (lookup_compound: PubChem -> ChEBI fallback), mints/reuses the MolecularEntity carrying the looked-up CAS + PubChem CID (which the build turns into [CAS, PubChem CID] identifier PropertyValues), then VERIFIES each minted identifier against source. D5: a value that does not resolve is cleared, never kept as a fabricated id — the per-field verdicts are returned. Idempotent (keyed by name, no duplicate). Prefer this over lookup_compound + draft_molecular_entity + verify_identifier for a single compound. On a lookup miss returns {ok:false, error}. Example: resolve_compound(name='Silychristin A', hints={'description': 'a flavonolignan'}).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Compound name to resolve, e.g. 'Silychristin A'."},
+                "hints": draft_hints_schema("MolecularEntity"),
+                "verify": {"type": "boolean", "description": "Verify the minted identifiers against source (default true). Pass false only when you will verify later — never to attach an unverified id."},
+            },
+            "required": ["name"],
+        },
+    },
+    {
         "name": "materialize_aop_subgraph",
         "description": "Turn ONE AOP-Wiki id into the full crate subgraph in one call: an AdverseOutcomePathway node plus every KeyEvent (MIE/KE/AO, discriminated by eventType) and KeyEventRelationship, all cross-linked deterministically from AOP-Wiki (never fabricated). Pass only the numeric aop_id; optionally pass study_id to wire the AOP onto that Study (schema:mentions). Idempotent (keyed by AOP-Wiki IRI). Prefer this over lookup_aop + manual drafting when you want the whole pathway in the crate. Example: materialize_aop_subgraph(aop_id='610', study_id='study_silychristin_exposure').",
         "parameters": {

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -21,15 +21,18 @@ from typing import Any
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
 from builder.tools.drafters import (
     VALID_PROCESS_TYPES,
+    _make_entity_id,
     draft_assay,
     draft_investigation,
+    draft_molecular_entity,
     draft_process,
     draft_publication,
     draft_sample,
     draft_study,
 )
 from builder.tools.hitl import HumanInterface
-from builder.tools.lookups import lookup_doi, lookup_orcid
+from builder.tools.lookups import lookup_compound, lookup_doi, lookup_orcid
+from builder.tools.verification import verify_identifier
 from lookups.orcid import lookup_orcid_by_name
 
 logger = logging.getLogger(__name__)
@@ -940,12 +943,157 @@ def _hitl_prompt_count(human: HumanInterface | None) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Compound resolution: lookup -> draft -> verify (Issue #179, task 3)
+# ---------------------------------------------------------------------------
+
+# The order matters: CAS first, then PubChem CID — this mirrors the build's
+# _identifier_pv path which emits [CAS, PubChem CID] identifier PropertyValues in
+# exactly this order for a MolecularEntity. ``identifier`` is the generic field
+# verify_identifier also accepts; we verify the concrete source fields instead.
+_COMPOUND_IDENTIFIER_FIELDS: tuple[str, ...] = ("cas", "pubchem_cid")
+
+# Lookup-data keys copied onto the drafted MolecularEntity. ``cas``/``pubchem_cid``
+# are the verifiable identifiers; the rest are descriptive structure that needs no
+# verification. ``iupac_name`` is intentionally NOT copied onto ``name`` (the
+# user-supplied name wins) but is exposed in the return for the caller.
+_COMPOUND_DATA_FIELDS: tuple[str, ...] = (
+    "cas",
+    "pubchem_cid",
+    "smiles",
+    "inchikey",
+    "inchi",
+    "formula",
+    "mass",
+    "chebi_id",
+    "chebi_iri",
+)
+
+
+def resolve_compound(
+    state: CrateState,
+    name: str,
+    hints: dict[str, Any] | None = None,
+    verify: bool | None = None,
+) -> dict[str, Any]:
+    """Resolve a chemical name to a verified ``MolecularEntity`` in ONE call.
+
+    Fuses the recurring ``lookup_compound`` -> ``draft_molecular_entity`` ->
+    ``verify_identifier`` sequence into a single deterministic composite (the
+    chemistry counterpart of ``scaffold_isa_backbone``). The ONLY model-supplied
+    input is the compound ``name`` (plus optional descriptive ``hints``); every
+    identifier comes straight from PubChem/ChEBI, so nothing is fabricated (D5):
+
+    1. :func:`~builder.tools.lookups.lookup_compound` resolves the chemical from
+       its name (PubChem, then a ChEBI fallback). On a miss it returns
+       ``{"ok": False, "error": ...}`` and creates no entity.
+    2. :func:`~builder.tools.drafters.draft_molecular_entity` mints (or reuses) the
+       ``MolecularEntity``, carrying the looked-up ``cas`` / ``pubchem_cid`` (and
+       ``smiles`` / ``inchikey`` / …) as fields. At build time the shared
+       ``_identifier_pv`` path turns ``cas`` + ``pubchem_cid`` into the
+       ``[CAS, PubChem CID]`` identifier PropertyValues — this composite does not
+       hand-roll that wiring.
+    3. :func:`~builder.tools.verification.verify_identifier` confirms each minted
+       identifier against its source (D5). ``verify_identifier`` **clears** any
+       value that does not resolve, so a failed identifier never lingers on the
+       entity as a fabricated id; the per-field verdicts are surfaced in the
+       return value (``verified`` is the AND of all of them).
+
+    It is **idempotent**: the entity id is derived deterministically from the
+    name, so an existing ``MolecularEntity`` for this name is reused (its
+    descriptive fields refreshed) rather than duplicated, consistent with the
+    other composites.
+
+    Args:
+        state: The crate state to resolve into.
+        name: The compound name to resolve (e.g. ``"Silychristin A"``).
+        hints: Optional extra descriptive field values for the MolecularEntity
+            (e.g. ``{"description": ...}``). Looked-up identifier fields win over
+            same-named hints so the verified source value is never overwritten.
+        verify: When ``None``/``True`` (the default), verify the minted
+            identifiers against source. Pass ``False`` to skip verification (the
+            return then reports ``verified`` as ``None``); use only when you will
+            verify later, never to attach an unverified id.
+
+    Returns:
+        On success ``{"entity_id", "name", "identifiers": {cas?, pubchem_cid?,
+        ...}, "verifications": [{field, verified, message}], "verified": bool |
+        None, "source"}``. On a lookup miss ``{"ok": False, "error": ...}``.
+    """
+    lookup = lookup_compound(name)
+    if not lookup.get("found"):
+        return {
+            "ok": False,
+            "error": lookup.get("error", f"Compound '{name}' not found"),
+        }
+
+    data = lookup.get("data") or {}
+
+    # Identifier/source fields win over caller hints so a verified value from the
+    # source is never clobbered by a (possibly stale) hint.
+    merged_hints: dict[str, Any] = dict(hints or {})
+    for key in _COMPOUND_DATA_FIELDS:
+        value = data.get(key)
+        if value not in (None, ""):
+            merged_hints[key] = value
+
+    # Idempotent: reuse the deterministically-keyed MolecularEntity if present,
+    # refreshing its looked-up fields, rather than minting a duplicate.
+    entity_id = _make_entity_id("chem", name, merged_hints)
+    existing = state.get_entity(entity_id)
+    if existing is not None and existing.type == "MolecularEntity":
+        entity = existing
+        refreshed = {**merged_hints, "name": name}
+        entity.set_fields_from_dict(refreshed, source="lookup")
+    else:
+        entity = draft_molecular_entity(state, name, merged_hints)
+
+    identifiers = {
+        key: data[key]
+        for key in _COMPOUND_IDENTIFIER_FIELDS
+        if data.get(key) not in (None, "")
+    }
+
+    verifications: list[dict[str, Any]] = []
+    do_verify = verify is None or verify
+    if do_verify:
+        for field in _COMPOUND_IDENTIFIER_FIELDS:
+            if entity.fields.get(field) in (None, ""):
+                continue
+            verdict = verify_identifier(state, entity.entity_id, field)
+            verifications.append(
+                {
+                    "field": field,
+                    "verified": bool(verdict.get("verified")),
+                    "message": verdict.get("message", ""),
+                }
+            )
+
+    verified: bool | None
+    if not do_verify:
+        verified = None
+    elif not verifications:
+        verified = False
+    else:
+        verified = all(v["verified"] for v in verifications)
+
+    return {
+        "entity_id": entity.entity_id,
+        "name": name,
+        "identifiers": identifiers,
+        "verifications": verifications,
+        "verified": verified,
+        "source": data.get("source", "pubchem"),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
 TOOL_REGISTRY.register("scaffold_isa_backbone", scaffold_isa_backbone, takes_state=True)
 TOOL_REGISTRY.register("draft_process_chain", draft_process_chain, takes_state=True)
+TOOL_REGISTRY.register("resolve_compound", resolve_compound, takes_state=True)
 TOOL_REGISTRY.register(
     "materialize_aop_subgraph", materialize_aop_subgraph, takes_state=True
 )

--- a/tests/test_tools_resolve_compound.py
+++ b/tests/test_tools_resolve_compound.py
@@ -1,0 +1,217 @@
+"""Tests for the ``resolve_compound`` composite tool (Issue #179, task 3).
+
+``resolve_compound`` fuses the recurring lookup -> draft -> verify sequence for a
+chemical into ONE deterministic call: it resolves a compound name via
+:func:`lookup_compound` (PubChem/ChEBI), mints the ``MolecularEntity`` via the
+pure :func:`draft_molecular_entity` drafter (reusing the existing identifier-PV
+wiring for CAS + PubChem CID), then confirms the minted identifiers against
+source via :func:`verify_identifier`. D5: if verification fails, the identifier is
+NOT fabricated/kept — the failure is surfaced in the return value.
+
+Tests never hit the network: ``lookup_compound`` and ``verify_identifier`` are
+monkeypatched on the ``composites`` module (where ``resolve_compound`` calls
+them), so the chain runs entirely offline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools import composites
+from builder.tools.composites import resolve_compound
+
+pytestmark = pytest.mark.timeout(120)
+
+
+def _by_type(state: CrateState, type_name: str) -> list:
+    return [e for e in state.list_entities() if e.type == type_name]
+
+
+_PUBCHEM_HIT = {
+    "found": True,
+    "error": None,
+    "data": {
+        "cas": "33889-69-9",
+        "smiles": "C[C@H]1...",
+        "inchikey": "ABCDEFGHIJKLMN-UHFFFAOYSA-N",
+        "inchi": "InChI=1S/...",
+        "formula": "C25H22O10",
+        "mass": "482.4",
+        "iupac_name": "silychristin A",
+        "pubchem_cid": "443515",
+    },
+}
+
+
+@pytest.fixture
+def offline_lookup(monkeypatch):
+    """Serve a fixed PubChem hit and a verifier that always confirms.
+
+    Both are patched on the ``composites`` module namespace, which is where
+    ``resolve_compound`` resolves the symbols (it imports them at module scope).
+    """
+    calls: dict[str, list] = {"lookup": [], "verify": []}
+
+    def fake_lookup(name):  # noqa: ANN001
+        calls["lookup"].append(name)
+        return dict(_PUBCHEM_HIT)
+
+    def fake_verify(state, entity_id, field):  # noqa: ANN001
+        calls["verify"].append((entity_id, field))
+        entity = state.get_entity(entity_id)
+        if entity is not None and entity.fields.get(field):
+            entity.set_field_status(field, "verified", "lookup")
+            return {
+                "verified": True,
+                "entity_id": entity_id,
+                "field": field,
+                "message": f"Verified {field}",
+                "suggested_fix": None,
+            }
+        return {
+            "verified": False,
+            "entity_id": entity_id,
+            "field": field,
+            "message": f"No value for {field}",
+            "suggested_fix": None,
+        }
+
+    monkeypatch.setattr(composites, "lookup_compound", fake_lookup)
+    monkeypatch.setattr(composites, "verify_identifier", fake_verify)
+    return calls
+
+
+class TestResolveCompoundHappyPath:
+    def test_mints_verified_molecular_entity(self, offline_lookup):
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+
+        mols = _by_type(state, "MolecularEntity")
+        assert len(mols) == 1
+        mol = mols[0]
+
+        # The entity id is returned and the entity exists in state.
+        assert result["entity_id"] == mol.entity_id
+        assert state.get_entity(result["entity_id"]) is mol
+
+        # CAS + PubChem CID land on the entity as the verifiable identifier
+        # fields the build's _identifier_pv path turns into PropertyValues.
+        assert mol.fields.get("cas") == "33889-69-9"
+        assert mol.fields.get("pubchem_cid") == "443515"
+
+    def test_reports_verification_verdict(self, offline_lookup):
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+
+        assert result["verified"] is True
+        # Both minted identifiers were verified against source.
+        fields = {v["field"]: v["verified"] for v in result["verifications"]}
+        assert fields.get("cas") is True
+        assert fields.get("pubchem_cid") is True
+
+    def test_returns_resolved_identifiers(self, offline_lookup):
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+        assert result["identifiers"]["cas"] == "33889-69-9"
+        assert result["identifiers"]["pubchem_cid"] == "443515"
+
+    def test_extra_hints_are_applied(self, offline_lookup):
+        state = CrateState()
+        resolve_compound(
+            state, name="Silychristin A", hints={"description": "a flavonolignan"}
+        )
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert mol.fields.get("description") == "a flavonolignan"
+
+
+class TestResolveCompoundIdempotent:
+    def test_second_call_no_duplicate(self, offline_lookup):
+        state = CrateState()
+        first = resolve_compound(state, name="Silychristin A")
+        second = resolve_compound(state, name="Silychristin A")
+        assert len(_by_type(state, "MolecularEntity")) == 1
+        assert first["entity_id"] == second["entity_id"]
+
+
+class TestResolveCompoundLookupMiss:
+    def test_lookup_miss_creates_no_entity(self, monkeypatch):
+        def fake_lookup(name):  # noqa: ANN001
+            return {"found": False, "data": {}, "error": "not found"}
+
+        monkeypatch.setattr(composites, "lookup_compound", fake_lookup)
+        state = CrateState()
+        result = resolve_compound(state, name="Nonexistadiol")
+
+        assert result["ok"] is False
+        assert "error" in result
+        assert _by_type(state, "MolecularEntity") == []
+
+
+class TestResolveCompoundVerificationFailure:
+    def test_failed_verification_is_reported_not_fabricated(self, monkeypatch):
+        """A verifier that rejects the value must NOT leave a fabricated id (D5).
+
+        The verifier mimics the real ``verify_identifier``, which clears a value
+        that does not resolve at its source. ``resolve_compound`` must surface
+        the failure (verified=False) and not present the cleared id as resolved.
+        """
+
+        def fake_lookup(name):  # noqa: ANN001
+            return dict(_PUBCHEM_HIT)
+
+        def fake_verify(state, entity_id, field):  # noqa: ANN001
+            # Real verify_identifier clears an unresolvable value from the entity.
+            entity = state.get_entity(entity_id)
+            if entity is not None:
+                entity.fields.pop(field, None)
+                entity.set_field_status(field, "missing", "lookup")
+            return {
+                "verified": False,
+                "entity_id": entity_id,
+                "field": field,
+                "message": f"{field} could not be verified; value cleared.",
+                "suggested_fix": "Provide a resolvable identifier.",
+            }
+
+        monkeypatch.setattr(composites, "lookup_compound", fake_lookup)
+        monkeypatch.setattr(composites, "verify_identifier", fake_verify)
+
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+
+        assert result["verified"] is False
+        # The failure is surfaced, not swallowed.
+        assert any(v["verified"] is False for v in result["verifications"])
+        # D5: no unverified identifier remains on the entity masquerading as real.
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert "cas" not in mol.fields
+        assert "pubchem_cid" not in mol.fields
+
+
+class TestResolveCompoundViaEngine:
+    def test_callable_through_run_tool(self, monkeypatch):
+        def fake_lookup(name):  # noqa: ANN001
+            return dict(_PUBCHEM_HIT)
+
+        def fake_verify(state, entity_id, field):  # noqa: ANN001
+            entity = state.get_entity(entity_id)
+            if entity is not None and entity.fields.get(field):
+                entity.set_field_status(field, "verified", "lookup")
+            return {
+                "verified": True,
+                "entity_id": entity_id,
+                "field": field,
+                "message": "ok",
+                "suggested_fix": None,
+            }
+
+        monkeypatch.setattr(composites, "lookup_compound", fake_lookup)
+        monkeypatch.setattr(composites, "verify_identifier", fake_verify)
+
+        engine = AgentEngine()
+        engine.initialize()
+        result = engine.run_tool("resolve_compound", name="Silychristin A")
+        assert result["entity_id"]
+        assert engine.state.get_entity(result["entity_id"]) is not None


### PR DESCRIPTION
## Summary

Adds `resolve_compound`, the chemistry counterpart of `scaffold_isa_backbone` — a deterministic composite meta-tool (#179 task 3) that fuses the recurring `lookup_compound` → `draft_molecular_entity` → `verify_identifier` chain into ONE idempotent call. The only model-supplied input is the compound name; every identifier comes straight from the source, so nothing is fabricated (D5).

The chain:
1. `lookup_compound(name)` resolves the chemical (PubChem, then a ChEBI fallback). A miss returns `{ok: False, error}` and creates no entity.
2. `draft_molecular_entity` mints (or, idempotently, reuses) the `MolecularEntity` carrying the looked-up `cas` / `pubchem_cid` (+ `smiles` / `inchikey` / …). The build's shared `_identifier_pv` path turns `cas` + `pubchem_cid` into the `[CAS, PubChem CID]` identifier PropertyValues — this composite never hand-rolls that wiring.
3. `verify_identifier` confirms each minted identifier against source. **D5:** `verify_identifier` *clears* any value that does not resolve, so a failed identifier never lingers as a fabricated id — the per-field verdicts are surfaced in `verifications` and `verified` is the AND of them.

Idempotent (entity id derived deterministically from the name; an existing `MolecularEntity` for the name is reused, not duplicated). Looked-up identifier fields win over same-named caller `hints` so a verified source value is never clobbered.

## Four-place registration contract
Registered `resolve_compound` across all four lockstep places:
- `TOOL_REGISTRY` (bottom of `builder/tools/composites.py`, `takes_state=True`; picked up by the engine's `_build_registry`).
- `TOOL_SPECS` (`builder/agents/tools_spec.py`), with an `Example:` in the `draft_process_chain` style.
- The system-prompt `## Your Tools` catalogue (`builder/agents/system_prompt.py`).
- `AGENTS.md` §5 (signature line + descriptive paragraph; edits confined to §5).

## Testing (TDD)
New `tests/test_tools_resolve_compound.py` — failing test written first, then minimal implementation. Tests monkeypatch `lookup_compound` / `verify_identifier` on the composites module so they never hit the network. Covers: (a) happy path mints a verified MolecularEntity with CAS + CID, (b) idempotency (no duplicate on re-run), (c) verification failure is reported and the cleared id is NOT fabricated, (d) lookup miss creates no entity, (e) callable via the engine `run_tool`.

## Quality gates (all green)
- `uv run ruff check` — All checks passed
- `uv run --extra langchain ty check` — All checks passed
- The four-place parity tests pass: `tests/test_tools_spec.py` + `tests/test_agents_doc_toolbox.py` (registry ↔ TOOL_SPECS ↔ system prompt ↔ AGENTS.md §5), plus the new test module and the existing composites suite (26 passed). No regressions in the verification / process-chain / aop-subgraph / publication-authors suites (59 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)