### PR TITLE
fix(dashboard): watch session directory so live updates aren't missed (atomic saves)

### DIFF
--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -953,6 +953,22 @@ def run_dashboard(session_id: str | None = None, refresh_interval: float = 2.0) 
         print("\nDashboard closed.")
 
 
+def _change_touches(changes: Any, watched: set[str]) -> bool:
+    """Whether any watchfiles change touches one of *watched* file paths.
+
+    Watching the session DIRECTORY (see :func:`_run_live_dashboard`) also surfaces
+    churn from temp files — ``save_session`` writes ``.crate_state_tmp_*`` then
+    ``os.replace``\\ s it over ``crate_state.json`` — plus any exported payload. We
+    re-render only when ``profile.ndjson`` or ``crate_state.json`` actually changed
+    so unrelated churn doesn't thrash the display. ``changes`` is the
+    ``set[tuple[Change, str]]`` yielded by ``watchfiles.watch``.
+    """
+    try:
+        return any(path in watched for _change, path in changes)
+    except TypeError:
+        return False
+
+
 def _run_live_dashboard(
     profile_path: Path,
     session_id: str,
@@ -986,15 +1002,20 @@ def _run_live_dashboard(
         console.print(_build())
         return
 
-    # Watch both profile.ndjson and crate_state.json so CrateState updates too.
-    watch_paths = [str(profile_path)]
-    if crate_state_path.exists():
-        watch_paths.append(str(crate_state_path))
+    # Watch the session DIRECTORY, not the individual files. ``save_session``
+    # writes crate_state.json atomically (tempfile + ``os.replace``), which swaps
+    # the inode a file-path watcher holds — so a watcher bound to crate_state.json
+    # silently stopped seeing updates and the dashboard only refreshed on reload.
+    # Watching the directory catches the rename (and crate_state.json first
+    # appearing after the dashboard started). Filter to the two files we render
+    # from so unrelated temp/export churn doesn't thrash the display.
+    watched = {str(profile_path), str(crate_state_path)}
 
     with Live(
         _build(), console=console, refresh_per_second=1 / refresh_interval, screen=False
     ) as live:
         # `step` is watchfiles' debounce quiet-period (see _WATCH_STEP_MS), not
         # the render interval — keep it small so updates aren't throttled.
-        for _changes in watch(*watch_paths, step=_WATCH_STEP_MS):
-            live.update(_build())
+        for changes in watch(str(session_path), step=_WATCH_STEP_MS):
+            if _change_touches(changes, watched):
+                live.update(_build())

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -379,3 +379,64 @@ class TestLiveRefresh:
         records2, mtime2 = _read_records_cached(profile_path, mtime, records)
         assert len(records2) == 2
         assert mtime2 != mtime
+
+    def test_watches_session_directory_so_atomic_saves_are_caught(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """save_session writes crate_state.json atomically (tempfile + os.replace),
+        which swaps the inode a file-path watcher holds — so a watcher bound to the
+        FILE silently stops seeing updates and the dashboard only refreshes on
+        reload. The fix watches the session DIRECTORY, which catches the rename
+        (and crate_state.json first appearing after startup)."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools.dashboard import _run_live_dashboard
+
+        session_dir = tmp_path / "sess1"
+        session_dir.mkdir()
+        profile_path = session_dir / "profile.ndjson"
+        profile_path.write_text(json.dumps({"event": "node_end", "node": "model"}) + "\n")
+
+        captured: dict = {}
+
+        def fake_watch(*paths, **kwargs):
+            captured["paths"] = paths
+            return iter(())
+
+        class _DummyLive:
+            def __init__(self, *a, **k) -> None:
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a) -> bool:
+                return False
+
+            def update(self, *a) -> None:
+                pass
+
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", _DummyLive)
+
+        _run_live_dashboard(profile_path, "sess1", refresh_interval=2.0)
+
+        # Watch the directory, NOT the individual files (the old, broken behavior
+        # watched profile.ndjson / crate_state.json paths and missed atomic renames).
+        assert captured["paths"] == (str(session_dir),)
+
+    def test_change_touches_only_relevant_files(self) -> None:
+        """The directory watch fires on temp/export churn too; only re-render when
+        profile.ndjson or crate_state.json actually changed."""
+        from builder.tools.dashboard import _change_touches
+
+        prof = "/s/profile.ndjson"
+        crate = "/s/crate_state.json"
+        watched = {prof, crate}
+        # watchfiles yields a set of (Change, path); the helper inspects only path.
+        assert _change_touches({(2, prof)}, watched) is True
+        assert _change_touches({(1, crate)}, watched) is True
+        # the atomic-save temp churn must NOT trigger a re-render
+        assert _change_touches({(1, "/s/.crate_state_tmp_abc")}, watched) is False
+        assert _change_touches(set(), watched) is False


### PR DESCRIPTION
## Why (your "must reload to see updates")
The live dashboard watched the **individual files** (`profile.ndjson`, and `crate_state.json` only if it already existed at startup). But `save_session` writes `crate_state.json` **atomically** — tempfile → `fsync` → `os.replace` (`builder/tools/session.py:268-288`). `os.replace` swaps the inode the watcher holds, so `watchfiles` bound to the file path **silently stops firing** → the dashboard only refreshes on a manual reload. `crate_state.json` created *after* the dashboard started was never watched at all.

## Fix
Watch the **session directory** instead of the individual files (`watch(str(session_path), …)`). A directory watch catches the atomic rename (and the file first appearing later). Re-renders are filtered to `profile.ndjson`/`crate_state.json` via a new pure helper `_change_touches(...)` so temp-file (`.crate_state_tmp_*`) and export churn don't thrash the display. The `_WATCH_STEP_MS` debounce and the #121 records-cache behavior are unchanged.

## Tests (TDD)
- `TestLiveRefresh::test_watches_session_directory_so_atomic_saves_are_caught` — asserts `watch()` is called with the session dir, not the file paths (fails on old behavior).
- `TestLiveRefresh::test_change_touches_only_relevant_files` — profile/crate_state changes → re-render; temp-file churn / empty → no re-render.
- Full `test_dashboard.py` 18/18; ruff + ty clean.

## Notes
Standalone fix for the auto-refresh regression so it can merge fast for debugging. The companion #241/#242 PR adds the missing `save_session` calls on the pipeline path (so the pipeline actually *writes* `crate_state.json` for this watch to pick up); together they make the dashboard live-update during a pipeline run. Refs #242, #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)