### PR TITLE
fix(dashboard): restore live auto-refresh (basename match for relative SESSION_DIR)

### DIFF
--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -962,9 +962,17 @@ def _change_touches(changes: Any, watched: set[str]) -> bool:
     re-render only when ``profile.ndjson`` or ``crate_state.json`` actually changed
     so unrelated churn doesn't thrash the display. ``changes`` is the
     ``set[tuple[Change, str]]`` yielded by ``watchfiles.watch``.
+
+    Matching is by **basename**, not full path. ``watchfiles`` yields ABSOLUTE
+    paths, but ``watched`` is built from ``SESSION_DIR`` which is *relative*
+    (``Path("sessions")``), so a full-string ``path in watched`` never matched and
+    the dashboard stopped refreshing entirely (regression from the dir-watch
+    change). Comparing file names is robust to relative-vs-absolute and symlinked
+    paths.
     """
+    names = {Path(p).name for p in watched}
     try:
-        return any(path in watched for _change, path in changes)
+        return any(Path(path).name in names for _change, path in changes)
     except TypeError:
         return False
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -440,3 +440,22 @@ class TestLiveRefresh:
         # the atomic-save temp churn must NOT trigger a re-render
         assert _change_touches({(1, "/s/.crate_state_tmp_abc")}, watched) is False
         assert _change_touches(set(), watched) is False
+
+    def test_change_touches_matches_relative_watched_vs_absolute_event(self) -> None:
+        """REGRESSION: SESSION_DIR is relative ('sessions'), so `watched` holds
+        RELATIVE paths, but watchfiles yields ABSOLUTE paths. Full-string matching
+        never hit and the dashboard stopped refreshing — match by basename."""
+        from builder.tools.dashboard import _change_touches
+
+        # watched built from a relative SESSION_DIR; events arrive absolute.
+        watched = {"sessions/20260626_x/profile.ndjson", "sessions/20260626_x/crate_state.json"}
+        assert _change_touches(
+            {(2, "/Users/me/repo/sessions/20260626_x/profile.ndjson")}, watched
+        ) is True
+        assert _change_touches(
+            {(1, "/Users/me/repo/sessions/20260626_x/crate_state.json")}, watched
+        ) is True
+        # unrelated absolute churn still ignored
+        assert _change_touches(
+            {(1, "/Users/me/repo/sessions/20260626_x/.crate_state_tmp_x")}, watched
+        ) is False


### PR DESCRIPTION
## Regression
#248 switched the live dashboard to watch the session **directory** and added a `_change_touches` filter — but it compared `watchfiles`' **absolute** event paths against `watched`, which is built from the **relative** `SESSION_DIR` (`Path("sessions")`). `path in watched` therefore never matched → `live.update()` never fired → the dashboard stopped auto-refreshing (it "used to work perfectly" pre-#248).

## Fix
Match by **basename** (`profile.ndjson` / `crate_state.json`), robust to relative-vs-absolute and symlinked paths. Temp-file churn (`.crate_state_tmp_*`) still filtered out.

## Test
`test_change_touches_matches_relative_watched_vs_absolute_event` — relative `watched` + absolute event → True (fails on the buggy version). Full `test_dashboard.py` green; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)