### PR TITLE
feat(pipeline): materialize extracted plan via composites (#179 task 2b-B)

### DIFF
--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -74,6 +74,22 @@ def draft_entity_fields(
     return _leaf(entity_type, context, model=model)
 
 
+def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
+    """Lazy, no-op-safe shim over :func:`builder.agents.leaves.extract_plan`.
+
+    Stage A of the §14 hybrid loop: the whole-document candidate-plan extractor.
+    Mirrors the :func:`draft_entity_fields` shim — the real leaf imports
+    ``langchain_core`` at module load, so the deterministic spine must import it
+    lazily (inside this shim) and only ever after :func:`_materialize_plan` has
+    confirmed an LLM provider is configured. Defining the leaf as a module-level
+    attribute here also gives tests a stable monkeypatch target
+    (``builder.agents.pipeline.extract_plan``).
+    """
+    from builder.agents.leaves import extract_plan as _leaf
+
+    return _leaf(context, model=model)
+
+
 # Fields the drafter-leaf result must NEVER write onto a state entity (D5: Verify,
 # Don't Trust). The leaf already prunes identifier-bearing fields from the schema
 # the model sees and strips them from its output; we defend in depth here so the
@@ -304,6 +320,229 @@ def _draft_entities(engine: AgentEngine) -> dict[str, Any]:
     return {"drafted": drafted, "fields_applied": fields_applied}
 
 
+# The id of the scaffolded Assay / Study the materialized chain / AOP wire onto.
+# Resolved from state (the backbone is scaffolded first) so the chain and AOP
+# subgraph hang off the real backbone rather than minting an orphan one.
+def _first_entity_id(engine: AgentEngine, entity_type: str) -> str | None:
+    """entity_id of the first state entity of *entity_type*, or ``None``."""
+    return next(
+        (e.entity_id for e in engine.state.list_entities() if e.type == entity_type),
+        None,
+    )
+
+
+def _split_person_name(name: str) -> tuple[str, str]:
+    """Split a full name into ``(givenName, familyName)`` deterministically.
+
+    A purely descriptive parse of the plan's name (no identifier involved, so
+    D5-safe): the last whitespace-separated token is the family name and the rest
+    is the given name. ISA REQUIRES a non-empty given name on a Person, so a
+    single-token name maps wholesale to the given name (family left empty). Used
+    to make a plan-materialized Person ISA-conformant without an external lookup.
+    """
+    parts = name.split()
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return " ".join(parts[:-1]), parts[-1]
+
+
+def _materialize_plan(engine: AgentEngine) -> dict[str, Any]:
+    """Stage B (§14) — materialize the extracted candidate plan via composites.
+
+    Bridges the bounded whole-document extractor (:func:`extract_plan`, Stage A)
+    to the deterministic materialization composites: it gathers the same
+    free-text ``context`` the drafter-leaf uses, asks the leaf for a CANDIDATE
+    PLAN (names only — no identifiers), then deterministically turns each plan
+    section into real ISA-Tox entities by calling the **idempotent** composites
+    *through the engine*. It never re-implements tool logic and never hand-rolls
+    JSON-LD.
+
+    Plan → composite mapping (each call wrapped in ``try/except`` so one failing
+    section never breaks the spine — the failure is logged and the next section
+    proceeds):
+
+    * ``study`` → :func:`scaffold_isa_backbone` (idempotent; reuses the backbone
+      scaffolded in step 1, only filling a Study name/description from the plan).
+    * each ``compounds[]`` → :func:`resolve_compound` (mints the
+      ``MolecularEntity`` and its **verified** identifiers; the plan supplies the
+      NAME only — D5).
+    * each ``cell_lines[]`` → ``draft_cell_line_sample`` (a ``CellLineSample``
+      from the name only; the Cellosaurus accession is a later lookup, not the
+      plan).
+    * ``process_chain[]`` → ONE :func:`draft_process_chain` onto the scaffolded
+      Assay, mapping each step's ``process_type`` / ``name`` / hints (the
+      composite synthesizes EndpointReadout / DataAnalysis outputs).
+    * each ``aops[]`` → :func:`materialize_aop_subgraph` onto the scaffolded
+      Study (the only model input is the numeric ``aop_id``; every node id comes
+      from AOP-Wiki — D5).
+    * each ``people[]`` → ``draft_person`` with the name plus a deterministic
+      ``givenName`` / ``familyName`` split of that name (ISA REQUIRES a non-empty
+      given name; splitting a name is descriptive parsing, not identifier
+      fabrication, so it is D5-safe). ORCID stays empty for a later lookup.
+    * each ``publications[]`` is **deferred, not materialized.** A plan carries a
+      title ONLY (D5 — no DOI), but ISA REQUIRES a ScholarlyArticle to have an
+      identifier and BASE requires the auto-wired root ``citation`` @id to be an
+      absolute URI — both unreachable from a title alone without fabricating a
+      DOI. Per D5 (Verify, Don't Trust) we never invent that DOI here; the title
+      is surfaced under ``publications_deferred`` for a later
+      ``draft_publication_with_authors(doi=...)`` once a DOI is resolved. This
+      follows the project's design docs over the literal task wording, which
+      conflict on this one point (see ``.claude/CLAUDE.md``: "follow the
+      documents and say so").
+
+    Guarantees:
+
+    * **No-op when no LLM provider is configured** (the same
+      :func:`builder.config.get_provider` gate :func:`_draft_entities` uses) and
+      **no-op when there is no usable context** — Stage A is never called, so the
+      deterministic spine and its tests are unchanged.
+    * **D5 (Verify, Don't Trust).** Only plan *names/titles* reach the composites;
+      identifiers are produced by the composites' own lookups/verification and
+      are never set or overwritten from the plan. ``extract_plan`` already strips
+      identifiers from the plan; this step never re-introduces them.
+    * **Idempotent.** Every composite reuses an existing entity (deterministic
+      ids), so re-running the spine mints no duplicates.
+
+    Returns ``{"study", "compounds", "cell_lines", "processes", "aops",
+    "people", "publications", "publications_deferred"}`` — per-section counts of
+    what was materialized, plus the titles of publications deferred for a later
+    DOI lookup (``publications`` is therefore always ``0`` in this stage).
+    """
+    result: dict[str, Any] = {
+        "study": 0,
+        "compounds": 0,
+        "cell_lines": 0,
+        "processes": 0,
+        "aops": 0,
+        "people": 0,
+        "publications": 0,
+        "publications_deferred": [],
+    }
+
+    # Gate 1 — provider must be configured, else strict no-op (deterministic spine).
+    if get_provider() is None:
+        return result
+
+    # Gate 2 — there must be usable context to plan from, else strict no-op.
+    context = _gather_context(engine)
+    if not context:
+        return result
+
+    try:
+        plan = extract_plan(context)
+    except Exception as exc:  # noqa: BLE001 - a flaky extractor must not break the spine
+        logger.warning("extract_plan failed; skipping materialization: %s", exc)
+        return result
+    if not isinstance(plan, dict):
+        return result
+
+    # --- study: merge the plan's name/description into the scaffolded backbone ---
+    study_plan = plan.get("study")
+    if isinstance(study_plan, dict) and (study_plan.get("name") or study_plan.get("description")):
+        study_hints = {
+            key: study_plan[key]
+            for key in ("name", "description")
+            if str(study_plan.get(key) or "").strip()
+        }
+        try:
+            engine.run_tool("scaffold_isa_backbone", study=study_hints)
+            result["study"] = 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("scaffold_isa_backbone (plan study) failed: %s", exc)
+
+    # --- compounds: resolve_compound mints the MolecularEntity + verified ids ---
+    for compound in plan.get("compounds") or []:
+        name = str((compound or {}).get("name") or "").strip()
+        if not name:
+            continue
+        try:
+            # D5: only the NAME is passed; identifiers come from the lookup.
+            engine.run_tool("resolve_compound", name=name)
+            result["compounds"] += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("resolve_compound failed for %r: %s", name, exc)
+
+    # --- cell lines: a CellLineSample from the name only (accession is a lookup) ---
+    for cell_line in plan.get("cell_lines") or []:
+        name = str((cell_line or {}).get("name") or "").strip()
+        if not name:
+            continue
+        try:
+            engine.run_tool("draft_cell_line_sample", name=name, hints={})
+            result["cell_lines"] += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("draft_cell_line_sample failed for %r: %s", name, exc)
+
+    # --- process chain: ONE draft_process_chain onto the scaffolded Assay ---
+    assay_id = _first_entity_id(engine, "Assay")
+    chain_steps = [
+        {
+            "process_type": step["process_type"],
+            **(
+                {"hints": {"name": step["name"]}}
+                if str((step or {}).get("name") or "").strip()
+                else {}
+            ),
+        }
+        for step in (plan.get("process_chain") or [])
+        if isinstance(step, dict) and step.get("process_type")
+    ]
+    if assay_id and chain_steps:
+        try:
+            chain_result = engine.run_tool(
+                "draft_process_chain", assay_id=assay_id, chain=chain_steps
+            )
+            result["processes"] = len(chain_result.get("process_ids") or [])
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("draft_process_chain failed: %s", exc)
+
+    # --- AOPs: materialize each subgraph and wire it onto the scaffolded Study ---
+    study_id = _first_entity_id(engine, "Study")
+    for aop in plan.get("aops") or []:
+        aop_id = str((aop or {}).get("aop_id") or "").strip()
+        if not aop_id:
+            continue
+        try:
+            aop_result = engine.run_tool(
+                "materialize_aop_subgraph", aop_id=aop_id, study_id=study_id
+            )
+            if aop_result.get("aop_entity_id"):
+                result["aops"] += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("materialize_aop_subgraph failed for %r: %s", aop_id, exc)
+
+    # --- people: a Person from the name + a deterministic given/family split ---
+    for person in plan.get("people") or []:
+        name = str((person or {}).get("name") or "").strip()
+        if not name:
+            continue
+        given, family = _split_person_name(name)
+        # ISA REQUIRES a non-empty given name; the split is descriptive parsing of
+        # the plan's name, not identifier fabrication (D5-safe). ORCID stays empty.
+        person_hints = {"givenName": given}
+        if family:
+            person_hints["familyName"] = family
+        try:
+            engine.run_tool("draft_person", name=name, hints=person_hints)
+            result["people"] += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("draft_person failed for %r: %s", name, exc)
+
+    # --- publications: DEFERRED, not materialized (D5). A plan carries a title
+    # only, but ISA REQUIRES a ScholarlyArticle identifier and BASE requires the
+    # auto-wired root citation @id to be an absolute URI — neither reachable from
+    # a title without fabricating a DOI, which D5 forbids. Surface the titles for a
+    # later draft_publication_with_authors(doi=...) once a DOI is resolved. ---
+    for publication in plan.get("publications") or []:
+        title = str((publication or {}).get("title") or "").strip()
+        if title:
+            result["publications_deferred"].append(title)
+
+    return result
+
+
 def _run_fix_loop(engine: AgentEngine) -> tuple[dict[str, Any], int]:
     """Step 4 — bounded deterministic fix loop.
 
@@ -350,10 +589,12 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
 
     The engine MUST already be :meth:`~builder.engine.AgentEngine.initialize`-d
     (so scanning + approved-roots have happened). The spine then runs, in code:
-    scaffold backbone → draft entities → build_and_validate → bounded fix loop.
+    scaffold backbone → materialize plan → draft entities → build_and_validate →
+    bounded fix loop.
 
     No LLM decides control flow. With **no LLM provider configured** every step is
-    deterministic (the drafter-leaf step is a strict no-op), so the same input
+    deterministic (the materialize-plan and drafter-leaf steps are strict no-ops),
+    so the same input
     state yields the same built crate — the determinism guarantee the deterministic
     A/B path of the eval harness asserts. When a provider is configured, the
     bounded drafter-leaf (step 2) enriches entities with descriptive content.
@@ -364,12 +605,14 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
             through the engine (so they are profiled and validation is cached).
 
     Returns:
-        ``{"ok", "conformance", "issues", "scaffold", "drafted", "fix_rounds"}`` —
-        the final ``build_and_validate`` verdict (``ok`` / per-layer
-        ``conformance`` / routed ``issues``) plus a small trace of what each step
-        did. ``conformance`` always carries the ``base`` / ``isa`` / ``tox`` keys.
+        ``{"ok", "conformance", "issues", "scaffold", "materialized", "drafted",
+        "fix_rounds"}`` — the final ``build_and_validate`` verdict (``ok`` /
+        per-layer ``conformance`` / routed ``issues``) plus a small trace of what
+        each step did. ``conformance`` always carries the ``base`` / ``isa`` /
+        ``tox`` keys.
     """
     scaffold = _scaffold_backbone(engine)
+    materialized = _materialize_plan(engine)
     drafted = _draft_entities(engine)
     validation, fix_rounds = _run_fix_loop(engine)
 
@@ -378,6 +621,7 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
         "conformance": validation.get("conformance", {}),
         "issues": validation.get("issues", []),
         "scaffold": scaffold,
+        "materialized": materialized,
         "drafted": drafted,
         "fix_rounds": fix_rounds,
     }

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -279,6 +279,317 @@ class TestDraftEntitiesWiring:
         assert result.get("fields_applied") == 0
 
 
+class TestMaterializePlan:
+    """Stage B (`_materialize_plan`) turns the extracted candidate plan into real
+    domain entities via the deterministic composites (Issue #179 task 2b-B).
+
+    `extract_plan` (the whole-document leaf) is STUBBED at its pipeline import
+    site — no model, no network — and the composites' own lookups
+    (`lookup_compound` / `verify_identifier` / `lookup_aop`) are stubbed too, so
+    these tests are fully offline. The contract under test:
+
+    * a canned plan materializes the expected MolecularEntity / CellLineSample /
+      LabProcess chain / AOP subgraph / Person / Publication entities in state;
+    * with NO provider configured, the step is a STRICT no-op;
+    * with a provider but NO usable context, the step is a strict no-op;
+    * D5 — no identifier from the plan is ever set on an entity; identifiers come
+      only from the composites' lookups/verification;
+    * idempotent — running the spine twice produces no duplicates;
+    * `run_pipeline` still reaches `{base, isa, tox}` conformance with a plan.
+    """
+
+    _PLAN: dict = {
+        "study": {"name": "TPO inhibition study", "description": "A TPO assay."},
+        "compounds": [
+            {"name": "Methimazole", "role": "test"},
+            {"name": "Sodium iodide", "role": "control"},
+        ],
+        "cell_lines": [{"name": "FRTL-5"}],
+        "process_chain": [
+            {"process_type": "CellCulture", "name": "Seed cells"},
+            {"process_type": "Exposure", "name": "Dose"},
+            {"process_type": "EndpointReadout", "name": "Read TPO"},
+            {"process_type": "DataAnalysis", "name": "Fit dose-response"},
+        ],
+        "aops": [{"aop_id": "610"}],
+        "people": [{"name": "Ada Lovelace", "affiliation_name": "Analytical Engine"}],
+        "publications": [{"title": "On TPO inhibition in vitro"}],
+        "files": [{"path": "data/raw.csv", "role": "raw"}],
+        "notes": "Confirm the control compound role.",
+    }
+
+    def _titled_state(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "TPO inhibition dose-response screen"
+        state.metadata.description = "A cell-based in vitro TPO inhibition assay."
+        return state
+
+    def _enable_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+    def _stub_extract_plan(
+        self, monkeypatch: pytest.MonkeyPatch, plan: dict | None = None
+    ) -> list[str]:
+        """Patch the pipeline's `extract_plan` shim to return a canned plan."""
+        import builder.agents.pipeline as pipeline_mod
+
+        seen: list[str] = []
+
+        def fake_extract_plan(context, *, model=None):
+            seen.append(context)
+            return dict(self._PLAN if plan is None else plan)
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", fake_extract_plan)
+        return seen
+
+    def _stub_lookups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub every network lookup the composites would otherwise hit."""
+        import builder.tools.composites as composites_mod
+        from builder.tools import lookups as tool_lookups
+
+        # resolve_compound -> lookup_compound (imported into composites' namespace).
+        def fake_lookup_compound(name):
+            return {
+                "found": True,
+                "data": {
+                    "cas": "60-56-0",
+                    "pubchem_cid": "1349907",
+                    "smiles": "C1=CN(C(=S)N1)C",
+                    "source": "pubchem",
+                },
+                "error": None,
+            }
+
+        # verify_identifier marks the field verified without touching the network.
+        def fake_verify_identifier(state, entity_id, field):
+            ent = state.get_entity(entity_id)
+            if ent is not None:
+                ent.set_field_status(field, "verified", "lookup")
+            return {"verified": True, "entity_id": entity_id, "field": field, "message": "ok"}
+
+        # materialize_aop_subgraph -> lookup_aop (imported lazily from tool_lookups).
+        def fake_lookup_aop(aop_id):
+            iri = f"https://aopwiki.org/aops/{aop_id}"
+            mie = "https://aopwiki.org/events/1"
+            ao = "https://aopwiki.org/events/2"
+            ker = "https://aopwiki.org/relationships/1"
+            return {
+                "found": True,
+                "data": {
+                    "aop": {
+                        "@id": iri,
+                        "@type": "AdverseOutcomePathway",
+                        "name": f"AOP {aop_id}",
+                        "identifier": str(aop_id),
+                        "url": iri,
+                        "has_molecular_initiating_event": [{"@id": mie}],
+                        "has_adverse_outcome": [{"@id": ao}],
+                        "has_key_event_relationship": [{"@id": ker}],
+                    },
+                    "events": [
+                        {"@id": mie, "@type": "KeyEvent", "name": "MIE",
+                         "eventType": "Molecular Initiating Event"},
+                        {"@id": ao, "@type": "KeyEvent", "name": "AO",
+                         "eventType": "Adverse Outcome"},
+                    ],
+                    "relationships": [
+                        {"@id": ker, "@type": "KeyEventRelationship",
+                         "upstream_event": {"@id": mie},
+                         "downstream_event": {"@id": ao}},
+                    ],
+                },
+                "error": None,
+            }
+
+        monkeypatch.setattr(composites_mod, "lookup_compound", fake_lookup_compound)
+        monkeypatch.setattr(composites_mod, "verify_identifier", fake_verify_identifier)
+        monkeypatch.setattr(tool_lookups, "lookup_aop", fake_lookup_aop)
+
+    def _by_type(self, engine: AgentEngine, type_name: str) -> list[Entity]:
+        return [e for e in engine.state.list_entities() if e.type == type_name]
+
+    def test_materializes_plan_entities(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        seen = self._stub_extract_plan(monkeypatch)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        # Scaffold first so the assay/study ids exist for the chain/aop wiring.
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # The leaf saw the real gathered context (the crate title).
+        assert seen and any("TPO inhibition" in ctx for ctx in seen)
+
+        # Compounds → MolecularEntity (one per plan compound).
+        chems = self._by_type(engine, "MolecularEntity")
+        assert {c.fields.get("name") for c in chems} == {"Methimazole", "Sodium iodide"}
+
+        # Cell line → CellLineSample.
+        cells = self._by_type(engine, "CellLineSample")
+        assert [c.fields.get("name") for c in cells] == ["FRTL-5"]
+
+        # Process chain → 4 LabProcess steps wired to the assay.
+        procs = self._by_type(engine, "LabProcess")
+        ptypes = {p.fields.get("process_type") for p in procs}
+        assert ptypes == {"CellCulture", "Exposure", "EndpointReadout", "DataAnalysis"}
+
+        # AOP → AdverseOutcomePathway subgraph.
+        assert self._by_type(engine, "AdverseOutcomePathway")
+        assert self._by_type(engine, "KeyEvent")
+
+        # Person from the name, with a deterministic given/family split so it is
+        # ISA-conformant (a non-empty given name is REQUIRED). No ORCID (D5).
+        people = self._by_type(engine, "Person")
+        ada = next(p for p in people if p.fields.get("name") == "Ada Lovelace")
+        assert ada.fields.get("givenName") == "Ada"
+        assert ada.fields.get("familyName") == "Lovelace"
+        assert not ada.fields.get("orcid")
+
+        # Publications are DEFERRED (title-only cannot be ISA-conformant without a
+        # fabricated DOI — D5), so no Publication entity is minted; the title is
+        # surfaced for a later DOI lookup instead.
+        assert self._by_type(engine, "Publication") == []
+        assert "On TPO inhibition in vitro" in result["publications_deferred"]
+        assert result["publications"] == 0
+
+        # The result is informative (per-section counts).
+        assert result["compounds"] >= 2
+        assert result["cell_lines"] >= 1
+        assert result["processes"] >= 1
+        assert result["aops"] >= 1
+        assert result["people"] >= 1
+
+    def test_d5_no_fabricated_identifiers_from_plan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """D5: identifiers come from the composites' lookups, never the plan.
+
+        The plan carries only names. A MolecularEntity's `cas`/`pubchem_cid` must
+        be the LOOKED-UP value (here the stubbed `60-56-0` / `1349907`), and a
+        fabricated DOI an adversarial plan smuggles in must never land on any
+        entity (the title-only publication is deferred, not materialized).
+        """
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        # A plan that adversarially tries to smuggle identifiers (should be ignored
+        # by the materialization — names only are passed to the composites).
+        plan = {
+            "compounds": [{"name": "Methimazole", "role": "test", "cas": "FAKE-CAS"}],
+            "publications": [{"title": "Some paper", "doi": "10.0/FAKE"}],
+        }
+        self._stub_extract_plan(monkeypatch, plan)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        chem = self._by_type(engine, "MolecularEntity")[0]
+        # The CAS is the looked-up value, NOT the plan's fabricated one.
+        assert chem.fields.get("cas") == "60-56-0"
+        assert chem.fields.get("cas") != "FAKE-CAS"
+
+        # The publication is deferred (title surfaced) and no entity carries the
+        # plan's fabricated DOI anywhere in state.
+        assert "Some paper" in result["publications_deferred"]
+        for ent in engine.state.list_entities():
+            assert ent.fields.get("identifier") != "10.0/FAKE"
+            assert ent.fields.get("doi") != "10.0/FAKE"
+
+    def test_no_provider_is_strict_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: None)
+
+        def boom(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("extract_plan must not run without a provider")
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", boom)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        before = {e.entity_id for e in engine.state.list_entities()}
+        result = pipeline_mod._materialize_plan(engine)
+        after = {e.entity_id for e in engine.state.list_entities()}
+        assert before == after, "no-provider _materialize_plan must mint nothing"
+        assert result.get("compounds") == 0
+        assert result.get("aops") == 0
+
+    def test_no_context_is_strict_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+
+        def boom(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("extract_plan must not run without context")
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", boom)
+
+        # Untitled / undescribed / unscanned crate carries no usable context.
+        engine = _engine(CrateState())
+        pipeline_mod._scaffold_backbone(engine)
+        before = {e.entity_id for e in engine.state.list_entities()}
+        result = pipeline_mod._materialize_plan(engine)
+        after = {e.entity_id for e in engine.state.list_entities()}
+        assert before == after, "no-context _materialize_plan must mint nothing"
+        assert result.get("compounds") == 0
+
+    def test_idempotent_no_duplicates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+        counts_1 = {
+            t: len(self._by_type(engine, t))
+            for t in ("MolecularEntity", "CellLineSample", "LabProcess",
+                      "AdverseOutcomePathway", "KeyEvent", "Person", "Publication")
+        }
+        # Re-run on the SAME engine — composites are idempotent, so no dups.
+        pipeline_mod._materialize_plan(engine)
+        counts_2 = {
+            t: len(self._by_type(engine, t))
+            for t in ("MolecularEntity", "CellLineSample", "LabProcess",
+                      "AdverseOutcomePathway", "KeyEvent", "Person", "Publication")
+        }
+        assert counts_1 == counts_2
+
+    def test_run_pipeline_with_plan_reaches_conformance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from builder.agents.pipeline import run_pipeline
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch)
+        self._stub_lookups(monkeypatch)
+        # Keep the field-enrichment leaf a no-op (it is separately tested) so this
+        # test isolates materialization + the existing build/fix path.
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(
+            pipeline_mod, "draft_entity_fields", lambda *a, **k: {}
+        )
+
+        engine = _engine(self._titled_state())
+        result = run_pipeline(engine)
+
+        assert result["conformance"] == {"base": True, "isa": True, "tox": True}
+        assert result["ok"] is True
+        # The materialized plan is reflected in the result trace.
+        assert "materialized" in result
+        assert result["materialized"]["compounds"] >= 2
+
+
 class TestDeterminism:
     def test_identical_graph_hash_across_runs(self) -> None:
         """Same input ⇒ identical built @graph hash — the headline win to assert."""


### PR DESCRIPTION
## Stage B "Materialize" of the §14 hybrid build loop (#179 task 2b-B)

Makes the deterministic spine turn the extracted candidate plan into real domain
entities via the idempotent composites. A new `_materialize_plan(engine)` step
runs between the ISA-backbone **scaffold** and the existing **build/validate +
fix loop** (task 2b-D auto-resolve), so materialize lands before the loop tries
to repair.

### Flow
1. Gather the same free-text `context` `_draft_entities` uses (crate title /
   description + scanned-file digest).
2. `plan = extract_plan(context)` (Stage A leaf, stubbed in tests).
3. Materialize each section through the engine (each call `try/except`-wrapped so
   one failing section never breaks the spine — log and continue).
4. Keep the existing enrich (`draft_entity_fields`) + `build_and_validate` +
   bounded fix loop unchanged, running after materialize.

### Plan → composite mapping
| Plan section | Composite / drafter | Notes |
|---|---|---|
| `study{name,description}` | `scaffold_isa_backbone(study=…)` | idempotent; merges into the scaffolded backbone |
| `compounds[{name,role}]` | `resolve_compound(name=…)` | mints MolecularEntity + **verified** CAS/PubChem CID (name only — D5) |
| `cell_lines[{name}]` | `draft_cell_line_sample(name=…)` | CellLineSample from name; Cellosaurus accession is a later lookup |
| `process_chain[…]` | one `draft_process_chain(assay_id=…, chain=…)` | maps each step's `process_type`/`name`; synthesizes EndpointReadout/DataAnalysis outputs |
| `aops[{aop_id}]` | `materialize_aop_subgraph(aop_id=…, study_id=…)` | numeric id only; every node id from AOP-Wiki (D5) |
| `people[{name,…}]` | `draft_person` + deterministic given/family split | ISA REQUIRES a non-empty given name; the split is descriptive parsing, not identifier fabrication |
| `publications[{title}]` | **deferred** | see below |

### D5 / idempotency / no-op guarantees
- **D5 (Verify, Don't Trust):** only plan *names* reach the composites;
  identifiers come from the composites' own lookups/verification and are never
  set or overwritten from the plan. The person name split involves no identifier.
- **No-op** when no LLM provider is configured (the same `config.get_provider`
  gate `_draft_entities` uses) and when there is no usable context — `extract_plan`
  is never called, so the deterministic spine and its tests are unchanged.
- **Idempotent:** every composite reuses deterministically-keyed entities, so
  re-running the spine mints no duplicates (verified in a test).

### Publications: deferred, not materialized (design-doc note)
A plan carries a publication **title only** (D5 — no DOI), but ISA REQUIRES a
`ScholarlyArticle` to have an identifier and BASE requires the auto-wired root
`citation` `@id` to be an absolute URI — neither reachable from a title without
fabricating a DOI. Per `.claude/CLAUDE.md` ("when a request conflicts with these
documents, follow the documents and say so"), **D5 wins over the literal task
wording** on this one point. Titles are surfaced under
`result["publications_deferred"]` for a later
`draft_publication_with_authors(doi=…)` once a DOI is resolved.

### Tests (TDD — failing first, fully offline)
New `TestMaterializePlan` class. `extract_plan` is stubbed at its pipeline import
site; `lookup_compound` / `verify_identifier` / `lookup_aop` are stubbed so **no
network** is hit. Asserts: (a) the canned plan produces the expected
MolecularEntity / CellLineSample / process chain / AOP / Person entities; (b)
no-op without a provider; (c) no-op without context; (d) idempotent (run twice →
no dups); (e) D5 (no fabricated identifier from the plan lands on any entity);
(f) `run_pipeline` still reaches `{base, isa, tox}` conformance. Module keeps
`pytestmark = pytest.mark.timeout(120)`.

### Gates (all green, memory-constrained)
- `uv run ruff check` — All checks passed
- `uv run --extra langchain ty check` — All checks passed
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q tests/test_agents_pipeline.py` — 17 passed

### Scope
Edits only `builder/agents/pipeline.py` + `tests/test_agents_pipeline.py`. No
changes to `AGENTS.md`, `composites.py`, `leaves.py`, `guidance.py`, or `eval/`.

**Do NOT merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)