### PR TITLE
fix(guidance): skip un-progressable gaps instead of aborting the HITL loop (#230)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1598,6 +1598,16 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   the loop. It is NOT a ReAct/LLM-orchestrated agent: CODE owns control flow, the
   LLM only *drafts* a suggested value, and the user confirms every uncertain
   commit (D5). It is invoked **only for a real interactive user** (see §14.6.1).
+  The loop **advances over un-progressable gaps** rather than aborting on the
+  first one (#230): each round it draws the next *actionable* gap (`report-only`
+  gaps are never drawn — see below), and a gap it cannot progress (e.g. the user
+  skips it) is added to a **per-report skip-set** so the loop moves on to the gap
+  behind it. It only stops once the whole report is exhausted with no progress —
+  one cryptic, uncommittable gap can no longer abandon the 200 behind it — and is
+  still hard-bounded by `max_rounds`. The skip-set is cleared on every commit (the
+  re-assessed report is fresh). ask-user prompts are **human-readable** (a direct
+  question naming the field + entity, the reason, any suggestion, and the expected
+  format), never the raw failed-check `message`.
 
 **The deliberate split — automated vs interactive.** Stages 1–4 are the
 **automated** build: `run_pipeline` (§14.5) runs them with **no HITL**, so it
@@ -1665,10 +1675,19 @@ recommended, MAY = optional):
 Each `Gap` carries `{tier, source, entity_id, entity_type, property, message,
 suggestion, fix_hint, auto_fixable}`: `suggestion` is the expected propertyID
 IRI / ontology term / parameter description from the profile or MIT YAML;
-`fix_hint` is a deterministic tool name (`"fix_required_issues"`), `"draft"`, or
-`"ask-user"`. `GapReport` adds `{gaps, conformance, mit_overall, fair_summary,
-counts}`, with `gaps` sorted **all MUST, then SHOULD, then MAY**, stable
-secondary by `(source, entity_id, property)`.
+`fix_hint` is a deterministic tool name (`"fix_required_issues"`), `"draft"`,
+`"ask-user"`, or **`"report-only"`** (#230). A `report-only` gap is one the
+guidance loop can *not* commit deterministically from the gap's own fields — it
+has no settable entity field (`entity_id is None`) and its property maps to no
+Root Data Entity metadata slot (`_CRATE_SETTABLE_FIELDS` — which mirrors
+guidance's `_apply_value`). **Every FAIR gap is `report-only`** (its property is
+an indicator id like `RDA-F1-02M`, not a field), as are **crate-level MIT gaps
+whose field is not a crate slot**; they stay in the report for context but the
+guidance loop never spends an ask-user/draft turn on them. `GapReport` adds
+`{gaps, conformance, mit_overall, fair_summary, counts}`, with `gaps` sorted
+**all MUST, then SHOULD, then MAY**, then **committable before `report-only`**
+within a tier, stable secondary by `(source, entity_id, property)` — so the loop
+always reaches the gaps it can act on first.
 
 **`auto_fixable` is the load-bearing field** — it is `True` iff
 `fix_required_issues` can clear the gap deterministically from state alone. The

--- a/builder/agents/guidance.py
+++ b/builder/agents/guidance.py
@@ -28,14 +28,19 @@ The loop (:func:`run_guidance`) per round:
      (never hand-rolled JSON-LD).
 
 4. Re-assess after each committed change; **never loop forever** — bounded by
-   ``max_rounds`` and a no-progress guard (a round that resolves nothing stops the
-   loop, since spinning further cannot help).
+   ``max_rounds`` and a per-report skip-set. A gap the loop cannot progress this
+   round (e.g. the user skips it) is *skipped*, not fatal: the loop advances to the
+   next actionable gap and only stops once the whole report is exhausted with no
+   progress (#230). The skip-set is cleared on every commit (the re-assessed
+   report is fresh). ``report-only`` gaps — FAIR indicators and crate-level MIT
+   params with no settable target — are never drawn at all.
 
 Determinism & safety contract:
 
 * **Bounded.** At most ``max_rounds`` rounds; each round resolves at most one gap.
-* **Explicit termination.** Two independent stop conditions (no actionable gap /
-  no progress) plus the hard ``max_rounds`` cap.
+* **Explicit termination.** Two independent stop conditions (no actionable gap
+  left / the whole report exhausted with no progress) plus the hard ``max_rounds``
+  cap.
 * **Every LLM call is a bounded leaf.** The drafter leaf
   (:func:`draft_entity_fields`) is the *only* model call, and its output is shown
   to the user for confirmation before it is ever committed.
@@ -54,7 +59,7 @@ from typing import TYPE_CHECKING, Any
 # single stable monkeypatch target — and so a flaky/absent LLM drafter can be
 # stubbed without importing langchain.
 from builder.agents.pipeline import draft_entity_fields
-from builder.tools.gap_analysis import Gap, assess_gaps
+from builder.tools.gap_analysis import REPORT_ONLY, Gap, assess_gaps
 
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
@@ -203,12 +208,30 @@ def _drafted_value(engine: AgentEngine, gap: Gap) -> str | None:
     return str(candidate)
 
 
+def _ask_user_prompt(gap: Gap) -> str:
+    """Build a human-readable ask-user prompt for ``gap``.
+
+    The raw ``gap.message`` is a description of a *failed check* (e.g. "Study MUST
+    have a description"), not a question with a field label and expected format —
+    surfaced verbatim it reads as a cryptic "What?" box. Instead we assemble a
+    clear, multi-line prompt: a direct question naming the field (and the entity /
+    tier it applies to), the gap's own explanation, any suggestion, and the
+    expected input format. This keeps the human genuinely in the loop (D5).
+    """
+    field = _local_name(gap.property) or (gap.property or "this field")
+    target = f" on the {gap.entity_type}" if gap.entity_type else ""
+    lines: list[str] = [f"Please provide a value for '{field}'{target}."]
+    if gap.message:
+        lines.append(f"Why: {gap.message}")
+    if gap.suggestion:
+        lines.append(f"Suggestion: {gap.suggestion}")
+    lines.append("Expected: free text (leave blank or skip to defer this field).")
+    return "\n".join(lines)
+
+
 def _ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> str | None:
     """Prompt the human for ``gap`` and return their value, or ``None`` if skipped."""
-    prompt = gap.message or f"Provide a value for {gap.property or 'this field'}."
-    if gap.suggestion:
-        prompt = f"{prompt}\nSuggestion: {gap.suggestion}"
-    response = human.request_input(prompt)
+    response = human.request_input(_ask_user_prompt(gap))
     if response.get("skipped"):
         return None
     value = response.get("value")
@@ -312,13 +335,16 @@ def run_guidance(
 ) -> dict[str, Any]:
     """Run the deterministic HITL gap-resolution loop over the gap engine.
 
-    Each round re-assesses gaps from scratch (:func:`assess_gaps`), takes the
-    highest-priority actionable gap (MUST -> SHOULD -> MAY), and resolves it by
-    ``fix_hint`` / ``auto_fixable`` (auto-fix / draft-confirm-commit / ask-user).
-    The loop is bounded by ``max_rounds`` and a no-progress guard, and terminates
-    once no MUST gap remains and the user is done or no SHOULD/MAY gap is
-    actionable. CODE owns control flow; the LLM only drafts; the user confirms
-    every uncertain commit (D5). HITL is never bypassed.
+    Each round re-assesses gaps from scratch (:func:`assess_gaps`) after a commit,
+    takes the highest-priority actionable gap (MUST -> SHOULD -> MAY), and resolves
+    it by ``fix_hint`` / ``auto_fixable`` (auto-fix / draft-confirm-commit /
+    ask-user). A gap it cannot progress this round is added to a **per-report
+    skip-set** and the loop advances to the next actionable gap rather than
+    aborting, so one un-committable gap never abandons the ones behind it (#230).
+    The loop is bounded by ``max_rounds`` and terminates once the whole report is
+    exhausted with no progress, or once no MUST gap remains and the user is done.
+    CODE owns control flow; the LLM only drafts; the user confirms every uncertain
+    commit (D5). HITL is never bypassed.
 
     Args:
         engine: The :class:`~builder.engine.AgentEngine` whose ``state`` is
@@ -344,13 +370,22 @@ def run_guidance(
     asked: list[dict[str, Any]] = []
     rounds = 0
     report: GapReport = assess_gaps(engine.state)
+    # Indices into the CURRENT report's gaps that were tried this round and could
+    # not be progressed (e.g. the user skipped them). They are skipped so the loop
+    # advances to the next actionable gap instead of re-offering the same one; the
+    # set is cleared whenever a commit invalidates the report (a fresh re-assess).
+    skipped: set[int] = set()
 
     for _ in range(max(0, max_rounds)):
-        gap = _next_actionable_gap(report)
+        index = _next_actionable_index(report, skipped)
 
-        # --- termination: no actionable gap left ------------------------------
-        if gap is None:
+        # --- termination: the whole report is exhausted -----------------------
+        # No actionable gap remains that we have not already tried this round —
+        # either there are none, or every one was skipped (un-progressable). Either
+        # way, re-assessing would only reproduce the same gaps, so we stop.
+        if index is None:
             break
+        gap = report.gaps[index]
         # Once MUST gaps are cleared, an actionable SHOULD/MAY only continues the
         # loop while the user wants to keep going.
         if report.counts.get("must_open", 0) == 0 and _user_signals_done(human):
@@ -361,14 +396,18 @@ def run_guidance(
             engine, human, gap, resolved=resolved, asked=asked
         )
 
-        # --- termination: no-progress guard -----------------------------------
-        # A round that committed nothing means the current highest-priority gap is
-        # not resolvable right now; re-assessing would yield the same gap, so
-        # spinning further is wasted SHACL work.
-        if not progressed:
-            break
-
-        report = assess_gaps(engine.state)
+        if progressed:
+            # State changed: re-assess from scratch and forget the skip-set (the
+            # gap indices no longer refer to the same gaps).
+            report = assess_gaps(engine.state)
+            skipped = set()
+        else:
+            # This one gap is not resolvable right now (e.g. skipped); skip it and
+            # let the next round draw the next actionable gap in the SAME report.
+            # The loop only stops once EVERY gap in the report is exhausted, so a
+            # single un-progressable gap never abandons the ones behind it. Still
+            # bounded by ``max_rounds``.
+            skipped.add(index)
 
     return {
         "resolved": resolved,
@@ -379,19 +418,38 @@ def run_guidance(
     }
 
 
-def _next_actionable_gap(report: GapReport) -> Gap | None:
-    """The highest-priority *actionable* gap, or ``None``.
+def _next_actionable_index(report: GapReport, skipped: set[int]) -> int | None:
+    """Index of the highest-priority *actionable, not-yet-skipped* gap, or ``None``.
 
-    The report is already sorted MUST -> SHOULD -> MAY with a stable secondary
-    order, so the first gap with a resolution route (auto-fixable or a known
-    ``fix_hint``) is the one to work next. Every gap the gap engine emits carries
-    one of ``fix_required_issues`` / ``draft`` / ``ask-user``; a gap with an
-    unknown/absent ``fix_hint`` is treated as ask-user (the safe default that
-    keeps the human in the loop) rather than skipped.
+    The report is already sorted MUST -> SHOULD -> MAY (committable before
+    ``report-only`` within a tier), so we walk it in order and return the index of
+    the first gap that is BOTH actionable and not in ``skipped`` (indices into
+    ``report.gaps`` the loop has already tried and could not progress this round).
+
+    A gap is **actionable** when it has a resolution route the loop can drive:
+    ``auto_fixable``, or a ``fix_hint`` of ``fix_required_issues`` / ``draft`` /
+    ``ask-user`` (or an unknown/absent hint, which falls back to ask-user — the
+    safe default that keeps the human in the loop). A ``report-only`` gap is
+    **never** actionable: it has no deterministic settable target, so the loop
+    surfaces it for context but never spends an ask-user turn on it.
     """
-    for gap in report.gaps:
-        if gap.auto_fixable or gap.fix_hint in ("fix_required_issues", "draft", "ask-user"):
-            return gap
-        # Unknown fix_hint -> still actionable via the ask-user fallback.
-        return gap
+    for index, gap in enumerate(report.gaps):
+        if index in skipped:
+            continue
+        if gap.fix_hint == REPORT_ONLY:
+            continue
+        # Auto-fixable, a known committable hint, or an unknown hint (ask-user
+        # fallback) -> actionable.
+        return index
     return None
+
+
+def _next_actionable_gap(report: GapReport, *, skipped: set[int]) -> Gap | None:
+    """The highest-priority *actionable, not-yet-skipped* gap, or ``None``.
+
+    Thin wrapper over :func:`_next_actionable_index` for callers (and tests) that
+    only need the gap, not its position. See that function for the actionability
+    and skip-set rules.
+    """
+    index = _next_actionable_index(report, skipped)
+    return report.gaps[index] if index is not None else None

--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -109,12 +109,47 @@ _SEVERITY_TO_TIER: dict[str, Tier] = {
 # Stable tier rank for the primary sort.
 _TIER_RANK: dict[Tier, int] = {"MUST": 0, "SHOULD": 1, "MAY": 2}
 
+# Sentinel ``fix_hint`` for a gap the guidance loop can NOT commit deterministically
+# from the gap's own fields (no settable entity field and no crate-level slot). It
+# is recorded for reporting but never consumes an ask-user / draft turn — see
+# ``builder.agents.guidance._next_actionable_gap``.
+REPORT_ONLY = "report-only"
+
+# Local property names a crate-level gap (``entity_id is None``) can be committed
+# to via the Root Data Entity metadata setter. MUST stay in sync with
+# ``builder.agents.guidance._CRATE_METADATA_FIELDS`` (the guidance loop's
+# ``_apply_value`` is the single place these are actually written); kept here as a
+# lower-module constant to avoid a circular import (guidance imports gap_analysis).
+_CRATE_SETTABLE_FIELDS: frozenset[str] = frozenset(
+    {"name", "title", "description", "identifier", "accession"}
+)
+
 
 def _local_name(iri: str | None) -> str:
     """Local part of a property IRI (after the last ``/`` or ``#``)."""
     if not iri:
         return ""
     return iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+
+
+def _is_committable(entity_id: str | None, prop: str | None) -> bool:
+    """Whether the guidance loop could deterministically commit such a gap.
+
+    Mirrors :func:`builder.agents.guidance._apply_value`'s success conditions
+    *from the gap's own fields alone* so the gap engine and the guidance loop can
+    never drift on what "settable" means:
+
+    * an entity-scoped gap (``entity_id`` set) is committable — the loop resolves
+      the entity at runtime and writes the property via ``set_fields``;
+    * a crate-level gap (``entity_id is None``) is committable only when its
+      property's local name maps to a Root Data Entity metadata slot.
+
+    Anything else (e.g. a FAIR indicator id, or a crate-level field with no slot)
+    has no deterministic target and is recorded ``report-only``.
+    """
+    if entity_id is not None:
+        return True
+    return _local_name(prop) in _CRATE_SETTABLE_FIELDS
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +342,16 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
             # crate field the parameter maps to); the rest are alternatives.
             slot_entity_type, slot_field = slots[0] if slots else (None, None)
             param_name = param.get("name") or param.get("id") or slot_field or "parameter"
+            # MIT gaps are emitted crate-level (entity_id None). They are only
+            # committable when their field maps to a Root Data Entity slot; the
+            # rest have no deterministic settable target and are report-only, so
+            # the guidance loop surfaces them for context without burning a turn.
+            if not _is_committable(None, slot_field):
+                fix_hint = REPORT_ONLY
+            else:
+                # MIT enrichment needs content the user provides or a drafter
+                # synthesizes; it is never a deterministic auto-fix (D5).
+                fix_hint = "ask-user" if not additional else "draft"
             gaps.append(
                 Gap(
                     tier=tier,
@@ -319,9 +364,7 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
                         f"(crate_slot {crate_slot})."
                     ),
                     suggestion=_mit_suggestion(param),
-                    # MIT enrichment needs content the user provides or a drafter
-                    # synthesizes; it is never a deterministic auto-fix (D5).
-                    fix_hint="ask-user" if not additional else "draft",
+                    fix_hint=fix_hint,
                     auto_fixable=False,
                 )
             )
@@ -375,7 +418,9 @@ def _fair_gaps(state: CrateState) -> tuple[list[Gap], dict[str, Any]]:
                 ),
                 suggestion=f"Dimension {indicator.get('dimension', '')} "
                 f"({priority or 'unrated'})".strip(),
-                fix_hint="ask-user",
+                # A FAIR indicator id maps to no settable crate field, so the
+                # guidance loop cannot commit it — surface it for context only.
+                fix_hint=REPORT_ONLY,
                 auto_fixable=False,
             )
         )
@@ -394,9 +439,16 @@ def _fair_gaps(state: CrateState) -> tuple[list[Gap], dict[str, Any]]:
 
 
 def _sort_key(gap: Gap) -> tuple:
-    """Primary sort by tier, stable secondary by (source, entity_id, property)."""
+    """Primary sort by tier, then committable-before-report-only, then stable
+    secondary by ``(source, entity_id, property, message)``.
+
+    Ordering committable gaps ahead of ``report-only`` ones within a tier means
+    the guidance loop always reaches the gaps it can actually act on first, and
+    never has to skip past a wall of un-committable FAIR/MIT gaps to find them.
+    """
     return (
         _TIER_RANK[gap.tier],
+        0 if gap.fix_hint != REPORT_ONLY else 1,
         gap.source,
         gap.entity_id or "",
         gap.property or "",

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -460,22 +460,38 @@ class TestTermination:
         assert calls["n"] <= 4 + 2, calls["n"]
         assert isinstance(summary, dict)
 
-    def test_no_progress_guard_stops_when_nothing_resolvable(self, monkeypatch):
+    def test_no_progress_guard_stops_when_whole_round_unresolvable(self, monkeypatch):
+        """The no-progress guard fires only when the WHOLE round is un-progressable.
+
+        Two actionable ask-user gaps on real entities; the user skips *both*. No
+        gap in the round can be progressed, so the loop must exhaust the report
+        (skipping each gap once) and stop — without burning all 50 rounds and
+        without re-asking the same gap forever.
+        """
         from builder.agents import guidance
         from builder.agents.guidance import run_guidance
 
         engine = AgentEngine(state=_backbone())
 
-        # An ask-user gap the user always skips -> no progress -> stop early,
-        # well within max_rounds.
-        gap = Gap(
+        gap_a = Gap(
             tier="SHOULD",
-            source="fair",
-            entity_id=None,
-            entity_type=None,
-            property="F1",
-            message="FAIR F1 not met.",
-            suggestion="hint",
+            source="mit",
+            entity_id="st1",
+            entity_type="Study",
+            property="name",
+            message="Study SHOULD have a richer name.",
+            suggestion="hint a",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        gap_b = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="as1",
+            entity_type="Assay",
+            property="description",
+            message="Assay SHOULD have a description.",
+            suggestion="hint b",
             fix_hint="ask-user",
             auto_fixable=False,
         )
@@ -484,7 +500,8 @@ class TestTermination:
         def _always(_state):
             calls["n"] += 1
             return GapReport(
-                gaps=[gap], counts={"must_open": 0, "should_open": 1, "may_open": 0}
+                gaps=[gap_a, gap_b],
+                counts={"must_open": 0, "should_open": 2, "may_open": 0},
             )
 
         monkeypatch.setattr(guidance, "assess_gaps", _always)
@@ -492,8 +509,10 @@ class TestTermination:
         human = ScriptedHuman()  # always skips
         run_guidance(engine, human, max_rounds=50)
 
-        # Stopped on the no-progress guard, NOT by exhausting 50 rounds.
+        # Stopped because the whole round was un-progressable, NOT by exhausting
+        # 50 rounds. Both gaps were each offered once before the loop gave up.
         assert calls["n"] < 50, calls["n"]
+        assert len(human.inputs) == 2, human.inputs
 
     def test_processes_must_before_should_before_may(self, monkeypatch):
         from builder.agents import guidance
@@ -551,6 +570,171 @@ class TestTermination:
         st = _get(engine, "st1")
         assert st.fields.get("name") == "name value"
         assert st.fields.get("description") == "desc value"
+
+
+# ---------------------------------------------------------------------------
+# (f) an uncommittable gap is SKIPPED, not fatal — the loop keeps going
+# ---------------------------------------------------------------------------
+
+
+class TestSkipUncommittableGaps:
+    def test_uncommittable_gap_does_not_abort_remaining_gaps(self, monkeypatch):
+        """A report-only FAIR gap sorted ahead of a committable SHOULD gap must be
+        SKIPPED, and the committable gap behind it must still be resolved.
+
+        This is the regression for the production bug: one un-progressable gap
+        used to ``break`` the WHOLE loop, abandoning every remaining gap.
+        """
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+
+        # A FAIR report-only gap: entity_id None, property is an indicator token
+        # that maps to no settable field. The loop can never commit it.
+        fair_gap = Gap(
+            tier="SHOULD",
+            source="fair",
+            entity_id=None,
+            entity_type=None,
+            property="RDA-F1-02M",
+            message="FAIR indicator RDA-F1-02M not met: globally unique id.",
+            suggestion="Dimension Findable (essential)",
+            fix_hint="report-only",
+            auto_fixable=False,
+        )
+        # A committable SHOULD gap on a real entity behind it.
+        committable = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="st1",
+            entity_type="Study",
+            property="description",
+            message="Study SHOULD have a description.",
+            suggestion="A free-text study description.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+
+        reports = iter(
+            [
+                # Round 1: report-only gap is first (it would be drawn first), the
+                # committable gap is behind it.
+                GapReport(
+                    gaps=[fair_gap, committable],
+                    counts={"must_open": 0, "should_open": 2, "may_open": 0},
+                ),
+                # After the committable gap is resolved only the FAIR gap remains.
+                GapReport(
+                    gaps=[fair_gap],
+                    counts={"must_open": 0, "should_open": 1, "may_open": 0},
+                ),
+            ]
+        )
+        monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
+
+        human = ScriptedHuman(input_answers=[_value("A user-supplied description.")])
+        summary = run_guidance(engine, human, max_rounds=5)
+
+        # The committable gap WAS resolved despite the FAIR gap in front of it.
+        assert _get(engine, "st1").fields.get("description") == (
+            "A user-supplied description."
+        )
+        assert any(r.get("entity_id") == "st1" for r in summary["resolved"])
+        # The report-only FAIR gap was never offered to the user (no ask-user turn).
+        assert not any("RDA-F1-02M" in prompt for prompt, _ in human.inputs), (
+            human.inputs
+        )
+
+    def test_report_only_gap_is_never_actionable(self):
+        """``_next_actionable_gap`` must never return a report-only gap."""
+        from builder.agents.guidance import _next_actionable_gap
+
+        report_only = Gap(
+            tier="SHOULD",
+            source="fair",
+            entity_id=None,
+            entity_type=None,
+            property="RDA-F1-02M",
+            message="FAIR indicator not met.",
+            suggestion=None,
+            fix_hint="report-only",
+            auto_fixable=False,
+        )
+        report = GapReport(
+            gaps=[report_only],
+            counts={"must_open": 0, "should_open": 1, "may_open": 0},
+        )
+        assert _next_actionable_gap(report, skipped=set()) is None
+
+    def test_next_actionable_gap_respects_skip_set(self):
+        """A gap already in the skip-set is passed over for the next actionable one."""
+        from builder.agents.guidance import _next_actionable_gap
+
+        first = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="st1",
+            entity_type="Study",
+            property="name",
+            message="first",
+            suggestion=None,
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        second = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="as1",
+            entity_type="Assay",
+            property="description",
+            message="second",
+            suggestion=None,
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        report = GapReport(
+            gaps=[first, second],
+            counts={"must_open": 0, "should_open": 2, "may_open": 0},
+        )
+        assert _next_actionable_gap(report, skipped=set()) is first
+        assert _next_actionable_gap(report, skipped={0}) is second
+        assert _next_actionable_gap(report, skipped={0, 1}) is None
+
+
+# ---------------------------------------------------------------------------
+# (g) ask-user prompt is human-readable (field label + suggestion + format)
+# ---------------------------------------------------------------------------
+
+
+class TestAskUserPrompt:
+    def test_ask_user_prompt_is_human_readable(self):
+        """The prompt must name WHAT field and WHY, not echo the raw gap message."""
+        from builder.agents.guidance import _ask_user
+
+        engine = AgentEngine(state=_backbone())
+        gap = Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id="st1",
+            entity_type="Study",
+            property="https://schema.org/description",
+            message="Study MUST have a description.",
+            suggestion="A free-text study description.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        human = ScriptedHuman(input_answers=[_value("ok")])
+        _ask_user(engine, human, gap)
+
+        assert human.inputs, "ask-user must prompt the human"
+        prompt = human.inputs[0][0]
+        # Names the field label (the property's local name), not just the raw IRI.
+        assert "description" in prompt.lower()
+        # Carries the suggestion as guidance.
+        assert "A free-text study description." in prompt
+        # Tells the user what entity it applies to.
+        assert "Study" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -16,9 +16,20 @@ from __future__ import annotations
 import pytest
 
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
-from builder.tools.gap_analysis import Gap, GapReport, assess_gaps
+from builder.tools.gap_analysis import (
+    _CRATE_SETTABLE_FIELDS,
+    Gap,
+    GapReport,
+    _local_name,
+    assess_gaps,
+)
 
 pytestmark = pytest.mark.timeout(120)
+
+
+def _local(prop: str | None) -> str:
+    """Local name of a property IRI (test-side mirror of the engine helper)."""
+    return _local_name(prop)
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +199,77 @@ class TestSourcesUnified:
         assert any(g.suggestion for g in mit)
         # MIT gaps are filled by the user / a draft, not deterministic repair.
         assert all(g.auto_fixable is False for g in mit)
-        assert all(g.fix_hint in ("ask-user", "draft") for g in mit)
+        # A MIT gap is either committable (ask-user / draft, when its field maps
+        # to a deterministic crate-level target) or report-only (no settable
+        # target from the gap's own fields). Never anything else.
+        assert all(g.fix_hint in ("ask-user", "draft", "report-only") for g in mit)
+
+
+# ---------------------------------------------------------------------------
+# report-only fix_hint — uncommittable gaps are surfaced, never asked
+# ---------------------------------------------------------------------------
+
+
+class TestReportOnlyGaps:
+    def test_fair_gaps_are_report_only(self):
+        """FAIR gaps (entity_id None, property=indicator-id) cannot be committed.
+
+        Their ``property`` is an indicator token (e.g. ``RDA-F1-02M``) that maps
+        to no settable crate field, so the guidance loop must never spend an
+        ask-user turn on them — they are ``report-only``.
+        """
+        report = assess_gaps(_backbone())
+        fair = [g for g in report.gaps if g.source == "fair"]
+        assert fair, "failing FAIR indicators must surface as gaps"
+        assert all(g.fix_hint == "report-only" for g in fair), [
+            (g.property, g.fix_hint) for g in fair
+        ]
+
+    def test_crate_level_mit_without_settable_target_is_report_only(self):
+        """A crate-level (entity_id None) MIT gap whose field maps to no crate
+        metadata slot has no deterministic target -> report-only."""
+        report = assess_gaps(_backbone())
+        # ``char`` / ``keywords`` / ``datePublished`` style MIT fields are not in
+        # the crate-metadata field set, so with entity_id None they are report-only.
+        report_only_mit = [
+            g
+            for g in report.gaps
+            if g.source == "mit"
+            and g.entity_id is None
+            and _local(g.property) not in _CRATE_SETTABLE_FIELDS
+        ]
+        assert report_only_mit, "expected at least one uncommittable MIT gap"
+        assert all(g.fix_hint == "report-only" for g in report_only_mit), [
+            (g.property, g.fix_hint) for g in report_only_mit
+        ]
+
+    def test_committable_mit_keeps_ask_or_draft(self):
+        """A crate-level MIT gap whose field DOES map to a crate slot
+        (name / description / identifier) is still committable -> ask-user/draft."""
+        report = assess_gaps(_backbone())
+        committable_mit = [
+            g
+            for g in report.gaps
+            if g.source == "mit"
+            and g.entity_id is None
+            and _local(g.property) in _CRATE_SETTABLE_FIELDS
+        ]
+        assert committable_mit, "expected at least one committable MIT gap"
+        assert all(g.fix_hint in ("ask-user", "draft") for g in committable_mit), [
+            (g.property, g.fix_hint) for g in committable_mit
+        ]
+
+    def test_committable_gaps_sort_before_report_only_within_tier(self):
+        """Within a tier, gaps the loop can act on must precede report-only ones."""
+        report = assess_gaps(_backbone())
+        for tier in ("SHOULD", "MAY"):
+            within = [g for g in report.gaps if g.tier == tier]
+            committable_flags = [g.fix_hint != "report-only" for g in within]
+            # All committable (True) gaps must come before report-only (False):
+            # the boolean sequence is non-increasing.
+            assert committable_flags == sorted(committable_flags, reverse=True), [
+                (g.fix_hint, g.source, g.property) for g in within
+            ]
 
 
 # ---------------------------------------------------------------------------
@@ -288,8 +369,20 @@ class TestDeterminism:
 
 class TestStableSecondaryOrder:
     def test_within_tier_sorted_by_source_entity_property(self):
+        """Within a tier: committable gaps first, then report-only ones, and each
+        of those two groups is stably sorted by (source, entity_id, property)."""
         report = assess_gaps(_backbone())
         for tier in ("MUST", "SHOULD", "MAY"):
             within = [g for g in report.gaps if g.tier == tier]
-            keys = [(g.source, g.entity_id or "", g.property or "") for g in within]
-            assert keys == sorted(keys), f"{tier} gaps must have a stable secondary order"
+            committable = [g for g in within if g.fix_hint != "report-only"]
+            report_only = [g for g in within if g.fix_hint == "report-only"]
+
+            def _keys(gaps):
+                return [(g.source, g.entity_id or "", g.property or "") for g in gaps]
+
+            assert _keys(committable) == sorted(_keys(committable)), (
+                f"{tier} committable gaps must have a stable secondary order"
+            )
+            assert _keys(report_only) == sorted(_keys(report_only)), (
+                f"{tier} report-only gaps must have a stable secondary order"
+            )


### PR DESCRIPTION
Closes #230

## Problem

On a real interactive build the guidance/HITL tail (`run_guidance`) was effectively non-functional: it surfaced **one cryptic input box** ("What?"-style) and then **abandoned every remaining gap** (~190 SHOULD + 11 MAY in the reported run). Four interacting defects:

- **(d)** `_sort_key` floated FAIR gaps to the front of their tier (`"fair" < "mit"`), so the first gap drawn was an uncommittable FAIR gap.
- **(c)** `_ask_user` used the raw `gap.message` (a failed-check *description*, not a question) as the prompt.
- **(b)** FAIR gaps (and crate-level MIT gaps with no settable target) can never be committed by `_apply_value` (`entity_id=None`, `property`=indicator id), so the answer was silently discarded.
- **(a)** `run_guidance` did `if not progressed: break`, exiting the **entire** loop on the first un-progressable gap.

## Fix

- **gap engine (`gap_analysis.py`)** — classify gaps the loop can't deterministically commit (FAIR indicators; crate-level MIT params whose field maps to no Root Data Entity slot) with a new **`report-only`** `fix_hint`, decided by `_is_committable` / the shared `_CRATE_SETTABLE_FIELDS` constant (mirrors guidance's `_apply_value`). `_sort_key` now orders **committable gaps before report-only ones** within each tier. Report-only gaps stay in the report for context.
- **guidance loop (`guidance.py`)** — replace the loop-wide `break` with a **per-report skip-set**: each round draws the next *actionable, not-yet-skipped* gap (`report-only` gaps are never drawn); a gap that can't be progressed is added to the skip-set so the loop advances to the gap behind it. The loop stops only when the whole report is exhausted with no progress, still hard-bounded by `max_rounds`; the skip-set is cleared on every commit. `_ask_user` now builds a **human-readable** prompt (field label + entity + reason + suggestion + expected format).
- **AGENTS.md §14** — documents the `report-only` fix_hint, the committable-first sort order, the skip-set loop, and the readable prompts.

## Tests (TDD — written failing first, then made to pass)

New:
- `tests/test_agents_guidance.py::TestSkipUncommittableGaps::test_uncommittable_gap_does_not_abort_remaining_gaps` — the core regression: a report-only FAIR gap in front of a committable SHOULD gap is **skipped**, and the committable gap is still resolved.
- `tests/test_agents_guidance.py::TestSkipUncommittableGaps::test_report_only_gap_is_never_actionable`
- `tests/test_agents_guidance.py::TestSkipUncommittableGaps::test_next_actionable_gap_respects_skip_set`
- `tests/test_agents_guidance.py::TestAskUserPrompt::test_ask_user_prompt_is_human_readable`
- `tests/test_tools_gap_analysis.py::TestReportOnlyGaps::{test_fair_gaps_are_report_only, test_crate_level_mit_without_settable_target_is_report_only, test_committable_mit_keeps_ask_or_draft, test_committable_gaps_sort_before_report_only_within_tier}`

Rewritten:
- `test_no_progress_guard_stops_when_nothing_resolvable` → `test_no_progress_guard_stops_when_whole_round_unresolvable` — the guard now fires only when **every** gap in the round is un-progressable (was wrongly asserting that a single skipped gap stops the loop).
- `TestStableSecondaryOrder` / `test_mit_gap_carries_property_and_suggestion` updated for the new ordering + `report-only` hint.

## Verification

- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agents_guidance.py tests/test_tools_gap_analysis.py` → **40 passed**
- `uv run ruff check` → **All checks passed!**
- `uv run --extra langchain ty check` → **All checks passed!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
