### PR TITLE
feat(tools): resolve_publication composite (title→Crossref→DOI) (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,6 +499,7 @@ format only (D7); the ARC folder tree is materialised at export time by
 scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=False) → dict  # composite: linked Investigation→Study→Assay in one call (idempotent), the fast path to a BASE-passing crate
 materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
 resolve_compound(name: str, hints: dict | None = None, verify=None) → {entity_id, name, identifiers, verifications, verified, source}  # composite: chemical name → lookup_compound → draft_molecular_entity → verify_identifier, in one idempotent call; carries the looked-up CAS + PubChem CID and never keeps an unverified id (D5)
+resolve_publication(title: str, verify=None) → {ok, doi, entity_id, title, score} | {ok: False, reason, title}  # composite: publication title → Crossref title-search → confidence gate → draft_publication_with_authors(doi=…), in one idempotent call; commits a DOI only on a high-confidence match (score floor AND near-exact title) and never fabricates one (D5)
 draft_publication_with_authors(doi: str) → {publication_id, doi, authors:[{name, person_id, orcid, resolution}], hitl}  # composite (engine-routed, HITL-capable): publication + every author wired as a Person, each author's @id harmonized to their ORCID via a verify-first cascade
 draft_investigation(hints: dict) → Entity
 draft_study(investigation_id: str, hints: dict) → Entity
@@ -554,6 +555,24 @@ the per-field verdicts are surfaced in `verifications` and `verified` is the AND
 them. Looked-up identifier fields win over same-named caller `hints`, and the
 entity id is derived deterministically from the name so re-running reuses the
 entity rather than duplicating it.
+
+`resolve_publication` (Issue #179) is the citation counterpart of
+`resolve_compound`, closing the gap PR #217 deferred: a plan carries a
+publication *title* only (D5 — no DOI), but ISA REQUIRES a `ScholarlyArticle` with
+an identifier (and BASE requires the auto-wired root `citation` `@id` to be an
+absolute URI) — both unreachable from a title alone. From the single
+model-supplied `title` it (1) runs a Crossref `query.bibliographic` title-search
+(`lookups.crossref.search_works_by_title`) for candidate works ranked by
+Crossref's relevance `score`; (2) applies a **D5 confidence gate** — a candidate
+is committed ONLY when it clears BOTH the Crossref score floor AND a
+normalized-title near-exact match (token-overlap threshold), so a high score on a
+*different* paper, a weak score on the right title, or no candidate all return
+`{ok: False, reason: "no confident DOI match", title}` and create NO entity (a DOI
+is never fabricated from a title); (3) on a confident match delegates to
+`draft_publication_with_authors(doi=…)`, reusing its DOI→`ScholarlyArticle`+authors
+path (the ORCID cascade is handled there). It is idempotent (keyed by the resolved
+DOI). It is invoked by code (materialize / guidance), not chosen by the weak
+model, but is registered four-place for consistency with `resolve_compound`.
 
 `draft_publication_with_authors` (Issue #180, deferred item) is the citation
 counterpart of the composites above and the **only engine-routed, HITL-capable

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -24,6 +24,7 @@ Entity drafting:
 - draft_process_chain: Create and wire a whole LabProcess derivation chain (CellCulture->Exposure->EndpointReadout->DataAnalysis, any subset) in one idempotent call — synthesizes the outputs EndpointReadout/DataAnalysis require so the chain never dangles into a validation error
 - materialize_aop_subgraph: Turn one AOP-Wiki id into the full subgraph (AdverseOutcomePathway + KeyEvents + KeyEventRelationships, cross-linked) and optionally wire it onto a Study
 - resolve_compound: Resolve a chemical name to a verified MolecularEntity in one call (lookup_compound -> draft_molecular_entity -> verify_identifier), carrying the looked-up CAS + PubChem CID; idempotent and never keeps an unverified identifier (D5)
+- resolve_publication: Resolve a publication title to a DOI-backed ScholarlyArticle in one call (Crossref title-search -> confidence gate -> draft_publication_with_authors); commits a DOI ONLY on a high-confidence match (score floor AND near-exact title) and never fabricates one (D5); idempotent (keyed by the resolved DOI)
 - draft_investigation: Create an Investigation entity
 - draft_study: Create a Study entity
 - draft_assay: Create an Assay entity

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -102,6 +102,18 @@ TOOL_SPECS = [
         },
     },
     {
+        "name": "resolve_publication",
+        "description": "Resolve a publication TITLE to a DOI-backed ScholarlyArticle in ONE call (the citation counterpart of resolve_compound): it searches Crossref by title (query.bibliographic), applies a STRICT confidence gate, and on a confident match builds the publication + authors via draft_publication_with_authors(doi=...). D5 confidence gate: a DOI is committed ONLY when the top candidate clears BOTH Crossref's relevance score floor AND a normalized-title near-exact match — a high score on a different paper, a weak score on the right title, or no candidate all return {ok:false, reason:'no confident DOI match', title} and create NO entity. A DOI is never fabricated from a title. Idempotent (keyed by the resolved DOI). Returns {ok, doi, entity_id, title, score}. Example: resolve_publication(title='Adverse outcome pathway-based assessment of TPO inhibition in vitro').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Publication title to resolve to a DOI, e.g. 'Adverse outcome pathway-based assessment of TPO inhibition in vitro'."},
+                "verify": {"type": "boolean", "description": "Reserved for parity with resolve_compound; the DOI is implicitly verified by the Crossref resolution. Accepted and ignored."},
+            },
+            "required": ["title"],
+        },
+    },
+    {
         "name": "materialize_aop_subgraph",
         "description": "Turn ONE AOP-Wiki id into the full crate subgraph in one call: an AdverseOutcomePathway node plus every KeyEvent (MIE/KE/AO, discriminated by eventType) and KeyEventRelationship, all cross-linked deterministically from AOP-Wiki (never fabricated). Pass only the numeric aop_id; optionally pass study_id to wire the AOP onto that Study (schema:mentions). Idempotent (keyed by AOP-Wiki IRI). Prefer this over lookup_aop + manual drafting when you want the whole pathway in the crate. Example: materialize_aop_subgraph(aop_id='610', study_id='study_silychristin_exposure').",
         "parameters": {

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -33,6 +33,7 @@ from builder.tools.drafters import (
 from builder.tools.hitl import HumanInterface
 from builder.tools.lookups import lookup_compound, lookup_doi, lookup_orcid
 from builder.tools.verification import verify_identifier
+from lookups.crossref import search_works_by_title
 from lookups.orcid import lookup_orcid_by_name
 
 logger = logging.getLogger(__name__)
@@ -943,6 +944,150 @@ def _hitl_prompt_count(human: HumanInterface | None) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Publication resolution: title -> Crossref -> DOI -> publication (Issue #179)
+#
+# Closes the gap PR #217 deferred: a plan carries a publication *title* only
+# (D5 — no DOI), but ISA REQUIRES a ScholarlyArticle with an identifier. This
+# composite resolves the title to a DOI via a Crossref title-search, gated by a
+# strict confidence rule so a DOI is only ever committed when it is genuinely the
+# titled work — never fabricated (D5) — then reuses draft_publication_with_authors
+# (#192) to build the ScholarlyArticle + authors from that DOI.
+# ---------------------------------------------------------------------------
+
+# D5 confidence gate. A Crossref title-search hit is only trusted as the DOI for a
+# title when BOTH hold:
+#   1. Crossref's relevance ``score`` clears _MIN_CROSSREF_SCORE, AND
+#   2. the candidate's normalized title is a near-exact match for the query
+#      (exact after normalization, OR a containment match with a high token
+#      overlap) — so a high score on a *different* paper is rejected.
+# Either alone is too weak (a high score can rank an unrelated work first; a title
+# match alone says nothing about Crossref's own confidence), so the gate is the
+# AND of the two. A miss creates NO entity and reports the reason — never a guess.
+_MIN_CROSSREF_SCORE: float = 50.0
+_MIN_TITLE_TOKEN_OVERLAP: float = 0.9
+
+
+def _norm_title(text: Any) -> str:
+    """Lowercase + collapse whitespace + drop punctuation (for title matching)."""
+    lowered = str(text or "").lower()
+    kept = "".join(c if (c.isalnum() or c.isspace()) else " " for c in lowered)
+    return " ".join(kept.split())
+
+
+def _title_overlap(query: str, candidate: str) -> float:
+    """Fraction of the query's title tokens present in the candidate's (0..1).
+
+    A symmetric near-exact signal: 1.0 on an exact normalized match, and high
+    when one title is contained in / shares almost all tokens with the other
+    (e.g. a trailing subtitle on the Crossref side). 0.0 when either is empty.
+    """
+    q = set(_norm_title(query).split())
+    c = set(_norm_title(candidate).split())
+    if not q or not c:
+        return 0.0
+    if q == c:
+        return 1.0
+    # Token overlap against the *smaller* set, so a subtitle on one side does not
+    # penalise an otherwise-exact match.
+    return len(q & c) / min(len(q), len(c))
+
+
+def _confident_match(
+    title: str, candidates: list[dict] | tuple[dict, ...]
+) -> dict | None:
+    """Return the single confident Crossref candidate for *title*, or None (D5).
+
+    Confidence requires the top-scoring candidate to clear BOTH the Crossref
+    score floor and the normalized-title near-exact threshold. Anything weaker —
+    a low score, a title mismatch, or no candidates — yields ``None`` so the
+    caller commits no DOI and fabricates nothing.
+    """
+    best: dict | None = None
+    best_overlap = 0.0
+    for cand in candidates:
+        if float(cand.get("score") or 0.0) < _MIN_CROSSREF_SCORE:
+            continue
+        overlap = _title_overlap(title, cand.get("title", ""))
+        if overlap >= _MIN_TITLE_TOKEN_OVERLAP and overlap > best_overlap:
+            best, best_overlap = cand, overlap
+    return best
+
+
+def resolve_publication(
+    state: CrateState,
+    title: str,
+    verify: bool | None = None,
+) -> dict[str, Any]:
+    """Resolve a publication TITLE to a DOI-backed ``ScholarlyArticle`` in ONE call.
+
+    Closes the gap PR #217 deferred: a plan carries a publication *title* only
+    (D5 — no DOI), but ISA REQUIRES a ``ScholarlyArticle`` to have an identifier
+    and BASE requires the auto-wired root ``citation`` ``@id`` to be an absolute
+    URI — both unreachable from a title alone without a DOI. This composite is the
+    citation counterpart of :func:`resolve_compound`: the ONLY model-supplied
+    input is the ``title``; the identifier comes straight from Crossref, gated so
+    nothing is fabricated (D5):
+
+    1. :func:`~lookups.crossref.search_works_by_title` runs a Crossref
+       ``query.bibliographic`` search and returns candidate works ranked by
+       Crossref's relevance ``score``.
+    2. **D5 confidence gate** (:func:`_confident_match`): a candidate is accepted
+       ONLY when it clears BOTH the Crossref score floor (``_MIN_CROSSREF_SCORE``)
+       AND a normalized-title near-exact match (``_MIN_TITLE_TOKEN_OVERLAP``).
+       A high score on a *different* paper, a weak score on the right title, or no
+       candidate all fail the gate — in which case this returns
+       ``{ok: False, reason: "no confident DOI match", title}`` and creates NO
+       entity. A DOI is never invented from a title.
+    3. On a confident match it delegates to
+       :func:`draft_publication_with_authors` with the resolved DOI, which builds
+       the ``ScholarlyArticle`` and wires every author as a ``Person`` (the ORCID
+       cascade is already handled there).
+
+    It is **idempotent**, keyed by the resolved DOI: re-running reuses the existing
+    ``Publication`` (``draft_publication_with_authors`` find-or-creates it by DOI)
+    rather than minting a duplicate, consistent with the other composites.
+
+    This is called by code (materialize / guidance), not chosen by the weak model;
+    it is registered four-place for consistency with :func:`resolve_compound`.
+
+    Args:
+        state: The crate state to resolve into.
+        title: The publication title to resolve (e.g. from an extracted plan).
+        verify: Reserved for parity with :func:`resolve_compound`; the DOI is
+            implicitly verified by the Crossref resolution
+            (:func:`draft_publication_with_authors` re-looks up the DOI, so an
+            unresolvable DOI yields no publication). Accepted and ignored.
+
+    Returns:
+        On a confident match ``{"ok": True, "doi", "entity_id", "title",
+        "score"}``. On no confident match ``{"ok": False, "reason": "no confident
+        DOI match", "title"}`` (and no entity is created).
+    """
+    del verify  # parity-only with resolve_compound; see docstring.
+    candidates = list(search_works_by_title(title) or [])
+    match = _confident_match(title, candidates)
+    if match is None:
+        return {"ok": False, "reason": "no confident DOI match", "title": title}
+
+    doi = str(match["doi"])
+    drafted = draft_publication_with_authors(state, doi)
+    # A DOI that survived the confidence gate but fails the Crossref re-lookup in
+    # the drafter (e.g. a transient outage) yields no publication — surface it as
+    # an unconfident result rather than a fabricated entity (D5).
+    entity_id = drafted.get("publication_id")
+    if not entity_id:
+        return {"ok": False, "reason": "no confident DOI match", "title": title}
+
+    return {
+        "ok": True,
+        "doi": drafted.get("doi", doi),
+        "entity_id": entity_id,
+        "title": title,
+        "score": float(match.get("score") or 0.0),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Compound resolution: lookup -> draft -> verify (Issue #179, task 3)
 # ---------------------------------------------------------------------------
 
@@ -1094,6 +1239,7 @@ from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 TOOL_REGISTRY.register("scaffold_isa_backbone", scaffold_isa_backbone, takes_state=True)
 TOOL_REGISTRY.register("draft_process_chain", draft_process_chain, takes_state=True)
 TOOL_REGISTRY.register("resolve_compound", resolve_compound, takes_state=True)
+TOOL_REGISTRY.register("resolve_publication", resolve_publication, takes_state=True)
 TOOL_REGISTRY.register(
     "materialize_aop_subgraph", materialize_aop_subgraph, takes_state=True
 )

--- a/lookups/crossref.py
+++ b/lookups/crossref.py
@@ -90,3 +90,68 @@ def lookup_doi(doi: str) -> dict:
         raise
     except Exception:
         return {}
+
+
+@functools.lru_cache(maxsize=256)
+def search_works_by_title(title: str, rows: int = 5) -> tuple[dict, ...]:
+    """Search Crossref for works whose bibliographic metadata matches *title*.
+
+    A conservative title -> DOI search using Crossref's
+    ``query.bibliographic`` field, ranked by Crossref's own relevance
+    ``score`` (descending). This is the inverse of :func:`lookup_doi` (DOI ->
+    metadata): given only a title, it returns the candidate works so a caller
+    can apply a confidence gate before committing to a DOI (D5 — never fabricate
+    an identifier).
+
+    Args:
+        title: Publication title to search for.
+        rows: Maximum number of candidate works to return (Crossref ``rows``).
+
+    Returns:
+        A tuple of candidate dicts, each ``{"title", "doi", "score"}`` (the bare
+        DOI, e.g. ``"10.1016/j.tox.2021.152898"``), ordered by descending
+        ``score``. Empty when the title is blank or Crossref returns nothing.
+        Raises :class:`TransientLookupError` on a transient API failure.
+
+    Note:
+        Returns a ``tuple`` (not a ``list``) so the ``lru_cache`` return value is
+        immutable and cannot be mutated by a caller across cached calls.
+    """
+    query = title.strip()
+    if not query:
+        return ()
+    try:
+        time.sleep(0.1)
+        data = http_get_json(
+            _BASE,
+            params={
+                "query.bibliographic": query,
+                "rows": str(max(1, int(rows))),
+                # Ask only for the fields we score on, to keep the payload small.
+                "select": "DOI,title,score",
+            },
+            headers=_HEADERS,
+        )
+        if data is NOT_FOUND:
+            return ()
+
+        items = data.get("message", {}).get("items", []) or []
+        candidates: list[dict] = []
+        for item in items:
+            doi = str(item.get("DOI") or "").strip()
+            if not doi:
+                continue
+            titles = item.get("title") or []
+            name = titles[0] if titles else ""
+            try:
+                score = float(item.get("score") or 0.0)
+            except (TypeError, ValueError):
+                score = 0.0
+            candidates.append({"title": name, "doi": doi, "score": score})
+
+        candidates.sort(key=lambda c: c["score"], reverse=True)
+        return tuple(candidates)
+    except TransientLookupError:
+        raise
+    except Exception:
+        return ()

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -21,7 +21,7 @@ from lookups.aopwiki import lookup_aop
 from lookups.bao import lookup_bao_term, lookup_ontology_term, lookup_unit
 from lookups.cellosaurus import lookup_cellosaurus
 from lookups.comptox import lookup_dtxsid
-from lookups.crossref import lookup_doi
+from lookups.crossref import lookup_doi, search_works_by_title
 from lookups.orcid import lookup_orcid
 from lookups.pubchem import lookup_pubchem
 from lookups.ror import search_ror
@@ -923,3 +923,54 @@ class TestCrossrefContract:
         assert result["name"] == ""
         assert result["author"] == []
         assert result["datePublished"] == ""
+
+    @responses.activate
+    def test_title_search_returns_candidates(self):
+        """A bibliographic title search returns ranked {title, doi, score} dicts."""
+        body = {
+            "status": "ok",
+            "message": {
+                "items": [
+                    {
+                        "DOI": "10.1016/j.tox.2021.152898",
+                        "title": ["A nephrotoxicity study in vitro"],
+                        "score": 87.5,
+                    },
+                    {
+                        "DOI": "10.9999/other",
+                        "title": ["An unrelated paper"],
+                        "score": 12.0,
+                    },
+                ]
+            },
+        }
+        responses.add(
+            responses.GET,
+            "https://api.crossref.org/works",
+            json=body,
+            status=200,
+        )
+
+        candidates = search_works_by_title("A nephrotoxicity study in vitro")
+
+        assert len(candidates) == 2
+        top = candidates[0]
+        assert top["doi"] == "10.1016/j.tox.2021.152898"
+        assert top["title"] == "A nephrotoxicity study in vitro"
+        assert top["score"] == 87.5
+
+    @responses.activate
+    def test_title_search_no_items_returns_empty(self):
+        """An empty Crossref result set yields an empty candidate list."""
+        responses.add(
+            responses.GET,
+            "https://api.crossref.org/works",
+            json={"status": "ok", "message": {"items": []}},
+            status=200,
+        )
+        assert list(search_works_by_title("No such paper anywhere")) == []
+
+    @responses.activate
+    def test_title_search_blank_title_returns_empty(self):
+        """A blank title is a no-op (no request, no candidates)."""
+        assert list(search_works_by_title("   ")) == []

--- a/tests/test_tools_resolve_publication.py
+++ b/tests/test_tools_resolve_publication.py
@@ -1,0 +1,187 @@
+"""Tests for the ``resolve_publication`` composite tool (Issue #179).
+
+``resolve_publication`` closes the gap PR #217 deliberately deferred: a plan
+carries a publication *title* only (D5 — no DOI), but ISA REQUIRES a
+``ScholarlyArticle`` with an identifier. The composite resolves the title to a
+DOI via a Crossref title-search, gated by a strict confidence rule (D5 — never
+fabricate a DOI), then builds the publication via the existing
+:func:`draft_publication_with_authors` (DOI -> ScholarlyArticle + authors).
+
+The chain is::
+
+    title -> search_works_by_title (Crossref) -> confidence gate ->
+        draft_publication_with_authors(doi=<resolved>)
+
+Tests never hit the network: the Crossref title-search and the DOI-resolution
+drafter are monkeypatched on the ``composites`` module (where
+``resolve_publication`` resolves the symbols), so the chain runs entirely
+offline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools import composites
+from builder.tools.composites import resolve_publication
+
+pytestmark = pytest.mark.timeout(120)
+
+_TITLE = "Adverse outcome pathway-based assessment of TPO inhibition in vitro"
+_DOI = "10.1016/j.tox.2021.152898"
+_DOI_URL = f"https://doi.org/{_DOI}"
+
+
+def _by_type(state: CrateState, type_name: str) -> list:
+    return [e for e in state.list_entities() if e.type == type_name]
+
+
+def _candidate(title: str, doi: str, score: float) -> dict:
+    """A single Crossref title-search candidate (the shape the helper returns)."""
+    return {"title": title, "doi": doi, "score": score}
+
+
+@pytest.fixture
+def offline(monkeypatch):
+    """Serve a confident title-search hit + a fake DOI-resolution drafter.
+
+    Both are patched on the ``composites`` module namespace, which is where
+    ``resolve_publication`` resolves the symbols.
+    """
+    calls: dict[str, list] = {"search": [], "draft": []}
+
+    def fake_search(title, rows=5):  # noqa: ANN001
+        calls["search"].append((title, rows))
+        # Top candidate is an exact-normalized-title match with a high score.
+        return [
+            _candidate(_TITLE, _DOI, 92.5),
+            _candidate("Some unrelated paper", "10.9999/other", 12.0),
+        ]
+
+    def fake_draft(state, doi, human_interface=None):  # noqa: ANN001
+        calls["draft"].append(doi)
+        # Mimic draft_publication_with_authors: ensure a Publication entity in
+        # state keyed off the DOI, returning its standard result shape.
+        pub = composites._ensure_publication(
+            state,
+            doi,
+            {"identifier": _DOI_URL, "name": _TITLE, "headline": _TITLE},
+        )
+        return {
+            "publication_id": pub.entity_id,
+            "doi": _DOI_URL,
+            "authors": [],
+            "hitl": 0,
+        }
+
+    monkeypatch.setattr(composites, "search_works_by_title", fake_search)
+    monkeypatch.setattr(
+        composites, "draft_publication_with_authors", fake_draft
+    )
+    return calls
+
+
+class TestResolvePublicationHappyPath:
+    def test_confident_match_builds_publication(self, offline):
+        state = CrateState()
+        result = resolve_publication(state, title=_TITLE)
+
+        assert result["ok"] is True
+        # The resolved DOI is reported and a single Publication exists.
+        assert _DOI in result["doi"]
+        pubs = _by_type(state, "Publication")
+        assert len(pubs) == 1
+        assert result["entity_id"] == pubs[0].entity_id
+        assert state.get_entity(result["entity_id"]) is pubs[0]
+
+    def test_returns_title_and_score(self, offline):
+        state = CrateState()
+        result = resolve_publication(state, title=_TITLE)
+        assert result["title"] == _TITLE
+        assert result["score"] == 92.5
+
+    def test_delegates_to_draft_publication_with_authors(self, offline):
+        state = CrateState()
+        resolve_publication(state, title=_TITLE)
+        # The DOI-resolution drafter was called exactly once, with the resolved DOI.
+        assert len(offline["draft"]) == 1
+        assert _DOI in offline["draft"][0]
+
+
+class TestResolvePublicationConfidenceGate:
+    def test_low_score_no_match_creates_no_entity(self, monkeypatch):
+        """A weak Crossref score is rejected (D5) — no entity, reported."""
+
+        def fake_search(title, rows=5):  # noqa: ANN001
+            # Exact title text but a low score: not confident.
+            return [_candidate(_TITLE, _DOI, 3.0)]
+
+        def fake_draft(state, doi, human_interface=None):  # noqa: ANN001
+            raise AssertionError("draft must not be called on a low-confidence match")
+
+        monkeypatch.setattr(composites, "search_works_by_title", fake_search)
+        monkeypatch.setattr(
+            composites, "draft_publication_with_authors", fake_draft
+        )
+
+        state = CrateState()
+        result = resolve_publication(state, title=_TITLE)
+
+        assert result["ok"] is False
+        assert result["title"] == _TITLE
+        assert "no confident" in result["reason"].lower()
+        assert _by_type(state, "Publication") == []
+
+    def test_title_mismatch_creates_no_entity(self, monkeypatch):
+        """A high score but a non-matching title is rejected (D5)."""
+
+        def fake_search(title, rows=5):  # noqa: ANN001
+            # High score, but the candidate is a different paper.
+            return [_candidate("A completely different study", _DOI, 99.0)]
+
+        def fake_draft(state, doi, human_interface=None):  # noqa: ANN001
+            raise AssertionError("draft must not be called on a title mismatch")
+
+        monkeypatch.setattr(composites, "search_works_by_title", fake_search)
+        monkeypatch.setattr(
+            composites, "draft_publication_with_authors", fake_draft
+        )
+
+        state = CrateState()
+        result = resolve_publication(state, title=_TITLE)
+
+        assert result["ok"] is False
+        assert _by_type(state, "Publication") == []
+
+    def test_no_candidates_creates_no_entity(self, monkeypatch):
+        def fake_search(title, rows=5):  # noqa: ANN001
+            return []
+
+        monkeypatch.setattr(composites, "search_works_by_title", fake_search)
+
+        state = CrateState()
+        result = resolve_publication(state, title="Nonexistent paper title")
+
+        assert result["ok"] is False
+        assert _by_type(state, "Publication") == []
+
+
+class TestResolvePublicationIdempotent:
+    def test_second_call_no_duplicate(self, offline):
+        state = CrateState()
+        first = resolve_publication(state, title=_TITLE)
+        second = resolve_publication(state, title=_TITLE)
+        assert len(_by_type(state, "Publication")) == 1
+        assert first["entity_id"] == second["entity_id"]
+        assert first["ok"] is True and second["ok"] is True
+
+
+class TestResolvePublicationViaEngine:
+    def test_callable_through_run_tool(self, offline):
+        engine = AgentEngine()
+        engine.initialize()
+        result = engine.run_tool("resolve_publication", title=_TITLE)
+        assert result["ok"] is True
+        assert engine.state.get_entity(result["entity_id"]) is not None


### PR DESCRIPTION
## What

Adds a **`resolve_publication`** composite that closes the gap PR #217 deliberately deferred: a plan carries a publication *title* only (D5 — no DOI), but ISA REQUIRES a `ScholarlyArticle` with an identifier. This composite resolves the title → DOI via Crossref, then builds the publication.

`resolve_publication(state, title, *, verify=None) -> dict` in `builder/tools/composites.py`:

1. **Crossref title-search** (`lookups/crossref.py::search_works_by_title`, the new `query.bibliographic` helper) → candidate works ranked by Crossref's relevance `score`.
2. **D5 confidence gate** → on a confident match, delegate to the existing `draft_publication_with_authors(doi=...)` (#192) to build the `ScholarlyArticle` + authors (ORCID cascade handled there).
3. Idempotent, keyed by the resolved DOI. Returns `{ok, doi, entity_id, title, score}`.

It is the citation counterpart of `resolve_compound`, registered four-place (`TOOL_REGISTRY`, `TOOL_SPECS`, system-prompt catalogue, AGENTS.md §5).

## D5 confidence gate (chosen)

A DOI is committed **only** when the top candidate clears **BOTH**:

- **Crossref relevance `score` ≥ `_MIN_CROSSREF_SCORE` (50.0)**, AND
- a **normalized-title near-exact match** — token-overlap ≥ `_MIN_TITLE_TOKEN_OVERLAP` (0.9) against the smaller token set, so an exact normalized match or a contained title (e.g. a trailing subtitle on the Crossref side) passes, but a different paper does not.

Either signal alone is too weak (a high score can rank an unrelated work first; a title match alone says nothing about Crossref's own confidence), so the gate is the **AND** of the two. On no confident match (low score, title mismatch, or no candidate) it returns `{ok: False, reason: "no confident DOI match", title}` and creates **no entity** — a DOI is never fabricated from a title (D5).

## Deferred wiring (follow-up — not in this PR)

This is **not** wired into `pipeline.py`. A parallel lane owns that file. The tiny wiring into `_materialize_plan` — replacing the `publications_deferred` path with a `resolve_publication(title=...)` call — is a **follow-up to do after both land**.

## Tests (TDD)

- `tests/test_tools_resolve_publication.py` — confident match → publication built with the resolved DOI; low-confidence / title-mismatch / no-candidate → no entity, reported (D5); idempotency; engine `run_tool` routing. Crossref HTTP layer + drafter monkeypatched (no network). `pytestmark = pytest.mark.timeout(120)`.
- `tests/test_lookups_contract.py` — `search_works_by_title` contract tests via the `responses` fixture (ranked candidates, empty result, blank title).
- The four-place parity tests (`test_tools_spec.py`, `test_agents_doc_toolbox.py`) pass.

## Gates (all green, memory-constrained)

- `uv run ruff check` ✅
- `uv run --extra langchain ty check` ✅
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q tests/test_tools_spec.py tests/test_agents_doc_toolbox.py tests/test_tools_resolve_publication.py tests/test_lookups_contract.py::TestCrossrefContract` ✅ (25 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)