### PR TITLE
fix(cli): suspend thinking spinner during HITL prompts (scan-approval was unanswerable)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -26,6 +26,10 @@ except ImportError:
 from builder.agents.system_prompt import SYSTEM_PROMPT
 from builder.agents.tools_spec import TOOL_SPECS
 from builder.engine import AgentEngine
+from builder.tools.hitl import (
+    register_console_animation,
+    unregister_console_animation,
+)
 
 if TYPE_CHECKING:
     from typing import cast
@@ -72,6 +76,9 @@ class _ThinkingSpinner:
         self._tool: str | None = None
         self._start = monotonic()
         self._stop = threading.Event()
+        # Set while a HITL prompt owns the terminal: the tick thread must not
+        # repaint the Rich Live region over the prompt (else stdin is unusable).
+        self._paused = threading.Event()
         self._status = console.status(self._render(), spinner="dots", spinner_style="green")
         self._thread = threading.Thread(target=self._tick, daemon=True)
 
@@ -84,6 +91,8 @@ class _ThinkingSpinner:
 
     def _tick(self) -> None:
         while not self._stop.wait(0.5):
+            if self._paused.is_set():
+                continue
             try:
                 self._status.update(self._render())
             except Exception:
@@ -92,17 +101,41 @@ class _ThinkingSpinner:
     def set_tool(self, name: str | None) -> None:
         """Show (or clear, with ``None``) the tool currently running."""
         self._tool = name
+        if self._paused.is_set():
+            return
         try:
             self._status.update(self._render())
         except Exception:
             pass
 
+    def pause(self) -> None:
+        """Tear down the Live region and stop ticking so a HITL prompt is clean.
+
+        Called (via :func:`builder.tools.hitl.suspend_console_animation`) when a
+        tool needs ``input()`` mid-``invoke``. Best-effort and idempotent.
+        """
+        self._paused.set()
+        try:
+            self._status.stop()
+        except Exception:
+            logger.debug("spinner pause: status.stop failed", exc_info=True)
+
+    def resume(self) -> None:
+        """Restart the Live region after a HITL prompt completes."""
+        try:
+            self._status.start()
+        except Exception:
+            logger.debug("spinner resume: status.start failed", exc_info=True)
+        self._paused.clear()
+
     def __enter__(self) -> "_ThinkingSpinner":
         self._status.__enter__()
         self._thread.start()
+        register_console_animation(self)
         return self
 
     def __exit__(self, *exc: Any) -> None:
+        unregister_console_animation(self)
         self._stop.set()
         self._thread.join(timeout=1.0)
         self._status.__exit__(*exc)

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -10,10 +10,69 @@ as thin wrappers over a shared default simulator for backward compatibility.
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import threading
+from collections.abc import Iterator
 from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+
+# --- console animation suspension -------------------------------------------
+# A long-running CLI animation (e.g. the legacy agent loop's "thinking" spinner,
+# a Rich ``Live`` region driven by a daemon thread) repaints the terminal
+# continuously, which clobbers a blocking ``input()`` prompt — the user cannot
+# read or answer a HITL question (scan-root approval, ask-user) while it ticks.
+# The animation registers itself here; the console HITL prompts suspend it for
+# the duration of ``input()``. Frontend-agnostic: a non-CLI HumanInterface never
+# registers anything and these become no-ops.
+_active_animation: Any = None
+_animation_lock = threading.Lock()
+
+
+def register_console_animation(animation: Any) -> None:
+    """Register the active terminal animation so console prompts can pause it.
+
+    ``animation`` must expose ``pause()`` and ``resume()``. The most recent
+    registration wins (CLI animations are not nested).
+    """
+    global _active_animation
+    with _animation_lock:
+        _active_animation = animation
+
+
+def unregister_console_animation(animation: Any) -> None:
+    """Clear the registered animation, but only if it is *animation*."""
+    global _active_animation
+    with _animation_lock:
+        if _active_animation is animation:
+            _active_animation = None
+
+
+@contextlib.contextmanager
+def suspend_console_animation() -> Iterator[None]:
+    """Pause any registered console animation for the duration of the block.
+
+    Best-effort: no registered animation is a no-op, and a ``pause``/``resume``
+    that raises is logged but never propagated — UI chrome must not break a HITL
+    prompt. ``resume`` always runs, even if the body raises.
+    """
+    with _animation_lock:
+        animation = _active_animation
+    if animation is not None:
+        try:
+            animation.pause()
+        except Exception:  # noqa: BLE001 — never let UI chrome break a prompt
+            logger.debug("console animation pause failed", exc_info=True)
+    try:
+        yield
+    finally:
+        if animation is not None:
+            try:
+                animation.resume()
+            except Exception:  # noqa: BLE001 — never let UI chrome break a prompt
+                logger.debug("console animation resume failed", exc_info=True)
 
 
 class HumanResponse(TypedDict):
@@ -154,14 +213,17 @@ class ConsoleHumanInterface:
         purpose: str | None = None,
     ) -> HumanResponse:
         """Show *context* + *options* and read an approve/reject decision."""
-        print(context)
-        if options:
-            print(f"Options: {', '.join(options)}")
         suffix = " [y/N]: " if purpose == SCAN_ROOT_PURPOSE else " [Y/n]: "
-        try:
-            answer = input(f"Approve?{suffix}").strip().lower()
-        except EOFError:
-            answer = ""
+        # Suspend any active terminal spinner so the prompt is readable and stdin
+        # is not fighting a Rich Live repaint (legacy loop scan-root approval).
+        with suspend_console_animation():
+            print(context)
+            if options:
+                print(f"Options: {', '.join(options)}")
+            try:
+                answer = input(f"Approve?{suffix}").strip().lower()
+            except EOFError:
+                answer = ""
         if purpose == SCAN_ROOT_PURPOSE:
             # Fail-closed: a new scan root requires an explicit affirmative.
             approved = answer in ("y", "yes")
@@ -172,11 +234,12 @@ class ConsoleHumanInterface:
 
     def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
         """Prompt the user for a value; an empty answer (or EOF) is a skip."""
-        print(prompt)
-        try:
-            value = input(f"({field_type}) > ").strip()
-        except EOFError:
-            value = ""
+        with suspend_console_animation():
+            print(prompt)
+            try:
+                value = input(f"({field_type}) > ").strip()
+            except EOFError:
+                value = ""
         if not value:
             return {"value": None, "skipped": True}
         return {"value": value, "skipped": False}

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -853,4 +853,75 @@ class TestTrimHistory:
         assert TestTrimHistory._no_orphans(inner)
 
 
+class TestThinkingSpinnerPause:
+    """The thinking spinner must yield the terminal to a HITL prompt.
+
+    A scan-root approval (or any ask-user) calls ``input()`` mid-``invoke`` while
+    the spinner's Rich Live region is repainting; without a pause the prompt is
+    clobbered and stdin is unusable. The spinner registers itself as the active
+    console animation so ``suspend_console_animation`` can pause/resume it.
+    """
+
+    class _FakeStatus:
+        def __init__(self) -> None:
+            self.events: list[str] = []
+
+        def start(self) -> None:
+            self.events.append("start")
+
+        def stop(self) -> None:
+            self.events.append("stop")
+
+        def update(self, *_a, **_k) -> None:
+            pass
+
+        def __enter__(self):
+            self.start()
+            return self
+
+        def __exit__(self, *_a) -> None:
+            self.stop()
+
+    class _FakeConsole:
+        def __init__(self, status) -> None:
+            self._status = status
+
+        def status(self, *_a, **_k):
+            return self._status
+
+    def test_pause_stops_and_resume_starts_the_live_region(self) -> None:
+        from builder.agents.agent_loop import _ThinkingSpinner
+
+        st = self._FakeStatus()
+        sp = _ThinkingSpinner(self._FakeConsole(st), "x")
+
+        sp.pause()
+        assert sp._paused.is_set() is True
+        assert "stop" in st.events
+
+        sp.resume()
+        assert sp._paused.is_set() is False
+        assert "start" in st.events
+
+    def test_suspend_console_animation_pauses_then_resumes_spinner(self) -> None:
+        from builder.agents.agent_loop import _ThinkingSpinner
+        from builder.tools.hitl import (
+            register_console_animation,
+            suspend_console_animation,
+            unregister_console_animation,
+        )
+
+        st = self._FakeStatus()
+        sp = _ThinkingSpinner(self._FakeConsole(st), "x")
+        register_console_animation(sp)
+        try:
+            with suspend_console_animation():
+                paused_in_body = sp._paused.is_set()
+        finally:
+            unregister_console_animation(sp)
+
+        assert paused_in_body is True  # paused for the duration of the prompt
+        assert sp._paused.is_set() is False  # resumed after
+
+
 

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -199,3 +199,122 @@ class TestEngineHumanInterfaceInjection:
         engine = AgentEngine()
         result = engine.run_tool("present_to_human", context="Review")
         assert result == {"action": "approved", "comments": None, "edits": None}
+
+
+class TestConsoleAnimationSuspension:
+    """A console HITL prompt must pause any registered terminal animation (e.g. the
+    legacy agent loop's "thinking" spinner) for the duration of ``input()`` — else
+    the spinner repaints over the prompt and the user cannot read or answer it.
+    """
+
+    @staticmethod
+    def _recording_anim(events: list[str]):
+        class _Anim:
+            def pause(self) -> None:
+                events.append("pause")
+
+            def resume(self) -> None:
+                events.append("resume")
+
+        return _Anim()
+
+    def test_present_suspends_animation_around_input(self, monkeypatch):
+        from builder.tools.hitl import (
+            SCAN_ROOT_PURPOSE,
+            ConsoleHumanInterface,
+            register_console_animation,
+            unregister_console_animation,
+        )
+
+        events: list[str] = []
+        anim = self._recording_anim(events)
+        register_console_animation(anim)
+        try:
+            monkeypatch.setattr(
+                "builtins.input", lambda *a, **k: events.append("input") or "y"
+            )
+            resp = ConsoleHumanInterface().present("ctx", purpose=SCAN_ROOT_PURPOSE)
+        finally:
+            unregister_console_animation(anim)
+
+        # The spinner is paused BEFORE the prompt is read and resumed AFTER.
+        assert events == ["pause", "input", "resume"]
+        assert resp["action"] == "approved"
+
+    def test_request_input_suspends_animation_around_input(self, monkeypatch):
+        from builder.tools.hitl import (
+            ConsoleHumanInterface,
+            register_console_animation,
+            unregister_console_animation,
+        )
+
+        events: list[str] = []
+        anim = self._recording_anim(events)
+        register_console_animation(anim)
+        try:
+            monkeypatch.setattr(
+                "builtins.input",
+                lambda *a, **k: events.append("input") or "Methimazole",
+            )
+            resp = ConsoleHumanInterface().request_input("Name?", "text")
+        finally:
+            unregister_console_animation(anim)
+
+        assert events == ["pause", "input", "resume"]
+        assert resp == {"value": "Methimazole", "skipped": False}
+
+    def test_animation_resumes_even_on_eof(self, monkeypatch):
+        from builder.tools.hitl import (
+            SCAN_ROOT_PURPOSE,
+            ConsoleHumanInterface,
+            register_console_animation,
+            unregister_console_animation,
+        )
+
+        events: list[str] = []
+        anim = self._recording_anim(events)
+
+        def _raise_eof(*_a, **_k):
+            events.append("input")
+            raise EOFError
+
+        register_console_animation(anim)
+        try:
+            monkeypatch.setattr("builtins.input", _raise_eof)
+            resp = ConsoleHumanInterface().present("ctx", purpose=SCAN_ROOT_PURPOSE)
+        finally:
+            unregister_console_animation(anim)
+
+        # resume must run even though input() raised (fail-closed deny).
+        assert events == ["pause", "input", "resume"]
+        assert resp["action"] == "rejected"
+
+    def test_noop_without_registered_animation(self, monkeypatch):
+        from builder.tools.hitl import ConsoleHumanInterface, suspend_console_animation
+
+        # Nothing registered -> the context manager is a harmless no-op.
+        with suspend_console_animation():
+            pass
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+        resp = ConsoleHumanInterface().present("ctx")
+        assert resp["action"] == "approved"
+
+    def test_unregister_only_clears_matching_animation(self, monkeypatch):
+        from builder.tools.hitl import (
+            register_console_animation,
+            suspend_console_animation,
+            unregister_console_animation,
+        )
+
+        events: list[str] = []
+        anim = self._recording_anim(events)
+        register_console_animation(anim)
+        try:
+            # Unregistering a DIFFERENT animation must not clear the active one.
+            unregister_console_animation(object())
+            with suspend_console_animation():
+                events.append("body")
+        finally:
+            unregister_console_animation(anim)
+
+        assert events == ["pause", "body", "resume"]


### PR DESCRIPTION
## Why
On `--legacy-react`, the scan-root approval prompt (added in #228/#235) was **unanswerable**: the legacy loop wraps `app.invoke` in a Rich `Live` "thinking" spinner driven by a daemon thread, and when `scan_files → _authorize_scan_root` calls `input()` mid-`invoke`, the spinner keeps repainting over the prompt — so the prompt is clobbered and stdin is unusable (reported: spinner ticking on top of `Approve? :`, "one cannot really type yes").

## What
- **`builder/tools/hitl.py`** — new frontend-agnostic console-animation registry: `register_console_animation` / `unregister_console_animation` + `suspend_console_animation()` contextmanager. `ConsoleHumanInterface.present` and `request_input` now wrap their `print` + `input()` in `suspend_console_animation()`. Best-effort: no registered animation → no-op; `pause`/`resume` exceptions are logged, never propagated; `resume` always runs (even on `EOFError`).
- **`builder/agents/agent_loop.py`** — `_ThinkingSpinner` registers itself as the active animation in `__enter__` (unregisters in `__exit__`) and gains `pause()` (stop the Live region + set a paused flag so the tick thread stops repainting) / `resume()` (restart the Live region). 
- Non-CLI `HumanInterface`s (Streamlit/FastAPI/simulated) register nothing, so this is a CLI-only concern and a no-op elsewhere.

## Tests (TDD, red→green)
- `tests/test_tools_hitl.py::TestConsoleAnimationSuspension` (5): pause/input/resume ordering for `present` and `request_input`; resume-on-EOF; no-op without a registered animation; unregister only clears the matching animation.
- `tests/test_agent_loop.py::TestThinkingSpinnerPause` (2): `pause()`→stop / `resume()`→start the Live region; `suspend_console_animation` pauses then resumes a registered spinner.
- Gates: `test_tools_hitl.py` + full `test_agent_loop.py` = **81 passed**; `ruff` + `ty` clean.

Completes the scanner-approval UX from #228/#235. Refs #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)