### PR TITLE
feat(leaves): extract_plan — bounded candidate-plan extractor from docs (#179)

### DIFF
--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -112,6 +112,235 @@ def _strip_identifiers(fields: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Stage A: the bounded candidate-plan extractor (Issue #179).
+#
+# ``extract_plan`` is the *whole-document* sibling of ``draft_entity_fields``: a
+# SINGLE bounded structured-output call on the drafter tier that reads scanned
+# research docs and proposes a CANDIDATE PLAN of the ISA-Tox entities the docs
+# support — the study, the test/control compounds, cell lines, the
+# CellCulture→Exposure→EndpointReadout→DataAnalysis process chain, AOPs, people,
+# publications, files, and free-text notes for the user to confirm.
+#
+# It is a *proposal*, not committed truth: every field is optional and the model
+# is told to fill only what the context supports and to record ambiguity in
+# ``notes`` rather than invent. Crucially (D5) the plan proposes WHAT EXISTS *by
+# name only* — NO CAS / CID / InChIKey / SMILES / Cellosaurus accession / ORCID /
+# DOI / @id. Those identifiers are resolved later by deterministic lookups, never
+# guessed by this leaf. The schema the model sees carries no identifier field
+# (the strongest guard) and any identifier an adversarial model slips into the
+# output is defensively stripped (:func:`_strip_plan_identifiers`).
+# ---------------------------------------------------------------------------
+
+# D5: identifier-bearing keys an adversarial model might attach to any plan item.
+# Pruned from the schema the model sees AND stripped from the result. A superset
+# of :data:`_IDENTIFIER_SCALAR_FIELDS` with the plan-specific aliases the docs
+# might tempt the model toward (``cid``, ``cellosaurus``, ``@id``, ``id``).
+_PLAN_IDENTIFIER_FIELDS: frozenset[str] = _IDENTIFIER_SCALAR_FIELDS | frozenset(
+    {
+        "cid",
+        "inchi",
+        "cellosaurus",
+        "cellosaurus_accession",
+        "aop_url",
+        "@id",
+        "id",
+    }
+)
+
+_PLAN_SYSTEM_PROMPT = (
+    "You are a bounded planning extractor for ISA-Tox RO-Crates. Read the "
+    "provided research documents and propose a CANDIDATE PLAN of the entities "
+    "and connections the documents support: the study, test/control compounds, "
+    "cell lines, the CellCulture -> Exposure -> EndpointReadout -> DataAnalysis "
+    "process chain, AOPs (only if an AOP id is explicitly stated), people, "
+    "publications, and files. This is a PROPOSAL for the user to confirm, not "
+    "committed truth. Propose ONLY what the documents support; leave any field "
+    "you cannot support empty and record ambiguities or things the user should "
+    "confirm in 'notes'. Refer to compounds, cell lines, people and "
+    "publications BY NAME ONLY. NEVER include identifiers of any kind: no CAS, "
+    "PubChem CID, InChIKey, SMILES, InChI, Cellosaurus accession, ORCID, DOI, "
+    "or @id. Those are resolved later by dedicated lookup services, never by you."
+)
+
+
+def _plan_schema() -> dict[str, Any]:
+    """Build the structured-output schema for the candidate plan (D5-clean).
+
+    A hand-built JSON Schema describing the Plan shape. Every field is optional —
+    the model fills only what the docs support. By construction it contains NO
+    identifier field (no CAS/CID/InChIKey/SMILES/accession/ORCID/DOI/@id), so the
+    model is never even asked to produce one (the strongest D5 guard). Sections
+    stay open (``additionalProperties: true``) for descriptive long-tail fields,
+    but :func:`_strip_plan_identifiers` still scrubs the result as defense in
+    depth. A top-level ``title`` is added so langchain can use the schema as a
+    structured-output function spec.
+    """
+    str_field = {"type": "string"}
+
+    def _array_of(item_props: dict[str, Any], required: list[str] | None = None) -> dict[str, Any]:
+        item: dict[str, Any] = {
+            "type": "object",
+            "properties": item_props,
+            "additionalProperties": True,
+        }
+        if required:
+            item["required"] = required
+        return {"type": "array", "items": item}
+
+    return {
+        "title": "CandidatePlan",
+        "type": "object",
+        "description": (
+            "A candidate plan of the ISA-Tox entities the documents support. "
+            "All fields optional; propose only what the docs support and leave "
+            "the rest empty. Names only — no identifiers (D5)."
+        ),
+        "properties": {
+            "study": {
+                "type": "object",
+                "description": "The study the documents describe.",
+                "properties": {
+                    "name": {**str_field, "description": "Study name."},
+                    "description": {**str_field, "description": "Free-text study description."},
+                },
+                "additionalProperties": True,
+            },
+            "compounds": _array_of(
+                {
+                    "name": {**str_field, "description": "Compound name only (no identifiers)."},
+                    "role": {
+                        "type": "string",
+                        "enum": ["test", "control"],
+                        "description": "Whether the compound is the test article or a control.",
+                    },
+                },
+                required=["name"],
+            ),
+            "cell_lines": _array_of(
+                {"name": {**str_field, "description": "Cell-line name only (no accession)."}},
+                required=["name"],
+            ),
+            "process_chain": _array_of(
+                {
+                    "process_type": {
+                        "type": "string",
+                        "enum": ["CellCulture", "Exposure", "EndpointReadout", "DataAnalysis"],
+                        "description": "Which step of the ISA-Tox LabProcess chain this is.",
+                    },
+                    "name": {**str_field, "description": "Step name."},
+                    "object_hint": {**str_field, "description": "Free-text hint of the input."},
+                    "result_hint": {**str_field, "description": "Free-text hint of the output."},
+                },
+                required=["process_type"],
+            ),
+            "aops": _array_of(
+                {"aop_id": {**str_field, "description": "AOP-Wiki id, only if explicitly stated."}},
+                required=["aop_id"],
+            ),
+            "people": _array_of(
+                {
+                    "name": {**str_field, "description": "Person's name only (no ORCID)."},
+                    "affiliation_name": {**str_field, "description": "Affiliation org name."},
+                },
+                required=["name"],
+            ),
+            "publications": _array_of(
+                {"title": {**str_field, "description": "Publication title only (no DOI)."}},
+                required=["title"],
+            ),
+            "files": _array_of(
+                {
+                    "path": {**str_field, "description": "File path or name."},
+                    "role": {
+                        "type": "string",
+                        "enum": ["raw", "processed", "condition_table", "other"],
+                        "description": "What kind of data file this is.",
+                    },
+                },
+                required=["path"],
+            ),
+            "notes": {
+                **str_field,
+                "description": (
+                    "Free-text: ambiguities, gaps, and anything the user should "
+                    "confirm. Use this instead of guessing."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    }
+
+
+def _strip_plan_identifiers(value: Any) -> Any:
+    """Recursively drop any identifier field from a plan (D5, defense in depth).
+
+    Walks the plan's nested dicts/lists and removes every key in
+    :data:`_PLAN_IDENTIFIER_FIELDS` wherever it appears, so an identifier an
+    adversarial model slipped into any section (a compound's CAS, a person's
+    ORCID, a ``@id`` on any item) never propagates downstream.
+    """
+    if isinstance(value, dict):
+        return {
+            key: _strip_plan_identifiers(val)
+            for key, val in value.items()
+            if key not in _PLAN_IDENTIFIER_FIELDS
+        }
+    if isinstance(value, list):
+        return [_strip_plan_identifiers(item) for item in value]
+    return value
+
+
+def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
+    """Propose a candidate plan of ISA-Tox entities from research docs.
+
+    Stage A of the §14 hybrid build loop: a pure leaf making a SINGLE bounded
+    structured-output call on the drafter tier
+    (``_build_chat_model(role="drafter")``) over the scanned-document ``context``.
+    It returns a CANDIDATE PLAN — the study, test/control compounds, cell lines,
+    the CellCulture→Exposure→EndpointReadout→DataAnalysis process chain, AOPs,
+    people, publications, files, and free-text ``notes`` — for the user to
+    confirm. It does not mutate state and does not orchestrate.
+
+    Every field is optional: the model proposes only what the context supports and
+    records ambiguity in ``notes`` rather than inventing. D5: the plan names WHAT
+    EXISTS — no identifiers (CAS/CID/InChIKey/SMILES/Cellosaurus accession/ORCID/
+    DOI/@id). The schema the model sees carries no identifier field, and any that
+    an adversarial model slips into the output is stripped recursively. Real
+    identifiers are resolved later by deterministic lookups, never by this leaf.
+
+    Args:
+        context: The scanned research documents (or an excerpt) to plan from.
+        model: Optional explicit model name override; when ``None`` the drafter
+            tier resolves the configured drafter (or primary) model.
+
+    Returns:
+        A candidate-plan dict free of fabricated identifiers. An empty/
+        uninformative context yields an empty-but-valid plan rather than
+        fabricated entities.
+    """
+    llm = _build_chat_model(model=model, role="drafter")
+    schema = _plan_schema()
+    structured = llm.with_structured_output(schema)
+
+    messages = [
+        SystemMessage(content=_PLAN_SYSTEM_PROMPT),
+        HumanMessage(
+            content=(
+                "Documents:\n"
+                f"{context}\n\n"
+                "Propose the candidate plan. Fill only what the documents "
+                "support; leave the rest empty and note ambiguities in 'notes'. "
+                "Names only — no identifiers."
+            )
+        ),
+    ]
+    result = structured.invoke(messages)
+
+    plan = dict(result) if isinstance(result, dict) else {}
+    return _strip_plan_identifiers(plan)
+
+
 def draft_entity_fields(
     entity_type: str,
     context: str,
@@ -163,4 +392,4 @@ def draft_entity_fields(
     return _strip_identifiers(fields)
 
 
-__all__ = ["draft_entity_fields"]
+__all__ = ["draft_entity_fields", "extract_plan"]

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -269,3 +269,278 @@ class TestUnknownEntityType:
         out = leaves.draft_entity_fields("NotAType", "context")
 
         assert isinstance(out, dict)
+
+
+# ---------------------------------------------------------------------------
+# extract_plan — the Stage A candidate-plan extractor (Issue #179)
+#
+# `extract_plan` is the *whole-document* sibling of `draft_entity_fields`: one
+# bounded structured-output call on the drafter tier that reads scanned research
+# docs and proposes a CANDIDATE PLAN (study, compounds, cell lines, the
+# CellCulture→Exposure→EndpointReadout→DataAnalysis process chain, AOPs, people,
+# publications, files, free-text notes). It proposes WHAT EXISTS by name; it must
+# never fabricate identifiers (D5) — real CAS/CID/InChIKey/Cellosaurus/ORCID/DOI
+# come later from deterministic lookups, not from this leaf.
+# ---------------------------------------------------------------------------
+
+
+# A doc-like context the model could plausibly turn into a populated plan.
+_DOC_CONTEXT = """
+Investigation: Hepatotoxicity of acetaminophen in renal cells.
+
+Study: We exposed MDCK cells to acetaminophen (test compound) and a DMSO
+vehicle control, then read out viability and analysed dose-response.
+
+Cells were cultured in DMEM, exposed for 24h across a concentration series,
+viability was measured on a plate reader, and the data were analysed in R.
+
+Authors: Jane Doe (Acme University). Reference: "AAP renal tox", Doe et al.
+This relates to AOP 144.
+
+Files: plate_raw.csv (raw), results.xlsx (processed), conditions.csv.
+"""
+
+
+class TestExtractPlanDrafterTier:
+    """The plan extractor must run on the cheap drafter tier (mirrors the leaf)."""
+
+    def test_requests_drafter_role(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        rec = _patch_build_chat_model
+        rec["model"] = FakeChatModel({"study": {"name": "x"}})
+
+        leaves.extract_plan(_DOC_CONTEXT)
+
+        assert rec["calls"], "the leaf must build a chat model"
+        assert all(c.get("role") == "drafter" for c in rec["calls"]), (
+            "extract_plan must build the chat model on the drafter tier"
+        )
+
+    def test_explicit_model_is_forwarded(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        rec = _patch_build_chat_model
+        rec["model"] = FakeChatModel({})
+
+        leaves.extract_plan("context", model="gpt-4o-mini")
+
+        assert rec["calls"][0].get("model") == "gpt-4o-mini"
+
+
+class TestExtractPlanStructuredOutput:
+    """One bounded structured-output bind + one invocation (a leaf)."""
+
+    def test_single_structured_output_call(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"study": {"name": "x"}})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.extract_plan(_DOC_CONTEXT)
+
+        assert len(fake.structured_schemas) == 1, "exactly one structured-output bind"
+        assert len(fake.invoke_calls) == 1, "exactly one model invocation (a leaf)"
+
+
+class TestExtractPlanShape:
+    """A doc-like context yields a populated plan with the right shape."""
+
+    def test_populated_plan_round_trips(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {
+                "study": {"name": "AAP renal tox", "description": "Hepatotox study."},
+                "compounds": [
+                    {"name": "Acetaminophen", "role": "test"},
+                    {"name": "DMSO", "role": "control"},
+                ],
+                "cell_lines": [{"name": "MDCK"}],
+                "process_chain": [
+                    {"process_type": "CellCulture", "name": "Culture"},
+                    {"process_type": "Exposure", "name": "Expose"},
+                    {"process_type": "EndpointReadout", "name": "Readout"},
+                    {"process_type": "DataAnalysis", "name": "Analyse"},
+                ],
+                "aops": [{"aop_id": "144"}],
+                "people": [{"name": "Jane Doe", "affiliation_name": "Acme University"}],
+                "publications": [{"title": "AAP renal tox"}],
+                "files": [
+                    {"path": "plate_raw.csv", "role": "raw"},
+                    {"path": "results.xlsx", "role": "processed"},
+                    {"path": "conditions.csv", "role": "condition_table"},
+                ],
+                "notes": "Concentration series not fully specified.",
+            }
+        )
+
+        plan = leaves.extract_plan(_DOC_CONTEXT)
+
+        assert isinstance(plan, dict)
+        assert plan["study"]["name"] == "AAP renal tox"
+        assert {c["name"] for c in plan["compounds"]} == {"Acetaminophen", "DMSO"}
+        assert plan["cell_lines"][0]["name"] == "MDCK"
+        assert [p["process_type"] for p in plan["process_chain"]] == [
+            "CellCulture",
+            "Exposure",
+            "EndpointReadout",
+            "DataAnalysis",
+        ]
+        assert plan["aops"][0]["aop_id"] == "144"
+        assert plan["people"][0]["name"] == "Jane Doe"
+        assert plan["publications"][0]["title"] == "AAP renal tox"
+        assert {f["role"] for f in plan["files"]} == {
+            "raw",
+            "processed",
+            "condition_table",
+        }
+        assert plan["notes"]
+
+
+class TestExtractPlanEmptyContext:
+    """An uninformative context yields an empty-but-valid plan, not fabrication."""
+
+    def test_empty_context_returns_empty_plan(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # An honest model returns nothing it can support from an empty context.
+        _patch_build_chat_model["model"] = FakeChatModel({})
+
+        plan = leaves.extract_plan("")
+
+        assert isinstance(plan, dict)
+        # No fabricated entities: every list-valued section is empty/absent.
+        for key in (
+            "compounds",
+            "cell_lines",
+            "process_chain",
+            "aops",
+            "people",
+            "publications",
+            "files",
+        ):
+            assert not plan.get(key), f"empty context must not fabricate {key!r}"
+
+
+class TestExtractPlanD5NoIdentifiersInSchema:
+    """D5: the schema the model sees must never offer an identifier field.
+
+    Pushing D5 into the schema (not just post-filtering) is the strongest guard:
+    the model is never even asked to produce a CAS/CID/InChIKey/SMILES/
+    Cellosaurus accession/ORCID/DOI/@id.
+    """
+
+    def test_no_identifier_fields_anywhere_in_schema(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.extract_plan(_DOC_CONTEXT)
+
+        schema = fake.structured_schemas[0]
+        flat = _flatten_keys(schema)
+        for ident in (
+            "cas",
+            "casrn",
+            "cas_number",
+            "cid",
+            "pubchem_cid",
+            "inchikey",
+            "smiles",
+            "accession",
+            "cellosaurus",
+            "orcid",
+            "doi",
+            "identifier",
+            "@id",
+            "id",
+        ):
+            assert ident not in flat, (
+                f"D5: identifier field {ident!r} must not appear in the plan schema"
+            )
+        # The schema must be usable as a function-calling tool (carries a title).
+        assert schema.get("title"), "plan schema must carry a title"
+
+    def test_schema_is_convertible_to_a_tool(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        from langchain_core.utils.function_calling import convert_to_openai_tool
+
+        fake = FakeChatModel({})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.extract_plan(_DOC_CONTEXT)
+
+        tool = convert_to_openai_tool(fake.structured_schemas[0])  # must not raise
+        assert tool["function"]["name"]
+
+
+class TestExtractPlanD5StripsFabricatedIdentifiers:
+    """D5 defense-in-depth: an adversarial model that slips identifiers into the
+    plan output has them stripped from every section."""
+
+    def test_identifiers_stripped_from_all_sections(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {
+                "study": {"name": "S", "identifier": "FAKE-1"},
+                "compounds": [
+                    {
+                        "name": "Acetaminophen",
+                        "role": "test",
+                        "cas": "103-90-2",
+                        "pubchem_cid": "1983",
+                        "inchikey": "RZVAJINKPMORJF-UHFFFAOYSA-N",
+                        "smiles": "CC(=O)Nc1ccc(O)cc1",
+                        "@id": "https://pubchem.ncbi.nlm.nih.gov/compound/1983",
+                    }
+                ],
+                "cell_lines": [{"name": "MDCK", "accession": "CVCL_0027"}],
+                "people": [
+                    {"name": "Jane Doe", "orcid": "0000-0002-1825-0097"}
+                ],
+                "publications": [{"title": "P", "doi": "10.1234/fake"}],
+            }
+        )
+
+        plan = leaves.extract_plan(_DOC_CONTEXT)
+
+        # Descriptive fields survive; identifiers do not.
+        assert plan["study"]["name"] == "S"
+        assert "identifier" not in plan["study"]
+
+        compound = plan["compounds"][0]
+        assert compound["name"] == "Acetaminophen"
+        assert compound["role"] == "test"
+        for ident in ("cas", "pubchem_cid", "inchikey", "smiles", "@id"):
+            assert ident not in compound, f"D5: {ident!r} leaked into a compound"
+
+        assert plan["cell_lines"][0]["name"] == "MDCK"
+        assert "accession" not in plan["cell_lines"][0]
+
+        assert plan["people"][0]["name"] == "Jane Doe"
+        assert "orcid" not in plan["people"][0]
+
+        assert plan["publications"][0]["title"] == "P"
+        assert "doi" not in plan["publications"][0]
+
+
+def _flatten_keys(schema: Any) -> set[str]:
+    """Every property key appearing anywhere in a (possibly nested) JSON schema."""
+    keys: set[str] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "properties" and isinstance(value, dict):
+                    keys.update(value.keys())
+                _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(schema)
+    return keys


### PR DESCRIPTION
## What

Adds the **extraction leaf** — Stage A of the new hybrid ISA-Tox build loop
(epic #179). `extract_plan(context, *, model=None) -> dict` makes **one bounded
structured-output call on the drafter tier** over scanned research docs and
returns a **candidate plan** of the entities/connections to build, for the user
to confirm. It is a *proposal*, not committed truth.

It is a **library leaf**, not a registered tool — `tools_spec.py`,
`system_prompt.py`, and AGENTS.md §5/§14 are untouched (the gap-engine lane owns
§14 this round).

## Plan schema

All fields optional; the model fills only what the docs support and records
ambiguity in `notes` rather than inventing.

```
Plan:
  study:        {name, description}
  compounds:    [{name, role: "test"|"control"}]          # names only
  cell_lines:   [{name}]                                   # names only
  process_chain:[{process_type: "CellCulture"|"Exposure"|"EndpointReadout"|"DataAnalysis",
                  name, object_hint, result_hint}]
  aops:         [{aop_id}]                                 # only if explicitly stated
  people:       [{name, affiliation_name}]                 # names only
  publications: [{title}]                                  # titles only
  files:        [{path, role: "raw"|"processed"|"condition_table"|"other"}]
  notes:        str                                        # ambiguities / what to confirm
```

## D5 guarantee (Verify, Don't Trust)

The plan proposes **what exists by name**; identifiers are resolved later by
deterministic lookups, never guessed here. Two layers of defense:

1. **Schema-level pruning** — the JSON schema the model sees carries **no
   identifier field** (no CAS, PubChem CID, InChIKey, SMILES, InChI, Cellosaurus
   accession, ORCID, DOI, `@id`), so the model is never even asked to produce one
   (the strongest guard).
2. **Recursive output scrub** — any identifier an adversarial model slips into
   any section of the output is stripped recursively before returning.

## How it mirrors the existing leaf

Same patterns as `draft_entity_fields`: drafter tier via
`_build_chat_model(role="drafter")`, `model` override, `with_structured_output`
on a titled schema, lazy/shared `langchain_core` imports, and a stable
monkeypatch target for offline tests.

## Tests (TDD, offline)

8 new tests (mocked model — no network): drafter tier + `model` forwarding, a
single bounded structured-output call, populated-plan shape from a doc-like
context, empty context → empty-but-valid plan (no fabrication), no identifier
fields anywhere in the schema, schema convertible to a function-calling tool, and
recursive identifier stripping from adversarial output.

## Gates (all green)

- `uv run ruff check` — All checks passed!
- `uv run --extra langchain ty check` — All checks passed!
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q tests/agents/test_leaves.py` — 20 passed

**Do NOT merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
