### PR TITLE
feat(pipeline): materialize plan publications from PDF DOI/title (#224, #245)

### DIFF
--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -43,6 +43,7 @@ call, trading strict graph-hash determinism for richer drafted content.
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any, Callable
 
 from builder.config import get_provider
@@ -623,6 +624,156 @@ def _select_process_for_protocol(
     return None
 
 
+# --- Publication recovery from PDF text (#245) ------------------------------
+#
+# A plan publication carries a TITLE only (D5 — no DOI), but when the source
+# document IS a PDF the bounded extractor (`extract_plan`) frequently hands back
+# the PDF *filename* (e.g. `Wagenaars_etal_2025_OATP1C1.pdf`) as that title.
+# Looking a DOI up by filename essentially always fails the Crossref confidence
+# gate. So when a candidate publication maps to a PDF under an approved scan root
+# we read the PDF *text* and recover a real query — a DOI (regex first; most
+# reliable) or the article title (first non-trivial heading) — and resolve with
+# THAT, never the bare filename. When neither is recoverable we skip rather than
+# query Crossref with a filename.
+
+# DOI regex (Crossref's recommended pattern): `10.<registrant>/<suffix>`. The
+# suffix runs to the first whitespace/quote/closing bracket; trailing sentence
+# punctuation is trimmed by the caller. Case-insensitive — DOIs are.
+_DOI_RE = re.compile(r"10\.\d{4,9}/[^\s\"'<>]+", re.IGNORECASE)
+
+# Strip the structured section markers `extract_pdf_text` emits (`[Page N]`,
+# `[Text] `, `[Table …]`, `[Image]`) so the title heuristic sees plain lines.
+_PDF_MARKER_RE = re.compile(r"^\[(?:Page \d+|Table[^\]]*|Image[^\]]*)\]\s*$")
+_PDF_TEXT_PREFIX = "[Text] "
+
+# A recovered title must look like a real heading, not a fragment or boilerplate.
+_MIN_TITLE_WORDS = 3
+_MIN_TITLE_CHARS = 12
+
+
+def _extract_doi_from_text(text: str) -> str | None:
+    """Recover the first DOI from PDF *text* via regex (most reliable — #245).
+
+    Returns the bare DOI (``10.…/…``, any ``doi:``/URL prefix dropped, trailing
+    sentence punctuation trimmed) or ``None`` when the text carries no DOI.
+    """
+    match = _DOI_RE.search(text or "")
+    if match is None:
+        return None
+    doi = match.group(0).rstrip(".,;)]}>\"'")
+    return doi or None
+
+
+def _extract_title_from_pdf_text(text: str) -> str | None:
+    """Recover an article title from PDF *text* — its first non-trivial line (#245).
+
+    Walks the lines of :func:`~builder.tools.scanner.extract_pdf_text` output,
+    stripping its ``[Page N]`` / ``[Text] `` / ``[Table …]`` markers, and returns
+    the first line that reads like a heading (at least :data:`_MIN_TITLE_WORDS`
+    words and :data:`_MIN_TITLE_CHARS` characters, and not itself a DOI/URL). This
+    is descriptive parsing of the document body, not identifier fabrication
+    (D5-safe). Returns ``None`` when no plausible title line is found.
+    """
+    for raw_line in (text or "").splitlines():
+        line = raw_line.strip()
+        if not line or _PDF_MARKER_RE.match(line):
+            continue
+        if line.startswith(_PDF_TEXT_PREFIX):
+            line = line[len(_PDF_TEXT_PREFIX):].strip()
+        if not line:
+            continue
+        # A DOI/URL line is not a title; keep scanning.
+        if _DOI_RE.search(line) or line.lower().startswith(("http://", "https://", "doi:")):
+            continue
+        if len(line) >= _MIN_TITLE_CHARS and len(line.split()) >= _MIN_TITLE_WORDS:
+            return line
+    return None
+
+
+def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
+    """Path of the scanned PDF a plan publication *title* refers to, or ``None``.
+
+    A plan publication is treated as PDF-backed when its ``title`` itself names a
+    PDF (ends in ``.pdf``) and a scanned file matches it by basename — the common
+    #245 case where the extractor returned the filename as the title. The returned
+    path is **fail-closed to ``approved_scan_roots``** (the containment guard the
+    rest of the spine uses), so the publication path never widens filesystem
+    access. Returns ``None`` when the title is an ordinary article title (resolve
+    it directly) or names no scanned PDF.
+    """
+    candidate = title.strip()
+    if not candidate.lower().endswith(".pdf"):
+        return None
+
+    from pathlib import PurePath
+
+    from builder.tools.scanner import _contain
+
+    wanted = PurePath(candidate).name.lower()
+    roots = engine.state.approved_scan_roots
+    for f in engine.state.scanned_files:
+        fname = (f.filename or PurePath(f.path).name or "").lower()
+        if fname != wanted:
+            continue
+        # Fail-closed: only read a file that resolves inside an approved root.
+        if _contain(f.path, roots) is None:
+            logger.debug(
+                "Publication PDF %s is outside approved scan roots — skipping (#245).",
+                f.path,
+            )
+            return None
+        return f.path
+    return None
+
+
+def _recover_publication_query(
+    engine: AgentEngine, title: str
+) -> tuple[str, str] | None:
+    """Resolve a plan publication *title* to a real Crossref query (#245).
+
+    Returns one of:
+
+    * ``("doi", <doi>)`` — a DOI recovered from the PDF text (most reliable);
+    * ``("title", <title>)`` — a real title (the ordinary case: the plan title is
+      already an article title; or one extracted from the PDF text when no DOI was
+      found);
+    * ``None`` — the title is a PDF filename and neither a DOI nor a plausible
+      title could be recovered from the PDF text, so the caller must SKIP rather
+      than query Crossref with the bare filename.
+
+    The PDF read is fail-closed to ``approved_scan_roots`` and never raises out of
+    the spine: any reader error/missing dependency is logged and yields ``None``.
+    """
+    pdf_path = _pdf_path_for_publication(engine, title)
+    if pdf_path is None:
+        # An ordinary article title — resolve it directly (existing behaviour).
+        return ("title", title)
+
+    # Lazy import: keep the spine importable in the default env; only touch the
+    # PDF reader when there is actually a PDF-backed publication.
+    from builder.tools.scanner import extract_pdf_text
+
+    try:
+        text = extract_pdf_text(pdf_path)
+    except Exception as exc:  # noqa: BLE001 - a malformed PDF must not break the spine
+        logger.warning("Reading publication PDF %s failed; skipping: %s", pdf_path, exc)
+        return None
+
+    if not text or not text.strip():
+        return None
+
+    doi = _extract_doi_from_text(text)
+    if doi:
+        return ("doi", doi)
+
+    real_title = _extract_title_from_pdf_text(text)
+    if real_title:
+        return ("title", real_title)
+
+    # Neither recoverable — never query Crossref with the filename.
+    return None
+
+
 def _materialize_plan(
     engine: AgentEngine, usage_sink: UsageSink | None = None
 ) -> dict[str, Any]:
@@ -666,14 +817,21 @@ def _materialize_plan(
       ``givenName`` / ``familyName`` split of that name (ISA REQUIRES a non-empty
       given name; splitting a name is descriptive parsing, not identifier
       fabrication, so it is D5-safe). ORCID stays empty for a later lookup.
-    * each ``publications[]`` → :func:`resolve_publication` (#219/#224). A plan
-      carries a title ONLY (D5 — no DOI); the composite searches Crossref by title
-      and commits a DOI-backed ``ScholarlyArticle`` (+ authors) ONLY on a
-      confident match (counted under ``publications``). On no confident match it
-      returns ``ok=False`` and creates nothing, so the title is kept under
-      ``publications_deferred`` for a later resolution. A DOI is never fabricated
-      from a title — the identifier always comes from the Crossref lookup, never
-      the plan (D5).
+    * each ``publications[]`` → :func:`resolve_publication` /
+      :func:`draft_publication_with_authors` (#219/#224/#245). A plan carries a
+      title ONLY (D5 — no DOI), but when the source was a PDF that "title" is
+      often the PDF *filename* (which Crossref can never match). So each candidate
+      is first mapped (:func:`_recover_publication_query`) to a real Crossref
+      query: a **DOI** extracted from the PDF text (regex; most reliable) is
+      resolved via :func:`draft_publication_with_authors`; otherwise a **real
+      title** (an ordinary plan title, or one extracted from the PDF text) is
+      resolved via :func:`resolve_publication`, which commits a DOI-backed
+      ``ScholarlyArticle`` (+ authors) ONLY on a confident match (counted under
+      ``publications``) and otherwise leaves the title under
+      ``publications_deferred``. A PDF filename with no recoverable DOI/title is
+      **skipped** — never queried by filename. A DOI is never fabricated from a
+      title; the identifier always comes from the Crossref lookup, never the plan
+      (D5).
 
     Guarantees:
 
@@ -868,28 +1026,69 @@ def _materialize_plan(
         except Exception as exc:  # noqa: BLE001
             logger.warning("draft_person failed for %r: %s", name, exc)
 
-    # --- publications: resolve each title via resolve_publication (#219/#224). A
-    # plan carries a title ONLY (D5 — no DOI). resolve_publication searches Crossref
-    # by title and commits a DOI-backed ScholarlyArticle (+ authors) ONLY on a
-    # confident match; on no confident match it returns ok=False and creates
-    # nothing, so the title is kept under `publications_deferred`. A DOI is never
-    # fabricated from a title here — the identifier always comes from the Crossref
-    # lookup, never the plan. ---
+    # --- publications: materialize each via resolve_publication (#219/#224), with
+    # a PDF-text recovery step (#245). A plan publication carries a TITLE only
+    # (D5 — no DOI), but when the source was a PDF that "title" is frequently the
+    # PDF *filename* (e.g. `Wagenaars_etal_2025_OATP1C1.pdf`), which Crossref can
+    # never match. `_recover_publication_query` therefore maps each candidate to a
+    # real Crossref query:
+    #   * a DOI extracted from the PDF text (regex; most reliable) → resolve via
+    #     draft_publication_with_authors(doi=…), which looks the DOI up and commits
+    #     a DOI-backed ScholarlyArticle (+ authors). The identifier is the LOOKED-UP
+    #     DOI, never fabricated (D5).
+    #   * a real title (an ordinary plan title, or one extracted from the PDF text
+    #     when no DOI was found) → resolve via resolve_publication(title=…), which
+    #     commits a DOI-backed ScholarlyArticle ONLY on a confident Crossref match
+    #     and otherwise leaves the title deferred (D5).
+    #   * nothing recoverable from a PDF filename → SKIP (never query Crossref with
+    #     a bare filename); the publication is left as a gap rather than deferred
+    #     under an unmatchable filename.
     for publication in plan.get("publications") or []:
         title = str((publication or {}).get("title") or "").strip()
         if not title:
             continue
         try:
-            pub_result = engine.run_tool("resolve_publication", title=title)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("resolve_publication failed for %r: %s", title, exc)
-            result["publications_deferred"].append(title)
+            query = _recover_publication_query(engine, title)
+        except Exception as exc:  # noqa: BLE001 - recovery must never break the spine
+            logger.warning("publication query recovery failed for %r: %s", title, exc)
+            query = None
+        if query is None:
+            # A PDF filename with no recoverable DOI/title — skip (do NOT query
+            # Crossref with the filename, and do NOT defer the filename as a
+            # "title" to retry; a filename can never become a confident match).
+            logger.info(
+                "Skipping publication %r — no DOI/title recoverable from its PDF (#245).",
+                title,
+            )
             continue
-        if isinstance(pub_result, dict) and pub_result.get("ok"):
+
+        kind, value = query
+        try:
+            if kind == "doi":
+                # The DOI extracted from the PDF text drives the resolution; the
+                # composite re-looks it up, so an unresolvable DOI mints nothing.
+                pub_result = engine.run_tool(
+                    "draft_publication_with_authors", doi=value
+                )
+                ok = isinstance(pub_result, dict) and bool(
+                    pub_result.get("publication_id")
+                )
+            else:
+                pub_result = engine.run_tool("resolve_publication", title=value)
+                ok = isinstance(pub_result, dict) and bool(pub_result.get("ok"))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("publication resolution failed for %r: %s", value, exc)
+            # Only a real (non-filename) title is worth deferring for a retry.
+            if kind == "title":
+                result["publications_deferred"].append(value)
+            continue
+
+        if ok:
             result["publications"] += 1
-        else:
-            # No confident DOI match — keep the title for a later resolution (D5).
-            result["publications_deferred"].append(title)
+        elif kind == "title":
+            # No confident DOI match — keep the (real) title for later (D5). A DOI
+            # that failed its own lookup is not deferred (nothing to retry by).
+            result["publications_deferred"].append(value)
 
     return result
 

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -767,6 +767,217 @@ class TestMaterializePlan:
         assert result["materialized"]["compounds"] >= 2
 
 
+class TestPublicationFromPDF:
+    """Issue #245 — when a plan publication's "title" is actually a PDF FILENAME,
+    `_materialize_plan` must recover the real DOI/title from the PDF *text* and
+    resolve with that, never query Crossref with the bare filename.
+
+    The OATP1C1 symptom: ``extract_plan`` returned
+    ``{'title': 'Wagenaars_etal_2025_OATP1C1.pdf'}`` and Crossref answered "no
+    confident DOI match" — a title search on a filename can never match. These
+    tests stub the PDF reader and the Crossref/DOI lookups so they are fully
+    offline. Contract:
+
+    * a filename-title backed by a PDF whose text contains a DOI → resolved by
+      that DOI (``draft_publication_with_authors``), never by the filename;
+    * a PDF text with a real title but no DOI → resolved by the extracted title;
+    * neither DOI nor title recoverable → NO Crossref call with the filename;
+      the publication is skipped/deferred gracefully.
+    """
+
+    _PDF_NAME = "Wagenaars_etal_2025_OATP1C1.pdf"
+
+    def _enable_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+    def _state_with_pdf(self, tmp_path: Path) -> CrateState:
+        """A titled state whose scanned-file inventory includes a PDF under an
+        approved root (the PDF need only EXIST on disk; its text is stubbed)."""
+        pdf_path = tmp_path / self._PDF_NAME
+        pdf_path.write_bytes(b"%PDF-1.4 stub")  # real bytes irrelevant — reader stubbed
+        state = CrateState()
+        state.metadata.title = "OATP1C1 transporter study"
+        state.metadata.description = "An in vitro OATP1C1 uptake assay."
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [
+            FileClassification(
+                path=str(pdf_path),
+                filename=self._PDF_NAME,
+                size=pdf_path.stat().st_size,
+                mime_type="application/pdf",
+                first_rows=None,
+            )
+        ]
+        return state
+
+    def _stub_extract_plan_filename(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Make the leaf return the PDF FILENAME as the publication title (#245)."""
+        import builder.agents.pipeline as pipeline_mod
+
+        def fake_extract_plan(context, *, model=None, usage_sink=None):
+            return {"publications": [{"title": self._PDF_NAME}]}
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", fake_extract_plan)
+
+    def _by_type(self, engine: AgentEngine, type_name: str) -> list[Entity]:
+        return [e for e in engine.state.list_entities() if e.type == type_name]
+
+    def test_pdf_doi_in_text_resolves_by_doi_not_filename(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A PDF whose text carries a DOI → resolved by that DOI, not the filename."""
+        import builder.agents.pipeline as pipeline_mod
+        import builder.tools.composites as composites_mod
+        import builder.tools.scanner as scanner_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan_filename(monkeypatch)
+
+        # The PDF text the reader returns, carrying a real DOI on the first page.
+        def fake_extract_pdf_text(path):
+            return (
+                "[Page 1]\n"
+                "[Text] Hepatic OATP1C1 mediates thyroid hormone uptake\n"
+                "[Text] https://doi.org/10.1016/j.example.2025.01.002\n"
+                "[Text] Fabian Wagenaars, et al. 2025\n"
+            )
+
+        monkeypatch.setattr(scanner_mod, "extract_pdf_text", fake_extract_pdf_text)
+
+        # resolve_publication (title path) must NOT be called with the filename.
+        def boom_search(query):  # pragma: no cover - must not run
+            raise AssertionError(
+                f"Crossref title search must not be called with {query!r}"
+            )
+
+        monkeypatch.setattr(composites_mod, "search_works_by_title", boom_search)
+
+        # The DOI path delegates to draft_publication_with_authors → lookup_doi.
+        seen_dois: list[str] = []
+
+        def fake_lookup_doi(doi):
+            seen_dois.append(doi)
+            return {
+                "found": True,
+                "data": {
+                    "identifier": "10.1016/j.example.2025.01.002",
+                    "name": "Hepatic OATP1C1 mediates thyroid hormone uptake",
+                    "author": [{"givenName": "Fabian", "familyName": "Wagenaars"}],
+                },
+                "error": None,
+            }
+
+        monkeypatch.setattr(composites_mod, "lookup_doi", fake_lookup_doi)
+
+        engine = _engine(self._state_with_pdf(tmp_path))
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # The DOI extracted from the PDF text drove the resolution.
+        assert seen_dois == ["10.1016/j.example.2025.01.002"]
+        pubs = self._by_type(engine, "Publication")
+        assert len(pubs) == 1
+        assert pubs[0].fields.get("identifier") == "10.1016/j.example.2025.01.002"
+        assert result["publications"] >= 1
+        # The bare filename never lingers as a deferred title.
+        assert self._PDF_NAME not in result["publications_deferred"]
+
+    def test_pdf_title_no_doi_resolves_by_extracted_title(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A PDF with a real title but no DOI → resolved by the extracted title."""
+        import builder.agents.pipeline as pipeline_mod
+        import builder.tools.composites as composites_mod
+        import builder.tools.scanner as scanner_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan_filename(monkeypatch)
+
+        real_title = "Hepatic OATP1C1 mediates thyroid hormone uptake"
+
+        def fake_extract_pdf_text(path):
+            # First non-trivial line is the article title; no DOI anywhere.
+            return (
+                "[Page 1]\n"
+                f"[Text] {real_title}\n"
+                "[Text] Fabian Wagenaars, et al. 2025\n"
+            )
+
+        monkeypatch.setattr(scanner_mod, "extract_pdf_text", fake_extract_pdf_text)
+
+        # The title path must be called with the REAL extracted title, not the file.
+        seen_titles: list[str] = []
+
+        def fake_search(query):
+            seen_titles.append(query)
+            return [{"doi": "10.1016/j.example.2025.01.002", "title": real_title, "score": 99.0}]
+
+        def fake_lookup_doi(doi):
+            return {
+                "found": True,
+                "data": {
+                    "identifier": "10.1016/j.example.2025.01.002",
+                    "name": real_title,
+                    "author": [{"givenName": "Fabian", "familyName": "Wagenaars"}],
+                },
+                "error": None,
+            }
+
+        monkeypatch.setattr(composites_mod, "search_works_by_title", fake_search)
+        monkeypatch.setattr(composites_mod, "lookup_doi", fake_lookup_doi)
+
+        engine = _engine(self._state_with_pdf(tmp_path))
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # Crossref was queried with the EXTRACTED TITLE, never the filename.
+        assert seen_titles == [real_title]
+        assert self._PDF_NAME not in seen_titles
+        pubs = self._by_type(engine, "Publication")
+        assert len(pubs) == 1
+        assert result["publications"] >= 1
+        assert self._PDF_NAME not in result["publications_deferred"]
+
+    def test_pdf_no_doi_or_title_does_not_query_with_filename(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No recoverable DOI/title → no Crossref-by-filename; graceful skip/defer."""
+        import builder.agents.pipeline as pipeline_mod
+        import builder.tools.composites as composites_mod
+        import builder.tools.scanner as scanner_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan_filename(monkeypatch)
+
+        # The PDF text is unreadable/empty — nothing to recover.
+        monkeypatch.setattr(scanner_mod, "extract_pdf_text", lambda path: None)
+
+        def boom_search(query):  # pragma: no cover - must not run
+            raise AssertionError(
+                f"Crossref title search must not be called with {query!r}"
+            )
+
+        def boom_lookup_doi(doi):  # pragma: no cover - must not run
+            raise AssertionError("DOI lookup must not run without a recovered DOI")
+
+        monkeypatch.setattr(composites_mod, "search_works_by_title", boom_search)
+        monkeypatch.setattr(composites_mod, "lookup_doi", boom_lookup_doi)
+
+        engine = _engine(self._state_with_pdf(tmp_path))
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # Nothing minted; the filename did NOT reach Crossref. Skipped gracefully:
+        # it is not counted as a resolved publication.
+        assert self._by_type(engine, "Publication") == []
+        assert result["publications"] == 0
+        # The bare filename is never surfaced as a "deferred title" to retry with —
+        # a filename can never become a confident title match.
+        assert self._PDF_NAME not in result["publications_deferred"]
+
+
 class TestTokenAccounting:
     """Issue #221 — the deterministic spine's leaf LLM calls must record their
     token usage to ``profile.ndjson`` in the SAME shape the ReAct model node


### PR DESCRIPTION
Closes #224, closes #245

## What

Wires the publication path of `_materialize_plan` (`builder/agents/pipeline.py`) so plan publications become real Publication entities, and fixes the #245 root cause: when the candidate publication's "title" is actually a PDF filename, recover the real title/DOI from the PDF *text* instead of querying Crossref with the filename.

## How DOI/title extraction works

For each `plan["publications"][].title`, `_recover_publication_query(engine, title)`:

1. **Is it PDF-backed?** `_pdf_path_for_publication` returns a path only when the title ends in `.pdf` AND matches a scanned file by basename — the #245 case where `extract_plan` returned the filename (e.g. `Wagenaars_etal_2025_OATP1C1.pdf`) as the title. The path is **fail-closed to `approved_scan_roots`** (the same `scanner._contain` guard the rest of the spine uses).
2. **DOI first (most reliable).** `_extract_doi_from_text` runs the Crossref-recommended `10.\d{4,9}/…` regex over the PDF text (via `extract_pdf_text`), strips any `doi:`/URL prefix and trailing punctuation. A found DOI is resolved with `draft_publication_with_authors(doi=…)`.
3. **Title fallback.** `_extract_title_from_pdf_text` strips the `[Page N]` / `[Text] ` / `[Table …]` markers `extract_pdf_text` emits and returns the first heading-like line (≥3 words, ≥12 chars, not a DOI/URL). It is resolved with `resolve_publication(title=…)`.
4. **Ordinary titles** (not PDF-backed) go straight to `resolve_publication(title=…)` — existing behaviour, unchanged.

DOI → `draft_publication_with_authors`; title → `resolve_publication`. Both look the identifier up against Crossref, so a DOI is never fabricated from the plan (D5 preserved).

## Fallback behavior

- **PDF with no recoverable DOI/title** → the publication is **skipped**: Crossref is never queried with the bare filename, and the filename is never deferred as a retryable "title" (a filename can never become a confident match).
- **Real title, no confident Crossref match** → kept under `publications_deferred` for a later resolution (unchanged).
- **DOI lookup fails** → not deferred (nothing to retry by); no entity minted.
- All PDF reads are fail-closed to `approved_scan_roots` and reader errors/missing deps are logged and swallowed — a single malformed PDF can never break the deterministic spine. No-provider / no-context strict-no-op gates are untouched.

## Tests (new — `tests/test_agents_pipeline.py::TestPublicationFromPDF`)

- `test_pdf_doi_in_text_resolves_by_doi_not_filename` — DOI in PDF text → `draft_publication_with_authors` with that DOI; Crossref title search asserts it is never called with the filename.
- `test_pdf_title_no_doi_resolves_by_extracted_title` — real title, no DOI → `resolve_publication` with the extracted title, not the filename.
- `test_pdf_no_doi_or_title_does_not_query_with_filename` — neither recoverable → no Crossref/DOI call; graceful skip, filename not deferred.

Existing pipeline, e2e, and no-provider determinism tests stay green.

## Changed files

- `builder/agents/pipeline.py` — publication section of `_materialize_plan` + helpers (`_recover_publication_query`, `_pdf_path_for_publication`, `_extract_doi_from_text`, `_extract_title_from_pdf_text`).
- `tests/test_agents_pipeline.py` — new `TestPublicationFromPDF` class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)