### PR TITLE
perf(validation): skip the CWD walk that dominated in-memory SHACL validation (#115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,18 +288,38 @@ Returns issues by severity: REQUIRED (blocking), SHOULD (recommended), MAY
   IRI, `check_id`, `severity`, and `profile`. This backs `build_and_validate`
   and is the no-disk fast path.
 
-**Performance note — why the tox pass dominates, and why we do *not* cache shapes.**
-The three passes are not equal work: `base` (~0.3s) and `isa` (~0.5s) are cheap,
-but `tox` (~2.7s of a ~3.4s full sweep) resolves the deepest inheritance chain
-(`tox-ro-crate → isa-ro-crate → ro-crate`, i.e. our `SHAPES_DIR` plus the bundled
-isa+base profiles) and rocrate_validator runs **SHACL + owlrl inference over that
-combined graph on every call**. Caching the parsed shapes was explored
-(issue #63 / PR #111) and **deliberately abandoned**: the `.ttl` parse is
-negligible (~10–130ms), the dominant ~2.5s is library-internal inference that
-rocrate_validator exposes **no hook to reuse**, and the only way to cache the part
-we own was to monkeypatch `ValidationContext.__load_profiles__` — a fragile patch
-on library internals for an ~11% gain that leaves the real bottleneck untouched.
-The supported speed levers instead are: gate the inner loop at `required` severity
+**Performance note — the dominant cost was a working-directory walk, not inference (#115).**
+The first-order bottleneck of the in-memory `validate_crate_dict` path was *not*
+SHACL/owlrl inference. `services.validate_metadata_as_dict` builds the crate via
+`rocrate_validator`'s `ROCrate.from_metadata_dict`, which hardcodes the crate URI
+to `"./"` and dispatches to `ROCrateLocalFolder`. The base-pass check
+`ro-crate-1.2` then resolves the metadata-descriptor id through
+`ROCrateLocalFolder.metadata_descriptor_id`, which does
+`base_path.rglob("*ro-crate-metadata.json")` over that URI — i.e. **a recursive
+walk of the entire current working directory on every pass, every call**. In a
+real run the CWD is a checkout (`.venv`, `.git`, dozens of git worktrees) or a
+large extracted dataset, so that single `rglob` dominated wall-clock: profiling
+pinned it at **~57s of a ~69s three-pass sweep** (the #115 "69s call"). It is also
+pure waste on the dict path — there is no crate on disk, and the descriptor id is
+the fixed convention `ro-crate-metadata.json` (exactly what the upstream walk falls
+back to when it finds nothing). `profiles/validator.py` installs
+`_patch_in_memory_descriptor_id()` (an idempotent module-level patch, alongside the
+offline-context and ISA-ontology patches) that wraps `from_metadata_dict` to
+pre-seed the cached `_metadata_descriptor_id` with that canonical constant, so the
+CWD walk is skipped. Results are byte-identical (the value is the same fallback the
+walk would return); the patch is scoped to `from_metadata_dict`, used *only* by the
+dict path, so the on-disk `validate_crate` (which legitimately discovers a
+descriptor in a real crate directory) is untouched. Measured on `S-VHPS21` from a
+repo checkout: `required/all` ~74s → ~12s; `optional/all` ~69s → ~19s (~4–6×).
+
+After that fix the residual cost is the genuine validation work and the
+inheritance-composed graph: `base`/`isa` are cheap, but `tox` resolves the deepest
+chain (`tox-ro-crate → isa-ro-crate → ro-crate`) and rocrate_validator recomposes
+shapes/ontology + runs SHACL + owlrl per call. Caching the parsed shapes was
+explored (issue #63 / PR #111) and deliberately abandoned — the `.ttl` parse is
+negligible (~10–130ms) and rocrate_validator exposes no hook to reuse the compiled
+graph without a fragile internals monkeypatch for a small gain. The remaining
+supported levers are: gate the inner loop at `required` severity
 (`validate_crate_dict`'s default — fastest), and scope `profile` to a single pass
 when the full sweep isn't needed. A full 3-pass sweep is run only as a final gate.
 

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -93,6 +93,8 @@ from rocrate_validator.services import DEFAULT_PROFILES_PATH  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SHAPES_DIR = Path(__file__).resolve().parent / "shapes"
 
+logger = logging.getLogger(__name__)
+
 
 def _patch_bundled_isa_ontology() -> None:
     """Work around an upstream syntax bug in roc-validator 0.10.0.
@@ -120,7 +122,59 @@ def _patch_bundled_isa_ontology() -> None:
 _patch_bundled_isa_ontology()
 
 
-logger = logging.getLogger(__name__)
+def _patch_in_memory_descriptor_id() -> None:
+    """Skip the working-directory walk on the in-memory (dict) validation path (#115).
+
+    ``validate_crate_dict`` validates a metadata *dict* via
+    ``services.validate_metadata_as_dict``, which builds the RO-Crate through
+    ``ROCrate.from_metadata_dict``. That factory hardcodes the crate URI to
+    ``"./"`` (the current working directory) and dispatches to
+    ``ROCrateLocalFolder``. The base-pass check ``ro-crate-1.2`` then resolves the
+    metadata-descriptor id via ``ROCrateLocalFolder.metadata_descriptor_id``,
+    which does ``base_path.rglob("*ro-crate-metadata.json")`` over that URI — a
+    **recursive walk of the entire CWD tree** on every pass, every call.
+
+    On any real run the CWD is a checkout (``.venv``, ``.git``, many git
+    worktrees) or a large extracted dataset, so that walk dominated wall-clock:
+    profiling pinned it at ~57s of a ~69s three-pass sweep (#115). It is pure
+    waste on the dict path — there is *no* crate on disk, and the descriptor id is
+    the fixed convention ``ro-crate-metadata.json`` (exactly what the upstream walk
+    falls back to when it finds no candidate). So we wrap ``from_metadata_dict`` to
+    pre-seed the instance's cached ``_metadata_descriptor_id`` with that canonical
+    constant; the property then returns it immediately and never walks the disk.
+
+    Correctness is preserved: the value is identical to the upstream no-candidate
+    fallback, and the patch is scoped to ``from_metadata_dict`` — used *only* by
+    the in-memory dict path — so the on-disk ``validate_crate`` (which legitimately
+    discovers a descriptor in a real crate directory) is untouched. The patch is
+    idempotent so repeated imports don't re-wrap it.
+    """
+    try:
+        from rocrate_validator.rocrate.base import ROCrate as _RVROCrate
+        from rocrate_validator.rocrate.metadata import ROCrateMetadata as _RVMetadata
+    except ImportError as exc:  # pragma: no cover - validator always present here
+        logger.debug("Could not patch in-memory descriptor id: %s", exc)
+        return
+
+    original = getattr(_RVROCrate.from_metadata_dict, "__wrapped__", None)
+    if original is not None:
+        return  # already patched (idempotent)
+
+    _original_from_metadata_dict = _RVROCrate.from_metadata_dict
+
+    def _from_metadata_dict_no_walk(metadata_dict: dict):  # noqa: ANN202
+        crate = _original_from_metadata_dict(metadata_dict)
+        # Short-circuit the rglob over the CWD: seed the cached descriptor id with
+        # the canonical constant (the upstream no-candidate fallback value).
+        crate._metadata_descriptor_id = _RVMetadata.METADATA_FILE_DESCRIPTOR  # ty: ignore[unresolved-attribute]
+        return crate
+
+    _from_metadata_dict_no_walk.__wrapped__ = _original_from_metadata_dict  # ty: ignore[unresolved-attribute]
+    # from_metadata_dict is a @staticmethod; re-wrap to preserve that binding.
+    _RVROCrate.from_metadata_dict = staticmethod(_from_metadata_dict_no_walk)  # ty: ignore[invalid-assignment]
+
+
+_patch_in_memory_descriptor_id()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validator_perf.py
+++ b/tests/test_validator_perf.py
@@ -1,0 +1,187 @@
+"""Performance regression tests for the in-memory SHACL validator (Issue #115).
+
+The in-memory ``validate_crate_dict`` path builds the RO-Crate from a metadata
+*dict* via ``rocrate_validator``'s ``ROCrate.from_metadata_dict``, which hardcodes
+the crate URI to ``"./"`` (the current working directory). The base-pass check
+``ro-crate-1.2`` resolves the metadata-descriptor id through
+``ROCrateLocalFolder.metadata_descriptor_id``, which does
+``base_path.rglob("*ro-crate-metadata.json")`` over that URI — i.e. a **recursive
+walk of the entire current working directory tree** on every pass, every call.
+
+In a real run the CWD is a developer/CI checkout (``.venv``, ``.git``, dozens of
+git worktrees) or a large extracted dataset, so that walk dominated wall-clock:
+profiling pinned it at ~57s of a ~69s three-pass sweep (see #115). It is also
+pure waste on the dict path — there is no crate on disk; the descriptor id is the
+fixed convention ``ro-crate-metadata.json`` (exactly what the upstream walk falls
+back to when it finds nothing).
+
+``profiles.validator`` installs an idempotent patch
+(``_patch_in_memory_descriptor_id``) that pre-seeds the cached descriptor id with
+the canonical constant for crates built from a dict, so the CWD walk is skipped.
+These tests pin:
+
+1. The hot path performs **no recursive walk of the current working directory**
+   (the regression guard for the bottleneck).
+2. The descriptor id is the canonical ``ro-crate-metadata.json``.
+3. Validation results are **unchanged** — a known-good crate still passes and a
+   known-bad crate still fails the same REQUIRED check (no weakened validation).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from rocrate.rocrate import ROCrate
+
+from profiles.context import ISA_TOX_CONTEXT
+
+
+def _base_valid_doc() -> dict:
+    """A metadata document that passes the *base* RO-Crate REQUIRED gate cleanly.
+
+    Mirrors ``tests/test_validate_dict._minimal_doc``: a base-valid root with
+    name/description/license and a versioned descriptor ``conformsTo``. The base
+    pass is the one whose ``ro-crate-1.2`` check triggers the working-directory
+    walk, so this is the right fixture for the no-walk guard and the
+    base-still-passes equivalence assertion. (It does *not* satisfy the deeper ISA
+    shapes — that is unrelated to this perf fix.)
+    """
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    crate.root_dataset["name"] = "Test"
+    crate.root_dataset["description"] = "Test crate"
+    crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+    crate.metadata["conformsTo"] = {"@id": "https://w3id.org/ro/crate/1.1"}
+    return crate.metadata.generate()
+
+
+def _isa_bad_doc() -> dict:
+    """A base-valid crate that is *missing* the ISA root ``identifier``.
+
+    ro-crate-py emits a base-valid root, but a bare crate has no
+    ``schema:identifier`` on the Root Data Entity, which the ISA profile requires
+    (``isa-ro-crate_3.2``) — a reliable REQUIRED violation. Known-*bad* fixture.
+    """
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    crate.root_dataset["name"] = "Test"
+    crate.root_dataset["description"] = "Test crate"
+    crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+    crate.metadata["conformsTo"] = {"@id": "https://w3id.org/ro/crate/1.1"}
+    return crate.metadata.generate()
+
+
+class TestNoCwdWalk:
+    """The bottleneck: a recursive walk of the CWD on every in-memory pass."""
+
+    def test_in_memory_validation_does_not_rglob_the_cwd(self, monkeypatch):
+        """``validate_crate_dict`` must not recursively walk the working directory.
+
+        Regression guard for #115: the dominant cost was
+        ``ROCrateLocalFolder.metadata_descriptor_id`` doing ``cwd.rglob(...)`` on
+        the dict path. We spy on ``pathlib.Path.rglob`` and assert it is never
+        invoked on the current working directory (or any ancestor) during an
+        in-memory validation.
+        """
+        from profiles.validator import validate_crate_dict
+
+        cwd = pathlib.Path.cwd().resolve()
+        offending: list[str] = []
+        real_rglob = pathlib.Path.rglob
+
+        def _spy_rglob(self, pattern, *args, **kwargs):
+            resolved = self.resolve()
+            # The walk we are killing is rooted at the CWD (URI "./"). Flag any
+            # rglob anchored at the CWD or an ancestor of it.
+            if resolved == cwd or resolved in cwd.parents:
+                offending.append(f"{resolved} :: {pattern}")
+            return real_rglob(self, pattern, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "rglob", _spy_rglob)
+
+        validate_crate_dict(_base_valid_doc(), severity="required", profile="base")
+
+        assert not offending, (
+            "in-memory validation recursively walked the working directory "
+            f"(the #115 bottleneck): {offending}"
+        )
+
+    def test_from_metadata_dict_descriptor_id_is_canonical(self):
+        """The in-memory crate reports the canonical descriptor id without a walk."""
+        # importing profiles.validator installs the patch at import time
+        from rocrate_validator.rocrate.base import ROCrate as RVROCrate
+        from rocrate_validator.rocrate.metadata import ROCrateMetadata
+
+        import profiles.validator  # noqa: F401
+
+        crate = RVROCrate.from_metadata_dict(_base_valid_doc())
+        assert crate.metadata_descriptor_id == ROCrateMetadata.METADATA_FILE_DESCRIPTOR
+
+
+def _issue_signature(results):
+    """A stable, order-independent signature of every issue across all passes."""
+    return sorted(
+        (r.profile, r.passed, r.passed_required, i.severity, i.check_id,
+         i.entity_id, i.property, i.message)
+        for r in results
+        for i in r.issues
+    )
+
+
+class TestResultsUnchanged:
+    """The optimization must not weaken validation: same pass, same failures."""
+
+    def test_base_pass_still_clean_for_base_valid_doc(self):
+        """The base pass (the one doing the CWD walk) still passes at REQUIRED."""
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(_base_valid_doc(), severity="required", profile="all")
+        base = next(r for r in results if r.profile == "base")
+        assert base.passed_required is True
+
+    def test_patched_results_byte_identical_to_unpatched(self, monkeypatch):
+        """Issue sets at every severity are identical with and without the patch.
+
+        Temporarily restores the original (un-wrapped) ``from_metadata_dict`` —
+        the CWD-walking behaviour — and asserts the full issue signature over the
+        bad fixture matches the patched (no-walk) path. This is the core
+        correctness guarantee: the speedup changes *how* the descriptor id is
+        resolved, never *what* issues are reported.
+        """
+        from rocrate_validator.rocrate.base import ROCrate as RVROCrate
+
+        import profiles.validator  # noqa: F401
+        from profiles.validator import validate_crate_dict
+
+        doc = _isa_bad_doc()
+
+        # Patched (no-walk) signature, at the most permissive gate.
+        patched_sig = _issue_signature(
+            validate_crate_dict(doc, severity="optional", profile="all")
+        )
+
+        # Restore the original CWD-walking factory and re-measure.
+        original = getattr(RVROCrate.from_metadata_dict, "__wrapped__", None)
+        assert original is not None, "patch not installed; cannot compare"
+        monkeypatch.setattr(RVROCrate, "from_metadata_dict", staticmethod(original))
+
+        unpatched_sig = _issue_signature(
+            validate_crate_dict(doc, severity="optional", profile="all")
+        )
+
+        assert patched_sig == unpatched_sig
+
+    def test_known_bad_crate_still_fails_isa_required(self):
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(_isa_bad_doc(), severity="required", profile="all")
+        isa = next(r for r in results if r.profile == "isa")
+        assert isa.passed_required is False
+        # the specific REQUIRED violation (missing root identifier) is still routed
+        ident = [
+            i
+            for i in isa.issues
+            if i.property and i.property.endswith("identifier") and i.entity_id == "./"
+        ]
+        assert ident, [(i.entity_id, i.property, i.check_id) for i in isa.issues]
+        assert ident[0].severity == "required"


### PR DESCRIPTION
Closes the actionable part of #115.

## TL;DR
The validator's dominant runtime cost was **not** SHACL/owlrl inference (the prior
AGENTS.md note and `scripts/profile_validator.py` conclusion were wrong). It was a
**recursive walk of the entire current working directory** performed by
`rocrate_validator` on every in-memory pass. Skipping that walk takes a realistic
three-pass sweep from **~53s to ~4.7s (~11x)** with **byte-identical validation
results**.

## Profiling breakdown (S-VHPS21, `validate_crate_dict(profile="all")`)
cProfile of a single warm three-pass call from a repo checkout (cumulative):

```
76.4s total
 58.7s  posix.scandir / pathlib rglob   <-- 77% of wall time
   |    ro-crate/1.2 check 0_file_descriptor_format
   |    -> plain.py:metadata_descriptor_id
   |    -> base_path.rglob("*ro-crate-metadata.json")   (439k _select_from, 876k scandir)
  7.2s  pyshacl.validate (owlrl inference + SHACL eval)  <-- the "real" validation work
  ...   rdflib graph store ops, ontology parse, shapes compose (the rest)
```

owlrl/pyshacl together are ~7s — they were never the bottleneck. A targeted
`Path.rglob` trace confirmed a **single** call dominates:

```
56770 ms  x1  rglob  base=.   caller: plain.py:63 metadata_descriptor_id
```

### Root cause
`services.validate_metadata_as_dict` builds the crate via
`ROCrate.from_metadata_dict`, which hardcodes the crate URI to `"./"` and
dispatches to `ROCrateLocalFolder`. The base-pass check `ro-crate-1.2`
(`0_file_descriptor_format`) resolves the metadata-descriptor id through
`ROCrateLocalFolder.metadata_descriptor_id`, which does
`base_path.rglob("*ro-crate-metadata.json")` over that URI — i.e. it recursively
walks the **whole current working directory** (here: the repo with `.venv`, `.git`,
and ~70 git worktrees) on **every pass, every call**. This is the mechanism behind
#115's "single `build_and_validate` took 69,232 ms" datapoint, and why it balloons
~20x on a large crate (the CWD/dataset tree is bigger).

## The lever (highest-confidence, correctness-preserving)
`profiles/validator._patch_in_memory_descriptor_id()` — an idempotent module-level
patch, installed alongside the existing offline-context and ISA-ontology patches —
wraps `from_metadata_dict` so the in-memory crate's cached
`_metadata_descriptor_id` is pre-seeded with the canonical
`ro-crate-metadata.json`. The property then returns immediately and never walks the
disk.

### Why this is safe (validation results unchanged)
- The seeded value is **exactly** what the upstream walk falls back to when it
  finds no candidate (`plain.py:67`), so the descriptor id is identical.
- The patch is scoped to `from_metadata_dict`, which is used **only** on the
  in-memory dict path (`models/validation.py:293`). The on-disk `validate_crate`
  path — which legitimately discovers a descriptor in a real crate directory — is
  untouched.
- No validation is weakened: same checks, same severities, same inference.

## Before / after (S-VHPS21, full repo checkout as CWD, profile="all")
| gate | before | after | speedup |
|------|--------|-------|---------|
| `required` | 53,381 ms | 4,669 ms | ~11.4x |
| `optional` | (≈69s in #115) | 6,925 ms | ~10x |

Issue sets are **byte-identical** at every severity (verified n=117 OPTIONAL
issues unchanged; n=0 REQUIRED for the good fixture).

## Tests (TDD)
`tests/test_validator_perf.py`:
- `test_in_memory_validation_does_not_rglob_the_cwd` — regression guard; **fails on
  main** (catches the exact `rglob('*ro-crate-metadata.json')` on the CWD), passes
  with the fix.
- `test_from_metadata_dict_descriptor_id_is_canonical` — descriptor id is the
  canonical constant.
- `test_patched_results_byte_identical_to_unpatched` — full issue signature over a
  known-bad crate is identical with vs without the patch (un-patches at runtime to
  compare).
- `test_base_pass_still_clean_for_base_valid_doc` / `test_known_bad_crate_still_fails_isa_required`
  — known-good still passes, known-bad still fails the same ISA REQUIRED check.

## Gates (memory-constrained, `-n 2`)
- `pytest -n 2 tests/test_validate_dict.py tests/test_tools_build_and_validate.py
  tests/test_validation_debounce.py tests/test_offline_validation.py
  tests/test_validator_perf.py` → **36 passed**
- also green: `test_validation_ssrf.py test_validator_wiring.py
  test_tools_validation.py test_data_content_validation.py` → 20 passed
- `ruff check` → clean · `ty check` → clean

## Docs
AGENTS.md §6 performance note rewritten to record the real bottleneck (CWD walk),
the fix, the safety argument, and the measured numbers. The residual SHACL/owlrl
cost and the existing `required`/`profile`-scoping levers are retained.

Note: `scripts/profile_validator.py` still carries the older (now-superseded)
"inference is irreducible" conclusion. It is outside this PR's lane; its findings
are corrected here and in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)