### PR TITLE
fix(cli): friendly notice + visible progress for interactive build with no --input

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,21 +22,34 @@ from builder.engine import AgentEngine
 logger = logging.getLogger(__name__)
 
 
-def setup_logging(verbose: int = 0) -> None:
+def setup_logging(verbose: int = 0, interactive: bool = False) -> None:
     """Configure logging for the builder.
 
     Levels:
         0 = WARNING (only warnings and errors)
         1 = INFO    (normal progress)
         2 = DEBUG   (verbose/tool internals)
+
+    The interactive build drives a multi-step deterministic pipeline whose
+    progress is logged at INFO; with the default WARNING level the run looks
+    dead. When *interactive* is set and the user has not requested any extra
+    verbosity (``verbose == 0``), the effective level is raised to INFO so that
+    pipeline progress is visible. A user-requested higher verbosity (``-v`` /
+    ``-vv``) is never downgraded.
     """
     level_map = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
     level = level_map.get(verbose, logging.WARNING)
+    if interactive and verbose == 0:
+        level = logging.INFO
     logging.basicConfig(
         level=level,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+    # basicConfig is a no-op once the root logger has handlers (e.g. a prior
+    # call in the same process), so set the level explicitly to honour the
+    # interactive bump and the requested verbosity deterministically.
+    logging.getLogger().setLevel(level)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -340,7 +353,11 @@ def main(argv: list[str] | None = None) -> int:
     Returns 0 on success, 1 on error.
     """
     args = parse_args(argv)
-    setup_logging(args.verbose)
+    # The default interactive build (pipeline + guidance) logs progress at INFO;
+    # bump the default level there so the run does not look dead. The legacy
+    # ReAct loop keeps its own output, so the bump applies to the whole
+    # interactive path.
+    setup_logging(args.verbose, interactive=args.interactive)
 
     logger.info("ISA-Tox RO-Crate Builder v0.1.0")
 
@@ -422,6 +439,18 @@ def main(argv: list[str] | None = None) -> int:
                 provider=args.provider,
                 model=args.model,
                 base_url=args.api_base,
+            )
+            return 0
+
+        # The default interactive build is folder-driven: with no scanned files
+        # there is genuinely nothing to build. Tell the user how to proceed
+        # instead of exiting near-silently, then return gracefully.
+        if len(engine.state.scanned_files) == 0:
+            print(
+                "No input documents found. The interactive build is "
+                "folder-driven: pass --input <folder> to build an ISA-Tox crate "
+                "from your research documents, or use --legacy-react for the "
+                "conversational agent."
             )
             return 0
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,9 +135,16 @@ class TestInteractiveDispatch:
         args = parse_args(["--interactive", "--legacy-react"])
         assert args.legacy_react is True
 
-    def test_default_interactive_routes_to_pipeline_build(self, monkeypatch):
-        """--interactive (no opt-in) runs the deterministic pipeline + guidance."""
+    def test_default_interactive_routes_to_pipeline_build(self, monkeypatch, tmp_path):
+        """--interactive (no opt-in) runs the deterministic pipeline + guidance.
+
+        Supplies an --input folder with a file so the folder-driven build has
+        something to do (an empty state now short-circuits with a notice).
+        """
         self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
         calls: list[str] = []
 
         import builder.agents.build as build_mod
@@ -156,7 +163,7 @@ class TestInteractiveDispatch:
             lambda *a, **kw: calls.append("react"),
         )
 
-        result = main(["--interactive"])
+        result = main(["--interactive", "--input", str(d)])
         assert result == 0
         assert calls == ["build"]
 
@@ -185,11 +192,18 @@ class TestInteractiveDispatch:
         assert result == 0
         assert calls == ["react"]
 
-    def test_default_interactive_engine_is_interactive(self, monkeypatch):
-        """The engine handed to the default pipeline build reports interactive HITL."""
+    def test_default_interactive_engine_is_interactive(self, monkeypatch, tmp_path):
+        """The engine handed to the default pipeline build reports interactive HITL.
+
+        Supplies an --input folder so the folder-driven build runs (an empty
+        state short-circuits with a notice before reaching the build).
+        """
         from builder.tools.hitl import is_interactive
 
         self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
         seen: list[bool] = []
 
         import builder.agents.build as build_mod
@@ -200,8 +214,115 @@ class TestInteractiveDispatch:
 
         monkeypatch.setattr(build_mod, "run_interactive_build", _capture)
 
-        result = main(["--interactive"])
+        result = main(["--interactive", "--input", str(d)])
         assert result == 0
         # The default interactive build must run behind a REAL interactive
         # interface, else run_interactive_build would skip guidance.
         assert seen == [True]
+
+
+class TestInteractiveNoInput:
+    """First-run UX for the default interactive build with no --input.
+
+    The default interactive build is folder-driven; with zero scanned files there
+    is genuinely nothing to build. These tests assert a friendly notice and a
+    graceful exit (no crash), with the real pipeline stubbed out.
+    """
+
+    def _stub_config(self, monkeypatch):
+        import builder.config as cfg
+
+        monkeypatch.setattr(cfg, "is_configured", lambda: True)
+        monkeypatch.setattr(cfg, "load_config", lambda: {})
+        monkeypatch.setattr(cfg, "merge_with_env", lambda c: None)
+
+    def test_no_input_prints_notice_and_returns_zero(self, monkeypatch, capsys):
+        """--interactive with no --input prints the notice and returns 0."""
+        self._stub_config(monkeypatch)
+        calls: list[str] = []
+
+        import builder.agents.build as build_mod
+
+        monkeypatch.setattr(
+            build_mod,
+            "run_interactive_build",
+            lambda engine, **kw: calls.append("build")
+            or {"pipeline": {}, "guidance": None},
+        )
+
+        result = main(["--interactive"])
+        captured = capsys.readouterr()
+        assert result == 0
+        assert "No input documents found" in captured.out
+        assert "--input" in captured.out
+        # Nothing to build: the pipeline build must not run.
+        assert calls == []
+
+    def test_with_input_does_not_print_notice(self, monkeypatch, capsys, tmp_path):
+        """--interactive with --input (files present) skips the notice and builds."""
+        self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
+        calls: list[str] = []
+
+        import builder.agents.build as build_mod
+
+        monkeypatch.setattr(
+            build_mod,
+            "run_interactive_build",
+            lambda engine, **kw: calls.append("build")
+            or {"pipeline": {}, "guidance": None},
+        )
+
+        result = main(["--interactive", "--input", str(d)])
+        captured = capsys.readouterr()
+        assert result == 0
+        assert "No input documents found" not in captured.out
+        assert calls == ["build"]
+
+
+class TestInteractiveVerbosity:
+    """The interactive path raises the default log level to INFO for visibility."""
+
+    def test_interactive_default_verbose_is_info(self):
+        """setup_logging(0, interactive=True) yields effective level INFO."""
+        import logging
+
+        from main import setup_logging
+
+        root = logging.getLogger()
+        original = root.level
+        try:
+            setup_logging(0, interactive=True)
+            assert root.level == logging.INFO
+        finally:
+            root.setLevel(original)
+
+    def test_noninteractive_default_verbose_is_warning(self):
+        """setup_logging(0) (batch) keeps the WARNING default."""
+        import logging
+
+        from main import setup_logging
+
+        root = logging.getLogger()
+        original = root.level
+        try:
+            setup_logging(0, interactive=False)
+            assert root.level == logging.WARNING
+        finally:
+            root.setLevel(original)
+
+    def test_interactive_does_not_downgrade_explicit_debug(self):
+        """An explicit -vv (DEBUG) is never downgraded by the interactive bump."""
+        import logging
+
+        from main import setup_logging
+
+        root = logging.getLogger()
+        original = root.level
+        try:
+            setup_logging(2, interactive=True)
+            assert root.level == logging.DEBUG
+        finally:
+            root.setLevel(original)


### PR DESCRIPTION
## Two first-run papercuts

After the #179 cutover, `main.py --interactive` defaults to the deterministic pipeline + guidance build (`builder/agents/build.py:run_interactive_build`). Two first-run UX papercuts:

1. **Hidden progress.** Default log level is WARNING (`setup_logging`, `verbose=0`), so the pipeline's INFO progress is invisible and the run looks dead.
2. **Silent no-op with no `--input`.** With no `--input`, the state is empty, so the folder-driven build has nothing to do and exits near-silently — no message telling the user to pass a folder.

## The fix (main.py only, + tests)

1. **Friendly notice.** On the default interactive build path (`args.interactive and not args.legacy_react`), when `len(engine.state.scanned_files) == 0`, print a clear notice to stdout and return 0 gracefully (no crash, no empty-state build):

   > No input documents found. The interactive build is folder-driven: pass --input <folder> to build an ISA-Tox crate from your research documents, or use --legacy-react for the conversational agent.

2. **Visible progress.** `setup_logging(verbose, interactive=...)` raises the effective level to INFO when `verbose == 0` on the interactive path. `-v` (INFO) / `-vv` (DEBUG) semantics are preserved and a user-requested higher verbosity is never downgraded.

## Scope

- Touches only `main.py` and `tests/test_main.py`. No changes to `build.py`, `pipeline.py`, `leaves.py`, or `eval/`.
- Disjoint from #221 / #222 / #224.

## TDD / gates

Tests written failing first, then implemented. All gates green:
- `uv run ruff check` — pass
- `uv run --extra langchain ty check` — pass
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 -q tests/test_main.py` — 23 passed

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)