### PR TITLE
fix(cli): --legacy-react interactive runs get a HumanInterface so scan approval prompts

### DIFF
--- a/main.py
+++ b/main.py
@@ -388,12 +388,14 @@ def main(argv: list[str] | None = None) -> int:
         if not _ensure_configured():
             return 1
 
-    # The DEFAULT interactive build is the deterministic pipeline + HITL guidance
-    # tail (AGENTS.md §14.6.1), so it must run behind a REAL interactive
-    # HumanInterface — else run_interactive_build would (correctly) skip guidance.
-    # The legacy ReAct loop (--legacy-react) keeps the headless simulated default;
-    # its own HITL routes through the agent loop, not the guidance tail.
-    if args.interactive and not args.legacy_react:
+    # Any interactive run gets a REAL interactive HumanInterface. The DEFAULT
+    # build needs it so run_interactive_build won't (correctly) skip guidance
+    # (AGENTS.md §14.6.1); the legacy ReAct loop needs it too so the scanner
+    # approval guard (engine._authorize_scan_root) can prompt-once for a
+    # user-named folder instead of fail-closing — without it a conversational
+    # legacy scan of an un-approved folder returns no files. Non-interactive
+    # (batch) runs keep the headless simulated default.
+    if args.interactive:
         from builder.tools.hitl import ConsoleHumanInterface
 
         engine = AgentEngine(human_interface=ConsoleHumanInterface())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -220,6 +220,30 @@ class TestInteractiveDispatch:
         # interface, else run_interactive_build would skip guidance.
         assert seen == [True]
 
+    def test_legacy_react_engine_is_interactive(self, monkeypatch):
+        """--legacy-react also runs behind a REAL interactive interface.
+
+        Otherwise the scanner-approval guard (``_authorize_scan_root``) fail-closes
+        on a non-interactive (simulated) human, so a conversational legacy-react
+        scan of a user-named folder returns no files. Giving the interactive
+        legacy run a ``ConsoleHumanInterface`` lets it prompt-once and approve.
+        """
+        from builder.tools.hitl import is_interactive
+
+        self._stub_config(monkeypatch)
+        seen: list[bool] = []
+
+        import builder.agents.agent_loop as agent_loop
+
+        def _capture(engine, *a, **kw):
+            seen.append(is_interactive(engine.human_interface))
+
+        monkeypatch.setattr(agent_loop, "run_interactive_agent", _capture)
+
+        result = main(["--interactive", "--legacy-react"])
+        assert result == 0
+        assert seen == [True]
+
 
 class TestInteractiveNoInput:
     """First-run UX for the default interactive build with no --input.


### PR DESCRIPTION
## Why
Follow-up to #228 (merged). #228 added the children-only scan-root approval guard (`AgentEngine._authorize_scan_root`), which **prompts** only when the engine has a real interactive `ConsoleHumanInterface` and otherwise fail-closes. But `main.py` only handed that interface to the **default pipeline** path — `--legacy-react` got a bare `AgentEngine()` (headless `SimulatedHumanInterface`). So a **conversational** legacy-react scan of a user-named folder fail-closed → `scan_files` returned no files (the exact symptom originally reported on a `--legacy-react` call).

## What
- `main.py`: any `args.interactive` run now constructs `AgentEngine(human_interface=ConsoleHumanInterface())` (previously gated with `and not args.legacy_react`). Non-interactive batch runs keep the simulated default. The default pipeline path is unaffected (it already got the interface).
- Net effect: scanner approval now works on **both** the default pipeline path **and** `--legacy-react` — prompt-once, children-only, parent never (all the #228 semantics).

## Tests (TDD)
- New `tests/test_main.py::TestInteractiveDispatch::test_legacy_react_engine_is_interactive` — asserts the engine handed to `run_interactive_agent` reports `is_interactive(engine.human_interface) is True`. Confirmed red before the fix (`False != True`), green after.
- `tests/test_main.py` 24/24, `ruff` + `ty` clean.

Refs #228, epic #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)