### PR TITLE
fix(agents): deterministic finish backstop + completeness nudge for --legacy-react (#251)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 
     from pydantic import BaseModel
 
+    from builder.state import CrateState
+
 
 from typing import TypedDict
 
@@ -222,6 +224,12 @@ _FILE_READ_TOOLS = frozenset(
     {"read_file_sample", "read_file", "read_excel", "read_docx"}
 )
 
+# Attribute stamped on the engine once the crate has been exported this session,
+# so the deterministic finish backstop (#251) is idempotent across the two exit
+# paths (quit/exit and EOF) and never double-exports — whether the export came
+# from the agent itself or from the backstop.
+_EXPORTED_FLAG = "_crate_exported_this_session"
+
 
 def _unreadable_file_message(path: str, tool_name: str = "read_file_sample") -> str:
     """Actionable message for the LLM when a file reader can't return text.
@@ -295,6 +303,15 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     return _unreadable_file_message(
                         kwargs.get("path", ""), tool_name
                     )
+                # When the agent itself successfully exports, stamp the engine so
+                # the deterministic finish backstop (#251) does not double-export
+                # on session exit.
+                if (
+                    tool_name in ("export_crate", "build_crate")
+                    and isinstance(result, dict)
+                    and result.get("success")
+                ):
+                    setattr(engine, _EXPORTED_FLAG, True)
                 return result
 
             _run.__name__ = tool_name
@@ -625,12 +642,88 @@ def _wrap_tools_node(tool_node: Any, profiler: Any, iteration_getter: Any) -> An
     return timed_tools_node
 
 
+def _completeness_nudge(state: CrateState) -> str:
+    """Compute a short deterministic present/missing/next-action steering line.
+
+    Issue #251: once the obvious entities exist, a weak ReAct model tends to
+    stall (empty completions) instead of advancing to the process chain, file
+    attachments, validation, and export — so a crate never lands. This collapses
+    the current ``CrateState`` into ONE token-cheap line naming what is present
+    (with a ✓), what is still missing, and the single concrete *next tool* to
+    call, e.g.::
+
+        backbone ✓, person ✓, 22 compounds ✓; missing: process chain, file
+        attachments → next: draft_process_chain
+
+    When the crate looks complete (backbone + person + compounds + a process
+    chain + file attachments) the next action becomes validate + export. The
+    line is deterministic (no LLM), idempotent, and never raises — it is a pure
+    read over the entity store.
+    """
+    counts: dict[str, int] = {}
+    for ent in state.list_entities():
+        typ = getattr(ent, "type", "Unknown")
+        counts[typ] = counts.get(typ, 0) + 1
+
+    has_backbone = any(counts.get(t) for t in ("Investigation", "Study", "Assay"))
+    has_person = bool(counts.get("Person"))
+    n_compounds = counts.get("MolecularEntity", 0)
+    n_cells = counts.get("CellLineSample", 0)
+    has_process = any(counts.get(t) for t in ("LabProcess", "LabProtocol"))
+    has_files = bool(counts.get("File"))
+
+    present: list[str] = []
+    if has_backbone:
+        present.append("backbone ✓")
+    if has_person:
+        present.append("person ✓")
+    if n_compounds:
+        present.append(f"{n_compounds} compounds ✓")
+    if n_cells:
+        present.append(f"{n_cells} cell line(s) ✓")
+
+    missing: list[str] = []
+    if not has_backbone:
+        missing.append("backbone")
+    if not has_person:
+        missing.append("person/org")
+    if not n_compounds and not n_cells:
+        missing.append("compounds/cell lines")
+    if not has_process:
+        missing.append("process chain")
+    if not has_files:
+        missing.append("file attachments")
+    # Validation + export are always the closing steps until the crate lands.
+    missing.append("validation")
+    missing.append("export")
+
+    # Pick the single highest-priority next action (drives the weak model to ONE
+    # concrete step instead of re-deriving the whole plan).
+    if not has_backbone:
+        next_action = "scaffold_isa_backbone"
+    elif not n_compounds and not n_cells:
+        next_action = "resolve_compound / draft_cell_line_sample"
+    elif not has_person:
+        next_action = "draft_person"
+    elif not has_process:
+        next_action = "draft_process_chain"
+    elif not has_files:
+        next_action = "attach_files"
+    else:
+        # The crate looks complete — close it out.
+        next_action = "build_and_validate then export_crate"
+
+    present_str = ", ".join(present) if present else "nothing yet"
+    return f"[Completeness: {present_str}; missing: {', '.join(missing)} → next: {next_action}]"
+
+
 def _build_system_prompt_with_state(
     session_id: str,
     entity_count: int,
     file_count: int,
     iteration_count: int,
     next_fix: str | None = None,
+    nudge: str | None = None,
 ) -> str:
     """Build a lightweight state brief appended to the system prompt.
 
@@ -645,6 +738,11 @@ def _build_system_prompt_with_state(
     ``state.validation`` after the #153 write-back), a second line names it so a
     weak model has a durable next-step pointer and stops re-deriving the
     BASE->ISA->TOX plan from the system prompt every turn.
+
+    When ``nudge`` is given (the deterministic present/missing/next-action line
+    from :func:`_completeness_nudge`, #251), it is appended as a third line so a
+    weak model is steered to the next concrete step instead of stalling once the
+    obvious entities exist.
     """
     brief = (
         f"[Session: {session_id} | "
@@ -654,6 +752,8 @@ def _build_system_prompt_with_state(
     )
     if next_fix:
         brief += f"\n[Next REQUIRED fix: {next_fix}]"
+    if nudge:
+        brief += f"\n{nudge}"
     return brief
 
 
@@ -779,6 +879,7 @@ def _assemble_model_messages(
     file_count: int,
     iteration_count: int,
     next_fix: str | None = None,
+    nudge: str | None = None,
     max_history_tokens: int | None = None,
 ) -> list:
     """Assemble the message list for a model invocation with a cache-friendly
@@ -821,6 +922,7 @@ def _assemble_model_messages(
         file_count=file_count,
         iteration_count=iteration_count,
         next_fix=next_fix,
+        nudge=nudge,
     )
     return [
         SystemMessage(content=SYSTEM_PROMPT),
@@ -936,6 +1038,10 @@ def _build_agent_graph(
         # surfaced in the brief as a durable next-step pointer for a weak model.
         required_issues = engine.state.validation.required_issues
         next_fix = required_issues[0] if required_issues else None
+        # Deterministic completeness nudge (#251): present/missing/next-action,
+        # so a weak model is steered to the next concrete step instead of
+        # stalling once the obvious entities exist.
+        nudge = _completeness_nudge(engine.state)
         model_messages = _assemble_model_messages(
             messages,
             session_id=engine.state.session_id,
@@ -943,6 +1049,7 @@ def _build_agent_graph(
             file_count=len(engine.state.scanned_files),
             iteration_count=engine.state.iteration_count,
             next_fix=next_fix,
+            nudge=nudge,
         )
         # Progressive tool disclosure (#156): advertise only the state-relevant
         # subset so a weak model chooses from a smaller menu. Bind per-turn; the
@@ -972,6 +1079,98 @@ def _build_agent_graph(
     graph.add_edge(START, "model")
 
     return graph.compile(checkpointer=MemorySaver())
+
+
+# ---------------------------------------------------------------------------
+# Deterministic finish backstop (#251)
+# ---------------------------------------------------------------------------
+
+
+def _finish_backstop(
+    engine: AgentEngine,
+    *,
+    emit: Any = None,
+) -> dict[str, Any] | None:
+    """Deterministically build + export the crate on session end (#251).
+
+    The weak ReAct model frequently stalls (empty completions) *before* ever
+    choosing ``export_crate``, so a rich in-memory crate exits without anything
+    landing on disk. This backstop guarantees a crate is always written when the
+    session ends with un-exported entities:
+
+    1. If the crate is **empty** (``state.list_entities()`` is falsy) there is
+       nothing to write — return ``None`` (no build, no export).
+    2. If the crate was **already exported this session** (the agent chose to, or
+       the backstop already ran) — return ``None`` (idempotent, no double-export).
+    3. Otherwise run ``build_and_validate`` then ``export_crate`` via
+       ``engine.run_tool`` (so each is profiled and validation is cached).
+       ``export_crate`` is called with no explicit path so it honors
+       ``state.metadata.output_path`` (default ``<input>-ro-crate/``). The
+       resolved ABSOLUTE crate path is surfaced via *emit*.
+
+    This runs on the **exit path**, so it must NEVER raise: every failure is
+    caught, logged, surfaced via *emit*, and reported as a ``{"success": False}``
+    result (or ``None``). The export-success flag is stamped on the engine so a
+    second call is a no-op.
+
+    Args:
+        engine: The engine whose ``state`` is built and written.
+        emit: Optional single-arg sink for human-readable status lines (e.g.
+            ``console.print`` or ``print``). Defaults to a no-op.
+
+    Returns:
+        The ``export_crate`` result dict on a fresh export, or ``None`` when
+        there was nothing to export / it was already exported / it failed before
+        producing a result.
+    """
+    say = emit or (lambda _msg: None)
+
+    try:
+        if not engine.state.list_entities():
+            # Nothing to write — a clean no-op (e.g. user quit immediately).
+            return None
+        if getattr(engine, _EXPORTED_FLAG, False):
+            # Already exported this session (agent did it, or a prior backstop).
+            return None
+
+        say("Finalizing: building and exporting the crate before exit…")
+        # Build + validate in memory first so the written crate is the validated
+        # one (mirrors the deterministic pipeline's finish, §14.5/§14.6.1).
+        try:
+            engine.run_tool("build_and_validate")
+        except (ValueError, KeyError, TypeError, RuntimeError) as exc:
+            # A validation hiccup must not block the export — log and continue.
+            logger.warning("Finish backstop: build_and_validate failed: %s", exc)
+
+        # No explicit path → export_crate resolves state.metadata.output_path
+        # (CLI --output / default <input>-ro-crate/) then the session fallback.
+        result = engine.run_tool("export_crate")
+
+        if isinstance(result, dict) and result.get("success"):
+            # Stamp BEFORE surfacing so any later call is a strict no-op.
+            setattr(engine, _EXPORTED_FLAG, True)
+            crate_path = result.get("crate_path")
+            try:
+                from pathlib import Path
+
+                resolved = str(Path(crate_path).resolve()) if crate_path else crate_path
+            except (OSError, TypeError, ValueError):
+                resolved = crate_path
+            say(f"Crate written to: {resolved}")
+            logger.info("Finish backstop exported crate to %s", resolved)
+            return result
+
+        # export_crate returned a failure dict (it never raises by contract).
+        error = (result or {}).get("error") if isinstance(result, dict) else result
+        logger.error("Finish backstop: export_crate failed: %s", error)
+        say(f"Could not write the crate on exit: {error}")
+        return result if isinstance(result, dict) else None
+
+    except Exception as exc:  # noqa: BLE001 — the exit path must never raise.
+        # A crate failing to land must never crash the goodbye/quit flow.
+        logger.exception("Finish backstop failed unexpectedly")
+        say(f"Could not write the crate on exit: {exc}")
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -1422,6 +1621,17 @@ def run_interactive_agent(
         console.print(Panel(t, title="[yellow]Goodbye![/yellow]", border_style="yellow"))
         console.print()
 
+    def _finalize_on_exit() -> None:
+        """Deterministically build + export the crate before the goodbye (#251).
+
+        The weak ReAct model often stalls before it ever calls ``export_crate``,
+        so a rich in-memory crate would exit unwritten. This guarantees a crate
+        ALWAYS lands when the session ends with un-exported entities. It is
+        idempotent (never double-exports) and never raises (the goodbye must
+        always print).
+        """
+        _finish_backstop(engine, emit=console.print)
+
     # ── Main loop ───────────────────────────────────────────────────────
     while True:
         try:
@@ -1439,10 +1649,12 @@ def run_interactive_agent(
         except EOFError:
             # Ctrl+D: exit
             console.print()
+            _finalize_on_exit()
             _print_goodbye(engine.state)
             break
 
         if user_input.lower() in ("quit", "exit", "q"):
+            _finalize_on_exit()
             _print_goodbye(engine.state)
             break
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -924,4 +924,241 @@ class TestThinkingSpinnerPause:
         assert sp._paused.is_set() is False  # resumed after
 
 
+class TestCompletenessNudge:
+    """Issue #251: a deterministic present/missing/next-action nudge in the
+    per-turn brief steers the weak model to the next concrete step instead of
+    stalling once the obvious entities exist."""
+
+    def _state(self, *types: str):
+        """A CrateState pre-populated with one entity per requested type."""
+        from builder.state import CrateState, Entity
+
+        state = CrateState()
+        for i, t in enumerate(types):
+            state.add_entity(Entity(entity_id=f"e{i}", type=t))  # ty: ignore[invalid-argument-type]
+        return state
+
+    def test_nudge_lists_present_and_missing_with_next_action(self):
+        """Backbone + person + compounds but no process chain / files / export
+        => the nudge names what's present, what's missing, and a next action."""
+        from builder.agents.agent_loop import _completeness_nudge
+
+        state = self._state(
+            "Investigation",
+            "Study",
+            "Assay",
+            "Person",
+            "MolecularEntity",
+            "MolecularEntity",
+        )
+        nudge = _completeness_nudge(state)
+
+        # Present items are surfaced (with the ✓ marker)
+        assert "backbone ✓" in nudge
+        assert "person ✓" in nudge
+        # Compound count is surfaced
+        assert "2 compounds ✓" in nudge
+        # Missing items are named
+        assert "process chain" in nudge
+        assert "file" in nudge.lower()
+        assert "export" in nudge.lower()
+        # A concrete next-action hint with real tool names is present
+        assert "next:" in nudge.lower()
+        assert (
+            "draft_process_chain" in nudge
+            or "attach_files" in nudge
+            or "build_and_validate" in nudge
+            or "export_crate" in nudge
+        )
+
+    def test_nudge_is_short(self):
+        """The nudge stays token-cheap — a single short line."""
+        from builder.agents.agent_loop import _completeness_nudge
+
+        state = self._state("Investigation", "Study", "Assay", "Person")
+        nudge = _completeness_nudge(state)
+        assert nudge.count("\n") == 0
+        assert len(nudge) < 320
+
+    def test_complete_state_suggests_validate_and_export(self):
+        """When the crate looks complete (backbone, person, compounds, process
+        chain, files), the nudge suggests validate + export."""
+        from builder.agents.agent_loop import _completeness_nudge
+
+        state = self._state(
+            "Investigation",
+            "Study",
+            "Assay",
+            "Person",
+            "MolecularEntity",
+            "LabProcess",
+            "File",
+        )
+        nudge = _completeness_nudge(state)
+        assert "export_crate" in nudge or "export" in nudge.lower()
+        assert "build_and_validate" in nudge or "validate" in nudge.lower()
+
+    def test_empty_state_nudge_does_not_crash(self):
+        """An empty crate still yields a (short, non-crashing) nudge."""
+        from builder.agents.agent_loop import _completeness_nudge
+
+        nudge = _completeness_nudge(self._state())
+        assert isinstance(nudge, str)
+        # The very first thing to do on an empty crate is the backbone
+        assert "backbone" in nudge.lower()
+
+    def test_brief_includes_nudge_when_passed(self):
+        """_build_system_prompt_with_state surfaces the nudge when given one."""
+        from builder.agents.agent_loop import _build_system_prompt_with_state
+
+        nudge = "backbone ✓; missing: export → next: export_crate"
+        brief = _build_system_prompt_with_state(
+            session_id="sid",
+            entity_count=3,
+            file_count=0,
+            iteration_count=1,
+            nudge=nudge,
+        )
+        assert nudge in brief
+
+    def test_brief_omits_nudge_line_when_none(self):
+        """No nudge => the brief is unchanged (back-compat)."""
+        from builder.agents.agent_loop import _build_system_prompt_with_state
+
+        brief = _build_system_prompt_with_state(
+            session_id="sid",
+            entity_count=0,
+            file_count=0,
+            iteration_count=1,
+        )
+        assert "next:" not in brief.lower()
+
+
+class TestFinishBackstop:
+    """Issue #251: a deterministic finish backstop guarantees a crate lands on
+    disk when the session ends with un-exported entities — even when the weak
+    LLM stalled before ever calling export_crate."""
+
+    def _engine(self, *types: str):
+        """A real engine with one entity per requested type."""
+        from builder.engine import AgentEngine
+        from builder.state import Entity
+
+        engine = AgentEngine()
+        engine.state.session_id = "test_backstop"
+        for i, t in enumerate(types):
+            engine.state.add_entity(Entity(entity_id=f"e{i}", type=t))  # ty: ignore[invalid-argument-type]
+        return engine
+
+    def _spy(self, engine):
+        """Replace engine.run_tool with a recording spy that no-ops the heavy
+        build/validate/export tools and records the call order."""
+        calls: list[str] = []
+
+        def fake_run_tool(tool_name: str, **kwargs):
+            calls.append(tool_name)
+            if tool_name == "export_crate":
+                return {"success": True, "crate_path": "/tmp/out-ro-crate", "error": None}
+            return {"ok": True}
+
+        engine.run_tool = fake_run_tool  # type: ignore[method-assign]
+        return calls
+
+    def test_backstop_builds_and_exports_when_entities_exist(self):
+        """Non-empty crate not yet exported => build_and_validate THEN
+        export_crate run, and the resolved path is surfaced."""
+        from builder.agents.agent_loop import _finish_backstop
+
+        engine = self._engine("Investigation", "Study")
+        calls = self._spy(engine)
+        surfaced: list[str] = []
+
+        result = _finish_backstop(engine, emit=surfaced.append)
+
+        assert "build_and_validate" in calls
+        assert "export_crate" in calls
+        # build_and_validate must precede export_crate
+        assert calls.index("build_and_validate") < calls.index("export_crate")
+        assert result is not None and result.get("success") is True
+        # The resolved path is surfaced to the user
+        assert any("ro-crate" in m for m in surfaced)
+
+    def test_backstop_noop_when_crate_empty(self):
+        """An empty crate => no build, no export (nothing to write)."""
+        from builder.agents.agent_loop import _finish_backstop
+
+        engine = self._engine()  # no entities
+        calls = self._spy(engine)
+
+        result = _finish_backstop(engine, emit=lambda _m: None)
+
+        assert calls == []
+        assert result is None
+
+    def test_backstop_is_idempotent(self):
+        """Calling the backstop twice exports only once (no double-export)."""
+        from builder.agents.agent_loop import _finish_backstop
+
+        engine = self._engine("Investigation")
+        calls = self._spy(engine)
+
+        _finish_backstop(engine, emit=lambda _m: None)
+        first = list(calls)
+        _finish_backstop(engine, emit=lambda _m: None)
+
+        assert calls.count("export_crate") == 1, (
+            f"export_crate must run at most once, got {calls}"
+        )
+        # The second call adds nothing
+        assert calls == first
+
+    def test_backstop_never_raises(self):
+        """A failure inside the export path is caught, not propagated out of the
+        exit path."""
+        from builder.agents.agent_loop import _finish_backstop
+
+        engine = self._engine("Investigation")
+
+        def boom(tool_name: str, **kwargs):
+            raise RuntimeError("export blew up")
+
+        engine.run_tool = boom  # type: ignore[method-assign]
+
+        # Must not raise
+        result = _finish_backstop(engine, emit=lambda _m: None)
+        assert result is None or result.get("success") is False
+
+    def test_backstop_honors_metadata_output_path(self):
+        """export_crate is called via run_tool with no explicit path so it honors
+        state.metadata.output_path; the resolved path is surfaced."""
+        from builder.agents.agent_loop import _finish_backstop
+
+        engine = self._engine("Investigation")
+        engine.state.metadata.output_path = "/tmp/custom-ro-crate"
+        captured: list[str] = []
+
+        def fake_run_tool(tool_name: str, **kwargs):
+            if tool_name == "export_crate":
+                # honor metadata.output_path exactly as export_crate would
+                path = kwargs.get("output_path") or engine.state.metadata.output_path
+                return {"success": True, "crate_path": path, "error": None}
+            return {"ok": True}
+
+        engine.run_tool = fake_run_tool  # type: ignore[method-assign]
+
+        _finish_backstop(engine, emit=captured.append)
+        assert any("custom-ro-crate" in m for m in captured)
+
+    def test_run_interactive_agent_calls_backstop_on_exit(self):
+        """run_interactive_agent must call the backstop on its exit paths."""
+        import inspect
+
+        from builder.agents import agent_loop
+
+        source = inspect.getsource(agent_loop.run_interactive_agent)
+        assert "_finish_backstop" in source, (
+            "run_interactive_agent must invoke _finish_backstop on session end"
+        )
+
+
 


### PR DESCRIPTION
Closes #251

The `--legacy-react` agent (`run_interactive_agent` in `builder/agents/agent_loop.py`) builds a strong partial crate then **stalls** (the weak LLM emits empty completions) before it ever chooses `export_crate`, so a rich in-memory crate exits **without anything landing on disk**. It also lacks "what's left / do this next" steering once the obvious entities exist. Two fixes, both confined to `agent_loop.py` + tests.

## 1. Deterministic finish backstop (`_finish_backstop`)

A crate now **always** lands when the session ends with un-exported entities.

**Where it fires:** on the session exit paths in `run_interactive_agent` — the `quit`/`exit`/`q` branch and the EOF (Ctrl+D) branch — via a `_finalize_on_exit()` closure invoked **just before** `_print_goodbye`.

**What it does:** if `engine.state.list_entities()` is non-empty **and** the crate has not been exported this session, it runs `build_and_validate` then `export_crate(engine.state)` through `engine.run_tool` (so both are profiled / validation-cached). `export_crate` is called with **no explicit path**, so it honors `state.metadata.output_path` (default `<input>-ro-crate/`) then the session fallback. The resolved **absolute** crate path is surfaced to the console.

**Guarantees:**
- **No-op on an empty crate** (nothing to write → returns `None`, no build, no export).
- **Idempotent / no double-export** — an `_crate_exported_this_session` flag is stamped on the engine whether the *agent* exported (detected in the LangChain tool wrapper on a successful `export_crate`/`build_crate`) or the *backstop* did, so a second call (e.g. EOF after quit, or the agent already exported) is a strict no-op.
- **Never raises out of the exit path** — every failure is caught, logged, and reported (the goodbye must always print).

## 2. Completeness nudge (`_completeness_nudge`)

A short, deterministic **present / missing / next-action** line is computed from `CrateState` and appended to the per-turn state brief (in the dynamic brief builder `_build_system_prompt_with_state`, threaded through `_assemble_model_messages` → `call_model`). `system_prompt.py` is **not** touched (owned by another open PR).

**Nudge format** (single token-cheap line):

```
[Completeness: backbone ✓, person ✓, 22 compounds ✓; missing: process chain, file attachments, validation, export → next: draft_process_chain]
```

The single highest-priority `next:` action is chosen deterministically: `scaffold_isa_backbone` → `resolve_compound / draft_cell_line_sample` → `draft_person` → `draft_process_chain` → `attach_files` → and, when the crate looks complete, `build_and_validate then export_crate`.

## Tests (TDD, red → green)

`tests/test_agent_loop.py`, two new classes (12 tests):
- `TestCompletenessNudge`: present/missing/next-action content, single-line/short, complete-state → validate+export, empty state, brief includes/omits the nudge.
- `TestFinishBackstop`: builds+exports (order: validate before export) and surfaces the path, no-op on empty crate, idempotent (single export), never raises, honors `metadata.output_path`, and `run_interactive_agent` invokes the backstop on exit.

## Gates
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agent_loop.py` → **61 passed**
- `uv run ruff check` → **All checks passed!**
- `uv run --extra langchain ty check` → clean for changed files (one pre-existing unrelated diagnostic in `tests/test_agents_guidance.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)