### PR TITLE
fix(readers): legacy file readers return full content and stop looping (#240)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,21 @@ The agent loop turns a bare `None` from any file reader
 (`read_file_sample`/`read_file`/`read_excel`/`read_docx`) into an actionable
 "unreadable/too-large — skip it" message so a weak model stops re-calling it.
 
+**Full-return text budget & loop fixes (Issue #240):** `read_file` returns
+plain-text/JSON **in full** up to `_TEXT_BUDGET_BYTES` (64 KiB) — a 32 KB JSON
+comes back complete instead of being clipped at the old 100-line cap, which made
+weak models loop "let me read the rest". A file over the budget is returned with
+the content shown plus an explicit, machine-stable marker
+(`[truncated: showing first 64 KiB of N KiB; this is the maximum for this tool —
+do not re-read]`) so the model knows re-reading the same way yields nothing more;
+the 100 MB `_MAX_BYTES` hard cap still skips genuinely huge binaries entirely.
+A *directory* handed to `read_file`/`read_file_sample` no longer returns a silent
+`None` (which looped the agent) — it returns "`<path>` is a directory … use
+list_scanned_files …". `read_file_sample`'s `lines` argument controls how much
+'content' mode returns. Reasoning-log entries now embed a compact, bounded repr
+of each tool's call args (`run_tool: read_file(path='…')`) so the recorded action
+shows *which* path/hints a tool ran with, not just its result.
+
 #### Entity Drafters (`builder/tools/drafters.py`)
 Generate metadata entities from files, conversation, or existing metadata.
 Each drafter collects hints, calls the LLM, and ensures identifiers come from
@@ -476,10 +491,11 @@ full readers are specced and LLM-callable during the agent loop.*
 ```
 scan_files(path: str) → [FileClassification]
 read_file_sample(path: str, lines: int = 20, mode: str = "content") → str | None
-  mode: "content" (first N lines), "summary" (file-type-aware), "overview" (metadata + summary)
+  mode: "content" (first `lines` lines — `lines` controls how much is returned), "summary" (file-type-aware), "overview" (metadata + summary)
+  a directory path returns an actionable "use list_scanned_files" message, never a silent None (#240)
 read_multiple_files(paths: list[str], lines: int = 50, mode: str = "content") → dict
   mode: same options as read_file_sample
-read_file(path: str) → str | None             # full read by extension (txt, csv, json, xlsx, docx, md, pdf)
+read_file(path: str) → str | None             # full read by extension (txt, csv, json, xlsx, docx, md, pdf); text/JSON returned COMPLETE up to a 64 KiB budget, over-budget files carry an explicit "[truncated … do not re-read]" marker; a directory returns the list_scanned_files guidance (#240)
 read_excel(path: str) → str | None            # .xlsx → pipe-delimited text
 read_docx(path: str) → str | None             # .docx → plain text
 extract_pdf_text(path: str) → str             # structured PDF: [Page N] text, tables, image metadata

--- a/builder/agents/system_prompt.py
+++ b/builder/agents/system_prompt.py
@@ -12,9 +12,9 @@ File scanning & reading:
 - scan_files: Scan an input directory or zip for files (archives auto-extracted)
 - preview_archive: List a zip archive's members without extracting
 - unzip_file: Extract a zip archive to a directory
-- read_file_sample: Read a sample of one file (content/summary/overview)
+- read_file_sample: Read a sample of one file (content/summary/overview); the lines argument controls how much 'content' returns; a directory returns guidance to use list_scanned_files
 - read_multiple_files: Read a sample of several files at once
-- read_file: Read a supported file in full (txt, csv, json, xlsx, docx, md, pdf)
+- read_file: Read a supported file in full (txt, csv, json, xlsx, docx, md, pdf) — text/JSON come back complete up to 64 KiB; a bigger file is returned with a '[truncated … do not re-read]' marker, so don't re-read it
 - read_excel: Read an .xlsx file as pipe-delimited text
 - read_docx: Read a .docx file's text
 - extract_pdf_text: Extract structured text, tables, and image metadata from a PDF

--- a/builder/agents/tools_spec.py
+++ b/builder/agents/tools_spec.py
@@ -712,12 +712,12 @@ TOOL_SPECS = [
     },
     {
         "name": "read_file_sample",
-        "description": "Read a sample from a file. Use mode 'content' (first N lines), 'summary' (file-type-aware overview like columns for CSV, keys for JSON, page count for PDF), or 'overview' (file metadata + summary). Use this instead of read_multiple_files when inspecting a single file.",
+        "description": "Read a sample from a single FILE (not a directory). Use mode 'content' (first N lines, where N is the 'lines' argument — raise it to read more), 'summary' (file-type-aware overview like columns for CSV, keys for JSON, page count for PDF), or 'overview' (file metadata + summary). Use this instead of read_multiple_files when inspecting a single file. Passing a directory returns guidance to use list_scanned_files; to read a small file IN FULL prefer read_file.",
         "parameters": {
             "type": "object",
             "properties": {
                 "path": {"type": "string", "description": "Path to the file to read"},
-                "lines": {"type": "integer", "description": "Number of lines to read in 'content' mode (default 20)"},
+                "lines": {"type": "integer", "description": "Number of lines to return in 'content' mode (default 20). This directly controls how much is returned — raise it (e.g. 1000) to read more of the file."},
                 "mode": {
                     "type": "string",
                     "enum": ["content", "summary", "overview"],
@@ -746,7 +746,7 @@ TOOL_SPECS = [
     },
     {
         "name": "read_file",
-        "description": "Read a supported file in full by extension (txt, csv, json, xlsx, docx, md, pdf) and return its text content. Use read_file_sample instead when you only need a preview of a large file.",
+        "description": "Read a supported FILE in full by extension (txt, csv, json, xlsx, docx, md, pdf) and return its text content. Text/JSON come back COMPLETE up to 64 KiB (a 32 KB JSON is returned whole — do NOT re-read it expecting more). A file larger than the budget is returned with an explicit '[truncated: showing first 64 KiB of N KiB; … do not re-read]' marker: re-reading the same way will NOT return more, so move on. A directory path returns guidance to use list_scanned_files. Use read_file_sample only when you want a small preview of a large file.",
         "parameters": {
             "type": "object",
             "properties": {

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -157,6 +157,29 @@ _FILE_READ_TOOLS: dict[str, str] = {
 # object (never a tool's own return value) so ``is`` comparison is unambiguous.
 _GATE_OK = object()
 
+# Max length of the compact call-args repr embedded in each reasoning_log entry
+# (#240). Bounded so a big ``hints`` blob or a long path can't bloat the log.
+_REASONING_ARGS_MAX = 240
+
+
+def _compact_args_repr(kwargs: dict[str, Any], *, max_len: int = _REASONING_ARGS_MAX) -> str:
+    """Render tool call kwargs as a compact, truncated string for the log (#240).
+
+    The reasoning_log used to record only the tool RESULT, so you couldn't tell
+    which path ``read_file`` was called with. This embeds a bounded repr of the
+    arguments in each entry. Values that fail to repr are rendered defensively so
+    logging never raises.
+    """
+    if not kwargs:
+        return ""
+    try:
+        rendered = ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
+    except Exception:  # never let logging crash on an exotic value
+        rendered = str(list(kwargs.keys()))
+    if len(rendered) > max_len:
+        rendered = rendered[: max_len - 1] + "…"
+    return rendered
+
 
 class AgentEngine:
     """Orchestrator for the LLM agent toolbox loop.
@@ -614,8 +637,15 @@ class AgentEngine:
         self._writeback_validation(tool_name, result)
 
         self.state.iteration_count += 1
+        # Embed a compact, bounded repr of the call args in the action so the log
+        # shows WHICH path/hints a tool was called with — not just its result
+        # (#240). Previously this was just "run_tool: <name>", hiding the args.
+        _args_repr = _compact_args_repr(kwargs)
+        _action = f"run_tool: {tool_name}"
+        if _args_repr:
+            _action = f"{_action}({_args_repr})"
         self.state.log_reasoning(
-            f"run_tool: {tool_name}",
+            _action,
             tool_name,
             str(result)[:300] if result is not None else "None",
         )

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -24,6 +24,31 @@ logger = logging.getLogger(__name__)
 _MAX_BYTES = 100 * 1024 * 1024  # 100 MB — skip files larger than this
 _MAX_ROWS = 500  # max rows to return from structured formats
 
+# Full-return byte budget for plain-text / JSON content (Issue #240). A 32 KB
+# JSON is only ~8K tokens and must come back COMPLETE — the old 100-line cap
+# dropped the tail, so a weak model never saw fields deep in the file and looped
+# "let me read the rest". We return text in full up to this budget; only a file
+# that genuinely exceeds it is truncated, and then with an explicit marker.
+_TEXT_BUDGET_BYTES = 64 * 1024  # 64 KiB — generous full-return budget for text
+
+
+def _format_kib(num_bytes: int) -> str:
+    """Format a byte count as a compact ``N.N KiB`` string for messages."""
+    return f"{num_bytes / 1024:.1f} KiB"
+
+
+def _directory_message(path: str) -> str:
+    """Actionable message for a reader that was handed a directory (Issue #240).
+
+    The LLM kept calling ``read_file``/``read_file_sample`` on a *directory* and
+    got a silent ``None`` each time, then looped. Return a clear "this is a
+    directory, browse the inventory then read a file" signal instead.
+    """
+    return (
+        f"{path} is a directory, not a file — use list_scanned_files to browse "
+        f"the inventory, then read a specific file by its path."
+    )
+
 
 # ---------------------------------------------------------------------------
 # Excel (.xlsx)
@@ -189,13 +214,27 @@ def read_docx(
 def _read_text_file(
     path: str,
     *,
-    max_lines: int = 100,
     max_bytes: int = _MAX_BYTES,
+    budget: int | None = None,
 ) -> str | None:
-    """Read first *max_lines* lines of a plain-text file.
+    """Read a plain-text file IN FULL, up to a generous byte *budget* (Issue #240).
 
-    Returns *None* if the file is too large, binary, or unreadable.
+    Returns the whole file when it fits in ``budget`` bytes (default
+    :data:`_TEXT_BUDGET_BYTES`, 64 KiB). When it exceeds the budget the content
+    shown is returned PLUS an explicit, unmistakable truncation marker stating
+    how much was shown and that re-reading the same way will NOT return more — so
+    a weak model stops looping instead of asking for "the rest".
+
+    The hard ``max_bytes`` safety cap (default 100 MB) still skips genuinely huge
+    files entirely (returns *None*) so we never load a 16 MB binary into memory.
+
+    Returns *None* if the file is too large (> ``max_bytes``), binary, or
+    unreadable.
     """
+    # Resolve the budget at call time so tests can monkeypatch the module attr.
+    if budget is None:
+        budget = _TEXT_BUDGET_BYTES
+
     file_path = Path(path)
     try:
         size = file_path.stat().st_size
@@ -213,20 +252,29 @@ def _read_text_file(
         return None
 
     try:
-        sample: list[str] = []
+        # Read up to budget+1 bytes so we can tell whether the file overflowed
+        # the budget without slurping the whole (possibly large) file.
         with file_path.open("r", encoding="utf-8", errors="replace") as f:
-            for _ in range(max_lines):
-                line = f.readline()
-                if not line:
-                    break
-                sample.append(line.rstrip("\n"))
-            return "\n".join(sample)
+            shown = f.read(budget)
+            overflowed = f.read(1) != ""
     except PermissionError:
         logger.warning("Permission denied reading file: %s", path)
         return None
     except Exception:
         logger.exception("Error reading text file: %s", path)
         return None
+
+    content = shown.rstrip("\n")
+    if not overflowed:
+        return content
+
+    shown_bytes = len(shown.encode("utf-8"))
+    marker = (
+        f"\n[truncated: showing first {_format_kib(shown_bytes)} of "
+        f"{_format_kib(size)}; this is the maximum for this tool — do not "
+        f"re-read]"
+    )
+    return content + marker
 
 
 def read_file(
@@ -246,17 +294,27 @@ def read_file(
     - ``.docx`` — Word via :func:`read_docx`
     - ``.pdf`` — via :func:`~builder.tools.scanner.extract_pdf_text`
 
+    Plain-text and JSON files are returned **in full** up to a generous byte
+    budget (:data:`_TEXT_BUDGET_BYTES`, 64 KiB); a file that genuinely exceeds it
+    comes back with an explicit truncation marker so a weak model does not loop
+    "read the rest" (Issue #240). A *directory* path returns a clear, actionable
+    message (browse the inventory, then read a specific file) instead of *None*.
+
     Unsupported or unreadable files return *None*.
 
     Args:
         path: Path to the file.
-        max_lines: Max lines/rows for text files and structured formats.
-        max_bytes: Max file size in bytes (1 MB default).
+        max_lines: Max rows to return from structured formats (``.xlsx``); text
+            and JSON are governed by the byte budget, not a line cap.
+        max_bytes: Hard safety cap in bytes (default 100 MB); files larger than
+            this are skipped (returns *None*).
 
     Returns:
-        File content as a string, or *None*.
+        File content as a string, a directory-guidance message, or *None*.
     """
     file_path = Path(path)
+    if file_path.is_dir():
+        return _directory_message(path)
     if not file_path.is_file():
         return None
 
@@ -273,17 +331,8 @@ def read_file(
 
         return extract_pdf_text(path)
 
-    text_extensions = {
-        ".txt", ".csv", ".tsv", ".json", ".yml", ".yaml",
-        ".xml", ".md", ".log", ".ini", ".cfg", ".toml",
-        ".py", ".r", ".sh", ".bat", ".ps1", ".env",
-        ".html", ".htm", ".css", ".js", ".mjs",
-    }
-
-    if suffix in text_extensions:
-        return _read_text_file(path, max_lines=max_lines, max_bytes=max_bytes)
-
-    return _read_text_file(path, max_lines=max_lines, max_bytes=max_bytes)
+    # Everything else is read as plain text (full content up to the byte budget).
+    return _read_text_file(path, max_bytes=max_bytes)
 
 # ---------------------------------------------------------------------------
 # Explicit ToolRegistry registration
@@ -304,5 +353,5 @@ TOOL_REGISTRY.register(
 TOOL_REGISTRY.register(
     "read_file",
     read_file,
-    description="Read any supported file format by extension (txt, csv, json, xlsx, docx, md, pdf)",
+    description="Read any supported file format by extension (txt, csv, json, xlsx, docx, md, pdf). Text/JSON come back in full up to 64 KiB; a larger file is truncated with an explicit marker, and a directory returns guidance to use list_scanned_files",  # noqa: E501
 )

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -1148,15 +1148,26 @@ def read_file_sample(
             the caller has already determined this is a text file. Avoids
             redundant _detect_mime_type and content checks during scanning.
         mode: Reading mode:
-            - "content" (default): First N lines of the file (legacy behavior).
+            - "content" (default): First *lines* lines of the file. ``lines``
+              directly controls how much is returned (Issue #240).
             - "summary": File-type-aware summary (columns for CSV, keys for JSON,
               sheet names for XLSX, page count for PDF, etc.).
             - "overview": File metadata (name, size, MIME type) plus the summary.
 
     Returns:
-        A string with the file content/summary, or None if the file cannot be read.
+        A string with the file content/summary, a directory-guidance message
+        when *path* is a directory (Issue #240), or None if the file cannot be
+        read.
     """
     file_path = Path(path)
+    if file_path.is_dir():
+        # A directory handed to a file reader (e.g. read_file_sample(<dir>,
+        # mode='overview')) used to return a silent None, which looped a weak
+        # model. Return a clear, actionable signal instead (Issue #240).
+        return (
+            f"{path} is a directory, not a file — use list_scanned_files to "
+            f"browse the inventory, then read a specific file by its path."
+        )
     if not file_path.is_file():
         return None
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -100,6 +100,28 @@ class TestAgentEngine:
         engine.run_tool("draft_investigation", hints={"name": "Test 2"})
         assert engine.state.iteration_count == 2
 
+    def test_reasoning_log_entry_includes_call_args(self):
+        """Issue #240: each reasoning_log entry records the tool ARGUMENTS, not
+        just the result, so you can see which path read_file was called with.
+        """
+        engine = AgentEngine()
+        engine.initialize()
+        engine.run_tool("draft_investigation", hints={"name": "Hepatotox screen"})
+        step = engine.state.checkpoint.reasoning_log[-1]
+        assert step.tool == "draft_investigation"
+        # The recorded action/args names the argument that was passed.
+        assert "Hepatotox screen" in step.action
+
+    def test_reasoning_log_args_are_bounded(self):
+        """A huge argument is truncated so reasoning_log entries stay small."""
+        engine = AgentEngine()
+        engine.initialize()
+        huge = "z" * 5000
+        engine.run_tool("draft_investigation", hints={"name": huge})
+        step = engine.state.checkpoint.reasoning_log[-1]
+        # The action (which embeds the args repr) is bounded.
+        assert len(step.action) < 1000
+
     def test_get_available_tools_returns_list(self):
         """get_available_tools returns a non-empty list of tool names."""
         engine = AgentEngine()

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -9,8 +9,10 @@ bounded; the byte ceiling is unified to 100 MB.
 
 from __future__ import annotations
 
+import json
+
 from builder.tools import file_readers
-from builder.tools.file_readers import _MAX_BYTES, read_file
+from builder.tools.file_readers import _MAX_BYTES, _TEXT_BUDGET_BYTES, read_file
 
 
 class TestSizeCeiling:
@@ -40,3 +42,81 @@ class TestSizeCeiling:
         csv = tmp_path / "huge.csv"
         csv.write_text("a,b\n" + "1,2\n" * 1000)
         assert read_file(str(csv), max_bytes=100) is None
+
+
+class TestTextBudget:
+    """Issue #240: text/JSON is returned IN FULL up to a generous byte budget,
+    not truncated at a tiny line cap, so a weak model isn't tricked into a
+    'let me read the rest' loop over a small file.
+    """
+
+    def test_text_budget_is_generous(self):
+        # The full-return budget for text/JSON is at least 64 KiB.
+        assert _TEXT_BUDGET_BYTES >= 64 * 1024
+
+    def test_32kb_pretty_json_returned_in_full(self, tmp_path):
+        # A ~32 KB pretty-printed JSON is well under the budget and must come
+        # back COMPLETE — the prior 100-line cap dropped the tail, so the LLM
+        # never saw fields deep in the file and looped 'read the rest'.
+        obj = {
+            "study": {"title": "Silychristin exposure in MDCK cells"},
+            "rows": [{"i": i, "v": f"value_{i}"} for i in range(700)],
+        }
+        js = tmp_path / "S-VHPS26.json"
+        js.write_text(json.dumps(obj, indent=2), encoding="utf-8")
+        size = js.stat().st_size
+        assert 20_000 < size < _TEXT_BUDGET_BYTES  # genuinely mid-size, under budget
+
+        result = read_file(str(js))
+        assert result is not None
+        # First AND last content present -> the whole file was returned.
+        assert "Silychristin exposure in MDCK cells" in result
+        assert "value_699" in result
+        # No truncation marker for an under-budget file.
+        assert "[truncated" not in result
+
+    def test_over_budget_text_returns_content_plus_explicit_marker(
+        self, tmp_path, monkeypatch
+    ):
+        # When a file genuinely exceeds the byte budget, return the content
+        # shown PLUS an unmistakable marker telling the model exactly how much
+        # was shown and that re-reading will NOT return more (so it stops).
+        monkeypatch.setattr(file_readers, "_TEXT_BUDGET_BYTES", 1024, raising=True)
+        big = tmp_path / "big.txt"
+        big.write_text("X" * 5000, encoding="utf-8")
+
+        result = read_file(str(big))
+        assert result is not None
+        # Content up to the budget is present.
+        assert result.count("X") >= 1024
+        # Explicit, machine-stable truncation marker.
+        assert "[truncated" in result
+        assert "do not re-read" in result
+        # The marker names both the shown amount and the full size.
+        assert "1.0 KiB" in result
+        assert "4.9 KiB" in result
+
+    def test_under_budget_text_has_no_marker(self, tmp_path):
+        small = tmp_path / "small.txt"
+        small.write_text("hello\nworld\n", encoding="utf-8")
+        result = read_file(str(small))
+        assert result == "hello\nworld"
+        assert "[truncated" not in result
+
+
+class TestDirectoryHandling:
+    """Issue #240: a DIRECTORY passed to read_file must return a CLEAR,
+    actionable message — never a silent None that makes the LLM loop.
+    """
+
+    def test_read_file_on_directory_returns_actionable_message(self, tmp_path):
+        result = read_file(str(tmp_path))
+        assert result is not None
+        assert isinstance(result, str)
+        assert "is a directory" in result
+        assert "list_scanned_files" in result
+
+    def test_read_file_on_missing_path_still_returns_none(self, tmp_path):
+        # A genuinely missing path stays None (the agent-loop maps that to its
+        # 'unreadable' message); only a directory gets the new guidance.
+        assert read_file(str(tmp_path / "does_not_exist.csv")) is None

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -354,6 +354,48 @@ class TestUnzipFile:
         assert "message" in result
 
 
+class TestReadFileSampleDirectory:
+    """Issue #240: read_file_sample on a DIRECTORY must return a clear,
+    actionable message instead of a silent None that loops the agent.
+    """
+
+    def test_directory_content_mode_returns_actionable_message(self, tmp_path):
+        result = read_file_sample(str(tmp_path), mode="content")
+        assert result is not None
+        assert "is a directory" in result
+        assert "list_scanned_files" in result
+
+    def test_directory_overview_mode_returns_actionable_message(self, tmp_path):
+        # 'overview' was the exact mode the looping run kept calling on a dir.
+        result = read_file_sample(str(tmp_path), mode="overview")
+        assert result is not None
+        assert "is a directory" in result
+        assert "list_scanned_files" in result
+
+    def test_missing_path_still_returns_none(self, tmp_path):
+        assert read_file_sample(str(tmp_path / "nope.json")) is None
+
+
+class TestReadFileSampleLinesHonored:
+    """Issue #240: the `lines` argument must actually control how much content
+    'content' mode returns (for JSON and other text alike).
+    """
+
+    def test_lines_controls_amount_returned_for_json(self, tmp_path):
+        import json as _json
+
+        obj = {"rows": [{"i": i} for i in range(500)]}
+        f = tmp_path / "big.json"
+        f.write_text(_json.dumps(obj, indent=2), encoding="utf-8")
+
+        few = read_file_sample(str(f), lines=10, mode="content")
+        many = read_file_sample(str(f), lines=1000, mode="content")
+        assert few is not None and many is not None
+        assert len(many) > len(few)
+        # lines=10 returns exactly 10 lines.
+        assert few.count("\n") <= 9
+
+
 class TestReadFileSampleMode:
     """Tests for the mode parameter on read_file_sample."""
 


### PR DESCRIPTION
## Why

A real `--legacy-react` run over a 32 KB `S-VHPS26.json` looped 29+ iterations (~\$0.27, >1M tokens) and **never** extracted the study title that was sitting in the file. Three reader bugs caused the loop, plus a reasoning-log gap that hid which path was being read. Fixes #240.

## The 3 reader fixes (old → new)

### 1. Directory → clear message, not silent `None`
`read_file` / `read_file_sample` handed a **directory** returned a bare `None`. The LLM called `read_file_sample(path=<dir>, mode='overview')` repeatedly, got `None` each time, and looped.

- **old:** `read_file(<dir>)` → `None`; `read_file_sample(<dir>, mode='overview')` → `None`
- **new:** both return `"<path> is a directory, not a file — use list_scanned_files to browse the inventory, then read a specific file by its path."`

### 2. Full-return byte budget for text/JSON (the real truncation — confirmed in a throwaway repro, NOT just a display issue)
`read_file` read plain-text/JSON through `_read_text_file` with a **100-line cap**. A 32 KB pretty-printed JSON has hundreds of lines, so the tail was dropped and the model looped "let me read the rest". Reproduced: a 23.9 KB pretty JSON came back as **1452 chars** with `value_399` (the tail) missing.

- **old:** text/JSON capped at `max_lines=100`, silently truncated, no marker, no way to ask for more (the `read_file` tool spec exposes only `path`).
- **new:** text/JSON returned **IN FULL** up to `_TEXT_BUDGET_BYTES = 64 KiB`. A file over the budget returns the shown content **plus** an explicit, machine-stable marker:
  `[truncated: showing first 64.0 KiB of 195.3 KiB; this is the maximum for this tool — do not re-read]`
  The 100 MB `_MAX_BYTES` hard cap is preserved (huge binaries are still skipped, never loaded into memory).

### 3. `lines` honored + documented
`read_file_sample(mode='content', lines=N)` already honored `lines` for JSON (verified: `lines=1000` returns more than `lines=20`). The reader is now documented to say `lines` controls how much is returned, in the tool spec, the system-prompt catalogue, and AGENTS.md §5.

## Observability fix: reasoning_log args (before → after)
`engine.run_tool` logged only the tool **result**, so you couldn't see which path `read_file` ran with.

- **before:** `action = "run_tool: read_file"`
- **after:** `action = "run_tool: read_file(path='/data/S-VHPS26.json')"` — a compact, bounded (`_REASONING_ARGS_MAX = 240`) repr of the call args; oversized args truncated with `…`.

## Four-place tool-registration contract kept in lockstep
`TOOL_REGISTRY` description (file_readers.py), `TOOL_SPECS` descriptions, the system-prompt "## Your Tools" catalogue, and AGENTS.md §5 all updated together; `tests/test_agents_doc_toolbox.py` + `tests/test_tools_spec.py` stay green.

## Tests (TDD: red first, then green)
- `tests/test_file_readers.py::TestTextBudget` — budget is generous; 32 KB pretty JSON returned in full (no marker); over-budget file returns content + explicit marker; under-budget has no marker
- `tests/test_file_readers.py::TestDirectoryHandling` — directory → actionable message; missing path still `None`
- `tests/test_scanner.py::TestReadFileSampleDirectory` — content & overview modes on a dir return the message; missing path still `None`
- `tests/test_scanner.py::TestReadFileSampleLinesHonored` — `lines` controls how much content mode returns for JSON
- `tests/test_engine.py::TestAgentEngine::test_reasoning_log_entry_includes_call_args` / `::test_reasoning_log_args_are_bounded`

## Gates (all clean)
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_file_readers.py tests/test_tools_spec.py tests/test_agents_doc_toolbox.py tests/test_engine.py tests/test_scanner.py` → 120 passed
- `uv run ruff check` → All checks passed
- `uv run --extra langchain ty check` → All checks passed
- Also ran `test_agent_loop.py test_agents_pipeline.py test_tools_session.py test_state_serializer.py` → 100 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)