### PR TITLE
feat(pipeline): read bounded file BODIES into the extraction context (#231)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1360,6 +1360,19 @@ INPUT (dir / zip / conversation)
 
 - **Spine = code.** The Priority 1–4 heuristic (§4) becomes control flow, not prose.
 - **Leaves = cheap model.** Drafting/disambiguation only (binds the §4.4 drafter tier).
+- **Leaf context = bounded file BODIES, not just filenames (#231).** The single
+  `extract`/`draft` leaf is fed by `pipeline.py::_gather_context`, which now reads a
+  bounded BODY excerpt of each non-tabular rich file (`.json` / `.docx` / `.pdf` …)
+  via the existing `builder/tools/file_readers.read_file` — preferring the cheap
+  tabular `first_rows` preview the scanner already captured. Reads are **fail-closed
+  to `state.approved_scan_roots`** (same `_contain` guard as `engine.py`), never
+  raise out of the spine (reader errors are logged + skipped), and are capped per
+  file AND in total by `pipeline.py::_MAX_CONTEXT_CHARS` so the one bounded call
+  stays token-safe. Before #231 the leaf saw filenames + tiny previews only, so
+  `extract_plan` returned an empty plan and the backbone fell back to the literal
+  default names; now document titles/abstracts/SOP headings reach the leaf. The
+  empty-context path is still a strict no-op (`""` ⇒ no provider call), preserving
+  the no-provider determinism guarantee.
 - **Fix loop = deterministic.** `build_and_validate` already returns issues pre-routed to
   `{entity_id, property, fix, severity, profile}`; a code loop dispatches each to a
   lookup / `set_fields` / `link`, calling the LLM only for "draft new content" repairs.
@@ -1520,7 +1533,10 @@ existing toolbox. The sequence:
    supplied this alone yields `{base, isa, tox}` on an empty crate (§14.3).
 2. **Draft entities** — the §14.2 bounded **drafter-leaf is now wired in here**
    (was a deferral): `_draft_entities` gathers a free-text context from what the
-   engine carries (crate `title`/`description` + a scanned-file digest) and, for
+   engine carries (crate `title`/`description` + a scanned-file digest that now
+   includes **bounded BODY excerpts** of non-tabular rich files — `.json` / `.docx`
+   / `.pdf` — read fail-closed to `approved_scan_roots` and capped by
+   `_MAX_CONTEXT_CHARS`, #231) and, for
    each draftable entity missing descriptive fields, calls `draft_entity_fields`
    (`leaves.py`) and applies only the returned **non-identifier descriptive**
    fields (fill, don't clobber). It is a **strict no-op when no LLM provider is

--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -224,6 +224,18 @@ _DEFAULT_INVESTIGATION_NAME = "Investigation"
 _DEFAULT_STUDY_NAME = "Study"
 _DEFAULT_ASSAY_NAME = "Assay"
 
+# Token-safety budget for the free-text context fed to the single bounded
+# extraction/drafter leaf (#231). `_gather_context` now reads non-tabular rich
+# file BODIES (`.json` / `.docx` / `.pdf` …) — not just filenames — so it must
+# cap how much disk content reaches the leaf so the one bounded call stays
+# affordable. The cap is applied BOTH per-file (each body excerpt is truncated to
+# `_MAX_CONTEXT_CHARS`) AND to the total accumulated body content (the running sum
+# of body excerpts never exceeds `_MAX_CONTEXT_CHARS`), so a folder of many large
+# files cannot blow the budget. ~8k chars is roughly a couple thousand tokens —
+# enough for a study title / abstract / SOP heading to survive, small enough to
+# stay cheap.
+_MAX_CONTEXT_CHARS = 8000
+
 
 def _backbone_hints(engine: AgentEngine) -> dict[str, dict[str, str]]:
     """Deterministic name hints for the Investigation / Study / Assay backbone.
@@ -260,17 +272,78 @@ def _scaffold_backbone(engine: AgentEngine) -> dict[str, Any]:
     return engine.run_tool("scaffold_isa_backbone", **hints)
 
 
+def _read_body_excerpt(path: str, approved_roots: set[str], remaining: int) -> str | None:
+    """Read a bounded BODY excerpt of *path*, fail-closed to *approved_roots* (#231).
+
+    Mirrors the engine's fail-closed containment guard (``engine.py`` /
+    :func:`builder.tools.scanner._contain`): the read is refused unless *path*
+    resolves inside an approved scan root, so the spine never widens filesystem
+    access on the leaf's say-so. Dispatches to the existing
+    :func:`builder.tools.file_readers.read_file` (so ``.json`` / ``.docx`` /
+    ``.xlsx`` / ``.pdf`` / text are all handled by code that already exists — no
+    hand-rolled parsing) and never lets a reader error escape: any
+    :class:`OSError`, missing optional dependency, or malformed-file error is
+    logged and yields ``None`` (skip), so a single unreadable file can never break
+    the deterministic spine.
+
+    The returned excerpt is truncated to ``min(remaining, _MAX_CONTEXT_CHARS)`` so
+    both the per-file cap and the caller's total budget are honoured. Returns
+    ``None`` when nothing readable was produced (so the caller emits no body line).
+    """
+    if remaining <= 0:
+        return None
+
+    # Lazy imports: keep the spine importable in the default env, and only touch
+    # the readers / containment primitive when there is actually a body to read.
+    from builder.tools.file_readers import read_file
+    from builder.tools.scanner import _contain
+
+    # Fail-closed containment: refuse any path not inside an approved scan root.
+    if _contain(path, approved_roots) is None:
+        logger.debug("Skipping body read of %s — outside approved scan roots (#231).", path)
+        return None
+
+    try:
+        body = read_file(path)
+    except (OSError, ValueError, ImportError) as exc:
+        logger.warning("Body read failed for %s; skipping: %s", path, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 - a malformed file must not break the spine
+        logger.warning("Unexpected body-read error for %s; skipping: %s", path, exc)
+        return None
+
+    if not body or not body.strip():
+        return None
+
+    cap = min(remaining, _MAX_CONTEXT_CHARS)
+    excerpt = body.strip()
+    if len(excerpt) > cap:
+        excerpt = excerpt[:cap].rstrip() + " […]"
+    return excerpt
+
+
 def _gather_context(engine: AgentEngine) -> str:
-    """Assemble a free-text context string for the drafter-leaf from the engine.
+    """Assemble a free-text context string for the drafter/extraction leaf (#231).
 
     Pulls from what an initialized engine actually carries: the crate title and
     description (``state.metadata``) and the scanned-file inventory
-    (``state.scanned_files`` — filenames plus any first-row previews the scanner
-    captured). Returns ``""`` when nothing usable is available, which the caller
-    treats as a strict no-op (no provider call is made).
+    (``state.scanned_files``). For each scanned file it prefers the cheap tabular
+    ``first_rows`` preview the scanner already captured; for non-tabular rich files
+    that lack a preview (``.json`` / ``.docx`` / ``.pdf`` …) it now reads a
+    **bounded body excerpt** from disk via :func:`_read_body_excerpt` so document
+    BODIES — study titles, abstracts, SOP headings — reach the single bounded leaf
+    rather than filenames alone. Without this the leaf saw only filenames + tiny
+    previews and ``extract_plan`` returned an empty plan, so the backbone fell back
+    to the literal default names (#231).
 
-    The context is intentionally a *digest*, not the full file bodies — the leaf is
-    a bounded single call, and the spine never re-reads disk here.
+    Body reads are **fail-closed to ``state.approved_scan_roots``** and never raise
+    out of the spine (see :func:`_read_body_excerpt`). Output is bounded by
+    :data:`_MAX_CONTEXT_CHARS` per file AND in total, so the one bounded leaf call
+    stays token-safe regardless of how many large files were scanned.
+
+    Returns ``""`` when nothing usable is available, which the caller treats as a
+    strict no-op (no provider call is made) — preserving the no-context strict-noop
+    and no-provider determinism guarantees.
     """
     state = engine.state
     parts: list[str] = []
@@ -283,13 +356,23 @@ def _gather_context(engine: AgentEngine) -> str:
         parts.append(f"Description: {description}")
 
     if state.scanned_files:
+        approved_roots = state.approved_scan_roots
         file_lines: list[str] = []
+        body_budget = _MAX_CONTEXT_CHARS  # total body content across all files
         for f in state.scanned_files:
             line = f"- {f.filename}"
             if f.first_rows:
+                # Prefer the cheap preview the scanner already captured — no disk read.
                 preview = " | ".join(str(r) for r in f.first_rows[:3])
                 if preview.strip():
                     line += f": {preview}"
+            elif body_budget > 0:
+                # No tabular preview: read a bounded body excerpt (fail-closed to
+                # approved roots; never raises) so the leaf sees the document body.
+                excerpt = _read_body_excerpt(f.path, approved_roots, body_budget)
+                if excerpt:
+                    body_budget -= len(excerpt)
+                    line += f":\n{excerpt}"
             file_lines.append(line)
         if file_lines:
             parts.append("Scanned files:\n" + "\n".join(file_lines))

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -17,10 +17,18 @@ The headline guarantees under test:
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from builder.engine import AgentEngine
-from builder.state import CrateState, Entity, EntityProvenance, EntityType
+from builder.state import (
+    CrateState,
+    Entity,
+    EntityProvenance,
+    EntityType,
+    FileClassification,
+)
 from builder.tools.hitl import SimulatedHumanInterface
 
 # The spine drives build_and_validate / fix_required_issues, which run the
@@ -920,3 +928,181 @@ class TestDeterminism:
         e2 = _engine(seeded())
         run_pipeline(e2)
         assert crate_graph_hash(e1.state) == crate_graph_hash(e2.state)
+
+
+class TestGatherContext:
+    """`_gather_context` now reads non-tabular rich file BODIES (Issue #231).
+
+    Before #231 the spine's single bounded extraction leaf only ever saw
+    filenames plus tiny tabular ``first_rows`` previews, so ``.json`` / ``.docx``
+    / ``.pdf`` rich files contributed nothing and ``extract_plan`` returned an
+    empty plan (the backbone then fell back to literal default names). These
+    tests pin the fix: bodies of readable non-tabular files appear in the
+    gathered context, bounded by ``_MAX_CONTEXT_CHARS`` (per-file + total),
+    confined to ``approved_scan_roots``, and never raising out of the spine. The
+    two strict no-op gates (empty context ⇒ ``""``) are preserved.
+    """
+
+    def _write_json(self, root: Path, marker: str) -> FileClassification:
+        path = root / "S-VHPS26.json"
+        path.write_text(
+            f'{{"studyTitle": "{marker}", "organism": "Rattus norvegicus"}}',
+            encoding="utf-8",
+        )
+        return FileClassification(
+            path=str(path),
+            filename=path.name,
+            size=path.stat().st_size,
+            mime_type="application/json",
+            first_rows=None,
+        )
+
+    def _write_docx(self, root: Path, marker: str) -> FileClassification:
+        from docx import Document  # type: ignore[import-untyped]
+
+        path = root / "SOP.docx"
+        doc = Document()
+        doc.add_paragraph(marker)
+        doc.add_paragraph("Standard operating procedure for the assay.")
+        doc.save(str(path))
+        return FileClassification(
+            path=str(path),
+            filename=path.name,
+            size=path.stat().st_size,
+            mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            first_rows=None,
+        )
+
+    def test_reads_json_and_docx_bodies_into_context(self, tmp_path: Path) -> None:
+        """Body substrings from non-tabular files under an approved root appear."""
+        from builder.agents.pipeline import _gather_context
+
+        json_fc = self._write_json(tmp_path, "JSONBODYMARKER")
+        docx_fc = self._write_docx(tmp_path, "DOCXBODYMARKER")
+
+        state = CrateState()
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [json_fc, docx_fc]
+        engine = _engine(state)
+
+        context = _gather_context(engine)
+
+        # The bodies — not just the filenames — reached the context.
+        assert "JSONBODYMARKER" in context
+        assert "DOCXBODYMARKER" in context
+        # Filenames are still listed.
+        assert "S-VHPS26.json" in context
+        assert "SOP.docx" in context
+
+    def test_prefers_cheap_first_rows_when_present(self, tmp_path: Path) -> None:
+        """A file carrying a tabular preview uses it; disk is not re-read for it."""
+        from builder.agents.pipeline import _gather_context
+        from builder.state import FileClassification
+
+        # A file that DOES carry first_rows — the cheap preview must be used and the
+        # body reader must not be invoked for it (the path need not even exist).
+        tabular = FileClassification(
+            path=str(tmp_path / "missing.csv"),
+            filename="data.csv",
+            size=10,
+            mime_type="text/csv",
+            first_rows=["col_a,col_b", "1,2"],
+        )
+        state = CrateState()
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [tabular]
+        engine = _engine(state)
+
+        context = _gather_context(engine)
+        assert "col_a,col_b" in context
+
+    def test_reads_are_confined_to_approved_scan_roots(self, tmp_path: Path) -> None:
+        """A body OUTSIDE every approved root is never read into the context."""
+        from builder.agents.pipeline import _gather_context
+
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        inside_fc = self._write_json(approved, "INSIDEMARKER")
+        outside_fc = self._write_json(outside, "OUTSIDEMARKER")
+        # Re-point filename so the two are distinguishable in the listing.
+        outside_fc.filename = "outside.json"
+
+        state = CrateState()
+        state.approved_scan_roots.add(str(approved.resolve()))
+        state.scanned_files = [inside_fc, outside_fc]
+        engine = _engine(state)
+
+        context = _gather_context(engine)
+        assert "INSIDEMARKER" in context
+        # The out-of-root body is fail-closed: its content never appears.
+        assert "OUTSIDEMARKER" not in context
+
+    def test_per_file_and_total_budget_are_bounded(self, tmp_path: Path) -> None:
+        """Per-file and total context are capped by `_MAX_CONTEXT_CHARS`."""
+        import builder.agents.pipeline as pipeline_mod
+        from builder.agents.pipeline import _gather_context
+        from builder.state import FileClassification
+
+        cap = pipeline_mod._MAX_CONTEXT_CHARS
+        assert isinstance(cap, int) and cap > 0
+
+        state = CrateState()
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        files: list[FileClassification] = []
+        # Several large files, each far bigger than the cap, so both the per-file
+        # and the total budget must clamp the result.
+        for i in range(6):
+            path = tmp_path / f"big{i}.txt"
+            path.write_text("X" * (cap * 4), encoding="utf-8")
+            files.append(
+                FileClassification(
+                    path=str(path),
+                    filename=path.name,
+                    size=path.stat().st_size,
+                    mime_type="text/plain",
+                    first_rows=None,
+                )
+            )
+        state.scanned_files = files
+        engine = _engine(state)
+
+        context = _gather_context(engine)
+        # Total context stays within a small multiple of the documented cap (the
+        # total budget is the binding ceiling — not 6x the per-file body).
+        assert len(context) <= cap * 3
+
+    def test_no_readable_files_is_strict_noop(self, tmp_path: Path) -> None:
+        """Nothing readable ⇒ ``""`` so the no-provider determinism gate holds."""
+        from builder.agents.pipeline import _gather_context
+        from builder.state import FileClassification
+
+        # A binary file with no first_rows whose body reader returns None, under an
+        # approved root, on an untitled/undescribed crate ⇒ no usable context.
+        path = tmp_path / "blob.pzfx"
+        path.write_bytes(b"\x00\x01\x02\x03binary-not-text\x00")
+        state = CrateState()
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [
+            FileClassification(
+                path=str(path),
+                filename=path.name,
+                size=path.stat().st_size,
+                mime_type="application/octet-stream",
+                first_rows=None,
+            )
+        ]
+        engine = _engine(state)
+
+        # Filenames alone still list, but no BODY content — and an untitled crate
+        # with only a filename listing is still usable context for the listing
+        # path. The strict no-op we must preserve is the *fully empty* one:
+        state_empty = CrateState()
+        engine_empty = _engine(state_empty)
+        assert _gather_context(engine_empty) == ""
+
+        # The binary body itself contributed nothing readable.
+        context = _gather_context(engine)
+        assert "binary-not-text" not in context

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -39,6 +39,7 @@ deterministic spine end to end without ever leaving the process.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -546,3 +547,123 @@ class TestPipelineE2ENoProviderSafety:
         assert {"Investigation", "Study", "Assay"} <= {
             e.type for e in engine.state.list_entities()
         }
+
+
+# ---------------------------------------------------------------------------
+# 5: extraction-context fidelity — bodies of rich files drive the plan (#231)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionContextFidelity:
+    """`_gather_context` now reads non-tabular rich file BODIES, so a study-specific
+    title in a ``.json`` / ``.docx`` reaches the extraction leaf and the
+    materialized Study gets a real name — NOT the literal default ``"Study"`` (#231).
+
+    Before #231 the spine fed the bounded extraction leaf only filenames + tiny
+    tabular previews, so ``extract_plan`` saw nothing and returned an empty plan,
+    and the backbone fell back to the literal ``"Study"`` default. The guard uses a
+    stub ``extract_plan`` that echoes a study title ONLY when the context actually
+    carries the document body marker — so a passing test proves the BODY made it
+    into the context.
+    """
+
+    _BODY_MARKER = "TPO-INHIBITION-SVHPS26"
+
+    def test_materialized_study_name_is_not_the_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A study title carried in a ``.json`` body materializes a real Study name.
+
+        The stub ``extract_plan`` echoes a study name ONLY when the gathered context
+        contains the document body marker (which lives in the ``.json`` BODY, never
+        the filename). Running ``_materialize_plan`` on a backbone-free engine then
+        creates the Study from the plan — proving the body reached the leaf and the
+        Study is named from it, not the literal ``"Study"`` default.
+        """
+        import builder.agents.pipeline as pipeline_mod
+        from builder.state import FileClassification
+
+        # Provider configured (no real model) so the leaf runs.
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+        study_name = "Methimazole TPO inhibition dose-response study"
+
+        def fake_extract_plan(
+            context: str, *, model: str | None = None, usage_sink: Any = None
+        ) -> dict[str, Any]:
+            # Echo a study name ONLY when the document BODY made it into context.
+            if self._BODY_MARKER in context:
+                return {"study": {"name": study_name}}
+            return {}
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", fake_extract_plan)
+
+        # A non-tabular rich file whose BODY (not its filename) carries the marker.
+        body_file = tmp_path / "S-VHPS26.json"
+        body_file.write_text(
+            f'{{"studyTitle": "{self._BODY_MARKER}", "organism": "Rattus"}}',
+            encoding="utf-8",
+        )
+        fc = FileClassification(
+            path=str(body_file),
+            filename=body_file.name,
+            size=body_file.stat().st_size,
+            mime_type="application/json",
+            first_rows=None,  # non-tabular: the scanner captured no preview
+        )
+
+        state = CrateState()  # NO title — the ONLY signal is the file body.
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [fc]
+        engine = _engine(state)
+
+        # Materialize the plan onto a backbone-free engine so the Study is created
+        # FROM the plan's (body-derived) name.
+        pipeline_mod._materialize_plan(engine)
+
+        study = next(
+            (e for e in engine.state.list_entities() if e.type == "Study"), None
+        )
+        assert study is not None, "the body-derived plan must materialize a Study"
+        name = str(study.fields.get("name") or "")
+        assert name == study_name
+        # The headline guard: NOT the literal default.
+        assert name != "Study"
+
+    def test_no_body_yields_no_study_specific_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Control: with no readable body, the leaf echoes nothing, so no Study is
+        materialized from a plan (the spine would fall back to the default)."""
+        import builder.agents.pipeline as pipeline_mod
+        from builder.state import FileClassification
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+        def fake_extract_plan(
+            context: str, *, model: str | None = None, usage_sink: Any = None
+        ) -> dict[str, Any]:
+            if self._BODY_MARKER in context:  # pragma: no cover - must not fire
+                return {"study": {"name": "should-not-happen"}}
+            return {}
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", fake_extract_plan)
+
+        # A binary file with no first_rows whose body reader returns None.
+        blob = tmp_path / "data.pzfx"
+        blob.write_bytes(b"\x00\x01binary\x00not-text\x00")
+        fc = FileClassification(
+            path=str(blob),
+            filename=blob.name,
+            size=blob.stat().st_size,
+            mime_type="application/octet-stream",
+            first_rows=None,
+        )
+        state = CrateState()
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [fc]
+        engine = _engine(state)
+
+        result = pipeline_mod._materialize_plan(engine)
+        # No body marker reached the leaf, so it echoed no study name.
+        assert result["study"] == 0


### PR DESCRIPTION
## Summary

Closes #231 (part of epic #179 — deterministic pipeline with bounded LLM leaves).

The deterministic spine's single bounded extraction/drafter leaf was **context-starved**: `_gather_context` (`builder/agents/pipeline.py`) fed the leaf only filenames plus tiny tabular `first_rows` previews — never document **bodies**. So `.json` / `.docx` / `.pdf` / `.pzfx` rich files contributed nothing, `extract_plan` returned an empty plan, and the ISA backbone fell back to the literal default names `Investigation` / `Study` / `Assay` (the "Wagenaars" single-field Person was a downstream symptom of the same starvation).

The capable readers already existed in `builder/tools/file_readers.py` (`read_file` dispatches `.docx` / `.xlsx` / `.json` / `.pdf`) but were wired only into the legacy ReAct loop, never the §179 spine.

## Fix

`_gather_context` now reads a **bounded BODY excerpt** of each non-tabular rich file via a new `_read_body_excerpt` helper that reuses the existing `read_file` (no hand-rolled parsing). The reads are:

- **fail-closed to `state.approved_scan_roots`** — same `_contain` containment guard `engine.py` uses; a path outside every approved root is never read;
- **never allowed to raise out of the spine** — `OSError` / missing optional dep / malformed-file errors are logged and skipped;
- **bounded** by a documented `_MAX_CONTEXT_CHARS` constant applied **per-file AND in total**, so a folder of many large files can't blow the single bounded leaf call's token budget;
- **cheap-first** — the scanner's `first_rows` preview is preferred when present (no disk re-read).

Both strict no-op gates are preserved: empty/unreadable context still returns `""`, so the no-context strict-noop and no-provider graph-hash determinism guarantees hold unchanged.

## Tests (TDD — failing first, confirmed on main)

- `tests/test_agents_pipeline.py::TestGatherContext` (appended, no collision with sibling #232):
  - `test_reads_json_and_docx_bodies_into_context` — body substrings from `.json` + `.docx` (both `first_rows=None`) appear under an approved root
  - `test_prefers_cheap_first_rows_when_present`
  - `test_reads_are_confined_to_approved_scan_roots` — out-of-root body never appears
  - `test_per_file_and_total_budget_are_bounded` — `_MAX_CONTEXT_CHARS` per-file + total cap
  - `test_no_readable_files_is_strict_noop`
- `tests/test_pipeline_e2e.py::TestExtractionContextFidelity` — with a stub `extract_plan` that echoes a study title ONLY when the context carries the document body marker, the materialized Study name is the body-derived name, **not** the literal default `"Study"` (+ a no-body control).

## Verification

- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agents_pipeline.py tests/test_pipeline_e2e.py` → **36 passed, 1 xpassed** (the pre-existing non-blocking spine-determinism xfail)
- `uv run ruff check` → **All checks passed!**
- `uv run --extra langchain ty check` → **All checks passed!**

Docs: AGENTS.md §14.2 + §14.5 and the `_gather_context` docstring/"digest" comment updated to record that bodies are now read (bounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
