### PR TITLE
test(eval): realistic arbitrary-tox-folder corpus case for the A/B gate (#179)

### DIFF
--- a/eval/corpus.py
+++ b/eval/corpus.py
@@ -43,6 +43,14 @@ _STRUCTURED_INPUT = _REPO_ROOT / "tests" / "fixtures" / "svhps21_input"
 # protocol + a couple of data files + a README, so a build must draft several
 # distinct domain entities rather than just a backbone.
 _DRAFTING_INPUT = _REPO_ROOT / "tests" / "fixtures" / "svhps22_input"
+# A realistic *arbitrary* research folder (Issue #179, decision-gate task 6): the
+# raw documents a researcher actually keeps — a study description, a methods /
+# protocol write-up, a compound list, and nested measurement + analysis CSVs, with
+# NO metadata file. It exercises the full scan -> extract -> materialize -> assess
+# path for both archs, and a *good* build must draft a COMPLETE in-vitro tox study
+# (the four-step process chain), not just a backbone. Lives under eval/ so the
+# A/B owns its own fixture independently of the tests/ end-to-end fixtures.
+_ARBITRARY_TOX_INPUT = _REPO_ROOT / "eval" / "fixtures" / "arbitrary_tox_folder"
 
 
 @dataclass(frozen=True)
@@ -270,6 +278,156 @@ def _drafting_state() -> CrateState:
     return state
 
 
+def _arbitrary_tox_folder_state() -> CrateState:
+    """A *complete* in-vitro tox study — the offline stand-in for a good build.
+
+    This is what a strong agent would materialize from the
+    ``arbitrary_tox_folder`` fixture: not just a backbone + one Exposure, but the
+    full ISA-Tox study described in ``profiles/docs/isa_tox.md`` — the ISA
+    backbone, the contributors, a cell line, a compound, a protocol, the two
+    attached data files, and the **four-step derivation chain** (CellCulture →
+    Exposure → EndpointReadout → DataAnalysis). It is REQUIRED-clean across
+    base/ISA/ISA-Tox *and* satisfies that case's complete-study ``min_entities``
+    quota, so the content-quality signal is exercisable offline with a mock agent.
+
+    The process I/O uses the builder's interchangeable I/O aliases (``samples`` /
+    ``object`` / ``input`` for consumed inputs, ``result`` / ``output`` for
+    produced outputs; see :mod:`builder.tools._crate_mapping`) so the readout's
+    raw File and the analysis's processed File wire onto ``schema:result`` /
+    ``schema:object`` — the MUSTs those two steps would otherwise miss.
+    """
+    from builder.state import CrateState, Entity, EntityProvenance, EntityType
+
+    def _ent(entity_id: str, type_: EntityType, **fields: object) -> Entity:
+        return Entity(
+            entity_id=entity_id,
+            type=type_,
+            fields=fields,
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+
+    title = "TPO inhibition dose-response screen"
+    description = (
+        "A cell-based in vitro assay screening Methimazole for its capacity to "
+        "inhibit thyroid peroxidase (TPO) activity in a TPO-overexpressing FRTL-5 "
+        "rat thyroid follicular cell model, reported as a dose-response IC50."
+    )
+
+    state = CrateState()
+    state.metadata.title = title
+    state.metadata.description = description
+    state.metadata.accession = "ARB-TOX-01"
+
+    # ISA backbone.
+    state.add_entity(
+        _ent("inv", "Investigation", name=title, description=description, identifier="ARB-TOX-01")
+    )
+    state.add_entity(
+        _ent(
+            "study",
+            "Study",
+            name=title,
+            description=description,
+            identifier="ARB-TOX-01",
+            investigation_id="inv",
+            datePublished="2025-11-10",
+        )
+    )
+    state.add_entity(
+        _ent(
+            "assay",
+            "Assay",
+            name="TPO inhibition dose-response assay",
+            identifier="ARB-TOX-01-assay",
+            study_id="study",
+        )
+    )
+
+    # Contributors.
+    state.add_entity(
+        _ent(
+            "author",
+            "Person",
+            name="Marije Vonk",
+            givenName="Marije",
+            familyName="Vonk",
+            orcid="0000-0002-1825-0097",
+        )
+    )
+    state.add_entity(_ent("org", "Organization", name="Universiteit Utrecht"))
+
+    # Domain entities: cell line, compound, protocol.
+    state.add_entity(_ent("cell", "CellLineSample", name="FRTL-5 TPO-overexpressing cells"))
+    state.add_entity(_ent("compound", "MolecularEntity", name="Methimazole"))
+    state.add_entity(
+        _ent("protocol", "LabProtocol", name="Amplex Red fluorometric TPO activity readout")
+    )
+
+    # The raw + processed data files from the fixture folder.
+    state.add_entity(
+        _ent(
+            "raw",
+            "File",
+            name="dose_response_raw.csv",
+            path="measurements/dose_response_raw.csv",
+        )
+    )
+    state.add_entity(
+        _ent("proc", "File", name="ic50_results.csv", path="analysis/ic50_results.csv")
+    )
+
+    # The full four-step derivation chain: CellCulture → Exposure →
+    # EndpointReadout → DataAnalysis.
+    state.add_entity(
+        _ent(
+            "culture",
+            "LabProcess",
+            name="FRTL-5 cell culture",
+            process_type="CellCulture",
+            assay_id="assay",
+            samples="cell",
+            protocol_id="protocol",
+        )
+    )
+    state.add_entity(
+        _ent(
+            "exposure",
+            "LabProcess",
+            name="Methimazole TPO inhibition exposure",
+            process_type="Exposure",
+            assay_id="assay",
+            samples="cell",
+            chemicals="compound",
+            protocol_id="protocol",
+        )
+    )
+    state.add_entity(
+        _ent(
+            "readout",
+            "LabProcess",
+            name="Amplex Red TPO activity readout",
+            process_type="EndpointReadout",
+            assay_id="assay",
+            samples="cell",
+            output="raw",  # the raw measurement File (schema:result MUST)
+            protocol_id="protocol",
+        )
+    )
+    state.add_entity(
+        _ent(
+            "analysis",
+            "LabProcess",
+            name="Dose-response IC50 analysis",
+            process_type="DataAnalysis",
+            assay_id="assay",
+            input="raw",  # raw data consumed (schema:object MUST)
+            output="proc",  # processed-data File produced (schema:result MUST)
+            protocol_id="protocol",
+        )
+    )
+    return state
+
+
 DEFAULT_CORPUS: tuple[EvalCase, ...] = (
     EvalCase(
         case_id="minimal-backbone",
@@ -345,5 +503,55 @@ DEFAULT_CORPUS: tuple[EvalCase, ...] = (
             "this description, validating until base, ISA, and ISA-Tox all pass."
         ),
         build_state=_unstructured_state,
+    ),
+    EvalCase(
+        case_id="arbitrary-tox-folder",
+        description=(
+            "Realistic arbitrary research folder (Issue #179, decision-gate task "
+            "6): scan an in-repo folder of raw documents a researcher actually "
+            "keeps — a study description, a methods/protocol write-up, a compound "
+            "list, and nested measurement + analysis CSVs, with NO metadata file — "
+            "and build the COMPLETE in-vitro tox study. This is the case that "
+            "exercises the full scan -> extract -> materialize -> assess path for "
+            "BOTH archs (not a pre-seeded backbone). Success is the strict "
+            "{base, isa, tox} conformance gate; the additive min_entities quota is "
+            "set to a complete-study floor (the four-step process chain, a cell "
+            "line, a compound, a protocol, the data files) so the A/B compares "
+            "whether the build drafted a WHOLE study, not just that it acted."
+        ),
+        # An arbitrary folder with no metadata file is the unstructured tier — the
+        # whole crate must be elicited from the raw documents the agent scans.
+        kind="unstructured",
+        prompt=(
+            "Scan the provided input folder. Read the study description, the "
+            "methods/protocol write-up, the compound list, and both data files, "
+            "then build the full ISA-Tox RO-Crate for this in-vitro toxicology "
+            "study: the Investigation/Study/Assay backbone; the contributors; the "
+            "test compound and the cell line; the lab protocol; the complete "
+            "four-step process chain (Cell Culture -> Exposure -> Endpoint "
+            "Readout -> Data Analysis) wired to its inputs and outputs; and attach "
+            "the raw measurement and processed-results files. Then build and "
+            "validate until base, ISA, and ISA-Tox all pass."
+        ),
+        input_path=str(_ARBITRARY_TOX_INPUT),
+        build_state=_arbitrary_tox_folder_state,
+        # Complete-study quota (counted from profiles/docs/isa_tox.md): the ISA
+        # backbone is 3 entities (Investigation + Study + Assay); a complete study
+        # adds >= 1 CellLine Sample, >= 1 MolecularEntity (the test chemical), >= 1
+        # LabProtocol, the full four-step LabProcess chain (CellCulture, Exposure,
+        # EndpointReadout, DataAnalysis = 4), and the raw + processed data Files
+        # (>= 2). That is a conservative floor: it demands the WHOLE derivation
+        # chain, so an agent that reaches conformance with only a backbone + one
+        # Exposure (which the strict predicate alone accepts) still misses the bar.
+        min_entities={
+            "Investigation": 1,
+            "Study": 1,
+            "Assay": 1,
+            "CellLineSample": 1,
+            "MolecularEntity": 1,
+            "LabProtocol": 1,
+            "LabProcess": 4,
+            "File": 2,
+        },
     ),
 )

--- a/eval/fixtures/arbitrary_tox_folder/analysis/ic50_results.csv
+++ b/eval/fixtures/arbitrary_tox_folder/analysis/ic50_results.csv
@@ -1,0 +1,2 @@
+compound,cell_line,endpoint,value,unit
+Methimazole,FRTL-5 TPO-overexpressing cells,IC50,2.7,uM

--- a/eval/fixtures/arbitrary_tox_folder/compounds.csv
+++ b/eval/fixtures/arbitrary_tox_folder/compounds.csv
@@ -1,0 +1,2 @@
+name,role,inchikey,cas,pubchem_cid
+Methimazole,test_compound,PMRYVIKBURPHAH-UHFFFAOYSA-N,60-56-0,1349

--- a/eval/fixtures/arbitrary_tox_folder/measurements/dose_response_raw.csv
+++ b/eval/fixtures/arbitrary_tox_folder/measurements/dose_response_raw.csv
@@ -1,0 +1,5 @@
+well,compound,cell_line,concentration_uM,exposure_hours,tpo_activity_rfu
+A1,Methimazole,FRTL-5 TPO-overexpressing cells,0.0,1,18420
+A2,Methimazole,FRTL-5 TPO-overexpressing cells,0.3,1,15110
+A3,Methimazole,FRTL-5 TPO-overexpressing cells,3.0,1,8260
+A4,Methimazole,FRTL-5 TPO-overexpressing cells,30.0,1,2140

--- a/eval/fixtures/arbitrary_tox_folder/methods_protocol.txt
+++ b/eval/fixtures/arbitrary_tox_folder/methods_protocol.txt
@@ -1,0 +1,37 @@
+METHODS / PROTOCOL — TPO inhibition dose-response screen
+========================================================
+
+This describes the full experimental workflow as four steps. A complete in-vitro
+tox study runs the chain: cell culture -> exposure -> endpoint readout -> data
+analysis. Each step below maps onto one process in that chain.
+
+1. CELL CULTURE
+   FRTL-5 TPO-overexpressing rat thyroid follicular cells were maintained in
+   Coon's modified Ham's F-12 medium supplemented with 5% calf serum and a six-
+   hormone mix. Cells were passaged at ~80% confluence and seeded into black
+   96-well microplates the day before exposure.
+   - Culture medium: Coon's modified Ham's F-12 + 5% calf serum
+   - Seeding density: 2.0e4 cells/well
+
+2. EXPOSURE
+   Seeded cells were exposed to Methimazole across a four-point dose series
+   (0, 0.3, 3, 30 uM) for 1 hour at 37 C. Each concentration was a separate well.
+   - Compound: Methimazole
+   - Concentrations: 0, 0.3, 3, 30 uM
+   - Exposure duration: 1 hour
+   - Microplate: black 96-well
+
+3. ENDPOINT READOUT
+   TPO enzymatic activity was measured with an Amplex Red fluorometric assay.
+   Fluorescence (relative fluorescence units, RFU) was read on a plate reader.
+   - Detection instrument: fluorescence microplate reader
+   - Endpoint: TPO activity (RFU)
+   - Assay kit: Amplex Red
+
+4. DATA ANALYSIS
+   Per-well RFU values were normalized to the vehicle control and fitted with a
+   four-parameter log-logistic dose-response model to estimate the IC50.
+   - Computational tool: four-parameter log-logistic fit
+   - Data calculation: vehicle-normalized dose-response, IC50 estimation
+
+Protocol name: Amplex Red fluorometric TPO activity readout

--- a/eval/fixtures/arbitrary_tox_folder/study_description.md
+++ b/eval/fixtures/arbitrary_tox_folder/study_description.md
@@ -1,0 +1,37 @@
+# TPO inhibition screen — study notes
+
+These are my working notes for the in-vitro thyroid peroxidase (TPO) inhibition
+study. This folder is the raw research material as it sat on disk before any
+RO-Crate was built: a description, a methods write-up, a compound list, and the
+measurement files. It is deliberately *arbitrary* — there is no metadata file,
+just the documents a researcher actually keeps.
+
+## What we did
+
+We ran a cell-based in-vitro assay measuring whether a reference chemical inhibits
+thyroid peroxidase (TPO) activity in a TPO-overexpressing rat thyroid follicular
+cell line. The goal was a dose-response IC50 for the reference inhibitor as a
+positive control for the assay.
+
+- Study: TPO inhibition dose-response screen
+- Test system: FRTL-5 TPO-overexpressing rat thyroid follicular cells
+- Endpoint: TPO enzymatic activity (Amplex Red fluorometric readout)
+- Reference compound: Methimazole (a known TPO inhibitor)
+
+## People
+
+- Lead researcher: Marije Vonk (ORCID 0000-0002-1825-0097)
+- Affiliation: Universiteit Utrecht
+
+## Folder contents
+
+- `study_description.md` — this file.
+- `methods_protocol.txt` — culture, exposure, readout and analysis protocol.
+- `compounds.csv` — the chemicals used, with identifiers.
+- `measurements/dose_response_raw.csv` — per-well raw fluorescence at each dose.
+- `analysis/ic50_results.csv` — the fitted IC50 result for the compound.
+
+No real experimental data is committed — the numbers are small and synthetic. This
+folder is a deterministic, offline input fixture for the A/B evaluation harness
+(Issue #179): a realistic *arbitrary* research folder that exercises the full
+scan -> extract -> materialize -> assess path, not a pre-seeded backbone.

--- a/eval/tests/test_corpus.py
+++ b/eval/tests/test_corpus.py
@@ -30,8 +30,10 @@ class TestEvalCase:
 
 
 class TestDefaultCorpus:
-    def test_is_non_empty_and_sized_three_to_four(self) -> None:
-        assert 3 <= len(DEFAULT_CORPUS) <= 4
+    def test_is_non_empty_and_sized_three_to_five(self) -> None:
+        # Three input tiers, plus the two richer structured/arbitrary cases that
+        # carry a min_entities content-quality floor (Issue #179).
+        assert 3 <= len(DEFAULT_CORPUS) <= 5
 
     def test_case_ids_are_unique(self) -> None:
         ids = [c.case_id for c in DEFAULT_CORPUS]

--- a/eval/tests/test_corpus_arbitrary_tox_folder.py
+++ b/eval/tests/test_corpus_arbitrary_tox_folder.py
@@ -1,0 +1,158 @@
+"""Tests for the realistic *arbitrary tox folder* corpus case (Issue #179).
+
+The existing structured cases scan a thin README-plus-CSV folder. The decision
+gate (epic #179, task 6) wants the A/B to exercise the full
+``scan -> extract -> materialize -> assess`` path over a *realistic* arbitrary
+research folder — a few raw documents a researcher actually keeps (a study
+description, a methods/protocol write-up, a compound list, and the measurement
+files) — so a good build must draft the complete in-vitro tox chain, not just a
+backbone.
+
+These tests are structural and fully offline: they assert the new case loads, its
+fixture files exist and are discoverable, its ``min_entities`` floor is set to a
+defensible *complete-study* bar, and ``meets_entity_quota`` works for it. They do
+**not** run a live LLM or the network. The conformance-touching build_state test
+carries the harness 120s timeout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eval.corpus import (
+    DEFAULT_CORPUS,
+    EvalCase,
+    meets_entity_quota,
+    reaches_isa_tox_conformance,
+)
+
+CASE_ID = "arbitrary-tox-folder"
+
+
+def _case() -> EvalCase:
+    match = [c for c in DEFAULT_CORPUS if c.case_id == CASE_ID]
+    assert match, f"expected an {CASE_ID!r} case in the corpus"
+    return match[0]
+
+
+class TestArbitraryToxFolderCaseRegistered:
+    """The realistic arbitrary-folder case is present and well-formed."""
+
+    def test_case_is_in_the_corpus(self) -> None:
+        case = _case()
+        # An arbitrary research folder with no metadata file is the unstructured
+        # tier: the whole crate must be elicited from raw docs the agent scans.
+        assert case.kind == "unstructured"
+        assert case.prompt, "the arbitrary-folder case must carry a prompt"
+
+    def test_case_scans_a_folder_so_the_full_path_runs(self) -> None:
+        # The case feeds its input by pointing input_path at a folder, so the
+        # harness runs scan -> extract -> materialize -> assess for BOTH archs.
+        case = _case()
+        assert case.input_path is not None, (
+            "the case must scan a folder (input_path) so the build runs the full "
+            "scan->extract->materialize path, not a pre-seeded backbone"
+        )
+        root = Path(case.input_path)
+        assert root.is_dir(), f"{case.input_path} must be an in-repo directory"
+
+    def test_fixture_ships_realistic_arbitrary_research_docs(self) -> None:
+        case = _case()
+        root = Path(case.input_path or "")
+        # A realistic folder: a study description, a methods/protocol doc, a
+        # compound list, and at least one measurements + one results file.
+        assert (root / "study_description.md").is_file()
+        assert (root / "methods_protocol.txt").is_file()
+        assert (root / "compounds.csv").is_file()
+
+    def test_fixture_files_are_discoverable_by_a_recursive_scan(self) -> None:
+        # The scanner walks the folder recursively; the data files live in
+        # subdirectories, so a recursive discovery must find them.
+        case = _case()
+        root = Path(case.input_path or "")
+        csvs = [p for p in root.rglob("*.csv") if p.is_file()]
+        assert len(csvs) >= 2, "expected at least a measurements and a results CSV"
+        # The measurement/analysis files are nested, proving recursion matters.
+        nested = [p for p in csvs if p.parent != root]
+        assert nested, "at least one data file should be in a subdirectory"
+
+    def test_case_declares_a_complete_study_entity_quota(self) -> None:
+        case = _case()
+        assert case.min_entities is not None, (
+            "the arbitrary-folder case must declare min_entities so the A/B "
+            "measures whether the build drafted a COMPLETE study"
+        )
+        q = case.min_entities
+        # A complete in-vitro tox study (profiles/docs/isa_tox.md): the ISA
+        # backbone, a cell line, a compound, a protocol, the four-step process
+        # chain, and the raw + processed data files.
+        assert q.get("Investigation", 0) >= 1
+        assert q.get("Study", 0) >= 1
+        assert q.get("Assay", 0) >= 1
+        assert q.get("CellLineSample", 0) >= 1
+        assert q.get("MolecularEntity", 0) >= 1
+        assert q.get("LabProtocol", 0) >= 1
+        # The full derivation chain is four LabProcess steps (CellCulture ->
+        # Exposure -> EndpointReadout -> DataAnalysis).
+        assert q.get("LabProcess", 0) >= 4
+        # Raw + processed data files attached.
+        assert q.get("File", 0) >= 2
+
+
+class TestArbitraryToxFolderQuota:
+    """The quota floor behaves as a pure content-quality check for this case."""
+
+    def test_empty_backbone_misses_the_complete_study_quota(self) -> None:
+        from builder.state import CrateState, Entity, EntityProvenance, EntityType
+
+        def _ent(eid: str, t: EntityType, **f: object) -> Entity:
+            return Entity(
+                entity_id=eid,
+                type=t,
+                fields=f,
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+
+        # A conformant-shaped backbone with a single Exposure (what a thin build
+        # produces) must FALL SHORT of the complete-study quota — that is the
+        # whole point of demanding the full chain.
+        state = CrateState()
+        state.add_entity(_ent("inv", "Investigation", name="x"))
+        state.add_entity(_ent("study", "Study", name="x"))
+        state.add_entity(_ent("assay", "Assay", name="x"))
+        state.add_entity(_ent("cell", "CellLineSample", name="c"))
+        state.add_entity(_ent("compound", "MolecularEntity", name="m"))
+        state.add_entity(
+            _ent("exp", "LabProcess", name="e", process_type="Exposure")
+        )
+
+        result = meets_entity_quota(state, _case().min_entities)
+        assert result["meets_quota"] is False
+        # It is short the protocol, three of the four process steps, and the files.
+        assert result["missing"].get("LabProtocol", 0) >= 1
+        assert result["missing"].get("LabProcess", 0) >= 3
+        assert result["missing"].get("File", 0) >= 2
+
+
+@pytest.mark.timeout(120)
+class TestArbitraryToxFolderBuildState:
+    """The case's mock build_state both conforms AND meets its own quota.
+
+    This is the offline stand-in a *good* agent would produce from the folder: it
+    must satisfy BOTH the strict ``{base, isa, tox}`` predicate and the complete-
+    study quota, so the quality signal is exercisable end to end without a model.
+    """
+
+    def test_build_state_reaches_conformance_and_meets_quota(self) -> None:
+        case = _case()
+        assert case.build_state is not None
+        state = case.build_state()
+
+        predicate = reaches_isa_tox_conformance(state)
+        assert predicate["success"] is True, predicate["issues"]
+        assert predicate["conformance"] == {"base": True, "isa": True, "tox": True}
+
+        quota = meets_entity_quota(state, case.min_entities)
+        assert quota["meets_quota"] is True, quota["missing"]


### PR DESCRIPTION
## Why

Epic #179 (ReAct-vs-pipeline decision gate), task 6. The existing corpus cases
either start from a pre-seeded backbone or scan a thin README-plus-CSV folder.
This adds a realistic **arbitrary toxicology research folder** so the A/B gate
exercises the full **scan -> extract -> materialize -> assess** path and is judged
on whether each architecture can build a *complete* in-vitro tox study from raw
docs, not just whether it acted.

Scope is `eval/` only (corpus + fixtures + tests). No `builder/`, `pipeline.py`,
`guidance.py`, or `AGENTS.md` changes — `EvalCase`/runner already support a
folder/scan input via `input_path`, so no harness extension was needed.

## Fixture contents — `eval/fixtures/arbitrary_tox_folder/`

The raw documents a researcher actually keeps, with **no metadata file** (an
arbitrary, unstructured folder). Thyroid TPO-inhibition study, but the *structure*
is domain-general — no thyroid-specific hacks:

- `study_description.md` — study notes: what was done, the test system (FRTL-5
  TPO-overexpressing cells), the endpoint, the reference compound (Methimazole),
  the people.
- `methods_protocol.txt` — the protocol as the four workflow steps (Cell Culture
  -> Exposure -> Endpoint Readout -> Data Analysis), each with its parameters.
- `compounds.csv` — the chemical list with identifiers (InChIKey, CAS, PubChem).
- `measurements/dose_response_raw.csv` — per-well raw fluorescence at each dose.
- `analysis/ic50_results.csv` — the fitted IC50 result.

The two data files are nested in subdirectories, so a **recursive** scan is
required to find them. All numbers are small and synthetic; no real data committed.

## `min_entities` justification (the A/B quality bar)

Counted from `profiles/docs/isa_tox.md` (what a COMPLETE in-vitro tox study
contains). The floor demands the whole derivation chain, so an agent that reaches
`{base, isa, tox}` conformance with only a backbone + one Exposure (which the
strict success predicate alone accepts) still misses the bar:

| Type | Floor | Rationale |
|------|-------|-----------|
| Investigation / Study / Assay | 1 / 1 / 1 | the ISA backbone (3) |
| CellLineSample | 1 | the cell-based test system |
| MolecularEntity | 1 | the test chemical |
| LabProtocol | 1 | the executed protocol |
| LabProcess | **4** | the full chain: CellCulture -> Exposure -> EndpointReadout -> DataAnalysis |
| File | 2 | the raw measurement + processed-results files |

`min_entities` is the additive content-quality signal only; it never changes the
success predicate (still strict `{base, isa, tox}` conformance).

## Tests (offline — no network, no live LLM)

New `eval/tests/test_corpus_arbitrary_tox_folder.py`:
- the case loads and is the unstructured tier with a prompt and an `input_path`;
- its fixture files exist and are discoverable by a recursive scan (nested CSVs);
- the complete-study `min_entities` floor is set;
- a backbone-plus-one-Exposure state **misses** the quota (the failure mode the
  case is designed to catch);
- the mock `build_state` both reaches `{base, isa, tox}` conformance AND meets its
  own quota.

The corpus-size bound in `test_corpus.py` is widened from 3..4 to 3..5.

## Gates (memory-constrained, no `-n auto`)

- `uv run ruff check` — passed
- `uv run --extra langchain ty check` — passed
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q eval/tests/ tests/ -k "corpus or eval or runner"` — **84 passed**

**Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)