### PR TITLE
feat(guidance): LLM-mediate the HITL ask-user step (#244)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1613,11 +1613,14 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   prioritized `GapReport` unifying SHACL + MIT + FAIR.
 - **Auto-resolve** (`fix_required_issues`, §5, the keystone) — clears every
   `auto_fixable` gap deterministically from state alone, no prompt.
-- **Guidance** (`run_guidance` #218, §14.6.1) — the **deterministic, code-driven
-  HITL loop** that walks the remaining `auto_fixable=False` gaps with the user in
-  the loop. It is NOT a ReAct/LLM-orchestrated agent: CODE owns control flow, the
-  LLM only *drafts* a suggested value, and the user confirms every uncertain
-  commit (D5). It is invoked **only for a real interactive user** (see §14.6.1).
+- **Guidance** (`run_guidance` #218 / #244, §14.6.1) — the **code-driven HITL
+  loop** that walks the remaining `auto_fixable=False` gaps with the user in the
+  loop. CODE still owns control flow (it is NOT a ReAct/LLM-orchestrated agent),
+  but the per-gap ask-user step is now a **small bounded LLM exchange** — the #179
+  hybrid's "small guidance agent" (#244) — so a cryptic gap becomes a real
+  conversation instead of an ask-and-set loop that stored the user's raw prose
+  verbatim (the real bug: typing "no idea which file you mean" landed as the crate
+  `description`). It is invoked **only for a real interactive user** (see §14.6.1).
   The loop **advances over un-progressable gaps** rather than aborting on the
   first one (#230): each round it draws the next *actionable* gap (`report-only`
   gaps are never drawn — see below), and a gap it cannot progress (e.g. the user
@@ -1625,9 +1628,40 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   behind it. It only stops once the whole report is exhausted with no progress —
   one cryptic, uncommittable gap can no longer abandon the 200 behind it — and is
   still hard-bounded by `max_rounds`. The skip-set is cleared on every commit (the
-  re-assessed report is fresh). ask-user prompts are **human-readable** (a direct
-  question naming the field + entity, the reason, any suggestion, and the expected
-  format), never the raw failed-check `message`.
+  re-assessed report is fresh).
+
+  **The per-gap LLM exchange (#244).** When a provider is configured (gated on
+  `config.get_provider()`, like the pipeline leaves), each ask-user gap runs a
+  bounded **phrase → ask → interpret → commit** cycle using two new drafter-tier
+  leaves in `builder/agents/leaves.py` (internal pipeline calls, NOT four-place
+  LLM-advertised tools):
+  - **Phrase** (`phrase_gap_question(gap_context) -> str`) turns the gap
+    (property, entity_type, tier, MIT/FAIR rationale, suggestion) into ONE clear
+    question with a concrete example — never raw SHACL shapes / FAIR indicator
+    codes / property IRIs. On an empty/failed result it falls back to the
+    deterministic human-readable prompt.
+  - **Interpret** (`interpret_gap_reply(question, reply, gap_context) -> dict`)
+    parses the free-text reply into a **structured decision** — one of
+    `{action: "commit", value}` | `{action: "skip"}` (covers "I don't
+    know"/empty) | `{action: "clarify", question}` | `{action: "from_file",
+    filename?}`. **Free-text musings never become field values.**
+  - **Commit** — only a `commit`'s clean `value` reaches `_apply_value`
+    (`set_fields` / `set_crate_metadata`, never hand-rolled JSON-LD). `skip`
+    commits nothing; `clarify` asks at most **one** bounded follow-up
+    (`_MAX_CLARIFY_FOLLOW_UPS`) then skips, so the clarify path can't loop;
+    `from_file` records the filename hint and commits nothing (file extraction is
+    a separate bounded reader, not this loop — never store the prose). **D5:**
+    identifier-bearing fields are never committed from the user's prose — those
+    come from lookups, so an identifier `commit` is refused (the interpret leaf
+    coerces it to `skip`).
+
+  **Offline / no-provider determinism.** With no provider configured the exchange
+  degrades to the original deterministic ask-and-set: phrase = the human-readable
+  prompt, interpret = non-empty reply → commit, empty/skip → skip. The same
+  deterministic decision is used when a configured leaf is unavailable or raises,
+  so a flaky/unreachable LLM never silently drops the user's answer — and offline
+  tests and headless runs stay deterministic. ask-user prompts remain
+  **human-readable**, never the raw failed-check `message`.
 
 **The deliberate split — automated vs interactive.** Stages 1–4 are the
 **automated** build: `run_pipeline` (§14.5) runs them with **no HITL**, so it

--- a/builder/agents/guidance.py
+++ b/builder/agents/guidance.py
@@ -1,12 +1,21 @@
-"""The guidance agent — HITL gap-resolution loop (Issue #179, task 2b-G).
+"""The guidance agent — HITL gap-resolution loop (Issue #179, task 2b-G; #244).
 
-This is the **deterministic, code-driven** loop that consumes the gap engine's
-prioritized :class:`~builder.tools.gap_analysis.GapReport` and resolves gaps with
-the human in the loop. It is the §14 hybrid architecture's "human-confirmed
-enrichment" half: **CODE owns control flow** (NOT a ReAct / LLM-orchestrated
-agent), the LLM is used *only* to draft a suggested value for a draftable gap, and
-the **user is the authority** — every commit of uncertain content is confirmed
-before it lands (D5: Verify, Don't Trust).
+This is the **code-driven** loop that consumes the gap engine's prioritized
+:class:`~builder.tools.gap_analysis.GapReport` and resolves gaps with the human in
+the loop. It is the §14 hybrid architecture's "human-confirmed enrichment" half:
+**CODE owns control flow** (NOT a ReAct / LLM-orchestrated agent) and the **user
+is the authority** — every commit of uncertain content is confirmed before it
+lands (D5: Verify, Don't Trust).
+
+The LLM is used only at bounded **leaves**: the drafter (:func:`draft_entity_fields`)
+suggests a value the user confirms, and — the #179 hybrid's "small guidance agent"
+(#244) — two more leaves make the *ask-user* step a small bounded exchange that
+**phrases** a cryptic gap as one clear question and **interprets** the free-text
+reply into a structured decision (commit / skip / clarify / from_file), so a
+musing like "no idea which file you mean" can never be stored verbatim as a field
+value. With no provider configured (or a leaf unavailable/flaky) the exchange
+degrades to the original deterministic ask-and-set, keeping offline runs
+deterministic.
 
 The loop (:func:`run_guidance`) per round:
 
@@ -22,10 +31,14 @@ The loop (:func:`run_guidance`) per round:
    - **draftable** (``fix_hint == "draft"``) -> draft a candidate value via
      :func:`draft_entity_fields`, **show it to the user and require confirmation
      before committing** (D5). On reject, fall through to *ask-user*.
-   - **ask-user** (``fix_hint == "ask-user"``) -> prompt via the
-     :class:`~builder.tools.hitl.HumanInterface` and apply the user's answer to
-     the entity through the existing ``set_fields`` / ``set_crate_metadata`` tools
-     (never hand-rolled JSON-LD).
+   - **ask-user** (``fix_hint == "ask-user"``) -> the LLM-mediated
+     phrase -> ask -> interpret exchange (#244, :func:`_resolve_ask_user`): one
+     clear phrased question via the :class:`~builder.tools.hitl.HumanInterface`,
+     the reply interpreted into a structured decision, and only a clean ``commit``
+     value applied through the existing ``set_fields`` / ``set_crate_metadata``
+     tools (never hand-rolled JSON-LD). ``skip``/``from_file`` commit nothing;
+     ``clarify`` asks at most one bounded follow-up. With no provider this is the
+     deterministic ask-and-set.
 
 4. Re-assess after each committed change; **never loop forever** — bounded by
    ``max_rounds`` and a per-report skip-set. A gap the loop cannot progress this
@@ -41,11 +54,15 @@ Determinism & safety contract:
 * **Explicit termination.** Two independent stop conditions (no actionable gap
   left / the whole report exhausted with no progress) plus the hard ``max_rounds``
   cap.
-* **Every LLM call is a bounded leaf.** The drafter leaf
-  (:func:`draft_entity_fields`) is the *only* model call, and its output is shown
-  to the user for confirmation before it is ever committed.
+* **Every LLM call is a bounded leaf.** The drafter (:func:`draft_entity_fields`)
+  and the guidance leaves (:func:`phrase_gap_question` / :func:`interpret_gap_reply`)
+  are single bounded calls gated on ``get_provider()``; the drafter's output is
+  confirmed before commit, and the interpreter's output is a *structured* decision
+  — a free-text reply is never stored verbatim.
 * **HITL is never removed.** ask-user and draft-confirm both route through the
   injected :class:`HumanInterface`; the loop cannot silently fabricate content.
+* **D5 at the leaf.** Identifier-bearing fields are never committed from the user's
+  prose (those come from lookups); the interpreter refuses such a commit.
 
 This is a clean library entrypoint — the CLI / spine wiring is a later PR.
 """
@@ -53,13 +70,36 @@ This is a clean library entrypoint — the CLI / spine wiring is a later PR.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 # Re-exported at module scope so the spine, tests, and the eval harness have a
-# single stable monkeypatch target — and so a flaky/absent LLM drafter can be
-# stubbed without importing langchain.
+# single stable monkeypatch target — and so a flaky/absent LLM drafter / guidance
+# leaf can be stubbed without importing langchain.
 from builder.agents.pipeline import draft_entity_fields
+from builder.config import get_provider
 from builder.tools.gap_analysis import REPORT_ONLY, Gap, assess_gaps
+
+# The guidance leaves (#244): PHRASE the gap into one human question, INTERPRET
+# the free-text reply into a structured decision. Imported at module scope as the
+# single monkeypatch target for tests, but guarded so that with langchain absent
+# the names resolve to ``None`` and the LLM path is simply skipped (it is gated on
+# ``get_provider()`` regardless). Typed as optional callables so the ``None``
+# fallback type-checks cleanly.
+phrase_gap_question: Callable[..., str] | None
+interpret_gap_reply: Callable[..., dict[str, Any]] | None
+try:  # pragma: no cover — exercised by both branches across the test matrix
+    from builder.agents.leaves import (
+        interpret_gap_reply as _interpret_leaf,
+    )
+    from builder.agents.leaves import (
+        phrase_gap_question as _phrase_leaf,
+    )
+
+    phrase_gap_question = _phrase_leaf
+    interpret_gap_reply = _interpret_leaf
+except Exception:  # pragma: no cover — langchain absent: LLM path is gated off anyway
+    phrase_gap_question = None
+    interpret_gap_reply = None
 
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
@@ -75,10 +115,46 @@ __all__ = ["run_guidance"]
 # gap never clears (e.g. a user value the validator still rejects).
 _DEFAULT_MAX_ROUNDS = 20
 
+# Cap on clarifying follow-ups within a SINGLE ask-user turn (#244). The interpret
+# leaf may ask for clarification, but a vague user could otherwise loop forever;
+# after this many follow-ups with no committable value the turn skips the gap.
+_MAX_CLARIFY_FOLLOW_UPS = 1
+
 # Descriptive context fields used for the draftable path. Mirrors the spine's
 # `_DESCRIPTIVE_APPLY_FIELDS`: the drafter leaf is only trusted for free-text
 # descriptive fields (identifiers come from lookups, D5).
 _DESCRIPTIVE_FIELDS: frozenset[str] = frozenset({"name", "description"})
+
+# D5: identifier-bearing field names the deterministic interpret fallback must
+# NEVER commit from the user's prose (those come from lookups). Mirrors
+# `builder.agents.leaves._IDENTIFIER_SCALAR_FIELDS`; kept local so the no-provider
+# / offline path stays free of the (langchain-importing) leaves module.
+_IDENTIFIER_FIELDS: frozenset[str] = frozenset(
+    {
+        "identifier",
+        "accession",
+        "inchikey",
+        "smiles",
+        "molecular_formula",
+        "pubchem_cid",
+        "cas",
+        "casrn",
+        "cas_number",
+        "orcid",
+        "ror",
+        "doi",
+        "term_code",
+        "in_defined_term_set",
+        "property_id",
+        "unit_code",
+        "url",
+    }
+)
+
+
+def _is_identifier_field(field: str) -> bool:
+    """Whether ``field`` (a local property name) is identifier-bearing (D5)."""
+    return field in _IDENTIFIER_FIELDS
 
 # Local property names that map onto crate-level (Root Data Entity) metadata via
 # `set_crate_metadata`, for a crate-level gap (entity_id is None). Anything else
@@ -230,7 +306,13 @@ def _ask_user_prompt(gap: Gap) -> str:
 
 
 def _ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> str | None:
-    """Prompt the human for ``gap`` and return their value, or ``None`` if skipped."""
+    """Deterministic ask-and-set: prompt with the canned prompt, return the reply.
+
+    This is the **no-provider / offline** behavior (#244): the user's non-empty
+    reply is returned verbatim (the caller commits it as-is) and an empty/skipped
+    reply returns ``None``. The LLM-mediated phrase/interpret exchange wraps this
+    only when a provider is configured (see :func:`_resolve_ask_user`).
+    """
     response = human.request_input(_ask_user_prompt(gap))
     if response.get("skipped"):
         return None
@@ -238,6 +320,172 @@ def _ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> str | Non
     if value is None or not str(value).strip():
         return None
     return str(value)
+
+
+def _reply_text(response: Any) -> str | None:
+    """Extract a non-empty reply string from a HumanInterface input response.
+
+    Returns the trimmed text, or ``None`` for a skip / empty reply (which the
+    interpret step would treat as a skip anyway).
+    """
+    if response.get("skipped"):
+        return None
+    value = response.get("value")
+    if value is None or not str(value).strip():
+        return None
+    return str(value)
+
+
+def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
+    """Assemble the per-gap context dict the guidance leaves consume (#244).
+
+    A compact, jargon-light digest of the gap plus the crate's title/description,
+    so :func:`phrase_gap_question` can rephrase it and :func:`interpret_gap_reply`
+    can interpret a reply in context. The ``property`` is the **local field name**
+    (not the raw IRI) so the interpret leaf's D5 identifier guard sees the same
+    token the loop would commit to.
+    """
+    field = _local_name(gap.property) or (gap.property or "")
+    context: dict[str, Any] = {
+        "property": field,
+        "entity_type": gap.entity_type,
+        "tier": gap.tier,
+        "message": gap.message,
+        "suggestion": gap.suggestion,
+    }
+    title = (engine.state.metadata.title or "").strip()
+    if title:
+        context["crate_title"] = title
+    description = (engine.state.metadata.description or "").strip()
+    if description:
+        context["crate_description"] = description
+    return context
+
+
+def _phrase_question(engine: AgentEngine, gap: Gap) -> str:
+    """Phrase ``gap`` as one human question via the LLM leaf, with a safe fallback.
+
+    Calls :func:`phrase_gap_question` (the drafter-tier leaf); on any failure or an
+    empty result it falls back to the deterministic :func:`_ask_user_prompt`, so a
+    flaky leaf never produces a blank question and never breaks the loop.
+    """
+    if phrase_gap_question is not None:
+        try:
+            question = phrase_gap_question(_gap_context(engine, gap))
+        except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
+            logger.warning("guidance: phrase leaf failed: %s", exc)
+            question = ""
+        if question and question.strip():
+            return question.strip()
+    return _ask_user_prompt(gap)
+
+
+def _deterministic_decision(gap: Gap, reply: str) -> dict[str, Any]:
+    """The deterministic interpret fallback: a non-empty reply is a commit (#244).
+
+    Used when the interpret leaf is unavailable or fails (and as the documented
+    no-provider behavior): treat a non-empty reply as a commit and an empty one as
+    a skip — *except* for an identifier-bearing field, where the user's prose must
+    NOT become an identifier value (D5), so it is skipped (identifiers come from
+    lookups). This preserves today's ask-and-set behavior without ever storing a
+    musing as an identifier.
+    """
+    if not reply or not reply.strip():
+        return {"action": "skip"}
+    field = _local_name(gap.property) or (gap.property or "")
+    if _is_identifier_field(field):
+        return {"action": "skip"}
+    return {"action": "commit", "value": reply.strip()}
+
+
+def _interpret_reply(
+    engine: AgentEngine, gap: Gap, question: str, reply: str
+) -> dict[str, Any]:
+    """Interpret ``reply`` into a structured decision via the LLM leaf.
+
+    Calls :func:`interpret_gap_reply` (the drafter-tier leaf) and returns its
+    normalised decision. On any failure it falls back to the **deterministic**
+    decision (:func:`_deterministic_decision`: non-empty reply -> commit, empty ->
+    skip, identifier field -> skip) — the same offline behavior the no-provider
+    path uses, so a flaky/unreachable leaf degrades to today's ask-and-set rather
+    than silently dropping the user's answer.
+    """
+    if interpret_gap_reply is None:  # pragma: no cover — provider gated elsewhere
+        return _deterministic_decision(gap, reply)
+    try:
+        return interpret_gap_reply(question, reply, _gap_context(engine, gap))
+    except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
+        logger.warning(
+            "guidance: interpret leaf failed (%s); deterministic fallback", exc
+        )
+        return _deterministic_decision(gap, reply)
+
+
+def _resolve_ask_user(
+    engine: AgentEngine, human: HumanInterface, gap: Gap
+) -> str | None:
+    """Run the LLM-mediated ask-user exchange for ``gap``; return a clean value.
+
+    The §14.6 "small guidance agent" (#244). When a provider is configured this is
+    a bounded PHRASE -> ask -> INTERPRET exchange:
+
+    * **PHRASE** the gap into one clear human question (never raw SHACL/FAIR text).
+    * **INTERPRET** the free-text reply into a structured decision:
+      ``commit`` -> return the clean value (the caller commits it via
+      :func:`_apply_value`); ``skip`` (covers "I don't know"/empty) -> return
+      ``None``; ``clarify`` -> ask ONE bounded follow-up
+      (:data:`_MAX_CLARIFY_FOLLOW_UPS`) then skip; ``from_file`` -> record the
+      filename hint and return ``None`` (NEVER store prose — file extraction is a
+      separate bounded reader, not this loop).
+
+    A free-text musing therefore can never become a field value (D5). With **no
+    provider** configured this degrades to the deterministic :func:`_ask_user`
+    (today's ask-and-set behavior), keeping offline runs deterministic.
+    """
+    # No provider -> deterministic ask-and-set (offline determinism, #244).
+    if get_provider() is None:
+        return _ask_user(engine, human, gap)
+
+    question = _phrase_question(engine, gap)
+    response = human.request_input(question)
+    reply = _reply_text(response)
+    if reply is None:
+        # An explicit skip / empty reply is a skip — never interpreted.
+        return None
+
+    follow_ups = 0
+    while True:
+        decision = _interpret_reply(engine, gap, question, reply)
+        action = decision.get("action")
+
+        if action == "commit":
+            value = decision.get("value")
+            # Defensive: the leaf normalises this, but never commit empty.
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            return None
+
+        if action == "clarify" and follow_ups < _MAX_CLARIFY_FOLLOW_UPS:
+            follow_ups += 1
+            follow_up = decision.get("question") or _ask_user_prompt(gap)
+            question = str(follow_up)
+            response = human.request_input(question)
+            reply = _reply_text(response)
+            if reply is None:
+                return None
+            continue
+
+        if action == "from_file":
+            filename = decision.get("filename")
+            logger.info(
+                "guidance: user says %s is in a file%s; not storing prose (#244)",
+                _local_name(gap.property) or gap.property,
+                f" ({filename})" if filename else "",
+            )
+            return None
+
+        # skip, an exhausted clarify budget, or any unrecognised action -> skip.
+        return None
 
 
 def _resolve_gap(
@@ -299,9 +547,9 @@ def _resolve_gap(
                 return False
         # No usable draft, or the user rejected it -> fall through to ask-user.
 
-    # --- ask-user: prompt and apply -------------------------------------------
+    # --- ask-user: phrase -> interpret -> apply (LLM-mediated, #244) ----------
     asked.append(record)
-    value = _ask_user(engine, human, gap)
+    value = _resolve_ask_user(engine, human, gap)
     if value is None:
         return False
     if _apply_value(engine, gap, value):

--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -464,4 +464,302 @@ def draft_entity_fields(
     return _strip_identifiers(fields)
 
 
-__all__ = ["draft_entity_fields", "extract_plan"]
+# ---------------------------------------------------------------------------
+# Guidance leaves (Issue #244): the §14.6 HITL tail's per-gap LLM exchange.
+#
+# These two leaves let the guidance loop turn a cryptic gap into a real
+# conversation instead of an ask-and-set loop that stores raw prose:
+#   - ``phrase_gap_question`` rephrases the gap (property / entity_type / tier /
+#     MIT-FAIR rationale / suggestion) into ONE clear human question with a
+#     concrete example — never the raw SHACL / FAIR-indicator text.
+#   - ``interpret_gap_reply`` parses the user's free-text reply into a STRUCTURED
+#     decision (commit / skip / clarify / from_file) so a musing like "no idea
+#     which file you mean" can NEVER become a field value.
+#
+# Both are pure bounded leaves (a single structured-output call on the drafter
+# tier); they do not mutate state and do not orchestrate. The guidance loop owns
+# control flow and the commit. D5: the interpret leaf refuses to commit a value
+# for an identifier-bearing field — identifiers come from lookups, never the user.
+# ---------------------------------------------------------------------------
+
+# The structured decision actions ``interpret_gap_reply`` may return. ``commit``
+# carries a clean value; ``clarify`` carries one follow-up question; ``from_file``
+# carries an optional filename hint (NEVER a value — D5); ``skip`` covers "I don't
+# know" / empty / unusable replies.
+_INTERPRET_ACTIONS: frozenset[str] = frozenset(
+    {"commit", "skip", "clarify", "from_file"}
+)
+
+_PHRASE_SYSTEM_PROMPT = (
+    "You are the conversational guidance assistant for an ISA-Tox RO-Crate "
+    "builder. You are given a metadata GAP a validator found (a field, the entity "
+    "type it belongs to, why it matters, and a hint). Rephrase it as ONE short, "
+    "clear question a non-expert researcher can answer, with a concrete example of "
+    "a good answer. NEVER show raw SHACL shapes, FAIR indicator codes, property "
+    "IRIs, or validator jargon. Ask only for what the field needs."
+)
+
+_INTERPRET_SYSTEM_PROMPT = (
+    "You interpret a researcher's free-text reply to a metadata question for an "
+    "ISA-Tox RO-Crate. Return a STRUCTURED decision, never prose to store. Choose:\n"
+    "- 'commit' with a clean, concise 'value' ONLY when the reply clearly supplies "
+    "the requested information; rewrite it into a proper field value (do not store "
+    "the raw musing).\n"
+    "- 'skip' when the reply is 'I don't know', empty, off-topic, or a complaint "
+    "(e.g. 'no idea which file you mean'). A skip carries NO value.\n"
+    "- 'clarify' with one short follow-up 'question' when the reply is on-topic but "
+    "too vague to commit.\n"
+    "- 'from_file' with an optional 'filename' hint when the reply says the answer "
+    "lives in a file ('it's in README.txt'). Do NOT put the prose in a value.\n"
+    "NEVER fabricate identifiers (CAS, InChIKey, SMILES, PubChem CID, ORCID, ROR, "
+    "DOI, accessions, ontology codes): for an identifier field, prefer 'skip' — "
+    "those are resolved by lookup services, not from the user's text."
+)
+
+
+def _phrase_schema() -> dict[str, Any]:
+    """Structured-output schema for the phrasing leaf: one question string."""
+    return {
+        "title": "GapQuestion",
+        "type": "object",
+        "description": "One clear human question rephrasing a metadata gap.",
+        "properties": {
+            "question": {
+                "type": "string",
+                "description": (
+                    "A single clear question for the user, with a concrete example. "
+                    "No SHACL/FAIR/IRI jargon."
+                ),
+            }
+        },
+        "required": ["question"],
+        "additionalProperties": False,
+    }
+
+
+def _interpret_schema() -> dict[str, Any]:
+    """Structured-output schema for the interpret leaf: a typed decision.
+
+    By construction the schema offers no identifier field — ``value`` is a clean
+    descriptive value only, ``filename`` is a plain name hint, and a ``commit``
+    for an identifier-bearing field is refused downstream (D5).
+    """
+    return {
+        "title": "GapReplyDecision",
+        "type": "object",
+        "description": (
+            "A structured decision interpreting the user's reply. Free-text musings "
+            "must never become field values."
+        ),
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": sorted(_INTERPRET_ACTIONS),
+                "description": "What to do with the reply.",
+            },
+            "value": {
+                "type": "string",
+                "description": (
+                    "Only for action='commit': the clean field value rewritten "
+                    "from the reply. Never an identifier."
+                ),
+            },
+            "question": {
+                "type": "string",
+                "description": "Only for action='clarify': one short follow-up.",
+            },
+            "filename": {
+                "type": "string",
+                "description": (
+                    "Only for action='from_file': an optional file name/path hint."
+                ),
+            },
+        },
+        "required": ["action"],
+        "additionalProperties": False,
+    }
+
+
+def _gap_context_block(gap_context: dict[str, Any]) -> str:
+    """Render a gap-context dict into a compact, jargon-light block for a leaf.
+
+    The guidance loop assembles ``gap_context`` (property, entity_type, tier,
+    message, suggestion, plus optional crate title/description). We surface the
+    human-meaningful parts; the leaf is told to translate the rest, never to echo
+    raw validator text.
+    """
+    field = gap_context.get("property") or "this field"
+    parts: list[str] = [f"Field: {field}"]
+    entity_type = gap_context.get("entity_type")
+    if entity_type:
+        parts.append(f"Belongs to: {entity_type}")
+    tier = gap_context.get("tier")
+    if tier:
+        parts.append(f"Importance: {tier}")
+    message = gap_context.get("message")
+    if message:
+        parts.append(f"Why it matters: {message}")
+    suggestion = gap_context.get("suggestion")
+    if suggestion:
+        parts.append(f"Hint: {suggestion}")
+    return "\n".join(parts)
+
+
+def phrase_gap_question(
+    gap_context: dict[str, Any],
+    *,
+    model: str | None = None,
+    usage_sink: UsageSink | None = None,
+) -> str:
+    """Rephrase a metadata gap into ONE clear human question (#244).
+
+    A pure bounded leaf: a SINGLE structured-output call on the drafter tier
+    (``_build_chat_model(role="drafter")``) that turns ``gap_context`` (property,
+    entity_type, tier, MIT/FAIR rationale, suggestion) into one short question a
+    non-expert can answer, with a concrete example. It never echoes raw SHACL
+    shapes / FAIR indicator codes / property IRIs.
+
+    Args:
+        gap_context: The guidance loop's per-gap context dict (``property``,
+            ``entity_type``, ``tier``, ``message``, ``suggestion``, ...).
+        model: Optional explicit model override; ``None`` resolves the drafter tier.
+        usage_sink: Optional token-usage callback (see :func:`draft_entity_fields`).
+
+    Returns:
+        The phrased question string, or ``""`` when the model returns nothing
+        usable (the caller then falls back to its deterministic prompt).
+    """
+    llm = _build_chat_model(model=model, role="drafter")
+    messages = [
+        SystemMessage(content=_PHRASE_SYSTEM_PROMPT),
+        HumanMessage(
+            content=(
+                "Rephrase this metadata gap as one clear question for the user, "
+                "with a concrete example of a good answer:\n\n"
+                f"{_gap_context_block(gap_context)}"
+            )
+        ),
+    ]
+    result = _invoke_structured_with_usage(
+        llm, _phrase_schema(), messages, usage_sink
+    )
+    if isinstance(result, dict):
+        question = result.get("question")
+        if isinstance(question, str) and question.strip():
+            return question.strip()
+    return ""
+
+
+def interpret_gap_reply(
+    question: str,
+    reply: str,
+    gap_context: dict[str, Any],
+    *,
+    model: str | None = None,
+    usage_sink: UsageSink | None = None,
+) -> dict[str, Any]:
+    """Interpret a free-text reply into a STRUCTURED decision (#244).
+
+    A pure bounded leaf: a SINGLE structured-output call on the drafter tier that
+    maps the user's ``reply`` to one of ``{action: "commit", value}`` |
+    ``{action: "skip"}`` | ``{action: "clarify", question}`` |
+    ``{action: "from_file", filename?}``. Free-text musings (e.g. "no idea which
+    file you mean") map to ``skip`` — they are NEVER stored as field values.
+
+    D5: identifiers come from lookups, never the user's prose. A ``commit`` whose
+    field is identifier-bearing (:data:`_IDENTIFIER_SCALAR_FIELDS`) is refused and
+    coerced to ``skip``. A malformed/unknown action, or a ``commit`` with no usable
+    value, is also coerced to ``skip`` — the safe default that commits nothing.
+
+    Args:
+        question: The phrased question the user was answering (context for the leaf).
+        reply: The user's raw free-text reply.
+        gap_context: The per-gap context dict (notably ``property`` for the D5 guard).
+        model: Optional explicit model override; ``None`` resolves the drafter tier.
+        usage_sink: Optional token-usage callback (see :func:`draft_entity_fields`).
+
+    Returns:
+        A normalised decision dict whose ``action`` is one of
+        :data:`_INTERPRET_ACTIONS`; ``commit`` carries a non-empty ``value`` and
+        ``clarify`` carries a non-empty ``question`` (else both coerce to ``skip``).
+    """
+    llm = _build_chat_model(model=model, role="drafter")
+    messages = [
+        SystemMessage(content=_INTERPRET_SYSTEM_PROMPT),
+        HumanMessage(
+            content=(
+                f"Question asked:\n{question}\n\n"
+                f"User's reply:\n{reply}\n\n"
+                "Gap context:\n"
+                f"{_gap_context_block(gap_context)}\n\n"
+                "Return the structured decision."
+            )
+        ),
+    ]
+    result = _invoke_structured_with_usage(
+        llm, _interpret_schema(), messages, usage_sink
+    )
+    return _normalise_interpretation(result, gap_context)
+
+
+def _normalise_interpretation(
+    result: Any, gap_context: dict[str, Any]
+) -> dict[str, Any]:
+    """Coerce a raw interpret result into a safe, well-formed decision (D5).
+
+    Guards (the model output is never trusted as-is):
+      * an unknown/absent action -> ``skip``;
+      * ``commit`` with no usable (non-whitespace) value -> ``skip``;
+      * ``commit`` for an identifier-bearing field -> ``skip`` (identifiers come
+        from lookups, never the user — D5);
+      * ``clarify`` with no usable question -> ``skip``;
+      * ``from_file`` keeps only a clean ``filename`` hint and NEVER a value.
+    """
+    decision = result if isinstance(result, dict) else {}
+    action = decision.get("action")
+    if action not in _INTERPRET_ACTIONS:
+        return {"action": "skip"}
+
+    if action == "commit":
+        value = decision.get("value")
+        if not isinstance(value, str) or not value.strip():
+            return {"action": "skip"}
+        field = _local_property_name(gap_context.get("property"))
+        if field in _IDENTIFIER_SCALAR_FIELDS:
+            # D5: never let the user's prose become an identifier value.
+            return {"action": "skip"}
+        return {"action": "commit", "value": value.strip()}
+
+    if action == "clarify":
+        follow_up = decision.get("question")
+        if not isinstance(follow_up, str) or not follow_up.strip():
+            return {"action": "skip"}
+        return {"action": "clarify", "question": follow_up.strip()}
+
+    if action == "from_file":
+        filename = decision.get("filename")
+        out: dict[str, Any] = {"action": "from_file"}
+        if isinstance(filename, str) and filename.strip():
+            out["filename"] = filename.strip()
+        return out
+
+    return {"action": "skip"}
+
+
+def _local_property_name(iri: str | None) -> str:
+    """Local part of a property IRI (after the last ``/`` or ``#``).
+
+    Mirrors the guidance loop's ``_local_name`` so the D5 identifier check sees the
+    same field token the loop would commit to (e.g. ``.../cas`` -> ``cas``).
+    """
+    if not iri:
+        return ""
+    return iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+
+
+__all__ = [
+    "draft_entity_fields",
+    "extract_plan",
+    "interpret_gap_reply",
+    "phrase_gap_question",
+]

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -652,6 +652,231 @@ class TestExtractPlanUsageCapture:
         assert fake.include_raw_flags == [False]
 
 
+# ---------------------------------------------------------------------------
+# phrase_gap_question / interpret_gap_reply — the guidance leaves (Issue #244)
+#
+# The §14.6 guidance tail's per-gap step is a small bounded LLM exchange:
+#   - `phrase_gap_question(gap_context)` turns a cryptic gap (property,
+#     entity_type, MIT/FAIR rationale, suggestion) into ONE clear human question
+#     with a concrete example — never the raw SHACL/indicator text.
+#   - `interpret_gap_reply(question, reply, gap_context)` parses the user's
+#     free-text reply into a STRUCTURED decision so musings never become field
+#     values. Both are bounded structured-output calls on the drafter tier.
+# ---------------------------------------------------------------------------
+
+
+# A gap-context double the guidance loop assembles for a single gap.
+_GAP_CONTEXT = {
+    "property": "description",
+    "entity_type": "Study",
+    "tier": "MUST",
+    "message": "Study MUST have a description.",
+    "suggestion": "A free-text study description.",
+}
+
+
+class TestPhraseGapQuestionDrafterTier:
+    """Phrasing runs on the cheap drafter tier and is a single bounded call."""
+
+    def test_requests_drafter_role(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        rec = _patch_build_chat_model
+        rec["model"] = FakeChatModel({"question": "What does this study examine?"})
+
+        leaves.phrase_gap_question(_GAP_CONTEXT)
+
+        assert rec["calls"], "the leaf must build a chat model"
+        assert all(c.get("role") == "drafter" for c in rec["calls"]), (
+            "phrase_gap_question must build the chat model on the drafter tier"
+        )
+
+    def test_single_structured_output_call(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"question": "What does this study examine?"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.phrase_gap_question(_GAP_CONTEXT)
+
+        assert len(fake.structured_schemas) == 1, "exactly one structured-output bind"
+        assert len(fake.invoke_calls) == 1, "exactly one model invocation (a leaf)"
+
+
+class TestPhraseGapQuestionShape:
+    """The leaf returns one human question string."""
+
+    def test_returns_the_question_string(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"question": "In one sentence, what does this study examine?"}
+        )
+
+        question = leaves.phrase_gap_question(_GAP_CONTEXT)
+
+        assert isinstance(question, str)
+        assert question == "In one sentence, what does this study examine?"
+
+    def test_empty_model_output_returns_empty_string(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # A model that returns nothing usable -> empty string; the caller falls
+        # back to the deterministic prompt rather than asking a blank question.
+        _patch_build_chat_model["model"] = FakeChatModel({})
+
+        question = leaves.phrase_gap_question(_GAP_CONTEXT)
+
+        assert question == ""
+
+
+class TestInterpretGapReplyDrafterTier:
+    """Interpretation runs on the cheap drafter tier and is a single call."""
+
+    def test_requests_drafter_role(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        rec = _patch_build_chat_model
+        rec["model"] = FakeChatModel({"action": "skip"})
+
+        leaves.interpret_gap_reply("Question?", "I don't know", _GAP_CONTEXT)
+
+        assert rec["calls"], "the leaf must build a chat model"
+        assert all(c.get("role") == "drafter" for c in rec["calls"]), (
+            "interpret_gap_reply must build the chat model on the drafter tier"
+        )
+
+    def test_single_structured_output_call(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"action": "commit", "value": "x"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.interpret_gap_reply("Question?", "the value is x", _GAP_CONTEXT)
+
+        assert len(fake.structured_schemas) == 1, "exactly one structured-output bind"
+        assert len(fake.invoke_calls) == 1, "exactly one model invocation (a leaf)"
+
+
+class TestInterpretGapReplyDecision:
+    """The leaf returns a STRUCTURED decision, not free text."""
+
+    def test_commit_returns_clean_value(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"action": "commit", "value": "A hepatotoxicity dose-response study."}
+        )
+
+        decision = leaves.interpret_gap_reply(
+            "What does this study examine?",
+            "it's a dose-response study of liver toxicity",
+            _GAP_CONTEXT,
+        )
+
+        assert decision["action"] == "commit"
+        assert decision["value"] == "A hepatotoxicity dose-response study."
+
+    def test_idk_reply_returns_skip(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel({"action": "skip"})
+
+        decision = leaves.interpret_gap_reply(
+            "What does this study examine?",
+            "No idea which file you are talking about",
+            _GAP_CONTEXT,
+        )
+
+        assert decision["action"] == "skip"
+        # A musing must NEVER carry a value.
+        assert not decision.get("value")
+
+    def test_clarify_returns_one_follow_up(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"action": "clarify", "question": "Do you mean the in-vitro assay?"}
+        )
+
+        decision = leaves.interpret_gap_reply(
+            "What does this study examine?", "the assay", _GAP_CONTEXT
+        )
+
+        assert decision["action"] == "clarify"
+        assert decision["question"] == "Do you mean the in-vitro assay?"
+
+    def test_from_file_returns_filename_hint(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"action": "from_file", "filename": "README.txt"}
+        )
+
+        decision = leaves.interpret_gap_reply(
+            "What does this study examine?",
+            "it's all written up in README.txt",
+            _GAP_CONTEXT,
+        )
+
+        assert decision["action"] == "from_file"
+        assert decision["filename"] == "README.txt"
+        # D5: a from-file reply must NEVER smuggle a value into the field.
+        assert not decision.get("value")
+
+    def test_unknown_action_normalises_to_skip(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # An adversarial / malformed action must be coerced to the safe default
+        # (skip) so it can never become a field value.
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"action": "nonsense", "value": "garbage"}
+        )
+
+        decision = leaves.interpret_gap_reply("Q?", "whatever", _GAP_CONTEXT)
+
+        assert decision["action"] == "skip"
+        assert not decision.get("value")
+
+    def test_commit_without_value_normalises_to_skip(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # A "commit" with no usable value is not a commit — coerce to skip so the
+        # loop never writes an empty/whitespace value.
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"action": "commit", "value": "   "}
+        )
+
+        decision = leaves.interpret_gap_reply("Q?", "...", _GAP_CONTEXT)
+
+        assert decision["action"] == "skip"
+
+
+class TestGuidanceLeavesD5:
+    """D5: the interpret leaf must never let the model fabricate an identifier.
+
+    Identifier-bearing gaps are resolved by lookups, never by interpreting the
+    user's prose, so a 'commit' the model proposes for an identifier field is
+    refused (coerced to skip)."""
+
+    def test_identifier_gap_commit_is_refused(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"action": "commit", "value": "103-90-2"}
+        )
+
+        decision = leaves.interpret_gap_reply(
+            "What is the CAS number?",
+            "103-90-2",
+            {"property": "cas", "entity_type": "MolecularEntity"},
+        )
+
+        assert decision["action"] == "skip", (
+            "D5: an identifier value must come from a lookup, not the user's prose"
+        )
+
+
 def _flatten_keys(schema: Any) -> set[str]:
     """Every property key appearing anywhere in a (possibly nested) JSON schema."""
     keys: set[str] = set()

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -754,3 +754,369 @@ class TestReassessmentIntegration:
         # The real re-assessment after the deterministic repair has no MUST left.
         assert summary["remaining_gaps"]["must_open"] == 0
         assert summary["conformance"].get("tox") is True
+
+
+# ---------------------------------------------------------------------------
+# (LLM-mediated ask-user, Issue #244) — the "small guidance agent"
+#
+# When a provider is configured, the per-gap ask-user step is a bounded LLM
+# exchange: PHRASE the gap into one human question, INTERPRET the free-text
+# reply into a structured decision (commit / skip / clarify / from_file), and
+# COMMIT only a clean structured value. With no provider it stays deterministic.
+# The phrase/interpret leaves are STUBBED (monkeypatch) — no real LLM.
+# ---------------------------------------------------------------------------
+
+
+def _single_ask_gap_report(monkeypatch, gap: Gap, *, counts: dict[str, int]):
+    """Patch ``assess_gaps`` to return ``gap`` once, then an empty report.
+
+    Mirrors the existing two-report ``iter`` pattern: the gap is offered once,
+    then (whether or not it was committed) the next round sees a clean report so
+    the loop terminates promptly.
+    """
+    from builder.agents import guidance
+
+    reports = iter(
+        [
+            GapReport(gaps=[gap], counts=counts),
+            GapReport(gaps=[], counts={"must_open": 0, "should_open": 0, "may_open": 0}),
+        ]
+    )
+    monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
+
+
+def _study_desc_gap(tier: str = "MUST") -> Gap:
+    return Gap(
+        tier=tier,
+        source="shacl",
+        entity_id="st1",
+        entity_type="Study",
+        property="https://schema.org/description",
+        message="Study MUST have a description.",
+        suggestion="A free-text study description.",
+        fix_hint="ask-user",
+        auto_fixable=False,
+    )
+
+
+class TestLLMMediatedAskUser:
+    def _enable_provider(self, monkeypatch):
+        """Make ``get_provider()`` (as seen by guidance) report a provider."""
+        from builder.agents import guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+
+    def test_idk_reply_is_skipped_not_stored(self, monkeypatch):
+        """The headline regression: a free-text 'I don't know' reply must SKIP —
+        it must NEVER be stored verbatim as the field value (#244)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        original = _get(engine, "st1").fields.get("description")
+        self._enable_provider(monkeypatch)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        # The phrase leaf produces a clean question; the interpret leaf reads the
+        # musing as a SKIP (action="skip"), carrying no value.
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+        )
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _reply, _ctx: {"action": "skip"},
+        )
+
+        human = ScriptedHuman(
+            input_answers=[_value("No idea which file you are talking about")]
+        )
+        run_guidance(engine, human, max_rounds=5)
+
+        # The musing was NOT committed — the description is unchanged.
+        applied = _get(engine, "st1")
+        assert applied.fields.get("description") == original
+        assert applied.fields.get("description") != (
+            "No idea which file you are talking about"
+        )
+
+    def test_natural_language_reply_is_interpreted_to_clean_value(self, monkeypatch):
+        """A NL reply carrying a value is interpreted to a clean committed value,
+        not stored verbatim (#244)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        self._enable_provider(monkeypatch)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+        )
+
+        captured: dict[str, object] = {}
+
+        def _interpret(question, reply, ctx):
+            captured["reply"] = reply
+            return {
+                "action": "commit",
+                "value": "A dose-response study of acetaminophen hepatotoxicity.",
+            }
+
+        monkeypatch.setattr(guidance, "interpret_gap_reply", _interpret)
+
+        verbose = "well it's about how acetaminophen damages the liver, dose-response"
+        human = ScriptedHuman(input_answers=[_value(verbose)])
+        run_guidance(engine, human, max_rounds=5)
+
+        applied = _get(engine, "st1")
+        # The CLEAN interpreted value landed — not the user's raw musing.
+        assert applied.fields.get("description") == (
+            "A dose-response study of acetaminophen hepatotoxicity."
+        )
+        assert applied.fields.get("description") != verbose
+        assert captured["reply"] == verbose
+
+    def test_clarify_asks_at_most_one_follow_up_then_skips(self, monkeypatch):
+        """A clarify decision asks ONE follow-up; if still unresolved, it skips —
+        the clarify path can never loop (#244)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        original = _get(engine, "st1").fields.get("description")
+        self._enable_provider(monkeypatch)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+        )
+
+        # Every interpretation says "clarify" — without a cap this loops forever.
+        interpret_calls = {"n": 0}
+
+        def _always_clarify(question, reply, ctx):
+            interpret_calls["n"] += 1
+            return {"action": "clarify", "question": "Could you be more specific?"}
+
+        monkeypatch.setattr(guidance, "interpret_gap_reply", _always_clarify)
+
+        # The user keeps replying with vague answers.
+        human = ScriptedHuman(
+            input_answers=[_value("the assay"), _value("the other one"), _value("dunno")]
+        )
+        run_guidance(engine, human, max_rounds=5)
+
+        # At most ONE follow-up was asked (initial reply + one clarify = 2 inputs),
+        # and nothing was committed (a clarify never becomes a value).
+        assert len(human.inputs) <= 2, human.inputs
+        assert interpret_calls["n"] <= 2, interpret_calls["n"]
+        assert _get(engine, "st1").fields.get("description") == original
+
+    def test_clarify_then_commit_lands_the_clarified_value(self, monkeypatch):
+        """One clarify follow-up that yields a value commits the clarified value."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        self._enable_provider(monkeypatch)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+        )
+
+        decisions = iter(
+            [
+                {"action": "clarify", "question": "Which endpoint?"},
+                {"action": "commit", "value": "A viability assay study."},
+            ]
+        )
+        monkeypatch.setattr(
+            guidance, "interpret_gap_reply", lambda _q, _r, _c: next(decisions)
+        )
+
+        human = ScriptedHuman(
+            input_answers=[_value("an assay"), _value("cell viability")]
+        )
+        run_guidance(engine, human, max_rounds=5)
+
+        assert _get(engine, "st1").fields.get("description") == (
+            "A viability assay study."
+        )
+
+    def test_from_file_does_not_store_prose(self, monkeypatch):
+        """A 'it's in a file' reply must NOT store the user's prose; it records a
+        filename hint and does not commit a value (#244)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        original = _get(engine, "st1").fields.get("description")
+        self._enable_provider(monkeypatch)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+        )
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _r, _c: {"action": "from_file", "filename": "README.txt"},
+        )
+
+        human = ScriptedHuman(
+            input_answers=[_value("it's all written up in README.txt")]
+        )
+        summary = run_guidance(engine, human, max_rounds=5)
+
+        # The prose was NOT stored.
+        assert _get(engine, "st1").fields.get("description") == original
+        # The gap was surfaced (asked), not committed.
+        assert any(a.get("entity_id") == "st1" for a in summary["asked"])
+        assert not any(r.get("entity_id") == "st1" for r in summary["resolved"])
+
+    def test_phrase_leaf_question_is_shown_to_the_user(self, monkeypatch):
+        """The PHRASED question (not the raw SHACL message) is what the user sees."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        self._enable_provider(monkeypatch)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        phrased = "In one sentence, what does this study set out to find?"
+        monkeypatch.setattr(guidance, "phrase_gap_question", lambda _ctx: phrased)
+        monkeypatch.setattr(
+            guidance, "interpret_gap_reply", lambda _q, _r, _c: {"action": "skip"}
+        )
+
+        human = ScriptedHuman(input_answers=[_value("hmm")])
+        run_guidance(engine, human, max_rounds=5)
+
+        assert human.inputs, "the user must be prompted"
+        prompt = human.inputs[0][0]
+        assert phrased in prompt
+        # The raw failed-check SHACL message is NOT shown verbatim as the question.
+        assert "Study MUST have a description." not in prompt
+
+
+class TestNoProviderDeterministicFallback:
+    """With NO provider configured the guidance loop preserves today's
+    deterministic ask-and-set behavior (#244)."""
+
+    def test_no_provider_commits_nonempty_reply_verbatim(self, monkeypatch):
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        # No provider -> deterministic path; the leaves must NEVER be called.
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+
+        def _boom(*_a, **_k):  # pragma: no cover - must not run
+            raise AssertionError("no-provider path must not call the LLM leaves")
+
+        monkeypatch.setattr(guidance, "phrase_gap_question", _boom)
+        monkeypatch.setattr(guidance, "interpret_gap_reply", _boom)
+
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        human = ScriptedHuman(input_answers=[_value("A user-typed description.")])
+        run_guidance(engine, human, max_rounds=5)
+
+        # Deterministic: a non-empty reply is committed as-is (today's behavior).
+        assert _get(engine, "st1").fields.get("description") == (
+            "A user-typed description."
+        )
+
+    def test_no_provider_skip_does_not_commit(self, monkeypatch):
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        original = _get(engine, "st1").fields.get("description")
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap("SHOULD"),
+            counts={"must_open": 0, "should_open": 1, "may_open": 0},
+        )
+
+        human = ScriptedHuman(input_answers=[_skip()])
+        run_guidance(engine, human, max_rounds=5)
+
+        # Deterministic: an empty/skipped reply commits nothing.
+        assert _get(engine, "st1").fields.get("description") == original
+
+
+class TestReportOnlyNeverAskedWithLLM:
+    """Report-only gaps stay report-only even with a provider configured:
+    they are never phrased, interpreted, or offered to the user (#244)."""
+
+    def test_report_only_gap_never_phrased_or_asked(self, monkeypatch):
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+
+        fair_gap = Gap(
+            tier="SHOULD",
+            source="fair",
+            entity_id=None,
+            entity_type=None,
+            property="RDA-F1-02M",
+            message="FAIR indicator RDA-F1-02M not met: globally unique id.",
+            suggestion="Dimension Findable (essential)",
+            fix_hint="report-only",
+            auto_fixable=False,
+        )
+        monkeypatch.setattr(
+            guidance,
+            "assess_gaps",
+            lambda _state: GapReport(
+                gaps=[fair_gap],
+                counts={"must_open": 0, "should_open": 1, "may_open": 0},
+            ),
+        )
+
+        def _boom(*_a, **_k):  # pragma: no cover - must not run
+            raise AssertionError("a report-only gap must never reach an LLM leaf")
+
+        monkeypatch.setattr(guidance, "phrase_gap_question", _boom)
+        monkeypatch.setattr(guidance, "interpret_gap_reply", _boom)
+
+        human = ScriptedHuman()
+        run_guidance(engine, human, max_rounds=5)
+
+        # The report-only gap was never offered to the user.
+        assert human.inputs == []
+        assert human.presented == []


### PR DESCRIPTION
Closes #244

## What

Turns the guidance tail's per-gap **ask-user** step into a small bounded LLM exchange — the #179 hybrid's "small guidance agent" — instead of the deterministic ask-and-set loop that stored the user's raw reply verbatim. Real bug it fixes: a user typed "No idea which file you are talking about" and it was stored as the crate `description`.

CODE still owns control flow (this is NOT a ReAct/LLM-orchestrated agent); the LLM is used only at bounded leaves.

## Design — phrase / interpret / commit

Two new drafter-tier leaves in `builder/agents/leaves.py` (internal pipeline calls, **not** four-place LLM-advertised tools, so the four-place `tools_spec.py`/`system_prompt.py` contract correctly does not apply):

- **Phrase** — `phrase_gap_question(gap_context: dict) -> str`: rephrases the gap (property, entity_type, tier, MIT/FAIR rationale, suggestion) into ONE clear human question with a concrete example. Never raw SHACL shapes / FAIR indicator codes / property IRIs. Empty/failed result -> deterministic human-readable prompt.
- **Interpret** — `interpret_gap_reply(question: str, reply: str, gap_context: dict) -> dict`: parses the free-text reply into a **structured decision**:
  - `{"action": "commit", "value": <clean value>}`
  - `{"action": "skip"}` (covers "I don't know" / empty / off-topic)
  - `{"action": "clarify", "question": <one follow-up>}`
  - `{"action": "from_file", "filename": <hint>}` (optional `filename`)
- **Commit** — only a `commit`'s clean `value` reaches the existing `_apply_value` (`set_fields` / `set_crate_metadata`, never hand-rolled JSON-LD). `skip`/`from_file` commit nothing; `from_file` records the filename hint and never stores prose; `clarify` asks at most **one** bounded follow-up (`_MAX_CLARIFY_FOLLOW_UPS = 1`) then skips, so it can't loop. **D5:** identifier-bearing fields are never committed from the user's prose (those come from lookups) — the interpret leaf coerces such a `commit` to `skip`. A malformed/unknown action or an empty `commit` value also coerces to `skip`.

A free-text musing therefore can never become a field value.

## Offline determinism

The LLM path is gated on `config.get_provider()` (the same gate the pipeline leaves use). With **no provider** configured the exchange degrades to the original deterministic ask-and-set: phrase = today's human-readable prompt, interpret = non-empty reply -> commit, empty/skip -> skip. The **same** deterministic decision is used when a configured leaf is unavailable or raises, so a flaky/unreachable LLM never silently drops the user's answer (this also keeps the repo's existing guidance tests green, since the test env reports a provider but has no reachable model). `report-only` gaps are still never phrased, interpreted, or offered to the user.

## Tests (TDD, red -> green)

New in `tests/test_agents_guidance.py`:
- `TestLLMMediatedAskUser::test_idk_reply_is_skipped_not_stored` — the headline regression
- `test_natural_language_reply_is_interpreted_to_clean_value`
- `test_clarify_asks_at_most_one_follow_up_then_skips`, `test_clarify_then_commit_lands_the_clarified_value`
- `test_from_file_does_not_store_prose`, `test_phrase_leaf_question_is_shown_to_the_user`
- `TestNoProviderDeterministicFallback::{test_no_provider_commits_nonempty_reply_verbatim, test_no_provider_skip_does_not_commit}`
- `TestReportOnlyNeverAskedWithLLM::test_report_only_gap_never_phrased_or_asked`

New in `tests/agents/test_leaves.py`: drafter-tier + single-call + decision-shape + D5 coverage for both leaves (`TestPhraseGapQuestion*`, `TestInterpretGapReply*`, `TestGuidanceLeavesD5`). Leaves are stubbed via monkeypatch — no real LLM, no network.

## Gates

- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agents_guidance.py tests/agents/test_leaves.py` -> 62 passed
- `tests/test_agents_build.py` (interactive wiring) -> 13 passed
- `uv run ruff check` -> All checks passed
- `uv run --extra langchain ty check builder/agents/guidance.py builder/agents/leaves.py` -> All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)