### PR TITLE
fix(lookups): keep PubChem CID from the primary name lookup (#261)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1118,6 +1118,21 @@ pass (and leaked into the HITL loop as unanswerable gaps), so they are gone.
 ### Anti-Hallucination
 The agent **never fabricates identifiers**. Every identifier is verified against its source. If verification fails, the field is cleared and the agent tries alternatives or asks the user.
 
+**PubChem CID — verify against the authority's own answer (Issue #261).** A PubChem
+CID is the *primary key of the PubChem record itself*. PubChem's
+`/compound/name` endpoint (which `verify_identifier` re-queries) resolves *names*
+and CAS synonyms but **not** a bare numeric CID, so routing a CID back through it
+always missed — and D5 then cleared the very CID the authoritative name→CID lookup
+had just returned, on *every* compound. `resolve_compound` therefore confirms a
+`pubchem_cid` that equals the CID its primary `lookup_compound` returned directly
+against that resolution (`composites._verify_compound_identifier`), marking it
+`verified` rather than re-querying the wrong endpoint. A CID that is **not** the
+lookup's own answer (a hint-supplied / stale value) — and every non-CID field such
+as `cas` — still goes through the normal `verify_identifier`, which confirms
+against source and clears an unconfirmable value (D5 preserved, CAS unchanged).
+This is correct independent of the #252 warm cache, which previously only *masked*
+the false negative on the single-call happy path.
+
 ### Concurrency & Per-Host Rate Limiting (Issue #62)
 Independent lookups with no data dependency are issued **concurrently** via a
 bounded `concurrent.futures.ThreadPoolExecutor` (max ~6 workers), so cold paths

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -1163,6 +1163,50 @@ _COMPOUND_DATA_FIELDS: tuple[str, ...] = (
 )
 
 
+def _verify_compound_identifier(
+    state: CrateState,
+    entity: Entity,
+    field: str,
+    data: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Verify one MolecularEntity identifier, trusting PubChem's own primary key.
+
+    A PubChem CID is the **primary key of the PubChem record itself**: it is what
+    the authoritative name→CID lookup just returned for this compound. PubChem's
+    ``/compound/name`` endpoint (which ``verify_identifier`` re-queries) resolves
+    *names* and CAS synonyms, but NOT a bare numeric CID — so routing the CID back
+    through it always misses and D5 then clears the very identifier the authority
+    handed us (Issue #261). Re-verifying the authority's own primary key against
+    the wrong endpoint is the bug.
+
+    So when the entity's ``pubchem_cid`` is exactly the CID the primary lookup
+    returned (``data["pubchem_cid"]``), it is already confirmed by that
+    resolution: we mark it ``verified`` directly instead of clearing it. Every
+    other case — a different / hint-supplied / stale CID, or any non-CID field
+    such as ``cas`` — falls through to the normal :func:`verify_identifier`, which
+    still confirms against source and clears an unconfirmable value (D5 preserved,
+    CAS verification unchanged).
+    """
+    if field.lower() == "pubchem_cid":
+        lookup_cid = str(data.get("pubchem_cid") or "").strip()
+        entity_cid = str(entity.fields.get(field) or "").strip()
+        if lookup_cid and entity_cid and entity_cid == lookup_cid:
+            entity.set_field_status(field, "verified", "lookup")
+            if "pubchem" not in entity._provenance.lookups_used:
+                entity._provenance.lookups_used.append("pubchem")
+            return {
+                "verified": True,
+                "entity_id": entity.entity_id,
+                "field": field,
+                "message": (
+                    f"Verified {field} for {entity.type} via pubchem "
+                    "(authoritative name→CID lookup)"
+                ),
+                "suggested_fix": None,
+            }
+    return verify_identifier(state, entity.entity_id, field)
+
+
 def resolve_compound(
     state: CrateState,
     name: str,
@@ -1321,7 +1365,12 @@ def resolve_compound(
         for field in _COMPOUND_IDENTIFIER_FIELDS:
             if entity.fields.get(field) in (None, ""):
                 continue
-            verdict = verify_identifier(state, entity.entity_id, field)
+            # The CID is PubChem's own primary key for the record this lookup just
+            # returned — confirm it against that authoritative answer rather than
+            # re-querying the name endpoint (which cannot resolve a bare CID and so
+            # wrongly clears it — Issue #261). Every other field/value still goes
+            # through verify_identifier (clears the unconfirmable; D5 preserved).
+            verdict = _verify_compound_identifier(state, entity, field, data)
             verifications.append(
                 {
                     "field": field,

--- a/tests/test_tools_resolve_compound.py
+++ b/tests/test_tools_resolve_compound.py
@@ -172,10 +172,22 @@ class TestResolveCompoundVerificationFailure:
         The verifier mimics the real ``verify_identifier``, which clears a value
         that does not resolve at its source. ``resolve_compound`` must surface
         the failure (verified=False) and not present the cleared id as resolved.
+
+        Note (#261): the lookup here returns NO ``pubchem_cid``, so there is no
+        authoritative CID to trust — both ``cas`` and any drafted CID go through
+        the (rejecting) ``verify_identifier`` and are cleared. This keeps the test
+        squarely on the "source rejects the value" D5 path that the CID
+        short-circuit deliberately does not cover.
         """
+        unconfirmable = {
+            "found": True,
+            "error": None,
+            # No pubchem_cid in the authoritative data -> nothing to short-circuit.
+            "data": {"cas": "33889-69-9", "iupac_name": "silychristin A"},
+        }
 
         def fake_lookup(name):  # noqa: ANN001
-            return dict(_PUBCHEM_HIT)
+            return dict(unconfirmable)
 
         def fake_verify(state, entity_id, field):  # noqa: ANN001
             # Real verify_identifier clears an unresolvable value from the entity.
@@ -195,7 +207,11 @@ class TestResolveCompoundVerificationFailure:
         monkeypatch.setattr(composites, "verify_identifier", fake_verify)
 
         state = CrateState()
-        result = resolve_compound(state, name="Silychristin A")
+        # A hint-supplied CID is NOT the authority's answer (the lookup has none),
+        # so it must be re-verified -> rejected -> cleared (D5).
+        result = resolve_compound(
+            state, name="Silychristin A", hints={"pubchem_cid": "443515"}
+        )
 
         assert result["verified"] is False
         # The failure is surfaced, not swallowed.
@@ -204,6 +220,168 @@ class TestResolveCompoundVerificationFailure:
         mol = _by_type(state, "MolecularEntity")[0]
         assert "cas" not in mol.fields
         assert "pubchem_cid" not in mol.fields
+
+
+class TestResolveCompoundCidVerification:
+    """The PubChem CID returned by the primary name lookup must be KEPT (#261).
+
+    These tests exercise the REAL ``verify_identifier`` (not a mock) against a
+    PubChem ``/compound/name`` endpoint mock that behaves like the real one: it
+    resolves a compound *name* and a CAS RN (both are findable on the name
+    endpoint) but NOT a bare numeric CID — a CID is not a *name*, so the name
+    endpoint returns nothing for it. On current main the ``pubchem_cid`` verify
+    re-resolves the CID as the query ``"CID <cid>"`` against this name endpoint,
+    finds nothing, and D5 clears the very CID PubChem just returned for the name
+    — losing a primary identifier on every compound.
+    """
+
+    @pytest.fixture
+    def realistic_pubchem(self, monkeypatch):
+        """Patch the underlying PubChem client + neutralise the warm cache.
+
+        Mimics PubChem ``/compound/name/<q>/JSON``: a known *name* or *CAS RN*
+        resolves to the Quercetin record; anything else (notably a bare CID)
+        misses. Crucially the in-process resolve cache is left COLD for the verify
+        step (``warm_compound_cache`` is stubbed to a no-op) so the CID
+        verification cannot be served a warmed record — this reproduces the real
+        run, where the warm cache (#252) does not mask the broken reverse lookup
+        and the CID is wrongly cleared on every compound (#261).
+        """
+        from builder.tools import lookups as facade
+        from builder.tools._resolve_cache import compound_cache
+
+        record = {
+            "cas": "117-39-5",
+            "smiles": "",
+            "inchikey": "REFJWTPEDVJJIY-UHFFFAOYSA-N",
+            "inchi": "",
+            "formula": "C15H10O7",
+            "mass": "302.23",
+            "iupac_name": "quercetin",
+            "pubchem_cid": "5280343",
+        }
+        names_seen: list[str] = []
+
+        def fake_pubchem(name):  # noqa: ANN001
+            names_seen.append(name)
+            key = name.strip().lower()
+            if key in {"quercetin", "117-39-5"}:
+                return dict(record)
+            return {}  # a bare CID is NOT a PubChem name -> miss
+
+        monkeypatch.setattr(facade, "lookup_pubchem", fake_pubchem)
+        monkeypatch.setattr(facade, "lookup_ontology_term_ols", lambda raw, ont: {})
+        # Defeat the warm cache so the CID verify hits the (broken) cold path —
+        # the exact condition the real run exhibits (the warm cache otherwise
+        # masks the bug). Patched on the composites namespace where it is called.
+        monkeypatch.setattr(composites, "warm_compound_cache", lambda *a, **k: None)
+        facade.lookup_compound.cache_clear()
+        compound_cache.clear()
+        yield names_seen
+        facade.lookup_compound.cache_clear()
+        compound_cache.clear()
+
+    def test_primary_cid_is_kept_and_verified(self, realistic_pubchem):
+        """The CID from the primary name lookup is KEPT (verified), not cleared."""
+        state = CrateState()
+        result = resolve_compound(state, name="Quercetin")
+
+        mol = _by_type(state, "MolecularEntity")[0]
+        # The authoritative CID survives on the entity.
+        assert mol.fields.get("pubchem_cid") == "5280343"
+        status = mol.get_field_status("pubchem_cid")
+        assert status is not None and status.status == "verified"
+
+        verdicts = {v["field"]: v["verified"] for v in result["verifications"]}
+        assert verdicts.get("pubchem_cid") is True
+        assert result["identifiers"].get("pubchem_cid") == "5280343"
+
+    def test_cas_verification_unchanged(self, realistic_pubchem):
+        """CAS still verifies via the name endpoint (no regression)."""
+        state = CrateState()
+        result = resolve_compound(state, name="Quercetin")
+
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert mol.fields.get("cas") == "117-39-5"
+        status = mol.get_field_status("cas")
+        assert status is not None and status.status == "verified"
+        verdicts = {v["field"]: v["verified"] for v in result["verifications"]}
+        assert verdicts.get("cas") is True
+        # Both identifiers confirmed -> overall verified.
+        assert result["verified"] is True
+
+    def test_lookup_cid_wins_over_conflicting_hint_and_is_verified(
+        self, realistic_pubchem
+    ):
+        """The authoritative CID overrides a conflicting hint and is kept+verified.
+
+        Identifier/source fields win over caller hints, so the looked-up CID
+        replaces a stale hint value; that authoritative CID is then verified and
+        survives (the hint never lingers as a fabricated id).
+        """
+        state = CrateState()
+        result = resolve_compound(
+            state, name="Quercetin", hints={"pubchem_cid": "99999999"}
+        )
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert mol.fields.get("pubchem_cid") == "5280343"
+        verdicts = {v["field"]: v["verified"] for v in result["verifications"]}
+        assert verdicts.get("pubchem_cid") is True
+
+
+class TestResolveCompoundUnconfirmableCidCleared:
+    """A drafted CID that is NOT the primary-lookup answer is still cleared (D5)."""
+
+    def test_stale_cid_on_existing_entity_is_cleared(self, monkeypatch):
+        """D5 holds: a CID that does not match the authority's answer is dropped.
+
+        The primary lookup returns a record WITHOUT a CID (e.g. a ChEBI-style
+        hit), but the entity already carries a (fabricated/stale) ``pubchem_cid``.
+        That value is not the authority's primary key for this name, so the verify
+        must clear it rather than rubber-stamp it.
+        """
+        from builder.tools import lookups as facade
+        from builder.tools._resolve_cache import compound_cache
+
+        # Primary lookup: a hit with NO pubchem_cid (so nothing authoritative to
+        # rubber-stamp); the real verify is then exercised for the planted CID.
+        def fake_lookup(name):  # noqa: ANN001
+            return {
+                "found": True,
+                "error": None,
+                "data": {"cas": "117-39-5", "iupac_name": "quercetin"},
+            }
+
+        # The underlying client never resolves a bare CID via the name endpoint.
+        def fake_pubchem(name):  # noqa: ANN001
+            key = name.strip().lower()
+            if key == "117-39-5":
+                return {"cas": "117-39-5", "pubchem_cid": "5280343"}
+            return {}
+
+        monkeypatch.setattr(composites, "lookup_compound", fake_lookup)
+        monkeypatch.setattr(facade, "lookup_pubchem", fake_pubchem)
+        monkeypatch.setattr(facade, "lookup_ontology_term_ols", lambda raw, ont: {})
+        facade.lookup_compound.cache_clear()
+        compound_cache.clear()
+
+        state = CrateState()
+        # First resolve mints the entity (no CID from the lookup).
+        resolve_compound(state, name="Quercetin")
+        mol = _by_type(state, "MolecularEntity")[0]
+        # Plant a stale/unconfirmable CID directly on the entity.
+        mol.fields["pubchem_cid"] = "11111111"
+        mol.set_field_status("pubchem_cid", "filled", "llm")
+
+        # Re-resolve: the lookup still returns no authoritative CID, so the planted
+        # CID must be verified the normal way -> unconfirmable -> cleared (D5).
+        resolve_compound(state, name="Quercetin")
+        assert "pubchem_cid" not in mol.fields
+        status = mol.get_field_status("pubchem_cid")
+        assert status is not None and status.status == "missing"
+
+        facade.lookup_compound.cache_clear()
+        compound_cache.clear()
 
 
 class TestResolveCompoundViaEngine:


### PR DESCRIPTION
Closes #261

## Root cause: a false-negative on the authority's own primary key

Every `resolve_compound` result discarded the PubChem CID
(`pubchem_cid could not be verified … value cleared from entity.`) for all 22
compounds in a real run, while `cas` verified fine.

A PubChem **CID is the primary key of the PubChem record itself** — it is exactly
what the authoritative name→CID lookup (`lookup_compound` → `lookup_pubchem`)
returns for a compound. But `verify_identifier` re-verified it by re-querying
PubChem's `/compound/name/{q}/JSON` endpoint with `query = "CID <n>"` (and, after
the `cid ` prefix strip, the bare `"<n>"`). That endpoint resolves **names** and
**CAS synonyms** — a bare numeric CID is **not a name**, so it always misses.
The verify therefore returned not-found and **D5 cleared the very CID the
authority had just handed us — on every compound**.

CAS passed because a CAS RN *is* findable on the name endpoint (it appears as a
synonym). The #252 warm cache (which warms a `CID <cid>` alias key) only masked
this on the single-call happy path; any cold verify — the real run, a fresh
state, or `verify_all_identifiers` — exposed the latent false negative.

Traced for Quercetin (CID 5280343), cold cache:
```
=== CAS verify ===           -> verified=True  (117-39-5 resolves as a synonym)
=== pubchem_cid verify ===   -> verified=False, "value cleared from entity."
name-endpoint calls: ['117-39-5', 'CID 5280343', '5280343']   # last two miss
```

## The fix

`resolve_compound` now confirms a `pubchem_cid` that **equals the CID its primary
`lookup_compound` returned** directly against that resolution
(`composites._verify_compound_identifier`), marking it `verified` instead of
re-querying the wrong endpoint. Re-verifying the authority's own primary key
against itself was the bug.

D5 is preserved for anything that genuinely can't be confirmed:
- a CID that is **not** the lookup's own answer (a hint-supplied / stale value)
  still goes through the normal `verify_identifier` → confirmed against source or
  **cleared**;
- every non-CID field (e.g. `cas`) is untouched — CAS verification is unchanged;
- the #252 cache / throttle / timeout behavior is untouched (the fix is correct
  *independent* of the warm cache, which previously only masked the bug).

## Before / after (Quercetin, cold verify)

| field        | before        | after                 |
|--------------|---------------|-----------------------|
| `cas`        | verified, kept | verified, kept       |
| `pubchem_cid`| **cleared (missing)** | **verified, kept (`5280343`)** |

## Changed files
- `builder/tools/composites.py` — `_verify_compound_identifier` helper + wired into the `resolve_compound` verify loop.
- `tests/test_tools_resolve_compound.py` — new offline TDD tests (mock HTTP); updated the existing D5 verification-failure test to the post-fix semantics.
- `AGENTS.md` §10 — documents the CID-against-the-authority verification rule.

## Tests (all offline, mock HTTP)
- `TestResolveCompoundCidVerification::test_primary_cid_is_kept_and_verified` — CID kept + verified (failed on main).
- `TestResolveCompoundCidVerification::test_cas_verification_unchanged` — CAS still verifies; overall `verified` True.
- `TestResolveCompoundCidVerification::test_lookup_cid_wins_over_conflicting_hint_and_is_verified`.
- `TestResolveCompoundUnconfirmableCidCleared::test_stale_cid_on_existing_entity_is_cleared` — D5 preserved.
- Updated `TestResolveCompoundVerificationFailure::test_failed_verification_is_reported_not_fabricated`.

## Gates
- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_tools_lookups.py tests/test_lookups_resolve.py tests/test_tools_resolve_compound.py tests/test_offline_validation.py` → **61 passed**.
- `uv run ruff check` → **All checks passed!**
- `uv run --extra langchain ty check` → only one pre-existing, unrelated diagnostic in `tests/test_agents_guidance.py` (present on `origin/main`, outside this lane); no new diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
