### PR TITLE
fix(eval): record real token usage for the --arch pipeline arm (#221)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -461,6 +461,49 @@ def _tool_names_from_state(state: dict[str, Any]) -> list[str]:
     return [tc.get("name", "") for tc in tool_calls]
 
 
+def _extract_token_usage(message: Any) -> tuple[int | None, int | None]:
+    """Extract ``(input_tokens, output_tokens)`` from a LangChain ``AIMessage``.
+
+    Provider-agnostic and the SINGLE source of truth for usage mining across the
+    ReAct model node (:func:`_wrap_model_node`) and the deterministic pipeline's
+    bounded leaves (:mod:`builder.agents.leaves`), so both arms of the eval
+    harness record token counts with identical semantics:
+
+    1. Prefer the standardised ``usage_metadata`` (langchain-core >=0.3).
+    2. Fall back to provider-specific ``response_metadata["token_usage"]`` /
+       ``["usage"]`` (``prompt_tokens`` / ``completion_tokens`` aliases).
+
+    Returns ``(None, None)`` when neither source carries usage (e.g. an offline
+    fake model) so callers can record a clean zero without crashing.
+    """
+    if message is None:
+        return None, None
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+    usage = getattr(message, "usage_metadata", None)
+    if usage is not None:
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+
+    if input_tokens is None or output_tokens is None:
+        meta = getattr(message, "response_metadata", None) or {}
+        tu = meta.get("token_usage") or meta.get("usage") or {}
+        if input_tokens is None:
+            input_tokens = tu.get("prompt_tokens") or tu.get("input_tokens")
+        if output_tokens is None:
+            output_tokens = tu.get("completion_tokens") or tu.get("output_tokens")
+
+    return input_tokens, output_tokens
+
+
+def _extract_model_name(message: Any) -> str | None:
+    """Extract the model name from an ``AIMessage``'s ``response_metadata``."""
+    resp_meta: dict = getattr(message, "response_metadata", None) or {}
+    return resp_meta.get("model_name") or resp_meta.get("model")
+
+
 def _wrap_model_node(call_model: Any, profiler: Any, iteration_getter: Any) -> Any:
     """Wrap the model node to log ``node_start``/``node_end`` timing.
 
@@ -488,21 +531,8 @@ def _wrap_model_node(call_model: Any, profiler: Any, iteration_getter: Any) -> A
         response_text: str | None = None
         if out_messages:
             last_msg = out_messages[-1]
-            # Prefer the standardised usage_metadata (langchain-core >=0.3)
-            usage = getattr(last_msg, "usage_metadata", None)
-            if usage is not None:
-                input_tokens = usage.get("input_tokens")
-                output_tokens = usage.get("output_tokens")
-            # Fall back to response_metadata (provider-specific)
-            if input_tokens is None or output_tokens is None:
-                meta = getattr(last_msg, "response_metadata", None) or {}
-                tu = meta.get("token_usage") or meta.get("usage") or {}
-                if input_tokens is None:
-                    input_tokens = tu.get("prompt_tokens") or tu.get("input_tokens")
-                if output_tokens is None:
-                    output_tokens = tu.get("completion_tokens") or tu.get("output_tokens")
-            resp_meta: dict = getattr(last_msg, "response_metadata", None) or {}
-            model_name = resp_meta.get("model_name") or resp_meta.get("model")
+            input_tokens, output_tokens = _extract_token_usage(last_msg)
+            model_name = _extract_model_name(last_msg)
             # Capture the model's reply text — truncate to avoid bloating profile
             content = getattr(last_msg, "content", None)
             if content:

--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -26,12 +26,52 @@ Design (AGENTS.md §4.4 Model Tiering, §14.2 "Leaves = cheap model"):
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from builder.agents.agent_loop import _build_chat_model
+from builder.agents.agent_loop import (
+    _build_chat_model,
+    _extract_model_name,
+    _extract_token_usage,
+)
 from builder.tools._crate_mapping import _REF_FIELDS, draft_hints_schema
+
+# A usage sink is notified of one leaf call's token usage:
+# ``(input_tokens, output_tokens, model_name)``. Any element may be ``None`` when
+# the provider/fake reported no usage. The deterministic pipeline passes a sink
+# that accumulates usage and logs it to the engine profiler so the eval harness
+# records real per-case token counts for the ``--arch pipeline`` arm (Issue #221).
+UsageSink = Callable[[int | None, int | None, str | None], None]
+
+
+def _invoke_structured_with_usage(
+    llm: Any,
+    schema: dict[str, Any],
+    messages: list[Any],
+    usage_sink: UsageSink | None,
+) -> Any:
+    """Invoke a structured-output call, reporting token usage when a sink is set.
+
+    With no ``usage_sink`` this is the legacy path: bind ``with_structured_output``
+    and return the bare parsed object. With a sink, it binds with
+    ``include_raw=True`` so the raw ``AIMessage`` is available, mines
+    ``(input_tokens, output_tokens, model_name)`` off it via the SAME
+    provider-agnostic helpers the ReAct model node uses
+    (:func:`builder.agents.agent_loop._extract_token_usage`), reports them, and
+    returns the parsed object — so callers are unaffected by the capture.
+    """
+    if usage_sink is None:
+        return llm.with_structured_output(schema).invoke(messages)
+
+    raw_result = llm.with_structured_output(schema, include_raw=True).invoke(messages)
+    if isinstance(raw_result, dict) and "parsed" in raw_result:
+        raw_msg = raw_result.get("raw")
+        input_tokens, output_tokens = _extract_token_usage(raw_msg)
+        usage_sink(input_tokens, output_tokens, _extract_model_name(raw_msg))
+        return raw_result.get("parsed")
+    # Defensive: a model/runnable that ignored include_raw still yields a result.
+    return raw_result
 
 # ---------------------------------------------------------------------------
 # D5: identifier-bearing scalar fields the leaf must NEVER let the model fill.
@@ -291,7 +331,12 @@ def _strip_plan_identifiers(value: Any) -> Any:
     return value
 
 
-def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
+def extract_plan(
+    context: str,
+    *,
+    model: str | None = None,
+    usage_sink: UsageSink | None = None,
+) -> dict[str, Any]:
     """Propose a candidate plan of ISA-Tox entities from research docs.
 
     Stage A of the §14 hybrid build loop: a pure leaf making a SINGLE bounded
@@ -313,6 +358,11 @@ def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
         context: The scanned research documents (or an excerpt) to plan from.
         model: Optional explicit model name override; when ``None`` the drafter
             tier resolves the configured drafter (or primary) model.
+        usage_sink: Optional callback notified of this call's token usage as
+            ``(input_tokens, output_tokens, model_name)``. When given, the call
+            binds structured output with ``include_raw=True`` so usage can be
+            mined off the raw response (Issue #221). Default ``None`` leaves the
+            call (and its return) unchanged.
 
     Returns:
         A candidate-plan dict free of fabricated identifiers. An empty/
@@ -321,7 +371,6 @@ def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
     """
     llm = _build_chat_model(model=model, role="drafter")
     schema = _plan_schema()
-    structured = llm.with_structured_output(schema)
 
     messages = [
         SystemMessage(content=_PLAN_SYSTEM_PROMPT),
@@ -335,7 +384,7 @@ def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
             )
         ),
     ]
-    result = structured.invoke(messages)
+    result = _invoke_structured_with_usage(llm, schema, messages, usage_sink)
 
     plan = dict(result) if isinstance(result, dict) else {}
     return _strip_plan_identifiers(plan)
@@ -346,6 +395,7 @@ def draft_entity_fields(
     context: str,
     *,
     model: str | None = None,
+    usage_sink: UsageSink | None = None,
 ) -> dict[str, Any]:
     """Extract one entity's descriptive fields from free-text ``context``.
 
@@ -366,6 +416,11 @@ def draft_entity_fields(
             or a conversation snippet.
         model: Optional explicit model name override; when ``None`` the drafter
             tier resolves the configured drafter (or primary) model.
+        usage_sink: Optional callback notified of this call's token usage as
+            ``(input_tokens, output_tokens, model_name)``. When given, the call
+            binds structured output with ``include_raw=True`` so usage can be
+            mined off the raw response (Issue #221). Default ``None`` leaves the
+            call (and its return) unchanged.
 
     Returns:
         A dict of the entity's descriptive fields, validating against
@@ -373,7 +428,6 @@ def draft_entity_fields(
     """
     llm = _build_chat_model(model=model, role="drafter")
     schema = _structured_output_schema(entity_type)
-    structured = llm.with_structured_output(schema)
 
     messages = [
         SystemMessage(content=_SYSTEM_PROMPT),
@@ -386,7 +440,7 @@ def draft_entity_fields(
             )
         ),
     ]
-    result = structured.invoke(messages)
+    result = _invoke_structured_with_usage(llm, schema, messages, usage_sink)
 
     fields = dict(result) if isinstance(result, dict) else {}
     return _strip_identifiers(fields)

--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -43,7 +43,7 @@ call, trading strict graph-hash determinism for richer drafted content.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from builder.config import get_provider
 
@@ -52,9 +52,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# A usage sink receives one leaf call's token usage as
+# ``(input_tokens, output_tokens, model_name)``. The spine passes a sink that
+# logs each leaf call's usage to the engine profiler so the eval harness records
+# real per-case token counts for the ``--arch pipeline`` arm (Issue #221).
+UsageSink = Callable[[int | None, int | None, str | None], None]
+
 
 def draft_entity_fields(
-    entity_type: str, context: str, *, model: str | None = None
+    entity_type: str,
+    context: str,
+    *,
+    model: str | None = None,
+    usage_sink: UsageSink | None = None,
 ) -> dict[str, Any]:
     """Lazy, no-op-safe shim over :func:`builder.agents.leaves.draft_entity_fields`.
 
@@ -67,14 +77,20 @@ def draft_entity_fields(
     (an unconfigured provider short-circuits before this is ever called).
 
     Defining the leaf as a module-level attribute here also gives tests a stable
-    monkeypatch target (``builder.agents.pipeline.draft_entity_fields``).
+    monkeypatch target (``builder.agents.pipeline.draft_entity_fields``). The
+    ``usage_sink`` is forwarded so the leaf can report its token usage (#221).
     """
     from builder.agents.leaves import draft_entity_fields as _leaf
 
-    return _leaf(entity_type, context, model=model)
+    return _leaf(entity_type, context, model=model, usage_sink=usage_sink)
 
 
-def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
+def extract_plan(
+    context: str,
+    *,
+    model: str | None = None,
+    usage_sink: UsageSink | None = None,
+) -> dict[str, Any]:
     """Lazy, no-op-safe shim over :func:`builder.agents.leaves.extract_plan`.
 
     Stage A of the §14 hybrid loop: the whole-document candidate-plan extractor.
@@ -83,11 +99,60 @@ def extract_plan(context: str, *, model: str | None = None) -> dict[str, Any]:
     lazily (inside this shim) and only ever after :func:`_materialize_plan` has
     confirmed an LLM provider is configured. Defining the leaf as a module-level
     attribute here also gives tests a stable monkeypatch target
-    (``builder.agents.pipeline.extract_plan``).
+    (``builder.agents.pipeline.extract_plan``). The ``usage_sink`` is forwarded so
+    the leaf can report its token usage (#221).
     """
     from builder.agents.leaves import extract_plan as _leaf
 
-    return _leaf(context, model=model)
+    return _leaf(context, model=model, usage_sink=usage_sink)
+
+
+def _as_int(value: Any) -> int:
+    """Coerce a possibly-missing/None token count to a non-negative int."""
+    if value is None:
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _make_usage_logger(
+    engine: AgentEngine, totals: dict[str, int]
+) -> UsageSink:
+    """Build a :data:`UsageSink` that records one leaf call's token usage (#221).
+
+    For each leaf call it (1) accumulates ``input``/``output`` tokens into
+    *totals* (the running per-run sum the spine surfaces in ``run_pipeline``'s
+    result) and (2) logs a ``node_end``/``node="model"`` event to the engine
+    profiler — the SAME profile-event shape the ReAct model node emits — so
+    :func:`eval.metrics.mine_profile_metrics` mines pipeline tokens identically to
+    the ReAct arm with no runner/factory changes. When no profiler is active (e.g.
+    an engine that was never initialized) the accumulation still happens; only the
+    profile write is skipped.
+    """
+
+    def _sink(
+        input_tokens: int | None,
+        output_tokens: int | None,
+        model_name: str | None,
+    ) -> None:
+        in_t = _as_int(input_tokens)
+        out_t = _as_int(output_tokens)
+        totals["input_tokens"] += in_t
+        totals["output_tokens"] += out_t
+        profiler = getattr(engine, "profiler", None)
+        if profiler is not None:
+            profiler.log_event(
+                event="node_end",
+                node="model",
+                iteration=engine.state.iteration_count,
+                input_tokens=in_t,
+                output_tokens=out_t,
+                model_name=model_name,
+            )
+
+    return _sink
 
 
 # Fields the drafter-leaf result must NEVER write onto a state entity (D5: Verify,
@@ -232,7 +297,9 @@ def _gather_context(engine: AgentEngine) -> str:
     return "\n\n".join(parts).strip()
 
 
-def _draft_entities(engine: AgentEngine) -> dict[str, Any]:
+def _draft_entities(
+    engine: AgentEngine, usage_sink: UsageSink | None = None
+) -> dict[str, Any]:
     """Step 2 — enrich entities via the bounded drafter-leaf (§14.2).
 
     Wires the cheap-model drafter-leaf (:func:`draft_entity_fields`) into the
@@ -286,7 +353,9 @@ def _draft_entities(engine: AgentEngine) -> dict[str, Any]:
             continue
 
         try:
-            leaf_fields = draft_entity_fields(entity.type, context)
+            leaf_fields = draft_entity_fields(
+                entity.type, context, usage_sink=usage_sink
+            )
         except Exception as exc:  # noqa: BLE001 - a flaky leaf must not break the spine
             logger.warning(
                 "drafter-leaf failed for %s (%s); skipping enrichment: %s",
@@ -348,7 +417,9 @@ def _split_person_name(name: str) -> tuple[str, str]:
     return " ".join(parts[:-1]), parts[-1]
 
 
-def _materialize_plan(engine: AgentEngine) -> dict[str, Any]:
+def _materialize_plan(
+    engine: AgentEngine, usage_sink: UsageSink | None = None
+) -> dict[str, Any]:
     """Stage B (§14) — materialize the extracted candidate plan via composites.
 
     Bridges the bounded whole-document extractor (:func:`extract_plan`, Stage A)
@@ -431,7 +502,7 @@ def _materialize_plan(engine: AgentEngine) -> dict[str, Any]:
         return result
 
     try:
-        plan = extract_plan(context)
+        plan = extract_plan(context, usage_sink=usage_sink)
     except Exception as exc:  # noqa: BLE001 - a flaky extractor must not break the spine
         logger.warning("extract_plan failed; skipping materialization: %s", exc)
         return result
@@ -606,14 +677,23 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
 
     Returns:
         ``{"ok", "conformance", "issues", "scaffold", "materialized", "drafted",
-        "fix_rounds"}`` — the final ``build_and_validate`` verdict (``ok`` /
-        per-layer ``conformance`` / routed ``issues``) plus a small trace of what
-        each step did. ``conformance`` always carries the ``base`` / ``isa`` /
-        ``tox`` keys.
+        "fix_rounds", "usage"}`` — the final ``build_and_validate`` verdict
+        (``ok`` / per-layer ``conformance`` / routed ``issues``) plus a small
+        trace of what each step did. ``conformance`` always carries the ``base`` /
+        ``isa`` / ``tox`` keys. ``usage`` is the accumulated token usage across all
+        leaf LLM calls (``{"input_tokens", "output_tokens", "total_tokens"}``,
+        all 0 when no provider is configured) — additive (#221), and ALSO written
+        to ``profile.ndjson`` as ``node_end``/``node="model"`` events so the eval
+        harness mines it exactly as it does the ReAct arm.
     """
+    # Accumulate per-run leaf token usage; the sink also logs each call to the
+    # profiler so eval/runner.py mines it via the same path as the ReAct arm.
+    totals = {"input_tokens": 0, "output_tokens": 0}
+    usage_sink = _make_usage_logger(engine, totals)
+
     scaffold = _scaffold_backbone(engine)
-    materialized = _materialize_plan(engine)
-    drafted = _draft_entities(engine)
+    materialized = _materialize_plan(engine, usage_sink)
+    drafted = _draft_entities(engine, usage_sink)
     validation, fix_rounds = _run_fix_loop(engine)
 
     return {
@@ -624,4 +704,9 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
         "materialized": materialized,
         "drafted": drafted,
         "fix_rounds": fix_rounds,
+        "usage": {
+            "input_tokens": totals["input_tokens"],
+            "output_tokens": totals["output_tokens"],
+            "total_tokens": totals["input_tokens"] + totals["output_tokens"],
+        },
     }

--- a/eval/tests/test_pipeline_factory.py
+++ b/eval/tests/test_pipeline_factory.py
@@ -83,3 +83,85 @@ class TestPipelineAgentWiring:
         assert outcome.error is not None
         assert "pipeline exploded" in outcome.error
         assert isinstance(outcome.state, CrateState)
+
+
+class TestPipelineTokenAccounting:
+    """Issue #221 — the eval case record must sum the deterministic spine's leaf
+    LLM token usage, the SAME way the ReAct arm does (mined from profile.ndjson).
+    Previously the pipeline arm recorded 0 because the leaves' usage was discarded.
+
+    Fully offline: a fake leaf reports a known usage payload through the
+    ``usage_sink`` the spine passes it; the real ``run_pipeline`` logs those as
+    ``node_end``/``node="model"`` profile events, and ``run_eval`` mines them with
+    its default (disk-backed) profile reader.
+    """
+
+    def test_eval_record_sums_pipeline_leaf_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builder.agents.pipeline as pipeline_mod
+        from eval.runner import run_eval
+
+        # Provider "configured" + a fake leaf that emits a known usage payload on
+        # every call. No real model, no network.
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+        monkeypatch.setattr(pipeline_mod, "extract_plan", lambda *a, **k: {})
+
+        calls = {"n": 0}
+
+        def fake_leaf(entity_type, context, *, model=None, usage_sink=None):
+            calls["n"] += 1
+            if usage_sink is not None:
+                usage_sink(100, 25, "gpt-4o-mini")
+            return {"description": f"drafted {entity_type}"}
+
+        monkeypatch.setattr(pipeline_mod, "draft_entity_fields", fake_leaf)
+
+        # A custom agent: real engine (so a real profile.ndjson is written), seed
+        # a title so the drafter has usable context, then run the REAL spine.
+        class _SpineAgent:
+            def __init__(self) -> None:
+                self._engine = AgentEngine(human_interface=SimulatedHumanInterface())
+
+            def build(self, case):  # type: ignore[no-untyped-def]
+                self._engine.initialize(input_path=case.input_path)
+                # Give the drafter usable context so it makes leaf calls.
+                self._engine.state.metadata.title = "Token accounting probe"
+                error = None
+                try:
+                    pipeline_mod.run_pipeline(self._engine)
+                except Exception as exc:  # noqa: BLE001
+                    error = str(exc)
+                finally:
+                    self._engine.close_profiler()
+                return BuildOutcome(
+                    state=self._engine.state,
+                    session_id=self._engine.state.session_id,
+                    error=error,
+                )
+
+        minimal = next(c for c in DEFAULT_CORPUS if c.kind == "minimal")
+        report = run_eval(lambda: _SpineAgent(), [minimal], repeats=1, label="pipe-tok")
+
+        res = report.results[0]
+        assert calls["n"] >= 1, "the spine must have made >=1 leaf call"
+        # The eval record sums every leaf call (calls × 100/25) — non-zero, in the
+        # SAME fields the ReAct arm uses.
+        assert res.input_tokens == 100 * calls["n"]
+        assert res.output_tokens == 25 * calls["n"]
+        assert res.total_tokens == 125 * calls["n"]
+
+    def test_no_provider_records_clean_zero_through_eval(self) -> None:
+        """The no-provider pipeline path records a clean 0 — no crash, no leak."""
+        from eval.runner import run_eval
+
+        # The real PipelineBuildAgent with NO provider configured: the spine's
+        # drafter/plan steps are strict no-ops, so the record is a clean zero.
+        factory = make_pipeline_agent_factory()
+        minimal = next(c for c in DEFAULT_CORPUS if c.kind == "minimal")
+        report = run_eval(factory, [minimal], repeats=1, label="pipe-zero")
+
+        res = report.results[0]
+        assert res.input_tokens == 0
+        assert res.output_tokens == 0
+        assert res.total_tokens == 0

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -31,35 +31,68 @@ from builder.tools._crate_mapping import draft_hints_schema
 
 
 class _FakeStructuredRunnable:
-    """The runnable returned by `model.with_structured_output(schema)`.
+    """The runnable returned by `model.with_structured_output(schema, ...)`.
 
-    Records the messages it was invoked with and returns canned output.
+    Records the messages it was invoked with and returns canned output. When the
+    leaf binds with ``include_raw=True`` (the usage-capture path) it returns the
+    langchain-shaped ``{"raw": AIMessage, "parsed": ..., "parsing_error": None}``
+    so the leaf can mine ``usage_metadata`` off the raw message; otherwise it
+    returns the bare parsed dict (the legacy contract).
     """
 
-    def __init__(self, parent: "FakeChatModel") -> None:
+    def __init__(self, parent: "FakeChatModel", *, include_raw: bool = False) -> None:
         self._parent = parent
+        self._include_raw = include_raw
 
     def invoke(self, messages: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
         self._parent.invoke_calls.append(messages)
+        if self._include_raw:
+            return {
+                "raw": self._parent.raw_message(),
+                "parsed": self._parent.canned_output,
+                "parsing_error": None,
+            }
         return self._parent.canned_output
 
 
 class FakeChatModel:
     """A fake LangChain chat model recording structured-output usage.
 
-    `with_structured_output(schema)` records the schema and returns a runnable
-    whose `.invoke(...)` yields `canned_output`. This lets the tests assert the
-    leaf goes through structured output exactly once without any network call.
+    `with_structured_output(schema, include_raw=...)` records the schema (and the
+    ``include_raw`` flag) and returns a runnable whose `.invoke(...)` yields
+    `canned_output`. Optionally carries a ``usage_metadata`` payload so the
+    usage-capture path can be exercised entirely offline.
     """
 
-    def __init__(self, canned_output: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        canned_output: dict[str, Any],
+        *,
+        usage_metadata: dict[str, Any] | None = None,
+        model_name: str | None = None,
+    ) -> None:
         self.canned_output = canned_output
+        self._usage_metadata = usage_metadata
+        self._model_name = model_name
         self.structured_schemas: list[Any] = []
         self.invoke_calls: list[Any] = []
+        self.include_raw_flags: list[bool] = []
 
-    def with_structured_output(self, schema: Any, **kwargs: Any) -> _FakeStructuredRunnable:
+    def raw_message(self) -> Any:
+        """Build the AIMessage the structured-output runnable returns as ``raw``."""
+        from langchain_core.messages import AIMessage
+
+        msg = AIMessage(content="", usage_metadata=self._usage_metadata)
+        if self._model_name is not None:
+            msg.response_metadata = {"model_name": self._model_name}
+        return msg
+
+    def with_structured_output(
+        self, schema: Any, *, include_raw: bool = False, **kwargs: Any
+    ) -> _FakeStructuredRunnable:
         self.structured_schemas.append(schema)
-        return _FakeStructuredRunnable(self)
+        self.include_raw_flags.append(include_raw)
+        return _FakeStructuredRunnable(self, include_raw=include_raw)
 
 
 @pytest.fixture(autouse=True)
@@ -526,6 +559,97 @@ class TestExtractPlanD5StripsFabricatedIdentifiers:
 
         assert plan["publications"][0]["title"] == "P"
         assert "doi" not in plan["publications"][0]
+
+
+# ---------------------------------------------------------------------------
+# Token-usage capture (Issue #221)
+#
+# The deterministic pipeline's leaves make their own chat-model calls; without
+# instrumentation their token usage is discarded and the eval `--arch pipeline`
+# arm records 0. The leaves accept an optional `usage_sink` callback: when given,
+# the leaf binds structured output with `include_raw=True`, mines
+# `(input_tokens, output_tokens, model_name)` off the raw AIMessage (the SAME
+# provider-agnostic source the ReAct model node uses), and reports it through the
+# sink. With no sink the behaviour is unchanged (the legacy bare-parsed contract).
+# ---------------------------------------------------------------------------
+
+
+class TestDraftEntityFieldsUsageCapture:
+    def test_usage_sink_receives_token_usage(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"name": "Acetaminophen"},
+            usage_metadata={"input_tokens": 120, "output_tokens": 35, "total_tokens": 155},
+            model_name="gpt-4o-mini",
+        )
+        captured: list[tuple[Any, Any, Any]] = []
+
+        out = leaves.draft_entity_fields(
+            "MolecularEntity",
+            "context",
+            usage_sink=lambda i, o, m: captured.append((i, o, m)),
+        )
+
+        assert out["name"] == "Acetaminophen"
+        assert captured == [(120, 35, "gpt-4o-mini")]
+
+    def test_usage_sink_binds_structured_output_with_include_raw(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel(
+            {"name": "x"},
+            usage_metadata={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        )
+        _patch_build_chat_model["model"] = fake
+
+        leaves.draft_entity_fields("Study", "context", usage_sink=lambda *_: None)
+
+        assert fake.include_raw_flags == [True]
+
+    def test_no_usage_sink_keeps_legacy_contract(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # Without a sink the leaf must NOT request include_raw and must still
+        # return the bare parsed dict (backward compatible).
+        fake = FakeChatModel({"name": "Acetaminophen"})
+        _patch_build_chat_model["model"] = fake
+
+        out = leaves.draft_entity_fields("MolecularEntity", "context")
+
+        assert out["name"] == "Acetaminophen"
+        assert fake.include_raw_flags == [False]
+
+
+class TestExtractPlanUsageCapture:
+    def test_usage_sink_receives_token_usage(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"study": {"name": "S"}},
+            usage_metadata={"input_tokens": 500, "output_tokens": 80, "total_tokens": 580},
+            model_name="gpt-4o-mini",
+        )
+        captured: list[tuple[Any, Any, Any]] = []
+
+        plan = leaves.extract_plan(
+            _DOC_CONTEXT,
+            usage_sink=lambda i, o, m: captured.append((i, o, m)),
+        )
+
+        assert plan["study"]["name"] == "S"
+        assert captured == [(500, 80, "gpt-4o-mini")]
+
+    def test_no_usage_sink_keeps_legacy_contract(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"study": {"name": "S"}})
+        _patch_build_chat_model["model"] = fake
+
+        plan = leaves.extract_plan(_DOC_CONTEXT)
+
+        assert plan["study"]["name"] == "S"
+        assert fake.include_raw_flags == [False]
 
 
 def _flatten_keys(schema: Any) -> set[str]:

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -171,7 +171,7 @@ class TestDraftEntitiesWiring:
         self._enable_provider(monkeypatch)
         calls: list[tuple[str, str]] = []
 
-        def fake_leaf(entity_type, context, *, model=None):
+        def fake_leaf(entity_type, context, *, model=None, usage_sink=None):
             calls.append((entity_type, context))
             # A descriptive field plus an identifier the leaf would normally strip
             # — assert the wiring NEVER applies the identifier even if present.
@@ -214,7 +214,7 @@ class TestDraftEntitiesWiring:
 
         self._enable_provider(monkeypatch)
 
-        def fake_leaf(entity_type, context, *, model=None):
+        def fake_leaf(entity_type, context, *, model=None, usage_sink=None):
             return {"name": "LEAF NAME", "description": "leaf desc"}
 
         monkeypatch.setattr(pipeline_mod, "draft_entity_fields", fake_leaf)
@@ -337,7 +337,7 @@ class TestMaterializePlan:
 
         seen: list[str] = []
 
-        def fake_extract_plan(context, *, model=None):
+        def fake_extract_plan(context, *, model=None, usage_sink=None):
             seen.append(context)
             return dict(self._PLAN if plan is None else plan)
 
@@ -588,6 +588,150 @@ class TestMaterializePlan:
         # The materialized plan is reflected in the result trace.
         assert "materialized" in result
         assert result["materialized"]["compounds"] >= 2
+
+
+class TestTokenAccounting:
+    """Issue #221 — the deterministic spine's leaf LLM calls must record their
+    token usage to ``profile.ndjson`` in the SAME shape the ReAct model node
+    uses, so ``eval/runner.py`` mines real per-case tokens for ``--arch pipeline``
+    (it previously recorded 0 because the leaves' usage was discarded).
+
+    Offline: the leaf is stubbed and reports a known usage payload via the
+    ``usage_sink`` the spine passes it; the engine writes ``node_end``/
+    ``node="model"`` events that :func:`eval.metrics.mine_profile_metrics` sums.
+    """
+
+    def _seeded_state(self) -> CrateState:
+        import uuid
+
+        state = CrateState()
+        # A unique session id so each test writes its OWN profile.ndjson; the
+        # _engine() default is second-precision, which collides under -n 2 and
+        # would mix one test's model events into another's profile (read below).
+        state.session_id = f"tok-{uuid.uuid4().hex[:12]}"
+        state.metadata.title = "TPO inhibition dose-response screen"
+        state.metadata.description = "A cell-based in vitro TPO inhibition assay."
+        state.add_entity(_entity("inv1", "Investigation", name="Inv"))
+        state.add_entity(_entity("st1", "Study", name="St", investigation_id="inv1"))
+        state.add_entity(_entity("as1", "Assay", name="As", study_id="st1"))
+        # Two bare entities (missing a description) for the leaf to enrich, so the
+        # spine makes >1 leaf call and we assert usage is ACCUMULATED across them.
+        state.add_entity(_entity("chem1", "MolecularEntity", name="Methimazole"))
+        state.add_entity(_entity("per1", "Person", name="Jane Doe"))
+        return state
+
+    def _mine(self, engine: AgentEngine):
+        import shutil
+        from pathlib import Path
+
+        from builder.tools.dashboard import read_profile
+        from builder.tools.profiler import SESSION_DIR
+        from eval.metrics import mine_profile_metrics
+
+        engine.close_profiler()  # flush + close before reading
+        session_dir = Path(SESSION_DIR) / engine.state.session_id
+        try:
+            return mine_profile_metrics(read_profile(session_dir / "profile.ndjson"))
+        finally:
+            # Don't litter sessions/ with this test's unique-id profile dir.
+            shutil.rmtree(session_dir, ignore_errors=True)
+
+    def test_draft_entities_records_accumulated_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+        def fake_leaf(entity_type, context, *, model=None, usage_sink=None):
+            # Each leaf call reports a known usage payload through the sink.
+            if usage_sink is not None:
+                usage_sink(100, 20, "gpt-4o-mini")
+            return {"description": f"drafted {entity_type}"}
+
+        monkeypatch.setattr(pipeline_mod, "draft_entity_fields", fake_leaf)
+
+        engine = _engine(self._seeded_state())
+        totals = {"input_tokens": 0, "output_tokens": 0}
+        sink = pipeline_mod._make_usage_logger(engine, totals)
+        result = pipeline_mod._draft_entities(engine, sink)
+
+        # The spine enriched every entity missing a descriptive field; at least
+        # the two bare domain entities, so >1 leaf call is made (we assert usage
+        # is ACCUMULATED, not just recorded once).
+        n_calls = len(result["drafted"])
+        assert n_calls >= 2
+
+        # The running accumulator summed every leaf call (n_calls × 100/20).
+        assert totals["input_tokens"] == 100 * n_calls
+        assert totals["output_tokens"] == 20 * n_calls
+
+        # …and those landed in profile.ndjson as node_end/model events, so the
+        # eval runner mines them identically to the ReAct arm.
+        pm = self._mine(engine)
+        assert pm.input_tokens == 100 * n_calls
+        assert pm.output_tokens == 20 * n_calls
+        assert pm.total_tokens == 120 * n_calls
+
+    def test_no_provider_records_clean_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        # No provider → the leaf is never called and no model events are written.
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: None)
+
+        def boom(*args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("leaf must not run without a provider")
+
+        monkeypatch.setattr(pipeline_mod, "draft_entity_fields", boom)
+
+        engine = _engine(self._seeded_state())
+        pipeline_mod._draft_entities(engine)
+
+        pm = self._mine(engine)
+        assert pm.input_tokens == 0
+        assert pm.output_tokens == 0
+        assert pm.total_tokens == 0
+
+    def test_run_pipeline_returns_usage_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``run_pipeline``'s result additively surfaces the accumulated usage."""
+        import builder.agents.pipeline as pipeline_mod
+        from builder.agents.pipeline import run_pipeline
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+        # Make the plan stage a no-op (empty plan) so only the drafter leaf runs.
+        monkeypatch.setattr(pipeline_mod, "extract_plan", lambda *a, **k: {})
+
+        def fake_leaf(entity_type, context, *, model=None, usage_sink=None):
+            if usage_sink is not None:
+                usage_sink(50, 10, "gpt-4o-mini")
+            return {"description": f"drafted {entity_type}"}
+
+        monkeypatch.setattr(pipeline_mod, "draft_entity_fields", fake_leaf)
+
+        import shutil
+        from pathlib import Path
+
+        from builder.tools.profiler import SESSION_DIR
+
+        engine = _engine(self._seeded_state())
+        try:
+            result = run_pipeline(engine)
+        finally:
+            engine.close_profiler()
+            shutil.rmtree(
+                Path(SESSION_DIR) / engine.state.session_id, ignore_errors=True
+            )
+
+        assert "usage" in result
+        usage = result["usage"]
+        # At least the two seeded bare entities were drafted (50/10 each).
+        assert usage["input_tokens"] >= 100
+        assert usage["output_tokens"] >= 20
+        assert usage["total_tokens"] == usage["input_tokens"] + usage["output_tokens"]
 
 
 class TestDeterminism:


### PR DESCRIPTION
## What was discarding usage

In the #179 A/B run the **pipeline arm recorded `input_tokens=0 / output_tokens=0 / total_tokens=0`** for every case while the ReAct arm recorded real usage. `eval/runner.py` mines tokens from `profile.ndjson` `node_end`/`node="model"` events (via `mine_profile_metrics`). The ReAct model node wrapper writes those events; the deterministic spine's bounded leaves (`builder/agents/leaves.py` → `draft_entity_fields` / `extract_plan`) make their **own** chat-model calls whose usage was never captured or written to the profile, so the runner defaulted to 0.

## Where usage is captured (root-cause, additive, offline)

- **Shared extraction.** Pulled the provider-agnostic usage logic out of the ReAct model node into `agent_loop._extract_token_usage` / `_extract_model_name` (prefer `usage_metadata`, fall back to `response_metadata["token_usage"]`/`["usage"]`) and refactored `_wrap_model_node` onto them — so **both arms mine usage from the identical source**.
- **Leaves report usage.** `draft_entity_fields` / `extract_plan` gained an optional `usage_sink` callback. When given, the leaf binds `with_structured_output(schema, include_raw=True)` and reports `(input_tokens, output_tokens, model_name)` off the raw `AIMessage`. Default `usage_sink=None` keeps the legacy bare-parsed return unchanged.
- **Spine accumulates + profiles.** `run_pipeline` builds a sink that (1) accumulates per-run usage and (2) logs each leaf call as a `node_end`/`node="model"` profile event — **the same field shape the ReAct arm writes** — so `mine_profile_metrics` picks pipeline tokens up with **no runner/factory changes**. `run_pipeline` additively returns a `usage` dict too.

## Field shape matching ReAct

Pipeline leaf usage now lands in `profile.ndjson` as `{"event": "node_end", "node": "model", "input_tokens": …, "output_tokens": …, "model_name": …}` — byte-identical to what the ReAct model node emits — so `eval/runner.py` records `input_tokens` / `output_tokens` / `total_tokens` for `--arch pipeline` exactly as it does for ReAct.

## Additive / offline

- No-op when no provider is configured: the leaves are never called, the sink never fires, the record is a clean `0` (no crash).
- `run_pipeline`'s new `usage` key is additive; the production consumer (`eval/pipeline_factory.py`) discards the return, and `tests/test_pipeline_e2e.py` / the interactive path don't call `run_pipeline`. No caller had to be adapted.
- Tests are fully offline: a fake chat model carries a known `usage_metadata` payload and the tests assert the eval case record **sums it across multiple leaf calls**, plus the no-provider clean-`0` path.

Closes #221. Fast-follow to the #179 pipeline cutover (the cost claim was deferred to this).

**DO NOT MERGE** — the user merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)