### PR TITLE
fix(lookups): emit context-valid ChEBI identity on resolved compounds (#243)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1071,7 +1071,13 @@ All lookups follow a consistent pattern: return `{found: bool, data: dict, error
 ### Multi-Strategy Lookups
 For chemicals, `lookup_compound` tries by name, then CAS, then **ChEBI** (via
 OLS4) — a PubChem miss now falls back to resolving a ChEBI IRI rather than a
-hard not-found. If all fail, ask the user for SMILES/InChI.
+hard not-found. If all fail, ask the user for SMILES/InChI. The ChEBI fallback's
+identity rides on **context-declared keys** so the `MolecularEntity` compacts
+cleanly under RO-Crate 1.2 (Issue #243): the ChEBI CURIE on `chebiId`
+(`schema:identifier`, mirroring `cas`/`pubchemCid`) and the dereferenceable
+ontology IRI on `sameAs` as an `{"@id": …}` node. The legacy bare
+`chebi_id`/`chebi_iri` keys were absent from the `@context` and failed the base
+pass (and leaked into the HITL loop as unanswerable gaps), so they are gone.
 
 ### Anti-Hallucination
 The agent **never fabricates identifiers**. Every identifier is verified against its source. If verification fails, the field is cleared and the agent tries alternatives or asks the user.

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -1142,8 +1142,12 @@ _COMPOUND_DATA_FIELDS: tuple[str, ...] = (
     "inchi",
     "formula",
     "mass",
-    "chebi_id",
-    "chebi_iri",
+    # ChEBI fallback identity, in context-declared keys (Issue #243): ``chebiId``
+    # (the CURIE, schema:identifier) and ``sameAs`` (the dereferenceable ontology
+    # IRI as an @id node). The legacy bare ``chebi_id`` / ``chebi_iri`` keys are
+    # gone — they were absent from the @context and failed base-profile validation.
+    "chebiId",
+    "sameAs",
 )
 
 

--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -90,14 +90,22 @@ def lookup_compound(name: str) -> dict[str, Any]:
         # returning a hard "not found".
         chebi = lookup_ontology_term_ols(raw, "chebi")
         if chebi and chebi.get("@id"):
-            return _success(
-                {
-                    "chebi_id": chebi.get("termCode", ""),
-                    "chebi_iri": chebi["@id"],
-                    "iupac_name": chebi.get("name", raw),
-                    "source": "chebi",
-                }
-            )
+            # Express ChEBI identity with context-declared keys so the
+            # MolecularEntity compacts cleanly under RO-Crate 1.2 (Issue #243).
+            # Bare ``chebi_id`` / ``chebi_iri`` keys are absent from the @context
+            # and fail base-profile validation. ``chebiId`` (the ChEBI CURIE) is
+            # already mapped to schema:identifier — mirroring ``cas`` / ``pubchemCid``
+            # — and the dereferenceable ontology IRI rides on ``sameAs`` as an
+            # ``@id`` node, the idiomatic machine-resolvable identity link.
+            data: dict[str, Any] = {
+                "iupac_name": chebi.get("name", raw),
+                "source": "chebi",
+                "sameAs": {"@id": chebi["@id"]},
+            }
+            term_code = chebi.get("termCode")
+            if term_code:
+                data["chebiId"] = term_code
+            return _success(data)
 
         return _failure(f"Compound '{name}' not found in PubChem or ChEBI")
     except TransientLookupError as exc:

--- a/profiles/context.py
+++ b/profiles/context.py
@@ -132,9 +132,16 @@ ISA_TOX_CONTEXT: list[dict] = [
         "ontologyName": "http://purl.org/dc/terms/isPartOf",
         "shortForm": "http://www.geneontology.org/formats/oboInOwl#shorthand",
         "synonym": "http://schema.org/alternateName",
+        # schema:sameAs — the dereferenceable identity link. Carries the ChEBI
+        # ontology IRI (as an @id node) for a compound resolved via the
+        # lookup_compound PubChem→ChEBI fallback (Issue #243), so the ChEBI identity
+        # is a machine-resolvable reference rather than a bare, context-less key.
         "sameAs": "http://schema.org/sameAs",
         # Chemical identifiers and molecular properties (from CompoundCloud / PubChem)
         "cas": "http://schema.org/identifier",
+        # chebiId — the ChEBI CURIE (e.g. "CHEBI:28748") as a schema:identifier,
+        # mirroring cas / pubchemCid. The lookup_compound ChEBI fallback emits this
+        # (with the IRI on sameAs) instead of the legacy context-less chebi_id/chebi_iri.
         "chebiId": "http://schema.org/identifier",
         "chemblId": "http://schema.org/identifier",
         "dsstoxId": "http://schema.org/identifier",

--- a/tests/test_offline_validation.py
+++ b/tests/test_offline_validation.py
@@ -143,6 +143,87 @@ class TestOfflineContextResolution:
         assert base.passed_required, [(i.check_id, i.message) for i in base.issues]
 
 
+class TestChebiResolvedCompoundContext:
+    """A ChEBI-resolved compound must serialise to context-valid JSON-LD (#243).
+
+    The PubChem-miss → ChEBI fallback in ``lookup_compound`` historically emitted
+    bare ``chebi_id`` / ``chebi_iri`` keys onto the MolecularEntity. Those keys are
+    NOT declared in the RO-Crate ``@context``, so RO-Crate 1.2 compaction rejects
+    them and the base pass fails on every crate that resolved a compound via ChEBI
+    (and the failure leaked into the HITL loop as an unanswerable gap). The ChEBI
+    identity must instead round-trip through context-valid keys.
+    """
+
+    @staticmethod
+    def _chebi_state(monkeypatch):
+        """A CrateState with a single ChEBI-resolved MolecularEntity.
+
+        Drives the *real* ``lookup_compound`` ChEBI fallback (PubChem patched to
+        miss, OLS/ChEBI patched to hit) and the real ``resolve_compound`` so the
+        keys the entity carries are exactly the ones the production path emits.
+        """
+        from builder.state import CrateState
+        from builder.tools import composites, lookups
+
+        lookups.lookup_compound.cache_clear()
+
+        def fake_pubchem(query):  # noqa: ANN001 — no PubChem hit, force the ChEBI branch
+            return {}
+
+        def fake_chebi(query, ontology):  # noqa: ANN001
+            assert ontology == "chebi"
+            return {
+                "@id": "http://purl.obolibrary.org/obo/CHEBI_28748",
+                "termCode": "CHEBI:28748",
+                "name": "doxorubicin",
+            }
+
+        monkeypatch.setattr(lookups, "lookup_pubchem", fake_pubchem)
+        monkeypatch.setattr(lookups, "lookup_ontology_term_ols", fake_chebi)
+
+        state = CrateState()
+        state.metadata.title = "ChEBI crate"
+        # verify=False keeps this fully offline (no source round-trip).
+        result = composites.resolve_compound(state, name="Doxorubicin", verify=False)
+        assert "error" not in result, result
+        return state, result
+
+    def test_chebi_compound_passes_base_validation(self, monkeypatch):
+        from builder.tools.validation import build_and_validate
+
+        state, _ = self._chebi_state(monkeypatch)
+        report = build_and_validate(state, profile="base")
+
+        assert report["conformance"].get("base") is True, [
+            (i["entity_id"], i["property"], i["message"]) for i in report["issues"]
+        ]
+        # No @context violation about an undeclared key (the #243 symptom).
+        joined = " ".join(i["message"] for i in report["issues"]).lower()
+        assert "not present in the @context" not in joined, report["issues"]
+        assert "chebi_id" not in joined and "chebi_iri" not in joined, report["issues"]
+
+    def test_chebi_identity_present_in_context_valid_form(self, monkeypatch):
+        state, _ = self._chebi_state(monkeypatch)
+        mol = next(e for e in state.list_entities() if e.type == "MolecularEntity")
+
+        # The ChEBI identity is retained — but only under context-declared keys,
+        # never the bare ``chebi_id`` / ``chebi_iri`` keys that fail compaction.
+        assert "chebi_id" not in mol.fields
+        assert "chebi_iri" not in mol.fields
+
+        serialised = " ".join(str(v) for v in mol.fields.values())
+        assert "CHEBI:28748" in serialised
+        assert "http://purl.obolibrary.org/obo/CHEBI_28748" in serialised
+
+        from profiles.context import ISA_TOX_CONTEXT
+
+        context_terms = set(ISA_TOX_CONTEXT[0])
+        for key in mol.fields:
+            if key.startswith("@") or key == "entity_id":
+                continue
+            assert key in context_terms, f"MolecularEntity key {key!r} not in @context"
+
+
 class TestTransportErrorNotReportedAsRequired:
     """A connection error during a pass is an error, not a spurious REQUIRED."""
 

--- a/tests/test_tools_lookups.py
+++ b/tests/test_tools_lookups.py
@@ -100,8 +100,15 @@ class TestLookupCompound:
         result = lookup_compound("water")
         assert result["found"] is True
         assert result["data"]["source"] == "chebi"
-        assert result["data"]["chebi_iri"] == "http://purl.obolibrary.org/obo/CHEBI_15377"
-        assert result["data"]["chebi_id"] == "CHEBI:15377"
+        # ChEBI identity rides on context-declared keys (Issue #243): the IRI as a
+        # ``sameAs`` @id node and the CURIE as ``chebiId`` (schema:identifier) — not
+        # the bare ``chebi_iri`` / ``chebi_id`` keys that fail @context compaction.
+        assert result["data"]["sameAs"] == {
+            "@id": "http://purl.obolibrary.org/obo/CHEBI_15377"
+        }
+        assert result["data"]["chebiId"] == "CHEBI:15377"
+        assert "chebi_iri" not in result["data"]
+        assert "chebi_id" not in result["data"]
         assert result["data"]["iupac_name"] == "water"
         assert result["error"] is None
 
@@ -641,7 +648,12 @@ class TestLookupCompoundChebiFallback:
         )
         result = lookup_compound("alpha-D-glucose")
         assert result["found"] is True
-        assert result["data"]["chebi_id"] == "CHEBI_28061"
+        # Context-valid ChEBI identity (Issue #243): CURIE under ``chebiId``,
+        # ontology IRI under a ``sameAs`` @id node.
+        assert result["data"]["chebiId"] == "CHEBI_28061"
+        assert result["data"]["sameAs"] == {
+            "@id": "http://purl.obolibrary.org/obo/CHEBI_28061"
+        }
         assert result["data"]["source"] == "chebi"
 
     def test_fails_when_both_pubchem_and_chebi_miss(self, monkeypatch):


### PR DESCRIPTION
Closes #243

## Problem

The PubChem→ChEBI fallback in `lookup_compound` (`builder/tools/lookups.py`) wrote
bare `chebi_id` / `chebi_iri` keys onto the `MolecularEntity`:

```python
"chebi_id": chebi.get("termCode", ""),
"chebi_iri": chebi["@id"],
```

Those keys are **not declared in the RO-Crate `@context`** (`profiles/context.py`),
so RO-Crate 1.2 compaction rejects them:

> The N occurrences of the JSON-LD key `chebi_id` / `chebi_iri` are not allowed in
> the compacted format because it is not present in the `@context` of the document.

This failed the **base** pass on every crate that resolved a compound via ChEBI,
and (being non-deterministically fixable) leaked into the HITL guidance loop as
unanswerable prompts.

## Representation chosen: context-declared keys (`chebiId` + `sameAs`), not new bare keys

I express ChEBI identity through keys **already in the `@context`**, mirroring the
established `cas` / `pubchemCid` identifier convention:

| ChEBI datum | Old (bare, context-less) | New (context-valid) | `@context` mapping |
|---|---|---|---|
| CURIE, e.g. `CHEBI:28748` | `chebi_id` | `chebiId` | `schema:identifier` (same as `cas`/`pubchemCid`) |
| ontology IRI | `chebi_iri` | `sameAs` → `{"@id": <iri>}` | `schema:sameAs` |

**Why this over the alternatives:** the gold-path identifier wiring
(`_identifier_pv` / `_MOLECULAR_IDENTIFIERS`) lives in `builder/tools/_crate_mapping.py`,
which is owned by parallel work and out of this PR's lane — so the PropertyValue-node
route isn't reachable here. The context route is the cleaner in-lane fix the issue
explicitly allows, and it stays consistent with the existing chemical identifiers:
`chebiId` is a `schema:identifier` exactly like `cas`/`pubchemCid`, and the
dereferenceable IRI rides on `sameAs` as an `{"@id": …}` node — the same
"identifier as a machine-resolvable `@id` IRI node, never a bare string" principle
AGENTS.md applies to DOI/PubMed. Both terms were already present in
`profiles/context.py`; I added comments documenting the coupling and updated
AGENTS.md §10.

## Before / after

Before: a ChEBI-resolved `MolecularEntity` carries `chebi_id` / `chebi_iri` →
base pass **FAILS** with the `@context` violation above.

After: it carries `chebiId` (CURIE) + `sameAs` (`{"@id": <ChEBI IRI>}`) → base pass
is **clean**, and the ChEBI identity is still present and retrievable.

## TDD

Failing-first regression test (confirmed red on the pre-fix code, reproducing the
exact `@context` violation, then green after the fix):

- `tests/test_offline_validation.py::TestChebiResolvedCompoundContext::test_chebi_compound_passes_base_validation`
- `tests/test_offline_validation.py::TestChebiResolvedCompoundContext::test_chebi_identity_present_in_context_valid_form`

It drives the **real** `lookup_compound` ChEBI fallback through `resolve_compound`
and `build_and_validate(profile="base")`. Existing ChEBI lookup tests updated to
the new keys:

- `tests/test_tools_lookups.py::...::test_falls_back_to_chebi_when_pubchem_misses`
- `tests/test_tools_lookups.py::TestLookupCompoundChebiFallback::test_falls_back_to_chebi_when_pubchem_empty`

## Changed files

- `builder/tools/lookups.py` — emit `chebiId` + `sameAs` instead of `chebi_id`/`chebi_iri`
- `builder/tools/composites.py` — `_COMPOUND_DATA_FIELDS` carries the new keys (ChEBI-mapping region only)
- `profiles/context.py` — documenting comments on `chebiId` / `sameAs`
- `AGENTS.md` — §10 ChEBI fallback note
- `tests/test_offline_validation.py`, `tests/test_tools_lookups.py` — tests

## Gates

- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_tools_resolve_compound.py tests/test_offline_validation.py tests/test_validate_dict.py tests/test_tools_lookups.py tests/test_tools_build_and_validate.py` — all pass
- `uv run ruff check` — clean
- `uv run --extra langchain ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)