### PR TITLE
feat(pipeline): staged progress + CrateState persistence for the interactive build (#241, #242)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1533,13 +1533,17 @@ build-path-only change.
 
 ### 14.5 The pipeline spine (task 4 — `builder/agents/pipeline.py`)
 
-`run_pipeline(engine: AgentEngine) -> dict` is the deterministic, code-driven
-orchestrator of §14.2 — the Priority 1-4 heuristic (§4) expressed as **control
-flow, not prose**, with **no LLM deciding control flow**. It operates on an
-already-`initialize()`-d engine (so scanning + approved-roots happened in the
-engine) and routes every step through `engine.run_tool(...)` (so each is profiled
-and validation is cached); it never re-implements tool logic, only orchestrates the
-existing toolbox. The sequence:
+`run_pipeline(engine: AgentEngine, *, progress=None, save=None) -> dict` is the
+deterministic, code-driven orchestrator of §14.2 — the Priority 1-4 heuristic (§4)
+expressed as **control flow, not prose**, with **no LLM deciding control flow**. It
+operates on an already-`initialize()`-d engine (so scanning + approved-roots
+happened in the engine) and routes every step through `engine.run_tool(...)` (so
+each is profiled and validation is cached); it never re-implements tool logic, only
+orchestrates the existing toolbox. The keyword-only `progress` sink (a no-op by
+default) receives one concise line per phase (#241) and the keyword-only `save`
+callback (defaulting to `save_session`) persists CrateState at each phase boundary
+so a concurrent dashboard live-updates (#242) — see §14.6.1 "Progress +
+persistence". The sequence:
 
 1. **Scaffold** the ISA backbone via `scaffold_isa_backbone` — always, and
    idempotent (existing layers are reused). The spine supplies deterministic
@@ -1660,7 +1664,9 @@ HITL and lives **outside** the spine, in the interactive entrypoint
 exporter=None, output=None) -> dict` joins the two halves into the end-to-end
 sequence a real user runs. It:
 
-1. runs the **automated** pipeline (`run_pipeline`) — always;
+1. emits a leading **progress** line (`Scanning ✓ (N files)`, #241) and runs the
+   **automated** pipeline (`run_pipeline`) — always — threading the `output`
+   channel in as the spine's progress sink (see "Progress + persistence" below);
 2. runs the **HITL guidance tail** (`run_guidance(engine, engine.human_interface)`)
    **iff the engine's `HumanInterface` is interactive**;
 3. surfaces a concise summary of the guidance results
@@ -1669,8 +1675,10 @@ sequence a real user runs. It:
    CLI's `print` / console writer);
 4. **exports the crate to disk LAST** (`export_crate(engine.state)`, #233) — after
    guidance, so the *enriched* crate is what lands — and surfaces the resolved
-   **absolute** crate path via `output`;
-5. returns `{"pipeline": <run_pipeline result>, "guidance": <run_guidance result
+   **absolute** crate path via `output` (`Crate written to <abs path>`);
+5. does a **final `save_session(state, always_write=True)`** (#242) so a populated
+   CrateState overview + a resumable session are guaranteed on disk, then
+6. returns `{"pipeline": <run_pipeline result>, "guidance": <run_guidance result
    or None>, "export": <export_crate result>}` — `guidance` is `None` exactly when
    the path was non-interactive; `export` is the (successful) export result dict.
 
@@ -1686,6 +1694,41 @@ build (interactive *and* headless), so the user always gets a crate on disk and
 logged, surfaced via `output`, and re-raised as `CrateExportError` so the CLI
 signals a non-zero exit. The exporter is injectable so the wiring is unit-tested
 with no ro-crate-py / disk (`tests/test_agents_build.py`).
+
+**Progress + persistence (#241 / #242).** Before these the default `--interactive`
+(pipeline) path *felt dead*: the deterministic spine ran for ~tens of seconds with
+**no output** (it looked frozen — the legacy ReAct loop has a `_ThinkingSpinner`,
+the pipeline had nothing, #241) and **never persisted CrateState** (so a concurrent
+`--dashboard`, which loads + watches `sessions/<id>/crate_state.json`, showed "No
+CrateState data available" and never live-updated even though a full crate was built
+in memory, #242). Both are fixed without an LLM and without perturbing the built
+`@graph`:
+
+- **Progress (#241)** is surfaced through the **existing `output` channel** — one
+  concise line per phase: `Scanning ✓ (N files)` (emitted by `run_interactive_build`
+  from `state.scanned_files`), then the spine's own threaded lines
+  (`Scaffolding ISA backbone…` / `Extracting plan…` / `Materializing N entities…` /
+  `Validating base→ISA→ISA-Tox…` / `Resolving gaps…`), then `Crate written to
+  <abs path>`. `run_pipeline` takes a keyword-only `progress` sink (defaulting to a
+  strict **no-op**); `run_interactive_build` threads `output` in only when the
+  injected `pipeline_runner` actually accepts a `progress` kwarg (signature-checked,
+  so a narrower injected test double still works). With the default no-op `output`
+  (non-interactive / eval / tests) **nothing is emitted**, so determinism and eval
+  output stay clean.
+- **Persistence (#242)** is driven by `save_session` calls at **phase boundaries**.
+  `run_pipeline` takes a keyword-only `save` callback (defaulting to the real
+  `builder.tools.session.save_session`) and calls it after **scaffold**, after
+  **materialize**, and after **each `build_and_validate`** in the fix loop — the
+  incremental, change-detected writes drive the dashboard's mtime-watch refresh so
+  a running `--dashboard` reflects the crate converging round by round.
+  `run_interactive_build` then does a **final `save_session(state,
+  always_write=True)`** after guidance + export (on **both** the interactive and the
+  headless path), which bypasses change-detection to guarantee a populated overview
+  + a resumable session. Persisting CrateState writes only `crate_state.json`; it
+  **never touches the built `@graph`**, so the no-provider determinism guarantee
+  (identical graph hash across runs) holds. Both `progress` and `save` are injected
+  so the wiring is unit-tested with no disk / no SHACL (`tests/test_agents_build.py`,
+  `tests/test_agents_pipeline.py`).
 
 **Output location (CLI, `main.py`).** The on-disk destination is resolved at
 dispatch time with this precedence (#233):

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -27,11 +27,13 @@ functions) so the wiring is unit-testable with no SHACL / no LLM / no network.
 
 from __future__ import annotations
 
+import inspect
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from builder.tools.hitl import is_interactive
+from builder.tools.session import save_session
 
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
@@ -43,12 +45,16 @@ logger = logging.getLogger(__name__)
 __all__ = ["run_interactive_build", "format_guidance_summary", "CrateExportError"]
 
 # A pipeline_runner runs the automated deterministic spine once over an engine,
-# mutating engine.state and returning the spine's result dict. A guidance_runner
-# runs the HITL gap-resolution loop over the engine + a human, returning its
-# summary dict. An exporter writes the assembled crate to disk and returns the
-# export result dict (``{success, crate_path, error}``). All three are injected
-# so the wiring is testable without SHACL / LLM / disk.
-PipelineRunner = Callable[["AgentEngine"], dict[str, Any]]
+# mutating engine.state and returning the spine's result dict. The real
+# ``run_pipeline`` additionally accepts a keyword-only ``progress`` sink (#241),
+# threaded in only when the runner's signature accepts it (see
+# ``_run_pipeline_with_progress``), so the alias is the open ``(...)`` form to
+# admit both shapes. A guidance_runner runs the HITL gap-resolution loop over the
+# engine + a human, returning its summary dict. An exporter writes the assembled
+# crate to disk and returns the export result dict (``{success, crate_path,
+# error}``). All three are injected so the wiring is testable without SHACL / LLM /
+# disk.
+PipelineRunner = Callable[..., dict[str, Any]]
 GuidanceRunner = Callable[..., dict[str, Any]]
 Exporter = Callable[..., dict[str, Any]]
 
@@ -95,6 +101,20 @@ def run_interactive_build(
     *and* headless). An export failure is logged, surfaced, and re-raised as
     :class:`CrateExportError` — it is never silently swallowed.
 
+    **Progress (#241).** The build surfaces staged progress through *output* — a
+    "Scanning ✓ (N files)" line up front, the spine's own per-phase lines threaded
+    in via a progress callback (Scaffolding / Materializing / Validating /
+    Resolving), and the final "Crate written to <abs path>" line — so the
+    ~tens-of-seconds deterministic spine no longer looks frozen. It is a strict
+    no-op when *output* is the default (non-interactive / tests).
+
+    **Persistence (#242).** The spine persists ``CrateState`` to
+    ``sessions/<id>/crate_state.json`` at each phase boundary (incremental saves
+    drive a concurrent ``--dashboard``'s live refresh), and this entrypoint does a
+    FINAL ``save_session(state, always_write=True)`` after guidance + export so a
+    populated overview + a resumable session are always written — on BOTH the
+    interactive and the headless path.
+
     Args:
         engine: An initialized engine. Its ``human_interface`` decides whether
             the guidance tail runs; ``run_guidance`` mutates ``engine.state`` in
@@ -106,8 +126,9 @@ def run_interactive_build(
         exporter: Injected on-disk writer; defaults to the real
             :func:`builder.tools.builder.export_crate` (crate assembly via
             ro-crate-py — never hand-rolled JSON-LD).
-        output: Sink for the human-readable guidance summary and the final crate
-            path (e.g. ``print`` or a console writer). Defaults to a no-op.
+        output: Sink for the staged progress lines, the human-readable guidance
+            summary, and the final crate path (e.g. ``print`` or a console
+            writer). Defaults to a no-op.
 
     Returns:
         ``{"pipeline": <run_pipeline result>, "guidance": <run_guidance result or
@@ -118,10 +139,16 @@ def run_interactive_build(
     Raises:
         CrateExportError: If the final on-disk export fails (surfaced first).
     """
-    emit = output or (lambda _msg: None)
+    emit: OutputChannel = output or (lambda _msg: None)
+
+    # Progress (#241): the input is already scanned by engine.initialize(); lead
+    # with a concise inventory line so the user sees the build picking up.
+    scanned = len(getattr(engine.state, "scanned_files", []) or [])
+    if scanned:
+        emit(f"Scanning ✓ ({scanned} files)")
 
     pipeline_runner = pipeline_runner or _default_pipeline_runner()
-    pipeline_result = pipeline_runner(engine)
+    pipeline_result = _run_pipeline_with_progress(pipeline_runner, engine, emit)
 
     human: HumanInterface | None = getattr(engine, "human_interface", None)
     if not is_interactive(human):
@@ -130,6 +157,7 @@ def run_interactive_build(
         # but the build is still completed, so it must still be written to disk.
         logger.debug("Non-interactive build: skipping the HITL guidance tail")
         export_result = _export_crate_to_disk(engine, exporter, emit)
+        _final_save(engine)
         return {
             "pipeline": pipeline_result,
             "guidance": None,
@@ -137,18 +165,76 @@ def run_interactive_build(
         }
 
     guidance_runner = guidance_runner or _default_guidance_runner()
+    emit("Resolving gaps…")
     guidance_result = guidance_runner(engine, human)
 
     emit(format_guidance_summary(guidance_result))
 
     # Export LAST so the guidance-enriched crate is what lands on disk (#233).
     export_result = _export_crate_to_disk(engine, exporter, emit)
+    # FINAL persist (#242): always_write guarantees a populated overview + resume.
+    _final_save(engine)
 
     return {
         "pipeline": pipeline_result,
         "guidance": guidance_result,
         "export": export_result,
     }
+
+
+def _run_pipeline_with_progress(
+    pipeline_runner: PipelineRunner,
+    engine: AgentEngine,
+    emit: OutputChannel,
+) -> dict[str, Any]:
+    """Call *pipeline_runner*, threading *emit* in as the spine's progress sink.
+
+    The real :func:`builder.agents.pipeline.run_pipeline` accepts a keyword-only
+    ``progress`` callback (#241). To stay backward-compatible with injected test
+    runners whose signature is ``(engine)`` only, we introspect the runner and pass
+    ``progress`` **only** when it is accepted — otherwise the runner is called the
+    legacy way. This keeps the spine's per-phase lines flowing to the user through
+    the real path while never breaking a narrower injected double.
+    """
+    if _accepts_kwarg(pipeline_runner, "progress"):
+        return pipeline_runner(engine, progress=emit)
+    return pipeline_runner(engine)
+
+
+def _accepts_kwarg(func: Callable[..., Any], name: str) -> bool:
+    """Return True if *func* accepts a keyword argument *name* (or ``**kwargs``)."""
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == name and param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            return True
+    return False
+
+
+def _final_save(engine: AgentEngine) -> None:
+    """Final, forced CrateState persist (#242) — never abort the build on failure.
+
+    ``always_write=True`` bypasses the change-detection skip so the session is
+    guaranteed written even when an incremental phase save already wrote identical
+    content, ensuring the dashboard's CrateState overview is populated and the
+    session is resumable. A save failure is logged, not raised — the crate is
+    already on disk from the export step, so the build still succeeded.
+    """
+    try:
+        result = save_session(engine.state, always_write=True)
+        if not result.get("success", True):
+            logger.warning(
+                "Final session save failed: %s", result.get("error", "unknown error")
+            )
+    except Exception:  # noqa: BLE001 - persistence is best-effort; never break the build
+        logger.exception("Unexpected error during final session save")
 
 
 def _export_crate_to_disk(

--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -65,6 +65,39 @@ logger = logging.getLogger(__name__)
 # real per-case token counts for the ``--arch pipeline`` arm (Issue #221).
 UsageSink = Callable[[int | None, int | None, str | None], None]
 
+# A progress sink receives one concise human-readable line per pipeline phase
+# (Issue #241). It defaults to a strict no-op so the eval and the determinism
+# tests stay silent; the interactive build path threads in the CLI's `output`
+# channel so a real user sees the deterministic spine is making progress rather
+# than a terminal that looks frozen for ~tens of seconds.
+ProgressSink = Callable[[str], Any]
+
+# A session-save callback persists CrateState at a phase boundary (Issue #242).
+# It mirrors :func:`builder.tools.session.save_session`'s call shape
+# ``save(state, *, always_write=...)`` and defaults to the real function. The
+# spine saves after each phase so a concurrent ``--dashboard`` (which watches
+# ``sessions/<id>/crate_state.json``) reflects pipeline progress live instead of
+# showing "No CrateState data available". Injected so the wiring is unit-testable
+# with no disk I/O.
+SaveFn = Callable[..., dict[str, Any]]
+
+
+def _noop_progress(_message: str) -> None:
+    """Default progress sink: discard. Keeps the spine silent under tests/eval."""
+
+
+def _default_save() -> SaveFn:
+    """The real session writer, imported lazily so the spine stays light.
+
+    :func:`builder.tools.session.save_session` performs an atomic write of
+    ``crate_state.json`` and is change-detecting (it skips identical content
+    unless ``always_write=True``). Deferred so a test injecting its own ``save``
+    is independent of the writer / disk.
+    """
+    from builder.tools.session import save_session
+
+    return save_session
+
 
 def draft_entity_fields(
     entity_type: str,
@@ -861,7 +894,12 @@ def _materialize_plan(
     return result
 
 
-def _run_fix_loop(engine: AgentEngine) -> tuple[dict[str, Any], int]:
+def _run_fix_loop(
+    engine: AgentEngine,
+    *,
+    progress: ProgressSink = _noop_progress,
+    save: Callable[[], None] | None = None,
+) -> tuple[dict[str, Any], int]:
     """Step 4 — bounded deterministic fix loop.
 
     Runs ``fix_required_issues`` up to ``_MAX_FIX_ROUNDS`` times, stopping early
@@ -873,21 +911,33 @@ def _run_fix_loop(engine: AgentEngine) -> tuple[dict[str, Any], int]:
     A round "makes progress" when it fixes at least one issue; a round that fixes
     nothing means the remaining issues are not deterministically repairable, so
     spinning further is wasted SHACL work.
+
+    ``progress`` receives one concise line per validate/fix phase (#241) and
+    ``save`` (when supplied) is called after each ``build_and_validate`` so a
+    concurrent dashboard sees the crate converge round by round (#242).
     """
     from builder.tools.validation import build_and_validate
 
     rounds = 0
+    progress("Validating base→ISA→ISA-Tox…")
     last_validation = engine.run_tool("build_and_validate", profile="all", severity="required")
+    if save is not None:
+        save()
     if last_validation.get("ok"):
         return last_validation, rounds
 
     for _ in range(_MAX_FIX_ROUNDS):
         rounds += 1
+        progress("Resolving gaps…")
         fix_result = engine.run_tool("fix_required_issues", profile="all", severity="required")
         # Re-validate to get the authoritative conformance after this round.
+        progress("Validating base→ISA→ISA-Tox…")
         last_validation = engine.run_tool(
             "build_and_validate", profile="all", severity="required"
         )
+        # Persist after each fix-loop validate so the dashboard live-updates (#242).
+        if save is not None:
+            save()
         if last_validation.get("ok"):
             break
         if not fix_result.get("fixed"):
@@ -902,7 +952,12 @@ def _run_fix_loop(engine: AgentEngine) -> tuple[dict[str, Any], int]:
     return last_validation, rounds
 
 
-def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
+def run_pipeline(
+    engine: AgentEngine,
+    *,
+    progress: ProgressSink | None = None,
+    save: SaveFn | None = None,
+) -> dict[str, Any]:
     """Run the deterministic pipeline spine on *engine* and return its outcome.
 
     The engine MUST already be :meth:`~builder.engine.AgentEngine.initialize`-d
@@ -917,10 +972,26 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
     A/B path of the eval harness asserts. When a provider is configured, the
     bounded drafter-leaf (step 2) enriches entities with descriptive content.
 
+    Progress + persistence (#241 / #242). The spine emits a concise line per phase
+    through *progress* and persists ``CrateState`` to ``sessions/<id>/`` via *save*
+    after each phase boundary (scaffold, materialize, and every fix-loop validate),
+    so a concurrent ``--dashboard`` reflects the build converging live instead of
+    showing "No CrateState data available". Persisting CrateState never perturbs
+    the built ``@graph`` (the change-detected, on-disk write touches only
+    ``crate_state.json``), so the no-provider determinism guarantee is preserved.
+
     Args:
         engine: An initialized headless :class:`~builder.engine.AgentEngine`. The
             spine mutates ``engine.state`` in place and routes all tool calls
             through the engine (so they are profiled and validation is cached).
+        progress: Optional per-phase progress sink (Issue #241). Defaults to a
+            strict no-op so the eval and determinism tests stay silent; the
+            interactive build threads the CLI ``output`` channel in.
+        save: Optional ``save(state, *, always_write=...)`` callback (Issue #242).
+            Defaults to the real :func:`builder.tools.session.save_session`. The
+            spine calls it (incrementally, change-detected) at each phase boundary
+            so a concurrent dashboard live-updates. Injected so the wiring is
+            unit-testable with no disk I/O.
 
     Returns:
         ``{"ok", "conformance", "issues", "scaffold", "materialized", "drafted",
@@ -933,15 +1004,36 @@ def run_pipeline(engine: AgentEngine) -> dict[str, Any]:
         to ``profile.ndjson`` as ``node_end``/``node="model"`` events so the eval
         harness mines it exactly as it does the ReAct arm.
     """
+    emit: ProgressSink = progress or _noop_progress
+    save_fn: SaveFn = save or _default_save()
+
+    def _persist() -> None:
+        """Persist CrateState at a phase boundary — never let a save failure break
+        the spine (the build itself is the load-bearing work)."""
+        try:
+            save_fn(engine.state)
+        except Exception as exc:  # noqa: BLE001 - a save failure must not abort the build
+            logger.warning("Pipeline session save failed: %s", exc)
+
     # Accumulate per-run leaf token usage; the sink also logs each call to the
     # profiler so eval/runner.py mines it via the same path as the ReAct arm.
     totals = {"input_tokens": 0, "output_tokens": 0}
     usage_sink = _make_usage_logger(engine, totals)
 
+    emit("Scaffolding ISA backbone…")
     scaffold = _scaffold_backbone(engine)
+    _persist()
+
+    emit("Extracting plan…")
     materialized = _materialize_plan(engine, usage_sink)
+    materialized_count = sum(v for v in materialized.values() if isinstance(v, int))
+    if materialized_count:
+        emit(f"Materializing {materialized_count} entities…")
+    _persist()
+
     drafted = _draft_entities(engine, usage_sink)
-    validation, fix_rounds = _run_fix_loop(engine)
+
+    validation, fix_rounds = _run_fix_loop(engine, progress=emit, save=_persist)
 
     return {
         "ok": bool(validation.get("ok")),

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -336,3 +336,173 @@ class TestDeterministicExport:
 
         assert result["export"]["success"] is True
         assert Path(result["export"]["crate_path"]).resolve() == out_dir.resolve()
+
+
+class TestStatePersistence:
+    """#242 — run_interactive_build persists CrateState so the dashboard sees it.
+
+    The pipeline path never wrote ``sessions/<id>/crate_state.json``, so a running
+    ``--dashboard`` showed "No CrateState data available" and never live-updated.
+    The interactive build must persist the final state (always_write) after
+    guidance + export, on BOTH the interactive and headless paths.
+    """
+
+    def _isolate_sessions(self, monkeypatch, tmp_path) -> Path:
+        import builder.tools.session as sess_mod
+
+        sessions = tmp_path / "sessions"
+        monkeypatch.setattr(sess_mod, "SESSION_DIR", sessions)
+        monkeypatch.setattr(sess_mod, "_last_saved_state_hash", None)
+        return sessions
+
+    def test_final_state_persisted_interactive(self, monkeypatch, tmp_path) -> None:
+        """After an interactive build, crate_state.json exists with the entities."""
+        from builder.agents.build import run_interactive_build
+        from builder.state import Entity
+        from builder.tools.session import load_session
+
+        sessions = self._isolate_sessions(monkeypatch, tmp_path)
+        out_dir = tmp_path / "x-ro-crate"
+        engine = _engine(_InteractiveHuman())
+        engine.state.metadata.output_path = str(out_dir)
+        # Seed an entity so the persisted state demonstrably carries content.
+        engine.state.add_entity(
+            Entity(entity_id="inv_1", type="Investigation", fields={"name": "Inv"})
+        )
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=[].append,
+        )
+
+        state_path = sessions / engine.state.session_id / "crate_state.json"
+        assert state_path.is_file(), "interactive build must persist crate_state.json (#242)"
+        loaded = load_session(engine.state.session_id)
+        assert loaded is not None
+        assert any(e.entity_id == "inv_1" for e in loaded.list_entities())
+
+    def test_final_state_persisted_headless(self, monkeypatch, tmp_path) -> None:
+        """A headless build (no guidance) still persists the final state (#242)."""
+        from builder.agents.build import run_interactive_build
+        from builder.tools.session import load_session
+
+        sessions = self._isolate_sessions(monkeypatch, tmp_path)
+        out_dir = tmp_path / "headless-ro-crate"
+        engine = _engine(SimulatedHumanInterface())
+        engine.state.metadata.output_path = str(out_dir)
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=[].append,
+        )
+
+        state_path = sessions / engine.state.session_id / "crate_state.json"
+        assert state_path.is_file()
+        assert load_session(engine.state.session_id) is not None
+
+    def test_final_save_uses_always_write(self, monkeypatch, tmp_path) -> None:
+        """The final save passes always_write=True so a populated overview +
+        resume is guaranteed even if a phase save deduped earlier."""
+        from builder.agents import build as build_mod
+
+        self._isolate_sessions(monkeypatch, tmp_path)
+        out_dir = tmp_path / "aw-ro-crate"
+        engine = _engine(SimulatedHumanInterface())
+        engine.state.metadata.output_path = str(out_dir)
+
+        saves: list[bool] = []
+
+        def fake_save(state, *, always_write: bool = False, **kw):
+            saves.append(always_write)
+            return {"success": True, "session_id": state.session_id, "skipped": False}
+
+        monkeypatch.setattr(build_mod, "save_session", fake_save, raising=False)
+
+        build_mod.run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=[].append,
+        )
+
+        # The final save is forced (always_write=True).
+        assert saves, "save_session must be called from run_interactive_build"
+        assert True in saves, "the final save must use always_write=True"
+
+
+class TestProgressOutput:
+    """#241 — the interactive build emits staged progress through `output`."""
+
+    def test_progress_lines_emitted_to_output(self, tmp_path) -> None:
+        """Concise per-phase progress lines reach the output channel."""
+        from builder.agents.build import run_interactive_build
+
+        out_dir = tmp_path / "prog-ro-crate"
+        engine = _engine(_InteractiveHuman())
+        engine.state.metadata.output_path = str(out_dir)
+        lines: list[str] = []
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=lines.append,
+        )
+
+        joined = "\n".join(lines).lower()
+        # The final crate-written line is always surfaced (the #233 export line).
+        assert "crate written" in joined
+        # And at least one staged progress marker precedes it.
+        assert any(
+            kw in joined
+            for kw in ("scaffold", "materializ", "validat", "resolv", "scanning", "extract")
+        ), "interactive build must emit staged progress (#241)"
+
+    def test_progress_threaded_into_pipeline(self, tmp_path) -> None:
+        """run_interactive_build threads a progress callback into run_pipeline so
+        the spine's per-phase lines reach output."""
+        from builder.agents.build import run_interactive_build
+
+        out_dir = tmp_path / "thread-ro-crate"
+        engine = _engine(SimulatedHumanInterface())
+        engine.state.metadata.output_path = str(out_dir)
+        seen_progress: list[Any] = []
+
+        def fake_pipeline(eng, *, progress=None, **kw):
+            # The build must hand the spine a usable (non-None) progress callback.
+            seen_progress.append(progress)
+            if progress is not None:
+                progress("Scaffolding ISA backbone…")
+            return dict(_PIPELINE_RESULT)
+
+        lines: list[str] = []
+        run_interactive_build(
+            engine,
+            pipeline_runner=fake_pipeline,
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=lines.append,
+        )
+
+        assert seen_progress and seen_progress[0] is not None
+        assert any("scaffold" in line.lower() for line in lines)
+
+    def test_default_output_is_noop_for_progress(self, tmp_path) -> None:
+        """With the default (no) output the build runs silently — no crash, no
+        print — so eval/tests stay clean."""
+        from builder.agents.build import run_interactive_build
+
+        out_dir = tmp_path / "silent-ro-crate"
+        engine = _engine(SimulatedHumanInterface())
+        engine.state.metadata.output_path = str(out_dir)
+
+        # No output kwarg => default no-op sink. Must not raise.
+        result = run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+        )
+        assert result["export"]["success"] is True

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -38,6 +38,21 @@ from builder.tools.hitl import SimulatedHumanInterface
 pytestmark = pytest.mark.timeout(120)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path_factory, monkeypatch):
+    """Redirect save_session's SESSION_DIR to a tmp dir for every test here.
+
+    ``run_pipeline`` now persists CrateState at each phase boundary (#242). Point
+    the writer at a throwaway dir (and reset its module-level dedup cache) so the
+    spine's saves never litter the repo's real ``sessions/`` directory and tests
+    stay hermetic.
+    """
+    import builder.tools.session as sess_mod
+
+    monkeypatch.setattr(sess_mod, "SESSION_DIR", tmp_path_factory.mktemp("sessions"))
+    monkeypatch.setattr(sess_mod, "_last_saved_state_hash", None)
+
+
 def _entity(entity_id: str, type_: EntityType, **fields) -> Entity:
     return Entity(
         entity_id=entity_id,
@@ -1334,3 +1349,119 @@ class TestMaterializeBackboneNaming:
 
         # The specific name wins over the plan (fill-don't-clobber).
         assert self._study(engine).fields.get("name") == "A real, specific study title"
+
+
+# ---------------------------------------------------------------------------
+# Issues #241 / #242 — pipeline progress + state persistence.
+#
+# #242: run_pipeline NEVER persisted CrateState, so a concurrent --dashboard read
+# "No CrateState data available" and never live-updated. The spine must
+# save_session at each phase boundary so the watched crate_state.json appears
+# and changes as the build progresses.
+#
+# #241: the pipeline emitted NO progress, so the ~tens-of-seconds deterministic
+# spine looked frozen. The spine must emit one concise line per phase through an
+# injected progress callback, defaulting to a strict no-op so eval + determinism
+# stay clean.
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineStatePersistence:
+    """#242 — run_pipeline persists CrateState at phase boundaries."""
+
+    def _isolate_sessions(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        """Point save_session at a tmp sessions dir and reset its dedup cache."""
+        import builder.tools.session as sess_mod
+
+        sessions = tmp_path / "sessions"
+        monkeypatch.setattr(sess_mod, "SESSION_DIR", sessions)
+        monkeypatch.setattr(sess_mod, "_last_saved_state_hash", None)
+        return sessions
+
+    def test_pipeline_writes_crate_state_json(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """After run_pipeline, sessions/<id>/crate_state.json exists with entities."""
+        from builder.agents.pipeline import run_pipeline
+        from builder.tools.session import load_session
+
+        sessions = self._isolate_sessions(monkeypatch, tmp_path)
+        engine = _engine()
+        run_pipeline(engine)
+
+        state_path = sessions / engine.state.session_id / "crate_state.json"
+        assert state_path.is_file(), "run_pipeline must persist crate_state.json (#242)"
+
+        loaded = load_session(engine.state.session_id)
+        assert loaded is not None
+        types = {e.type for e in loaded.list_entities()}
+        # The scaffolded backbone is persisted, so a dashboard sees real entities.
+        assert {"Investigation", "Study", "Assay"} <= types
+
+    def test_pipeline_saves_at_least_once(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A save callback is invoked during the spine so a concurrent dashboard
+        sees progress, not just the final state."""
+        import builder.agents.pipeline as pipeline_mod
+
+        self._isolate_sessions(monkeypatch, tmp_path)
+        saves: list[str] = []
+
+        def fake_save(state, *, always_write: bool = False, **kw):
+            saves.append(state.session_id)
+            return {"success": True, "session_id": state.session_id, "skipped": False}
+
+        engine = _engine()
+        pipeline_mod.run_pipeline(engine, save=fake_save)
+
+        # At least one save during the spine (incremental dashboard updates).
+        assert len(saves) >= 1
+
+    def test_pipeline_saves_at_multiple_phase_boundaries(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Multiple saves at phase boundaries (scaffold + each validate) so the
+        watched file changes incrementally during the run."""
+        import builder.agents.pipeline as pipeline_mod
+
+        self._isolate_sessions(monkeypatch, tmp_path)
+        saves: list[int] = []
+
+        def fake_save(state, *, always_write: bool = False, **kw):
+            saves.append(len(state.list_entities()))
+            return {"success": True, "session_id": state.session_id, "skipped": False}
+
+        engine = _engine()
+        pipeline_mod.run_pipeline(engine, save=fake_save)
+
+        # Scaffold boundary + fix-loop validate boundary => more than one save.
+        assert len(saves) >= 2
+
+
+class TestPipelineProgress:
+    """#241 — run_pipeline emits one concise progress line per phase."""
+
+    def test_progress_callback_receives_phase_lines(self) -> None:
+        from builder.agents.pipeline import run_pipeline
+
+        lines: list[str] = []
+        engine = _engine()
+        run_pipeline(engine, progress=lines.append)
+
+        joined = "\n".join(lines).lower()
+        # Each major phase surfaces a concise line.
+        assert "scaffold" in joined
+        assert "validat" in joined
+        # The lines are short, human-readable phase markers (not raw dicts).
+        assert lines
+        assert all(len(line) < 200 for line in lines)
+
+    def test_progress_defaults_to_noop(self) -> None:
+        """With no progress callback the spine emits nothing (clean eval/tests)."""
+        from builder.agents.pipeline import run_pipeline
+
+        engine = _engine()
+        # Must not raise and must not print — a missing callback is a strict no-op.
+        result = run_pipeline(engine)
+        assert result["ok"] is True


### PR DESCRIPTION
Closes #241, closes #242

The default `--interactive` (pipeline) path felt dead: `run_pipeline` ran the deterministic spine for ~tens of seconds with **no progress output** (looked frozen, #241) and **never persisted CrateState**, so a concurrent `--dashboard` showed "No CrateState data available" and never live-updated (#242).

## Persistence (#242) — where `save_session` is called
- **`run_pipeline`** gains a keyword-only `save` callback (defaults to the real `save_session`), invoked at each **phase boundary**:
  - after **scaffold** (`_scaffold_backbone`)
  - after **materialize** (`_materialize_plan`)
  - after **every `build_and_validate`** in the fix loop (`_run_fix_loop`)

  These incremental, change-detected writes make the watched `sessions/<id>/crate_state.json` appear and change as the build converges, so a running dashboard live-updates.
- **`run_interactive_build`** does a **final `save_session(state, always_write=True)`** after guidance + export, on **both** the interactive and the headless paths, guaranteeing a populated overview + a resumable session.
- Saving CrateState writes only `crate_state.json` — it never touches the built `@graph`, so the no-provider **determinism** guarantee (identical graph hash across runs) holds.

## Progress (#241) — phases emitted via the existing `output` channel
`run_interactive_build` emits, in order:
- `Scanning ✓ (N files)` (from `state.scanned_files`)
- the spine's threaded per-phase lines: `Scaffolding ISA backbone…` / `Extracting plan…` / `Materializing N entities…` / `Validating base→ISA→ISA-Tox…` / `Resolving gaps…`
- `Crate written to <abs path>` (the #233 export line)

`run_pipeline` takes a keyword-only `progress` sink (default **strict no-op**). The build threads `output` in only when the injected `pipeline_runner` accepts a `progress` kwarg (signature-checked, so narrower test doubles keep working). With the default no-op `output` (non-interactive / eval / tests) nothing is emitted — eval + determinism stay clean.

## Dashboard
The dashboard auto-refresh fix is being handled in a **separate PR** to avoid a conflict on `builder/tools/dashboard.py`; this PR makes the pipeline path *write* the watched `crate_state.json` (the missing half of #242). `dashboard.py` is untouched here.

## Changed files
- `builder/agents/pipeline.py` — `progress` + `save` params on `run_pipeline` / `_run_fix_loop`; phase-boundary saves + progress lines
- `builder/agents/build.py` — `Scanning ✓` + final-save (`always_write=True`); threads `output` into the spine's progress sink
- `AGENTS.md` §14.5 / §14.6.1 — documents progress + persistence
- `tests/test_agents_pipeline.py`, `tests/test_agents_build.py` — new tests + an autouse SESSION_DIR isolation fixture

## New tests
- pipeline: `TestPipelineStatePersistence` (`test_pipeline_writes_crate_state_json`, `test_pipeline_saves_at_least_once`, `test_pipeline_saves_at_multiple_phase_boundaries`), `TestPipelineProgress` (`test_progress_callback_receives_phase_lines`, `test_progress_defaults_to_noop`)
- build: `TestStatePersistence` (`test_final_state_persisted_interactive`, `test_final_state_persisted_headless`, `test_final_save_uses_always_write`), `TestProgressOutput` (`test_progress_lines_emitted_to_output`, `test_progress_threaded_into_pipeline`, `test_default_output_is_noop_for_progress`)

## Gates
`uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agents_build.py tests/test_agents_pipeline.py tests/test_dashboard.py tests/test_pipeline_e2e.py` → **90 passed, 1 xpassed**; `uv run ruff check` clean; `uv run --extra langchain ty check` clean. No-provider determinism (identical graph hash) tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
