### PR TITLE
feat(agents): invoke guidance loop on the interactive build path (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1291,10 +1291,15 @@ The `profile.ndjson` log produced by `ProfilingLogger` is the foundation for a l
 
 ## 14. Architecture Evolution: Deterministic Pipeline (planned — Issue #179)
 
-> **Status:** Decided direction, migration in progress (Issue #179). The as-built
-> agent loop is the prose-prompt ReAct StateGraph of §4 / D1; this section is the
-> **convergence target**. It supersedes the earlier "keep flat ReAct, structure in
-> the tool layer only" stance once the A/B gate (task 6 below) confirms it.
+> **Status:** Cutover DONE for the interactive build (Issue #179). The A/B gate
+> (task 6) is decided: on the 3 shared corpus cases the deterministic pipeline
+> reached **3/3** ISA-Tox conformance vs ReAct **1/3** (the weak LLM stalled at
+> 0–1 iterations on the hard cases), so the **deterministic pipeline + HITL
+> guidance tail is now the DEFAULT interactive architecture** (`main.py
+> --interactive` → `run_interactive_build`). The prose-prompt ReAct StateGraph of
+> §4 / D1 is **retained behind `--legacy-react`**, not deleted — the system-prompt
+> strip is a separate follow-up (task 7). This supersedes the earlier "keep flat
+> ReAct, structure in the tool layer only" stance.
 
 ### 14.1 Decision
 
@@ -1311,7 +1316,11 @@ retained only for the conversational / unstructured-input tail**.
 beats ReAct on reliability" claim — ReAct often has a higher final pass rate. The
 defensible win *for this system* (known step ordering + rigid SHACL-validated output +
 weak executor) is **cost, latency, reproducibility, testability, predictability** — not
-blanket correctness. Therefore the full cutover is **gated on an in-repo A/B** (task 6).
+blanket correctness. The cutover was **gated on an in-repo A/B** (task 6) and that gate
+has now passed for the interactive build (3/3 vs 1/3 ISA-Tox conformance on the shared
+corpus — the pipeline ALSO won on correctness for these cases because the weak executor
+stalled), so the pipeline is the default interactive path with ReAct retained behind an
+opt-in flag.
 
 ### 14.2 Target shape
 
@@ -1374,13 +1383,24 @@ step 2 — was a deferral), gated to a strict no-op when no LLM provider is conf
 (3) composite meta-tools incl. `draft_process_chain`
 — **done**: it synthesizes the EndpointReadout/DataAnalysis outputs the build has no
 fallback for (closing the §14.3 Violation trap) and wires the whole chain in one
-idempotent call (see §5 Derivation Chain Tools); (4) pipeline spine — **done as an
-opt-in parallel path** (`builder/agents/pipeline.py::run_pipeline`, see §14.5): a
-deterministic, code-driven orchestrator that does NOT yet replace the
-`should_continue` ReAct loop. **ReAct stays the DEFAULT**; the spine is selectable
-via the eval harness (`python -m eval --arch pipeline`) so the A/B gate (task 6)
-can prove it before any cutover; (5) shrink tail agent; (6) **A/B eval harness —
-decision gate**; (7) prompt + docs.
+idempotent call (see §5 Derivation Chain Tools); (4) pipeline spine — **done and now
+the DEFAULT interactive path** (`builder/agents/pipeline.py::run_pipeline`, see §14.5):
+a deterministic, code-driven orchestrator. Post-A/B-gate (task 6) it **replaces** the
+`should_continue` ReAct loop as the default `main.py --interactive` build (via
+`run_interactive_build`, §14.6.1); ReAct is retained behind `--legacy-react` (the
+`should_continue` graph itself is untouched pending the task-7 prompt strip). The spine
+is also selectable in the eval harness (`python -m eval --arch pipeline`); (5) the tail
+— **done**: the gap engine
+(`assess_gaps` #215, §14.6) feeds the deterministic HITL guidance loop
+(`run_guidance` #218, §14.6.1), now **wired into the interactive build path**
+(`run_interactive_build`, `builder/agents/build.py`) so a real user gets the
+guidance tail after the automated pipeline while the A/B path (simulated /
+headless) runs the guidance-free pipeline alone; (6) **A/B eval harness — decision
+gate — done & PASSED**: the harness compared the two architectures on the shared
+corpus and the pipeline won (3/3 vs 1/3 ISA-Tox conformance), triggering the
+interactive cutover above; (7) prompt + docs — **pending** (strip the orchestration
+prose from `system_prompt.py` now that code owns control flow; the ReAct loop stays
+reachable via `--legacy-react` until then).
 
 #### The drafter-leaf (`leaves.py`)
 
@@ -1496,7 +1516,14 @@ existing toolbox. The sequence:
    stopping when no REQUIRED issue remains *or* a round fixes nothing (deterministic
    dispatch only; the loop is monotone over the rule set, so a no-progress round
    means the rest needs the LLM leaf).
-5. Returns `{ok, conformance, issues, scaffold, drafted, fix_rounds}`.
+5. Returns `{ok, conformance, issues, scaffold, materialized, drafted, fix_rounds}`.
+
+`run_pipeline` is the **automated** build and stays **guidance-free** — the HITL
+guidance tail is invoked *around* it by the interactive entrypoint
+(`run_interactive_build`, §14.6.1), never inside the spine, so the A/B eval can
+drive the spine non-interactively. Post-A/B-gate (3/3 vs 1/3 ISA-Tox conformance)
+this spine is the **default** `main.py --interactive` build; ReAct is opt-in via
+`--legacy-react`.
 
 **Determinism contract:** with **no LLM provider configured** the drafter-leaf
 step (2) is a strict no-op, so every step is deterministic and the same input
@@ -1520,24 +1547,74 @@ The pre-migration ReAct baseline is frozen at git tag **`react-baseline`** for t
 
 ### 14.6 The hybrid build loop and the gap engine (`builder/tools/gap_analysis.py`)
 
-The full hybrid ISA-Tox build loop runs in five stages, all deterministic except
-where a bounded LLM leaf is explicitly invoked:
+The full hybrid ISA-Tox build loop runs in five stages — the first four are the
+**automated pipeline** (`run_pipeline`, §14.5) and the fifth is the **interactive
+HITL tail** (`run_guidance`). Every stage is deterministic *code* except the two
+explicit bounded LLM leaves (Extract's `extract_plan`, and the drafter the
+guidance tail uses to *suggest* a value the user must confirm):
 
 ```
-Extract → Materialize → Assess → Auto-resolve → Guidance
- (leaf)    (deterministic   │      (deterministic   (small strong-model
-            scaffold +       │       fix loop)        agent: ambiguity + HITL)
-            draft mutators)  ▼
-                          gap engine
+        ┌───────────── AUTOMATED PIPELINE (run_pipeline) ──────────────┐
+INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Guidance (run_guidance)
+        (leaf)    (deterministic   │      (deterministic         (deterministic HITL loop:
+                  composites)      │       fix loop)              ask-user / draft+confirm;
+                                   ▼                              INTERACTIVE ONLY)
+                                gap engine
 ```
 
-**Extract** pulls structured fields from input via the cheap drafter-leaf
-(§14.4); **Materialize** turns them into linked entities through the
-deterministic `scaffold_isa_backbone` / `draft_*` / `draft_process_chain`
-mutators; **Assess** runs the gap engine (this section); **Auto-resolve** clears
-every `auto_fixable` gap via `fix_required_issues` (§5, the keystone); and
-**Guidance** is the small tail agent that handles only what the deterministic
-path cannot — genuine ambiguity, missing content, and HITL.
+- **Extract** (`extract_plan`, leaf #213, §14.4) — the bounded whole-document
+  extractor pulls a *candidate plan* (names/titles only, no identifiers — D5)
+  from the input context in a single model call.
+- **Materialize** (`_materialize_plan` via the idempotent composites #217, §14.5)
+  — deterministically turns each plan section into linked ISA-Tox entities through
+  `scaffold_isa_backbone` / `resolve_compound` / `draft_cell_line_sample` /
+  `draft_process_chain` / `materialize_aop_subgraph` / `draft_person`. Identifiers
+  come from the composites' own lookups, never from the plan.
+- **Assess** (`assess_gaps`, the gap engine #215, this section) — one
+  prioritized `GapReport` unifying SHACL + MIT + FAIR.
+- **Auto-resolve** (`fix_required_issues`, §5, the keystone) — clears every
+  `auto_fixable` gap deterministically from state alone, no prompt.
+- **Guidance** (`run_guidance` #218, §14.6.1) — the **deterministic, code-driven
+  HITL loop** that walks the remaining `auto_fixable=False` gaps with the user in
+  the loop. It is NOT a ReAct/LLM-orchestrated agent: CODE owns control flow, the
+  LLM only *drafts* a suggested value, and the user confirms every uncertain
+  commit (D5). It is invoked **only for a real interactive user** (see §14.6.1).
+
+**The deliberate split — automated vs interactive.** Stages 1–4 are the
+**automated** build: `run_pipeline` (§14.5) runs them with **no HITL**, so it
+never blocks on a user and the A/B eval can drive it non-interactively
+(`--arch pipeline`, a clean automated-vs-automated comparison vs ReAct).
+`run_pipeline` therefore stays **guidance-free** — the Guidance tail (stage 5) is
+HITL and lives **outside** the spine, in the interactive entrypoint
+(`run_interactive_build`, §14.6.1). A headless / simulated run is exactly
+`run_pipeline` alone; a real user gets `run_pipeline` *then* `run_guidance`.
+
+#### 14.6.1 The interactive entrypoint (`builder/agents/build.py`)
+
+`run_interactive_build(engine, *, pipeline_runner=None, guidance_runner=None,
+output=None) -> dict` joins the two halves into the end-to-end sequence a real
+user runs. It:
+
+1. runs the **automated** pipeline (`run_pipeline`) — always;
+2. runs the **HITL guidance tail** (`run_guidance(engine, engine.human_interface)`)
+   **iff the engine's `HumanInterface` is interactive**;
+3. surfaces a concise summary of the guidance results
+   (`format_guidance_summary` — gaps resolved / asked / remaining per tier, plus
+   final base/isa/tox conformance) via the injected `output` channel (e.g. the
+   CLI's `print` / console writer);
+4. returns `{"pipeline": <run_pipeline result>, "guidance": <run_guidance result
+   or None>}` — `guidance` is `None` exactly when the path was non-interactive.
+
+**The interactive signal.** "Interactive vs headless" is read from a single,
+optional `HumanInterface.is_interactive` attribute via the fail-closed helper
+`builder.tools.hitl.is_interactive(human)`: a `None` interface, one that omits the
+attribute, or one that sets it falsy is **non-interactive**; only a frontend
+backed by a real user sets it `True`. The default `SimulatedHumanInterface`
+(used by the A/B eval, batch runs, and the test suite) is `is_interactive = False`,
+so behind it `run_interactive_build` degrades to `run_pipeline` alone and
+`run_guidance` is **never invoked** — guidance can never block a headless build.
+Both runners are injectable so the wiring is unit-tested with no SHACL / no LLM /
+no network (`tests/test_agents_build.py`).
 
 **Stage C — the gap engine.** `assess_gaps(state: CrateState) -> GapReport`
 (`builder/tools/gap_analysis.py`) unifies the three assessors into ONE

--- a/README.md
+++ b/README.md
@@ -102,20 +102,28 @@ export VITRO_ANTHROPIC_DRAFTER_MODEL="claude-haiku-4"
 
 ## Usage
 
-### Interactive agent mode (recommended)
+### Interactive build mode (recommended)
 
-Start a conversational session where the LLM agent walks you through crate creation:
+`--interactive` runs the **deterministic pipeline + human-in-the-loop guidance**
+build: code drives the known step ordering (scaffold the ISA backbone, draft and
+materialize entities, validate, auto-fix REQUIRED issues) and then walks you
+through any remaining gaps it cannot close on its own. This is the default since
+the in-repo A/B gate (it reached full ISA-Tox conformance on the shared corpus
+where the legacy ReAct loop stalled).
 
 ```bash
 # With existing research data folder:
 uv run python -m main --interactive -i /path/to/experiment/
 
-# Start fresh (no input — build everything from conversation):
+# Start fresh (no input — build the backbone, then guided enrichment):
 uv run python -m main --interactive
 
 # Specify provider / model / endpoint:
 uv run python -m main --interactive --provider openai --model gpt-4o-mini
 uv run python -m main --interactive --provider openai --api-base http://localhost:11434/v1
+
+# Legacy conversational ReAct agent (retained; being phased out):
+uv run python -m main --interactive --legacy-react
 ```
 
 ### Configuration file (pre-populated)
@@ -203,7 +211,10 @@ Options:
   -i, --input PATH       Path to input directory with research data
   -o, --output PATH      Output path for the ARC directory (RO-Crate)
   -r, --resume SESSION   Resume a previous session by ID
-  -I, --interactive      Run in interactive agent mode (requires LangChain + API key)
+  -I, --interactive      Run in interactive build mode: deterministic pipeline +
+                         HITL guidance tail (requires LangChain + API key)
+      --legacy-react     With --interactive, use the legacy ReAct agent loop
+                         instead of the default pipeline+guidance build
   -p, --provider STR     LLM provider: 'openai' or 'anthropic' (auto-detected from env)
   -m, --model STR        Model name override (e.g. gpt-4o-mini, llama3.2, claude-sonnet-4)
   -b, --api-base URL     Custom API base URL for OpenAI-compatible providers

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -1,0 +1,169 @@
+"""The interactive hybrid build path (Issue #179 — completes the §14 loop).
+
+This is the **interactive entrypoint** that joins the two halves of the §14.6
+hybrid build loop into the end-to-end sequence a real user runs:
+
+    Extract → Materialize → Assess → Auto-resolve   ──►   Guidance
+    └──────────── run_pipeline (AUTOMATED) ─────────┘     run_guidance (HITL)
+
+:func:`run_interactive_build` runs the **automated** deterministic pipeline
+(:func:`builder.agents.pipeline.run_pipeline`) and then — *only* when a REAL
+interactive :class:`~builder.tools.hitl.HumanInterface` is present — runs the
+HITL gap-resolution tail (:func:`builder.agents.guidance.run_guidance`) so the
+user is guided through the gaps the deterministic path could not close on its own.
+
+**Why the split is deliberate.** ``run_pipeline`` stays *guidance-free*: it is the
+automated build the A/B eval drives non-interactively (``--arch pipeline``), so it
+must be a clean automated-vs-automated comparison with the ReAct path. Guidance is
+HITL and would block on a real user, so it belongs only here, in the interactive
+tail, gated on :func:`builder.tools.hitl.is_interactive`. The headless
+:class:`~builder.tools.hitl.SimulatedHumanInterface` (the eval, batch runs, tests)
+reports ``is_interactive == False``, so this entrypoint then degrades to *exactly*
+``run_pipeline`` alone — guidance is never invoked behind a simulated human.
+
+Both the pipeline and guidance runners are **injected** (defaulting to the real
+functions) so the wiring is unit-testable with no SHACL / no LLM / no network.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Callable
+
+from builder.tools.hitl import is_interactive
+
+if TYPE_CHECKING:
+    from builder.engine import AgentEngine
+    from builder.tools.hitl import HumanInterface
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["run_interactive_build", "format_guidance_summary"]
+
+# A pipeline_runner runs the automated deterministic spine once over an engine,
+# mutating engine.state and returning the spine's result dict. A guidance_runner
+# runs the HITL gap-resolution loop over the engine + a human, returning its
+# summary dict. Both are injected so the wiring is testable without SHACL/LLM.
+PipelineRunner = Callable[["AgentEngine"], dict[str, Any]]
+GuidanceRunner = Callable[..., dict[str, Any]]
+
+# Default no-op output channel: discard. The CLI passes ``print`` (or a console
+# writer); tests pass a list's ``append`` to capture the surfaced summary.
+OutputChannel = Callable[[str], Any]
+
+
+def run_interactive_build(
+    engine: AgentEngine,
+    *,
+    pipeline_runner: PipelineRunner | None = None,
+    guidance_runner: GuidanceRunner | None = None,
+    output: OutputChannel | None = None,
+) -> dict[str, Any]:
+    """Run the automated pipeline, then the HITL guidance tail when interactive.
+
+    The engine MUST already be :meth:`~builder.engine.AgentEngine.initialize`-d.
+    The automated pipeline always runs. The HITL guidance loop runs **iff** the
+    engine's :class:`~builder.tools.hitl.HumanInterface` is interactive
+    (:func:`builder.tools.hitl.is_interactive`) — a real user's frontend — so the
+    non-interactive / simulated path (the A/B eval, batch, tests) runs the
+    automated pipeline alone and ``run_guidance`` is never invoked. When guidance
+    runs, a concise summary of its results is surfaced via *output*.
+
+    Args:
+        engine: An initialized engine. Its ``human_interface`` decides whether
+            the guidance tail runs; ``run_guidance`` mutates ``engine.state`` in
+            place through the existing tools (never hand-rolled JSON-LD).
+        pipeline_runner: Injected automated-build runner; defaults to the real
+            :func:`builder.agents.pipeline.run_pipeline` (kept guidance-free).
+        guidance_runner: Injected HITL runner; defaults to the real
+            :func:`builder.agents.guidance.run_guidance`.
+        output: Sink for the human-readable guidance summary (e.g. ``print`` or a
+            console writer). Defaults to a no-op (nothing is emitted). Only the
+            guidance summary is surfaced here — the pipeline's own output is the
+            caller's concern.
+
+    Returns:
+        ``{"pipeline": <run_pipeline result>, "guidance": <run_guidance result or
+        None>}`` — ``guidance`` is ``None`` exactly when the path was
+        non-interactive and the tail was skipped.
+    """
+    pipeline_runner = pipeline_runner or _default_pipeline_runner()
+    pipeline_result = pipeline_runner(engine)
+
+    human: HumanInterface | None = getattr(engine, "human_interface", None)
+    if not is_interactive(human):
+        # Headless / simulated: run the automated pipeline ALONE so the A/B stays
+        # a clean automated-vs-automated comparison. No guidance, no summary.
+        logger.debug("Non-interactive build: skipping the HITL guidance tail")
+        return {"pipeline": pipeline_result, "guidance": None}
+
+    guidance_runner = guidance_runner or _default_guidance_runner()
+    guidance_result = guidance_runner(engine, human)
+
+    emit = output or (lambda _msg: None)
+    emit(format_guidance_summary(guidance_result))
+
+    return {"pipeline": pipeline_result, "guidance": guidance_result}
+
+
+def format_guidance_summary(guidance_result: dict[str, Any] | None) -> str:
+    """Render a concise, human-readable summary of a guidance run.
+
+    Surfaces what the HITL tail did — gaps *resolved*, gaps *asked* about, gaps
+    *remaining* per tier — and the final per-layer (``base`` / ``isa`` / ``tox``)
+    conformance, so the user sees the build's state after guidance at a glance.
+    A ``None`` result (guidance never ran, e.g. a non-interactive build) yields a
+    short, non-crashing message.
+    """
+    if not guidance_result:
+        return "No interactive guidance ran (headless build)."
+
+    resolved = guidance_result.get("resolved") or []
+    asked = guidance_result.get("asked") or []
+    remaining = guidance_result.get("remaining_gaps") or {}
+    conformance = guidance_result.get("conformance") or {}
+    rounds = guidance_result.get("rounds", 0)
+
+    must = remaining.get("must_open", 0)
+    should = remaining.get("should_open", 0)
+    may = remaining.get("may_open", 0)
+
+    def _mark(layer: str) -> str:
+        return "pass" if conformance.get(layer) else "fail"
+
+    lines = [
+        "Guidance complete:",
+        f"  resolved: {len(resolved)} gap(s)",
+        f"  asked:    {len(asked)} gap(s)",
+        f"  remaining gaps: {must} MUST / {should} SHOULD / {may} MAY",
+        (
+            f"  conformance: base={_mark('base')} "
+            f"isa={_mark('isa')} tox={_mark('tox')}"
+        ),
+        f"  rounds: {rounds}",
+    ]
+    return "\n".join(lines)
+
+
+def _default_pipeline_runner() -> PipelineRunner:
+    """The real automated spine, imported lazily so this module stays light.
+
+    Importing :mod:`builder.agents.pipeline` is cheap and langchain-free (the
+    leaf imports are themselves lazy), but deferring it keeps a test that injects
+    its own runner fully independent of the spine.
+    """
+    from builder.agents.pipeline import run_pipeline
+
+    return run_pipeline
+
+
+def _default_guidance_runner() -> GuidanceRunner:
+    """The real HITL guidance loop, imported lazily.
+
+    Deferred so the import only happens on the interactive path — a headless
+    build never imports guidance, and a test injecting its own runner is
+    independent of the guidance module.
+    """
+    from builder.agents.guidance import run_guidance
+
+    return run_guidance

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -54,6 +54,16 @@ class HumanInterface(Protocol):
 
     Implementations adapt the agent's HITL requests to a concrete frontend
     (CLI prompt, Streamlit widget, FastAPI round-trip, test double, …).
+
+    An **optional** ``is_interactive: bool`` attribute is the single signal the
+    interactive build path uses to decide whether to run the HITL guidance tail
+    after the automated pipeline (AGENTS.md §14.6.1): a frontend backed by a REAL
+    user sets it ``True``; the headless :class:`SimulatedHumanInterface` (and the
+    A/B eval, batch runs, and tests that use it) leaves it ``False`` so guidance is
+    never invoked non-interactively. It is **deliberately NOT a required Protocol
+    member** — making it required would force every existing adapter / test double
+    to declare it. Read it via the fail-closed :func:`is_interactive` helper, which
+    treats an interface that omits it (or no interface at all) as non-interactive.
     """
 
     def present(
@@ -82,7 +92,13 @@ class SimulatedHumanInterface:
     without blocking on a real user — EXCEPT for scan-root escalations, which
     it denies: the simulator can never be the approver for filesystem access
     (fail-closed, #197).
+
+    ``is_interactive`` is ``False`` — this is the headless default, so the
+    interactive build path (AGENTS.md §14.6) never runs the HITL guidance tail
+    behind it (the A/B eval and batch runs stay automated-only).
     """
+
+    is_interactive: bool = False
 
     def present(
         self,
@@ -111,6 +127,73 @@ class SimulatedHumanInterface:
         """Log the request and return a skip response."""
         logger.info("HITL input request: %s (type=%s)", prompt, field_type)
         return {"value": None, "skipped": True}
+
+
+class ConsoleHumanInterface:
+    """A REAL interactive HITL interface that prompts on the terminal (stdin).
+
+    This is the CLI frontend the **default interactive build path** runs behind
+    (`main.py --interactive` → `run_interactive_build`, AGENTS.md §14.6.1). Unlike
+    :class:`SimulatedHumanInterface` it is ``is_interactive = True``, so the
+    guidance tail actually runs and routes its ask-user prompts / draft
+    confirmations to the user via ``input()``.
+
+    A scan-root escalation still routes through the user — they are the only
+    legitimate approver for widening filesystem access (#197); a non-affirmative
+    answer denies it (fail-closed). An empty answer to an input request is a skip.
+    Reading from a closed / non-tty stdin (``EOFError``) is treated as decline /
+    skip so the loop never hangs or crashes on a piped invocation.
+    """
+
+    is_interactive: bool = True
+
+    def present(
+        self,
+        context: str,
+        options: list[str] | None = None,
+        purpose: str | None = None,
+    ) -> HumanResponse:
+        """Show *context* + *options* and read an approve/reject decision."""
+        print(context)
+        if options:
+            print(f"Options: {', '.join(options)}")
+        suffix = " [y/N]: " if purpose == SCAN_ROOT_PURPOSE else " [Y/n]: "
+        try:
+            answer = input(f"Approve?{suffix}").strip().lower()
+        except EOFError:
+            answer = ""
+        if purpose == SCAN_ROOT_PURPOSE:
+            # Fail-closed: a new scan root requires an explicit affirmative.
+            approved = answer in ("y", "yes")
+        else:
+            approved = answer in ("", "y", "yes")
+        action = "approved" if approved else "rejected"
+        return {"action": action, "comments": None, "edits": None}
+
+    def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
+        """Prompt the user for a value; an empty answer (or EOF) is a skip."""
+        print(prompt)
+        try:
+            value = input(f"({field_type}) > ").strip()
+        except EOFError:
+            value = ""
+        if not value:
+            return {"value": None, "skipped": True}
+        return {"value": value, "skipped": False}
+
+
+def is_interactive(human: HumanInterface | None) -> bool:
+    """Whether *human* is a REAL interactive frontend (vs headless/simulated).
+
+    The single gate the interactive build path uses to decide whether to run the
+    HITL guidance tail after the automated pipeline (AGENTS.md §14.6). Reads the
+    optional :attr:`HumanInterface.is_interactive` signal **fail-closed**: a
+    ``None`` interface (a headless engine), an interface that does not declare the
+    attribute, or one that declares it falsy is treated as **non-interactive**.
+    Only an interface that explicitly sets ``is_interactive`` truthy — a frontend
+    backed by a real user — returns ``True``.
+    """
+    return bool(getattr(human, "is_interactive", False))
 
 
 # Shared default simulator backing the module-level convenience functions.
@@ -144,10 +227,12 @@ def request_input(
 
 __all__ = [
     "SCAN_ROOT_PURPOSE",
+    "ConsoleHumanInterface",
     "HumanInterface",
     "HumanResponse",
     "InputResponse",
     "SimulatedHumanInterface",
+    "is_interactive",
     "present_to_human",
     "request_input",
 ]

--- a/main.py
+++ b/main.py
@@ -75,7 +75,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--interactive",
         "-I",
         action="store_true",
-        help="Run in interactive agent mode (requires LangChain extra + API key)",
+        help="Run in interactive build mode (deterministic pipeline + HITL "
+        "guidance tail; requires LangChain extra + API key)",
+    )
+    parser.add_argument(
+        "--legacy-react",
+        action="store_true",
+        help="With --interactive, use the legacy ReAct agent loop instead of the "
+        "default deterministic pipeline + guidance build (retained pending the "
+        "system-prompt strip; see AGENTS.md §14)",
     )
     parser.add_argument(
         "--provider",
@@ -363,7 +371,17 @@ def main(argv: list[str] | None = None) -> int:
         if not _ensure_configured():
             return 1
 
-    engine = AgentEngine()
+    # The DEFAULT interactive build is the deterministic pipeline + HITL guidance
+    # tail (AGENTS.md §14.6.1), so it must run behind a REAL interactive
+    # HumanInterface — else run_interactive_build would (correctly) skip guidance.
+    # The legacy ReAct loop (--legacy-react) keeps the headless simulated default;
+    # its own HITL routes through the agent loop, not the guidance tail.
+    if args.interactive and not args.legacy_react:
+        from builder.tools.hitl import ConsoleHumanInterface
+
+        engine = AgentEngine(human_interface=ConsoleHumanInterface())
+    else:
+        engine = AgentEngine()
 
     if args.resume:
         logger.info("Resuming session: %s", args.resume)
@@ -391,16 +409,28 @@ def main(argv: list[str] | None = None) -> int:
         entity_count,
     )
 
-    # Interactive agent mode — enter the LangChain REPL
+    # Interactive build mode. Post-cutover (AGENTS.md §14, gated on the in-repo
+    # A/B: pipeline reached 3/3 ISA-Tox conformance vs ReAct 1/3) the DEFAULT is
+    # the deterministic pipeline + HITL guidance tail. The legacy ReAct loop is
+    # retained behind --legacy-react (pending the task-7 prompt strip), not deleted.
     if args.interactive:
-        from builder.agents.agent_loop import run_interactive_agent
+        if args.legacy_react:
+            from builder.agents.agent_loop import run_interactive_agent
 
-        run_interactive_agent(
-            engine,
-            provider=args.provider,
-            model=args.model,
-            base_url=args.api_base,
-        )
+            run_interactive_agent(
+                engine,
+                provider=args.provider,
+                model=args.model,
+                base_url=args.api_base,
+            )
+            return 0
+
+        # Default: automated pipeline, then the guidance tail for the real user
+        # (run_interactive_build gates guidance on the interactive interface and
+        # surfaces a concise summary via the output channel).
+        from builder.agents.build import run_interactive_build
+
+        run_interactive_build(engine, output=print)
         return 0
 
     # Batch / info mode — print summary and exit

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -1,0 +1,211 @@
+"""Tests for builder/agents/build.py — the interactive hybrid build path (#179).
+
+``run_interactive_build(engine)`` completes the §14 hybrid loop: it runs the
+**automated** deterministic pipeline (:func:`builder.agents.pipeline.run_pipeline`)
+and then — *only* for a REAL interactive user — runs the HITL guidance tail
+(:func:`builder.agents.guidance.run_guidance`). The non-interactive/simulated path
+(the A/B eval, headless/batch) must run the pipeline ALONE so the A/B stays a clean
+automated-vs-automated comparison.
+
+These tests stub both the pipeline and the guidance runners (no SHACL, no LLM, no
+network) so they assert *only* the wiring: that guidance is invoked iff the human
+interface is interactive, and that a concise summary is surfaced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools.hitl import HumanInterface, SimulatedHumanInterface
+
+
+class _InteractiveHuman:
+    """A HumanInterface double that declares itself interactive."""
+
+    is_interactive = True
+
+    def present(self, context, options=None, purpose=None):
+        return {"action": "approved", "comments": None, "edits": None}
+
+    def request_input(self, prompt, field_type="text"):
+        return {"value": None, "skipped": True}
+
+
+class _SilentHuman:
+    """A HumanInterface double with NO is_interactive attribute (defaults off)."""
+
+    def present(self, context, options=None, purpose=None):
+        return {"action": "approved", "comments": None, "edits": None}
+
+    def request_input(self, prompt, field_type="text"):
+        return {"value": None, "skipped": True}
+
+
+def _engine(human: HumanInterface) -> AgentEngine:
+    engine = AgentEngine(state=CrateState(), human_interface=human)
+    engine.initialize()  # assigns a session_id; no input => no scan
+    return engine
+
+
+_PIPELINE_RESULT: dict[str, Any] = {
+    "ok": True,
+    "conformance": {"base": True, "isa": True, "tox": True},
+    "issues": [],
+    "scaffold": {},
+    "materialized": {},
+    "drafted": {},
+    "fix_rounds": 0,
+}
+
+_GUIDANCE_RESULT: dict[str, Any] = {
+    "resolved": [{"tier": "MUST", "property": "name", "via": "ask-user"}],
+    "asked": [{"tier": "SHOULD", "property": "description"}],
+    "remaining_gaps": {"must_open": 0, "should_open": 1, "may_open": 2},
+    "conformance": {"base": True, "isa": True, "tox": False},
+    "rounds": 2,
+}
+
+
+class TestInteractiveGating:
+    """run_guidance runs IFF the human interface is interactive."""
+
+    def test_interactive_human_invokes_guidance(self) -> None:
+        from builder.agents.build import run_interactive_build
+
+        pipeline_calls: list[Any] = []
+        guidance_calls: list[Any] = []
+        engine = _engine(_InteractiveHuman())
+
+        def fake_pipeline(eng: AgentEngine) -> dict:
+            pipeline_calls.append(eng)
+            return dict(_PIPELINE_RESULT)
+
+        def fake_guidance(eng: AgentEngine, human: HumanInterface, **kw: Any) -> dict:
+            guidance_calls.append((eng, human))
+            return dict(_GUIDANCE_RESULT)
+
+        result = run_interactive_build(
+            engine, pipeline_runner=fake_pipeline, guidance_runner=fake_guidance
+        )
+
+        # Pipeline always runs; guidance runs because the human is interactive.
+        assert len(pipeline_calls) == 1
+        assert pipeline_calls[0] is engine
+        assert len(guidance_calls) == 1
+        assert guidance_calls[0][0] is engine
+        assert guidance_calls[0][1] is engine.human_interface
+        assert result["guidance"] == _GUIDANCE_RESULT
+
+    def test_simulated_human_skips_guidance(self) -> None:
+        from builder.agents.build import run_interactive_build
+
+        pipeline_calls: list[Any] = []
+        guidance_calls: list[Any] = []
+        engine = _engine(SimulatedHumanInterface())
+
+        def fake_pipeline(eng: AgentEngine) -> dict:
+            pipeline_calls.append(eng)
+            return dict(_PIPELINE_RESULT)
+
+        def fake_guidance(eng: AgentEngine, human: HumanInterface, **kw: Any) -> dict:
+            guidance_calls.append((eng, human))
+            return dict(_GUIDANCE_RESULT)
+
+        result = run_interactive_build(
+            engine, pipeline_runner=fake_pipeline, guidance_runner=fake_guidance
+        )
+
+        # Pipeline runs; guidance is SKIPPED (the simulated interface is headless).
+        assert len(pipeline_calls) == 1
+        assert guidance_calls == []
+        assert result["guidance"] is None
+
+    def test_missing_is_interactive_attribute_skips_guidance(self) -> None:
+        """A HumanInterface that does not declare is_interactive is non-interactive."""
+        from builder.agents.build import run_interactive_build
+
+        guidance_calls: list[Any] = []
+        engine = _engine(_SilentHuman())
+
+        result = run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: guidance_calls.append(human)
+            or dict(_GUIDANCE_RESULT),
+        )
+
+        assert guidance_calls == []
+        assert result["guidance"] is None
+
+    def test_pipeline_result_always_returned(self) -> None:
+        from builder.agents.build import run_interactive_build
+
+        engine = _engine(SimulatedHumanInterface())
+        result = run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+        )
+        assert result["pipeline"] == _PIPELINE_RESULT
+
+
+class TestGuidanceSummary:
+    """The guidance results are surfaced as a concise human-readable summary."""
+
+    def test_format_guidance_summary_mentions_counts(self) -> None:
+        from builder.agents.build import format_guidance_summary
+
+        text = format_guidance_summary(_GUIDANCE_RESULT)
+        assert isinstance(text, str)
+        # Resolved / asked / remaining counts are all surfaced.
+        assert "1" in text  # 1 resolved
+        assert "resolved" in text.lower()
+        assert "asked" in text.lower()
+        assert "remaining" in text.lower() or "gap" in text.lower()
+        # Per-layer conformance is surfaced.
+        assert "base" in text.lower()
+        assert "isa" in text.lower()
+        assert "tox" in text.lower()
+
+    def test_format_guidance_summary_handles_none(self) -> None:
+        """No guidance ran (non-interactive) -> a short, non-crashing message."""
+        from builder.agents.build import format_guidance_summary
+
+        text = format_guidance_summary(None)
+        assert isinstance(text, str)
+        assert text  # non-empty
+
+    def test_run_interactive_build_surfaces_summary_via_output(self) -> None:
+        """The interactive build prints the guidance summary to the output channel."""
+        from builder.agents.build import run_interactive_build
+
+        lines: list[str] = []
+        engine = _engine(_InteractiveHuman())
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=lines.append,
+        )
+        joined = "\n".join(lines)
+        assert "resolved" in joined.lower()
+        assert "tox" in joined.lower()
+
+    def test_non_interactive_build_does_not_emit_guidance_summary(self) -> None:
+        """A headless build emits no guidance summary (only the pipeline ran)."""
+        from builder.agents.build import run_interactive_build
+
+        lines: list[str] = []
+        engine = _engine(SimulatedHumanInterface())
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=lines.append,
+        )
+        joined = "\n".join(lines).lower()
+        # No "asked"/"resolved" guidance wording when guidance never ran.
+        assert "resolved" not in joined
+        assert "asked" not in joined

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -112,3 +112,96 @@ class TestMain:
         result = main(["--dashboard", "--resume", "test_session"])
         assert result == 0
         assert called == ["test_session"]
+
+
+class TestInteractiveDispatch:
+    """The interactive build path: pipeline+guidance is the DEFAULT; ReAct is opt-in.
+
+    The A/B gate (AGENTS.md §14) decided the cutover — the deterministic
+    pipeline + HITL guidance is now the default interactive architecture and the
+    legacy ReAct loop is retained behind ``--legacy-react``. These tests mock the
+    run functions (no live LLM, no network) and assert only the dispatch routing.
+    """
+
+    def _stub_config(self, monkeypatch):
+        """Make --interactive proceed without a real LLM config check."""
+        import builder.config as cfg
+
+        monkeypatch.setattr(cfg, "is_configured", lambda: True)
+        monkeypatch.setattr(cfg, "load_config", lambda: {})
+        monkeypatch.setattr(cfg, "merge_with_env", lambda c: None)
+
+    def test_legacy_react_flag_is_parsed(self):
+        args = parse_args(["--interactive", "--legacy-react"])
+        assert args.legacy_react is True
+
+    def test_default_interactive_routes_to_pipeline_build(self, monkeypatch):
+        """--interactive (no opt-in) runs the deterministic pipeline + guidance."""
+        self._stub_config(monkeypatch)
+        calls: list[str] = []
+
+        import builder.agents.build as build_mod
+
+        monkeypatch.setattr(
+            build_mod,
+            "run_interactive_build",
+            lambda engine, **kw: calls.append("build") or {"pipeline": {}, "guidance": None},
+        )
+
+        import builder.agents.agent_loop as agent_loop
+
+        monkeypatch.setattr(
+            agent_loop,
+            "run_interactive_agent",
+            lambda *a, **kw: calls.append("react"),
+        )
+
+        result = main(["--interactive"])
+        assert result == 0
+        assert calls == ["build"]
+
+    def test_legacy_react_flag_routes_to_react(self, monkeypatch):
+        """--interactive --legacy-react runs the legacy ReAct loop, not the pipeline."""
+        self._stub_config(monkeypatch)
+        calls: list[str] = []
+
+        import builder.agents.build as build_mod
+
+        monkeypatch.setattr(
+            build_mod,
+            "run_interactive_build",
+            lambda engine, **kw: calls.append("build") or {"pipeline": {}, "guidance": None},
+        )
+
+        import builder.agents.agent_loop as agent_loop
+
+        monkeypatch.setattr(
+            agent_loop,
+            "run_interactive_agent",
+            lambda *a, **kw: calls.append("react"),
+        )
+
+        result = main(["--interactive", "--legacy-react"])
+        assert result == 0
+        assert calls == ["react"]
+
+    def test_default_interactive_engine_is_interactive(self, monkeypatch):
+        """The engine handed to the default pipeline build reports interactive HITL."""
+        from builder.tools.hitl import is_interactive
+
+        self._stub_config(monkeypatch)
+        seen: list[bool] = []
+
+        import builder.agents.build as build_mod
+
+        def _capture(engine, **kw):
+            seen.append(is_interactive(engine.human_interface))
+            return {"pipeline": {}, "guidance": None}
+
+        monkeypatch.setattr(build_mod, "run_interactive_build", _capture)
+
+        result = main(["--interactive"])
+        assert result == 0
+        # The default interactive build must run behind a REAL interactive
+        # interface, else run_interactive_build would skip guidance.
+        assert seen == [True]

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from builder.engine import AgentEngine
 from builder.tools.hitl import (
+    ConsoleHumanInterface,
     HumanInterface,
     InputResponse,
     SimulatedHumanInterface,
+    is_interactive,
     present_to_human,
     request_input,
 )
@@ -54,6 +56,94 @@ class TestSimulatedHumanInterface:
         """Non-scan-root checkpoints keep the convenient auto-approve behaviour."""
         resp = SimulatedHumanInterface().present("Review investigation", purpose="entity_review")
         assert resp["action"] == "approved"
+
+
+class TestConsoleHumanInterface:
+    """The CLI console interface is REAL-interactive and prompts via stdin."""
+
+    def test_satisfies_human_interface_protocol(self):
+        assert isinstance(ConsoleHumanInterface(), HumanInterface)
+
+    def test_is_interactive_true(self):
+        assert ConsoleHumanInterface().is_interactive is True
+        assert is_interactive(ConsoleHumanInterface()) is True
+
+    def test_present_approves_on_affirmative(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_a: "y")
+        resp = ConsoleHumanInterface().present("Review entity")
+        assert resp["action"] == "approved"
+
+    def test_present_rejects_on_negative(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_a: "n")
+        resp = ConsoleHumanInterface().present("Review entity")
+        assert resp["action"] == "rejected"
+
+    def test_present_scan_root_requires_explicit_yes(self, monkeypatch):
+        """Fail-closed (#197): an empty answer must NOT approve a new scan root."""
+        from builder.tools.hitl import SCAN_ROOT_PURPOSE
+
+        monkeypatch.setattr("builtins.input", lambda *_a: "")
+        resp = ConsoleHumanInterface().present(
+            "Approve /etc?", options=["Approve", "Deny"], purpose=SCAN_ROOT_PURPOSE
+        )
+        assert resp["action"] == "rejected"
+
+    def test_request_input_returns_value(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_a: "Acme Corp")
+        resp = ConsoleHumanInterface().request_input("Name?")
+        assert resp == {"value": "Acme Corp", "skipped": False}
+
+    def test_request_input_empty_is_skip(self, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda *_a: "")
+        resp = ConsoleHumanInterface().request_input("Name?")
+        assert resp == {"value": None, "skipped": True}
+
+    def test_request_input_eof_is_skip(self, monkeypatch):
+        def _raise(*_a):
+            raise EOFError
+
+        monkeypatch.setattr("builtins.input", _raise)
+        resp = ConsoleHumanInterface().request_input("Name?")
+        assert resp == {"value": None, "skipped": True}
+
+
+class TestIsInteractive:
+    """The interactive signal distinguishes a real user from a headless run."""
+
+    def test_simulated_interface_is_not_interactive(self):
+        """The default simulator is headless — it must NOT be treated interactive."""
+        assert SimulatedHumanInterface().is_interactive is False
+
+    def test_helper_returns_false_for_simulated(self):
+        assert is_interactive(SimulatedHumanInterface()) is False
+
+    def test_helper_returns_false_for_none(self):
+        """No interface at all (a headless engine) is non-interactive."""
+        assert is_interactive(None) is False
+
+    def test_helper_returns_false_when_attribute_absent(self):
+        """An interface that does not declare the signal defaults to non-interactive."""
+
+        class _Bare:
+            def present(self, context, options=None, purpose=None):
+                return {"action": "approved", "comments": None, "edits": None}
+
+            def request_input(self, prompt, field_type="text"):
+                return {"value": None, "skipped": True}
+
+        assert is_interactive(_Bare()) is False
+
+    def test_helper_returns_true_when_declared_interactive(self):
+        class _Live:
+            is_interactive = True
+
+            def present(self, context, options=None, purpose=None):
+                return {"action": "approved", "comments": None, "edits": None}
+
+            def request_input(self, prompt, field_type="text"):
+                return {"value": None, "skipped": True}
+
+        assert is_interactive(_Live()) is True
 
 
 class TestBackwardCompatibleFunctions:


### PR DESCRIPTION
## What & why

Completes the §14 hybrid loop (#179): a **real interactive user** is now guided through the remaining gaps **after** the automated deterministic pipeline, while the non-interactive / A-B / test path runs the pipeline **alone**.

### The wiring

- **`builder/agents/build.py`** (new) — `run_interactive_build(engine)` is the interactive entrypoint. It runs the automated `run_pipeline(engine)` and then runs `run_guidance(engine, engine.human_interface)` **only when the engine's `HumanInterface` is a real interactive one**, surfacing a concise summary (resolved / asked / remaining gaps per tier + base/isa/tox conformance) via the injected `output` channel. Both runners are injectable so the wiring is unit-tested offline (no LLM, no SHACL, no network).
- **`builder/tools/hitl.py`** — the **interactive signal**. `is_interactive(human)` is a fail-closed helper (`None` / missing attr / falsy ⇒ non-interactive); `SimulatedHumanInterface.is_interactive = False`. New `ConsoleHumanInterface` (`is_interactive=True`) prompts on stdin so the CLI default actually runs the guidance tail. The attribute is **deliberately NOT a required Protocol member**, so every existing adapter / test double keeps satisfying `HumanInterface` (kept `ty` green).

### Why `run_pipeline` stays guidance-free

`run_pipeline` is the **automated** build the A/B eval drives non-interactively (`--arch pipeline`). Guidance is HITL and would block on a user, so it lives **only** in the interactive entrypoint, gated on `is_interactive` — keeping the A/B a clean automated-vs-automated comparison. Behind the simulated interface, `run_interactive_build` degrades to **exactly `run_pipeline` alone** and `run_guidance` is never invoked.

### Cutover (folded in at coordinator request — A/B gate passed)

On the 3 shared corpus cases the pipeline reached **3/3** ISA-Tox conformance vs ReAct **1/3** (the weak LLM stalled at 0–1 iterations on the hard cases). So `main.py --interactive` now **defaults** to the deterministic pipeline + guidance build; the legacy ReAct loop is **retained behind `--legacy-react`** (not deleted — the system-prompt strip is task 7). The ReAct `should_continue` graph itself is untouched.

### Docs

- **AGENTS.md §14** consolidated: new **§14.6.1** (the interactive entrypoint), the deliberate automated-vs-interactive split, the full end-to-end loop (Extract `extract_plan` → Materialize `_materialize_plan` → Assess `assess_gaps` → Auto-resolve `fix_required_issues` → **Guidance `run_guidance`, interactive only**), and task-4/5/6 status flipped to the cutover.
- **README** interactive-mode usage + CLI reference updated (`--legacy-react`).

## Tests (TDD)

- `tests/test_agents_build.py` — guidance is invoked iff the interface is interactive (spied), the summary is surfaced, and a simulated/headless build emits no guidance.
- `tests/test_tools_hitl.py` — `is_interactive` helper + `ConsoleHumanInterface`.
- `tests/test_main.py` — default `--interactive` routes to the pipeline build behind a real interactive interface; `--legacy-react` routes to ReAct.

## Gates (all green, memory-constrained, no `-n auto`)

- `uv run ruff check` ✅
- `uv run --extra langchain ty check` ✅
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q tests/test_agents_build.py tests/test_tools_hitl.py tests/test_main.py tests/test_agents_pipeline.py tests/test_agents_guidance.py` ✅ (79 passed)

**Do NOT merge** — for the maintainer to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)