### PR TITLE
fix(eval): hydrate config.toml→env for --arch pipeline too (drafter-leaf needs creds) (#179)

### DIFF
--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -143,16 +143,20 @@ def run_main(
     logging.basicConfig(level=logging.INFO)
 
     if agent_factory is None:
-        # LIVE path only. The ReAct factory reads provider/api_key/base_url/model
-        # from the environment (builder.agents.agent_loop), so bridge any creds
-        # kept solely in ~/.config/vitro-crate/config.toml into os.environ first —
-        # mirroring how the interactive CLI hydrates via merge_with_env(). Without
-        # this a live ReAct run with creds only in config.toml raises "No LLM
-        # provider configured" (#179). The deterministic pipeline calls no model,
-        # so it needs no creds; the offline/mock path (injected agent_factory)
-        # skips this entirely so its tests stay config-free.
-        if args.arch == "react":
-            merge_with_env(load_config())
+        # LIVE path only — and BOTH arches need creds. The ReAct factory reads
+        # provider/api_key/base_url/model from the environment
+        # (builder.agents.agent_loop); the deterministic pipeline now does too —
+        # post-#211 its drafter-leaf (builder/agents/leaves.py, via
+        # builder.agents.agent_loop._build_chat_model) reads the same env vars.
+        # So bridge any creds kept solely in ~/.config/vitro-crate/config.toml
+        # into os.environ first — mirroring how the interactive CLI hydrates via
+        # merge_with_env(). Without this, creds-in-config.toml make a live ReAct
+        # run raise "No LLM provider configured", and a live --arch pipeline run
+        # silently no-op the drafter-leaf -> a false-negative A/B comparison
+        # (#179). When no provider is configured both arches still no-op
+        # gracefully. The offline/mock path (injected agent_factory) skips this
+        # entirely so its tests stay config-free.
+        merge_with_env(load_config())
 
         agent_factory = select_agent_factory(
             args.arch,

--- a/eval/tests/test_main_config.py
+++ b/eval/tests/test_main_config.py
@@ -36,12 +36,21 @@ def _mock_factory() -> _MockAgent:
 
 
 class TestLiveConfigHydration:
+    @pytest.mark.parametrize("arch", ["react", "pipeline"])
     def test_live_path_hydrates_config_into_env(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+        self, arch: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
     ) -> None:
         """On the live path (no injected factory) the harness must bridge
         config.toml -> env via ``merge_with_env(load_config())`` before running,
-        so a live run finds creds that live only in the config file."""
+        so a live run finds creds that live only in the config file.
+
+        This must hold for **both** architectures: the ReAct engine and the
+        deterministic pipeline both call a model now — the pipeline's drafter-leaf
+        (``builder/agents/leaves.py``) builds a chat model from env vars
+        (post-#211). Gating hydration on ``--arch react`` would leave a live
+        ``--arch pipeline`` run with no creds, silently no-op the leaf, and yield
+        a false-negative A/B comparison (#179).
+        """
         calls: dict[str, int] = {"load": 0, "merge": 0}
 
         def fake_load_config() -> dict[str, Any]:
@@ -55,26 +64,38 @@ class TestLiveConfigHydration:
         monkeypatch.setattr(eval_main, "load_config", fake_load_config, raising=False)
         monkeypatch.setattr(eval_main, "merge_with_env", fake_merge_with_env, raising=False)
 
-        # Stub the live factory so no real LLM/network is contacted: it returns a
-        # mock agent that builds an empty state. We are only asserting hydration.
+        # Stub BOTH live factories so no real LLM/network is contacted: each
+        # returns a mock agent that builds an empty state. We are only asserting
+        # hydration, which happens before factory selection.
         def fake_make_react_agent_factory(**_: Any) -> Callable[[], _MockAgent]:
             return _mock_factory
 
+        def fake_make_pipeline_agent_factory() -> Callable[[], _MockAgent]:
+            return _mock_factory
+
+        import eval.pipeline_factory as pipeline_factory
         import eval.react_factory as react_factory
 
         monkeypatch.setattr(
             react_factory, "make_react_agent_factory", fake_make_react_agent_factory
         )
+        monkeypatch.setattr(
+            pipeline_factory,
+            "make_pipeline_agent_factory",
+            fake_make_pipeline_agent_factory,
+        )
 
         rc = eval_main.run_main(
-            ["--label", "live-hydration", "--repeats", "1"],
+            ["--arch", arch, "--label", "live-hydration", "--repeats", "1"],
             profile_reader=lambda sid: [],
             out_dir=str(tmp_path),
         )
 
         assert rc == 0
-        assert calls["load"] == 1, "live path must load config.toml exactly once"
-        assert calls["merge"] == 1, "live path must merge config into env exactly once"
+        assert calls["load"] == 1, f"live --arch {arch} must load config.toml exactly once"
+        assert calls["merge"] == 1, (
+            f"live --arch {arch} must merge config into env exactly once"
+        )
 
     def test_offline_path_does_not_require_config(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any


### PR DESCRIPTION
## Problem — false-negative A/B

The A/B harness (`eval/__main__.py`) only bridged `config.toml` credentials into `os.environ` (via `merge_with_env(load_config())`) for **`--arch react`**. The inline comment justified the gate by claiming *"the deterministic pipeline calls no model, so it needs no creds."*

That comment is **stale post-#211**. The pipeline's `_draft_entities` now calls `draft_entity_fields` (`builder/agents/leaves.py`), which builds a chat model from environment variables via `builder.agents.agent_loop._build_chat_model`. Both `config.get_provider()` and `_build_chat_model` read **env only** — `merge_with_env(load_config())` is the bridge that puts `config.toml` creds into the environment.

So a live `python -m eval --arch pipeline` run, with credentials living only in `~/.config/vitro-crate/config.toml` (the normal CLI setup), had **no provider configured**: the drafter-leaf silently no-op'd. The pipeline then looked weaker than it is, yielding a **false-negative A/B comparison** against the `react-baseline` — exactly the signal #179's migration decision depends on.

## Fix

Move `merge_with_env(load_config())` out of the `if args.arch == "react":` gate so it runs for **both** arches, while keeping it inside the existing `if agent_factory is None:` live-path block. The offline/mock path (injected `agent_factory`) stays config-free, and `--arch react` behavior is unchanged. When no provider is configured at all, both arches still no-op gracefully.

The stale comment is updated to explain that both arches need creds now (the pipeline because its drafter-leaf calls a model).

## Tests (TDD)

`eval/tests/test_main_config.py::TestLiveConfigHydration::test_live_path_hydrates_config_into_env` is now parametrized over `["react", "pipeline"]`. The `[pipeline]` case failed against the old gate (`load == 0`) and passes after the fix; both factories are stubbed so no LLM/network is touched. The offline-path test (injected `agent_factory`) still asserts `load_config`/`merge_with_env` are **not** called.

## Gates (all green, memory-constrained, no `-n auto`)

- `uv run ruff check` — passed
- `uv run --extra langchain ty check` — passed
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q tests/ -k "eval or main or agent_factory"` — 69 passed
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q eval/tests/` — 70 passed

## Scope

Edits only `eval/__main__.py` and `eval/tests/test_main_config.py`. No changes to `builder/`, `AGENTS.md`, `eval/corpus.py`, or `eval/pipeline_factory.py`.

**Do NOT merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)