### PR TITLE
fix(guidance): name the entity in every question + read files the user points at (#257)

### DIFF
--- a/builder/agents/guidance.py
+++ b/builder/agents/guidance.py
@@ -70,6 +70,7 @@ This is a clean library entrypoint — the CLI / spine wiring is a later PR.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 # Re-exported at module scope so the spine, tests, and the eval harness have a
@@ -79,15 +80,20 @@ from builder.agents.pipeline import draft_entity_fields
 from builder.config import get_provider
 from builder.tools.gap_analysis import REPORT_ONLY, Gap, assess_gaps
 
-# The guidance leaves (#244): PHRASE the gap into one human question, INTERPRET
-# the free-text reply into a structured decision. Imported at module scope as the
+# The guidance leaves (#244, #257): PHRASE the gap into one human question,
+# INTERPRET the free-text reply into a structured decision, and EXTRACT a field
+# value from a file the user pointed at (#257). Imported at module scope as the
 # single monkeypatch target for tests, but guarded so that with langchain absent
 # the names resolve to ``None`` and the LLM path is simply skipped (it is gated on
 # ``get_provider()`` regardless). Typed as optional callables so the ``None``
 # fallback type-checks cleanly.
 phrase_gap_question: Callable[..., str] | None
 interpret_gap_reply: Callable[..., dict[str, Any]] | None
+extract_field_from_file: Callable[..., str] | None
 try:  # pragma: no cover — exercised by both branches across the test matrix
+    from builder.agents.leaves import (
+        extract_field_from_file as _extract_file_leaf,
+    )
     from builder.agents.leaves import (
         interpret_gap_reply as _interpret_leaf,
     )
@@ -97,9 +103,11 @@ try:  # pragma: no cover — exercised by both branches across the test matrix
 
     phrase_gap_question = _phrase_leaf
     interpret_gap_reply = _interpret_leaf
+    extract_field_from_file = _extract_file_leaf
 except Exception:  # pragma: no cover — langchain absent: LLM path is gated off anyway
     phrase_gap_question = None
     interpret_gap_reply = None
+    extract_field_from_file = None
 
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
@@ -114,6 +122,12 @@ __all__ = ["run_guidance"]
 # so this caps the worst-case work and guarantees termination even if a resolved
 # gap never clears (e.g. a user value the validator still rejects).
 _DEFAULT_MAX_ROUNDS = 20
+
+# (#257, fix C) Max characters of a pointed-at file's text fed to the extraction
+# leaf. The file readers already cap their own output (Excel rows, the 64 KiB text
+# budget); this is a final per-gap belt-and-braces cap so one big file can't blow
+# the bounded leaf's token budget. One read per gap.
+_MAX_FILE_EXTRACT_CHARS = 32 * 1024
 
 # Cap on clarifying follow-ups within a SINGLE ask-user turn (#244). The interpret
 # leaf may ask for clarification, but a vague user could otherwise loop forever;
@@ -284,7 +298,7 @@ def _drafted_value(engine: AgentEngine, gap: Gap) -> str | None:
     return str(candidate)
 
 
-def _ask_user_prompt(gap: Gap) -> str:
+def _ask_user_prompt(gap: Gap, engine: AgentEngine | None = None) -> str:
     """Build a human-readable ask-user prompt for ``gap``.
 
     The raw ``gap.message`` is a description of a *failed check* (e.g. "Study MUST
@@ -293,9 +307,22 @@ def _ask_user_prompt(gap: Gap) -> str:
     clear, multi-line prompt: a direct question naming the field (and the entity /
     tier it applies to), the gap's own explanation, any suggestion, and the
     expected input format. This keeps the human genuinely in the loop (D5).
+
+    When ``engine`` is given and the gap resolves to a concrete named entity
+    (#257, fix A), the prompt NAMES that entity ("…for 'Silychristin A' (a
+    MolecularEntity)…") so even the deterministic / no-provider path never asks
+    about a bare "this chemical / this protocol".
     """
     field = _local_name(gap.property) or (gap.property or "this field")
-    target = f" on the {gap.entity_type}" if gap.entity_type else ""
+    entity_name = _gap_entity_name(engine, gap) if engine is not None else None
+    if entity_name:
+        target = f" for '{entity_name}'"
+        if gap.entity_type:
+            target += f" (a {gap.entity_type})"
+    elif gap.entity_type:
+        target = f" on the {gap.entity_type}"
+    else:
+        target = ""
     lines: list[str] = [f"Please provide a value for '{field}'{target}."]
     if gap.message:
         lines.append(f"Why: {gap.message}")
@@ -303,6 +330,19 @@ def _ask_user_prompt(gap: Gap) -> str:
         lines.append(f"Suggestion: {gap.suggestion}")
     lines.append("Expected: free text (leave blank or skip to defer this field).")
     return "\n".join(lines)
+
+
+def _gap_entity_name(engine: AgentEngine | None, gap: Gap) -> str | None:
+    """Resolve the gap's concrete entity name from state, or ``None`` (#257)."""
+    if engine is None:
+        return None
+    state_id = _resolve_entity_id(engine, gap)
+    if state_id is None:
+        return None
+    entity = engine.state.get_entity(state_id)
+    if entity is None:
+        return None
+    return _entity_display_name(entity)
 
 
 def _ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> str | None:
@@ -313,7 +353,7 @@ def _ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> str | Non
     reply returns ``None``. The LLM-mediated phrase/interpret exchange wraps this
     only when a provider is configured (see :func:`_resolve_ask_user`).
     """
-    response = human.request_input(_ask_user_prompt(gap))
+    response = human.request_input(_ask_user_prompt(gap, engine))
     if response.get("skipped"):
         return None
     value = response.get("value")
@@ -336,14 +376,61 @@ def _reply_text(response: Any) -> str | None:
     return str(value)
 
 
+# Fields, in preference order, that carry a human-meaningful entity name (#257).
+# Person splits the name into givenName/familyName, so those are combined.
+_NAME_FIELDS: tuple[str, ...] = ("name", "title")
+
+# Descriptive fields surfaced to the phrase leaf as the entity's KNOWN context
+# (#257) so a question can be grounded ("…for Silychristin A (a test compound)…").
+# Identifier fields are deliberately excluded — they are never the grounding.
+_KNOWN_CONTEXT_FIELDS: tuple[str, ...] = ("name", "title", "description")
+
+
+def _entity_display_name(entity: Any) -> str | None:
+    """A human-readable name for ``entity``, or ``None`` (#257).
+
+    Prefers ``name``/``title``; for a Person assembles ``givenName familyName``.
+    Returns ``None`` when nothing usable is recorded — the caller then never claims
+    a specific entity exists by a fabricated name.
+    """
+    fields = getattr(entity, "fields", {}) or {}
+    for key in _NAME_FIELDS:
+        value = str(fields.get(key) or "").strip()
+        if value:
+            return value
+    # Person: combine given/family when no ``name`` is set.
+    given = str(fields.get("givenName") or "").strip()
+    family = str(fields.get("familyName") or "").strip()
+    combined = " ".join(p for p in (given, family) if p).strip()
+    return combined or None
+
+
+def _known_fields(entity: Any) -> dict[str, str]:
+    """The entity's already-known descriptive fields, for grounding the question."""
+    fields = getattr(entity, "fields", {}) or {}
+    known: dict[str, str] = {}
+    for key in _KNOWN_CONTEXT_FIELDS:
+        value = str(fields.get(key) or "").strip()
+        if value:
+            known[key] = value
+    return known
+
+
 def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
-    """Assemble the per-gap context dict the guidance leaves consume (#244).
+    """Assemble the per-gap context dict the guidance leaves consume (#244, #257).
 
     A compact, jargon-light digest of the gap plus the crate's title/description,
     so :func:`phrase_gap_question` can rephrase it and :func:`interpret_gap_reply`
     can interpret a reply in context. The ``property`` is the **local field name**
     (not the raw IRI) so the interpret leaf's D5 identifier guard sees the same
     token the loop would commit to.
+
+    When the gap has a concrete ``entity_id`` that resolves to a real state entity
+    (#257, fix A), the entity's **name** (``entity_name``) and **known descriptive
+    fields** (``known_fields``) are threaded in so the phrased question references
+    the entity BY NAME — never a bare "this chemical / this protocol / this cell
+    line". The entity's own type takes precedence over the gap's coarser
+    ``entity_type`` when they differ.
     """
     field = _local_name(gap.property) or (gap.property or "")
     context: dict[str, Any] = {
@@ -353,6 +440,18 @@ def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
         "message": gap.message,
         "suggestion": gap.suggestion,
     }
+    # (#257, fix A) Resolve the concrete entity so the question names it.
+    state_id = _resolve_entity_id(engine, gap)
+    if state_id is not None:
+        entity = engine.state.get_entity(state_id)
+        if entity is not None:
+            context["entity_type"] = entity.type or gap.entity_type
+            name = _entity_display_name(entity)
+            if name:
+                context["entity_name"] = name
+            known = _known_fields(entity)
+            if known:
+                context["known_fields"] = known
     title = (engine.state.metadata.title or "").strip()
     if title:
         context["crate_title"] = title
@@ -377,7 +476,7 @@ def _phrase_question(engine: AgentEngine, gap: Gap) -> str:
             question = ""
         if question and question.strip():
             return question.strip()
-    return _ask_user_prompt(gap)
+    return _ask_user_prompt(gap, engine)
 
 
 def _deterministic_decision(gap: Gap, reply: str) -> dict[str, Any]:
@@ -426,17 +525,21 @@ def _resolve_ask_user(
 ) -> str | None:
     """Run the LLM-mediated ask-user exchange for ``gap``; return a clean value.
 
-    The §14.6 "small guidance agent" (#244). When a provider is configured this is
-    a bounded PHRASE -> ask -> INTERPRET exchange:
+    The §14.6 "small guidance agent" (#244, #257). When a provider is configured
+    this is a bounded PHRASE -> ask -> INTERPRET exchange:
 
-    * **PHRASE** the gap into one clear human question (never raw SHACL/FAIR text).
+    * **PHRASE** the gap into one clear human question (never raw SHACL/FAIR text),
+      naming the concrete entity it is about (#257, fix A).
     * **INTERPRET** the free-text reply into a structured decision:
       ``commit`` -> return the clean value (the caller commits it via
       :func:`_apply_value`); ``skip`` (covers "I don't know"/empty) -> return
       ``None``; ``clarify`` -> ask ONE bounded follow-up
-      (:data:`_MAX_CLARIFY_FOLLOW_UPS`) then skip; ``from_file`` -> record the
-      filename hint and return ``None`` (NEVER store prose — file extraction is a
-      separate bounded reader, not this loop).
+      (:data:`_MAX_CLARIFY_FOLLOW_UPS`) then skip; ``from_file`` -> **read the file
+      the user pointed at and EXTRACT the requested value** (#257, fix C), then
+      return it to commit. The reply prose is still NEVER stored verbatim — only a
+      value extracted from the file's text by the bounded
+      :func:`extract_field_from_file` leaf, and only when the file is inside an
+      approved scan root. An unreadable / outside-root file gracefully skips.
 
     A free-text musing therefore can never become a field value (D5). With **no
     provider** configured this degrades to the deterministic :func:`_ask_user`
@@ -467,7 +570,7 @@ def _resolve_ask_user(
 
         if action == "clarify" and follow_ups < _MAX_CLARIFY_FOLLOW_UPS:
             follow_ups += 1
-            follow_up = decision.get("question") or _ask_user_prompt(gap)
+            follow_up = decision.get("question") or _ask_user_prompt(gap, engine)
             question = str(follow_up)
             response = human.request_input(question)
             reply = _reply_text(response)
@@ -476,16 +579,153 @@ def _resolve_ask_user(
             continue
 
         if action == "from_file":
-            filename = decision.get("filename")
-            logger.info(
-                "guidance: user says %s is in a file%s; not storing prose (#244)",
-                _local_name(gap.property) or gap.property,
-                f" ({filename})" if filename else "",
-            )
-            return None
+            # (#257, fix C) Actually READ the file and EXTRACT the value — instead
+            # of logging the hint and skipping (the #244 behavior). The reply's
+            # prose is never stored; only a value the extraction leaf pulls from
+            # the file's text, gated to approved scan roots.
+            return _resolve_from_file(engine, gap, reply, decision.get("filename"))
 
         # skip, an exhausted clarify budget, or any unrecognised action -> skip.
         return None
+
+
+def _candidate_file_paths(
+    engine: AgentEngine, filename: str | None, reply: str
+) -> list[str]:
+    """Likely on-disk paths the user pointed at, best-effort and bounded (#257).
+
+    Combines, in priority order:
+
+    1. the ``filename`` hint the interpret leaf returned (as-is, and resolved
+       under each approved scan root / against the scanned-file inventory by base
+       name);
+    2. any scanned file whose base name appears verbatim in the user's ``reply``.
+
+    The result is de-duplicated, order-preserving. Containment (the sandbox) is
+    enforced by the caller via :func:`builder.tools.scanner._contain` — this only
+    proposes candidates, it never widens access.
+    """
+    candidates: list[str] = []
+
+    def _add(path: str | None) -> None:
+        if path and path not in candidates:
+            candidates.append(path)
+
+    scanned = list(getattr(engine.state, "scanned_files", []) or [])
+
+    if filename:
+        hint = filename.strip()
+        _add(hint)
+        base = Path(hint).name
+        # Resolve a bare base name against the approved roots and the inventory.
+        for root in engine.state.approved_scan_roots:
+            _add(str(Path(root) / base))
+        for f in scanned:
+            if Path(f.path).name == base or f.filename == base:
+                _add(f.path)
+
+    # Any scanned file the user named verbatim in their reply.
+    if reply:
+        for f in scanned:
+            name = f.filename or Path(f.path).name
+            if name and name in reply:
+                _add(f.path)
+
+    return candidates
+
+
+def _read_pointed_file(engine: AgentEngine, candidates: list[str]) -> str | None:
+    """Read the FIRST candidate inside an approved scan root, bounded (#257).
+
+    One read per gap: returns the (size-capped) text of the first candidate that
+    (a) resolves inside an approved scan root and (b) the readers can read.
+    Returns ``None`` when no candidate is readable in-sandbox — a graceful skip.
+    Never raises out: any reader/optional-dependency error is logged and skipped,
+    so a single unreadable file can never break the loop.
+    """
+    from builder.tools.file_readers import read_file
+    from builder.tools.scanner import _contain
+
+    roots = engine.state.approved_scan_roots
+    for candidate in candidates:
+        resolved = _contain(candidate, roots)
+        if resolved is None:
+            logger.debug(
+                "guidance: from_file refused %s — outside approved scan roots (#257).",
+                candidate,
+            )
+            continue
+        try:
+            body = read_file(str(resolved))
+        except (OSError, ValueError, ImportError) as exc:
+            logger.warning("guidance: from_file read failed for %s: %s", candidate, exc)
+            continue
+        except Exception as exc:  # noqa: BLE001 — a malformed file must not break the loop
+            logger.warning(
+                "guidance: unexpected from_file read error for %s: %s", candidate, exc
+            )
+            continue
+        if body and body.strip():
+            return body[:_MAX_FILE_EXTRACT_CHARS]
+    return None
+
+
+def _resolve_from_file(
+    engine: AgentEngine, gap: Gap, reply: str, filename: str | None
+) -> str | None:
+    """Read the file the user pointed at and extract the gap's value (#257, fix C).
+
+    Returns a clean value to commit, or ``None`` to skip. The flow:
+
+    1. locate likely file paths (:func:`_candidate_file_paths`);
+    2. read the first one INSIDE an approved scan root (:func:`_read_pointed_file`)
+       — one bounded read; an unreadable / outside-root file gracefully skips;
+    3. extract the requested field's value from the file text via the bounded
+       :func:`extract_field_from_file` leaf (a flaky leaf -> skip, never crashes);
+    4. D5: never return a value for an identifier-bearing field — those come from
+       lookups, not file text — so an identifier gap always skips here.
+
+    The user's reply prose is NEVER stored: only a value the leaf extracts from the
+    file's text is returned.
+    """
+    field = _local_name(gap.property) or (gap.property or "")
+    # D5: identifiers come from lookups, never extracted from a file's prose.
+    if _is_identifier_field(field):
+        logger.info(
+            "guidance: from_file for identifier field %s -> skip (lookups only, D5).",
+            field,
+        )
+        return None
+
+    if extract_field_from_file is None:  # pragma: no cover — provider gated elsewhere
+        return None
+
+    candidates = _candidate_file_paths(engine, filename, reply)
+    if not candidates:
+        logger.info("guidance: from_file but no file could be located; skipping (#257).")
+        return None
+
+    file_text = _read_pointed_file(engine, candidates)
+    if file_text is None:
+        logger.info(
+            "guidance: from_file file unreadable / outside scan roots; skipping (#257)."
+        )
+        return None
+
+    try:
+        value = extract_field_from_file(field, file_text, _gap_context(engine, gap))
+    except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
+        logger.warning("guidance: from_file extraction leaf failed: %s", exc)
+        return None
+
+    if isinstance(value, str) and value.strip():
+        logger.info("guidance: extracted %s from a pointed-at file (#257).", field)
+        return value.strip()
+    logger.info(
+        "guidance: pointed-at file did not yield a value for %s; skipping (#257).",
+        field,
+    )
+    return None
 
 
 def _resolve_gap(

--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -496,7 +496,11 @@ _PHRASE_SYSTEM_PROMPT = (
     "type it belongs to, why it matters, and a hint). Rephrase it as ONE short, "
     "clear question a non-expert researcher can answer, with a concrete example of "
     "a good answer. NEVER show raw SHACL shapes, FAIR indicator codes, property "
-    "IRIs, or validator jargon. Ask only for what the field needs."
+    "IRIs, or validator jargon. Ask only for what the field needs. CRITICAL: when "
+    "an entity name is given, the question MUST name that specific entity (e.g. "
+    "'What is the CAS Registry Number for Silychristin A?'), never a vague 'this "
+    "chemical', 'this protocol', or 'this cell line' — the user must know WHICH "
+    "entity you mean."
 )
 
 _INTERPRET_SYSTEM_PROMPT = (
@@ -580,19 +584,50 @@ def _interpret_schema() -> dict[str, Any]:
     }
 
 
+def _known_fields_block(known_fields: Any) -> str | None:
+    """Render the gap's KNOWN fields into a compact ``k=v`` line, or ``None``.
+
+    The guidance loop threads the resolved entity's already-known descriptive
+    fields (``known_fields``) so the leaf can ground the question in what is
+    already recorded ("…for Silychristin A (a test compound)…") instead of asking
+    about a nameless entity. Values are truncated so the block stays bounded.
+    """
+    if not isinstance(known_fields, dict) or not known_fields:
+        return None
+    parts: list[str] = []
+    for key, value in known_fields.items():
+        text = str(value).strip()
+        if not text:
+            continue
+        if len(text) > 80:
+            text = text[:80].rstrip() + "…"
+        parts.append(f"{key}={text}")
+    return "; ".join(parts) if parts else None
+
+
 def _gap_context_block(gap_context: dict[str, Any]) -> str:
     """Render a gap-context dict into a compact, jargon-light block for a leaf.
 
     The guidance loop assembles ``gap_context`` (property, entity_type, tier,
-    message, suggestion, plus optional crate title/description). We surface the
-    human-meaningful parts; the leaf is told to translate the rest, never to echo
-    raw validator text.
+    message, suggestion, plus optional crate title/description and — when the gap
+    is about a CONCRETE entity — that entity's ``entity_name`` and ``known_fields``,
+    #257). We surface the human-meaningful parts (crucially the entity NAME, so the
+    leaf phrases a question about *that* entity, never a bare "this chemical"); the
+    leaf is told to translate the rest, never to echo raw validator text.
     """
     field = gap_context.get("property") or "this field"
     parts: list[str] = [f"Field: {field}"]
     entity_type = gap_context.get("entity_type")
     if entity_type:
         parts.append(f"Belongs to: {entity_type}")
+    # Name the specific entity (#257) so the question can never be a contextless
+    # "this chemical / this protocol / this cell line".
+    entity_name = gap_context.get("entity_name")
+    if entity_name:
+        parts.append(f"Entity name: {entity_name}")
+    known_block = _known_fields_block(gap_context.get("known_fields"))
+    if known_block:
+        parts.append(f"Already known: {known_block}")
     tier = gap_context.get("tier")
     if tier:
         parts.append(f"Importance: {tier}")
@@ -757,8 +792,124 @@ def _local_property_name(iri: str | None) -> str:
     return iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
 
 
+# ---------------------------------------------------------------------------
+# extract_field_from_file — the file-extraction leaf (Issue #257, fix C)
+#
+# When the user points the guidance loop at a file ("the CAS number is in
+# assay-metadata.xlsx"), the loop READS the file (via file_readers) and calls
+# this leaf to extract the requested field value from the file text — instead of
+# logging a hint and skipping. It is a single bounded structured-output call on
+# the drafter tier; it returns a clean value or an empty string when the file
+# does not support the field. D5: an identifier-bearing field is NEVER extracted
+# from file text (those come from lookups), so the leaf returns "" for one.
+# ---------------------------------------------------------------------------
+
+_EXTRACT_FILE_SYSTEM_PROMPT = (
+    "You extract ONE metadata field value from the text of a research file for an "
+    "ISA-Tox RO-Crate. You are given the field name, the entity it belongs to, and "
+    "the file's text. Return the clean value for that field if — and only if — the "
+    "file clearly supplies it; rewrite it into a proper, concise field value. If "
+    "the file does not contain the answer, return an EMPTY value (do not guess). "
+    "NEVER fabricate or extract identifiers (CAS, InChIKey, SMILES, PubChem CID, "
+    "ORCID, ROR, DOI, accessions, ontology codes): those are resolved by lookup "
+    "services, so for an identifier field return an empty value."
+)
+
+
+def _extract_file_schema() -> dict[str, Any]:
+    """Structured-output schema for the file-extraction leaf: one value string."""
+    return {
+        "title": "ExtractedFieldValue",
+        "type": "object",
+        "description": (
+            "The value of one metadata field extracted from a file's text, or "
+            "empty when the file does not supply it. Never an identifier."
+        ),
+        "properties": {
+            "value": {
+                "type": "string",
+                "description": (
+                    "The clean field value extracted from the file text, or an "
+                    "empty string when the file does not contain it."
+                ),
+            }
+        },
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+
+
+def extract_field_from_file(
+    field: str,
+    file_text: str,
+    gap_context: dict[str, Any],
+    *,
+    model: str | None = None,
+    usage_sink: UsageSink | None = None,
+) -> str:
+    """Extract the value of ``field`` from ``file_text`` for a gap (#257, fix C).
+
+    A pure bounded leaf: a SINGLE structured-output call on the drafter tier
+    (``_build_chat_model(role="drafter")``) that reads the (already-read,
+    size-capped) text of a file the user pointed at and returns the clean value
+    for the requested ``field``, or ``""`` when the file does not support it. It
+    does not mutate state and does not read disk (the guidance loop reads the file
+    via ``file_readers`` and hands the text in).
+
+    D5: identifiers come from lookups, never from extracting prose/file text. When
+    ``field`` (or the gap's ``property``) is identifier-bearing
+    (:data:`_IDENTIFIER_SCALAR_FIELDS`) the leaf short-circuits to ``""`` so an
+    identifier is never lifted out of a file — the loop verifies it via a lookup
+    instead.
+
+    Args:
+        field: The local field name being filled (e.g. ``"description"``).
+        file_text: The file's (bounded) text content to extract from.
+        gap_context: The per-gap context dict (entity_type, property, ...), used
+            for grounding and the D5 identifier guard.
+        model: Optional explicit model override; ``None`` resolves the drafter tier.
+        usage_sink: Optional token-usage callback (see :func:`draft_entity_fields`).
+
+    Returns:
+        The extracted clean value, or ``""`` when the file does not supply it (or
+        the field is identifier-bearing — D5).
+    """
+    # D5: never extract an identifier from file text — those come from lookups.
+    target = _local_property_name(field) or _local_property_name(
+        gap_context.get("property")
+    )
+    if target in _IDENTIFIER_SCALAR_FIELDS:
+        return ""
+    if not file_text or not file_text.strip():
+        return ""
+
+    llm = _build_chat_model(model=model, role="drafter")
+    messages = [
+        SystemMessage(content=_EXTRACT_FILE_SYSTEM_PROMPT),
+        HumanMessage(
+            content=(
+                f"Field to extract: {field}\n"
+                f"{_gap_context_block(gap_context)}\n\n"
+                "File text:\n"
+                f"{file_text}\n\n"
+                "Return the field's value if the file clearly supplies it, else an "
+                "empty value. Never an identifier."
+            )
+        ),
+    ]
+    result = _invoke_structured_with_usage(
+        llm, _extract_file_schema(), messages, usage_sink
+    )
+    if isinstance(result, dict):
+        value = result.get("value")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
 __all__ = [
     "draft_entity_fields",
+    "extract_field_from_file",
     "extract_plan",
     "interpret_gap_reply",
     "phrase_gap_question",

--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -292,18 +292,35 @@ def _mit_suggestion(param: dict[str, Any]) -> str | None:
     return " | ".join(parts) if parts else None
 
 
+def _present_entity_types(state: CrateState) -> set[str]:
+    """The set of entity TYPES that have at least one instance in ``state``.
+
+    Used so a MIT parameter keyed solely on an entity type with NO instance (e.g.
+    ``MolecularEntity:cas`` when there are zero MolecularEntities) is surfaced as
+    a *creation prompt* / report-only gap rather than phrased as if a specific
+    chemical/protocol/cell line already exists (#257, fix B).
+    """
+    return {entity.type for entity in state.list_entities()}
+
+
 def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
     """Unfilled MIT parameters as gaps; also return the overall MIT score.
 
     A parameter is a gap when *none* of its ``crate_slot`` targets is filled.
     Core parameters (``additional: false``) are ``SHOULD``; ``additional: true``
     ones are ``MAY``. The overall MIT score mirrors ``assess_mit_coverage``.
+
+    A parameter keyed *only* on entity types with NO instance in state has no
+    concrete entity to ask about: it is surfaced as a **creation-prompt**,
+    ``report-only`` gap (#257, fix B) so the guidance loop never phrases it as a
+    specific "this chemical / this protocol" that does not exist.
     """
     mit_data = _load_mit_yaml()
     if mit_data is None:
         return [], 0.0
 
     filled = _filled_fields(state)
+    present_types = _present_entity_types(state)
     modules = mit_data.get("modules", [])
     gaps: list[Gap] = []
     total_completed = 0
@@ -342,13 +359,38 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
             # crate field the parameter maps to); the rest are alternatives.
             slot_entity_type, slot_field = slots[0] if slots else (None, None)
             param_name = param.get("name") or param.get("id") or slot_field or "parameter"
+            # (#257, fix B) Does ANY slot reference an entity type that actually has
+            # an instance? If not, the parameter is type-level only — there is no
+            # concrete entity to ask about, so phrasing it as a specific entity is
+            # exactly the bug (asking for "this chemical"'s CAS with zero chemicals).
+            has_instance = any(
+                et in present_types for et, _ in slots if et
+            )
+            if not has_instance:
+                # No instance of any of the parameter's entity types: surface a
+                # creation-prompt, report-only gap (never a per-field ask on a
+                # non-existent entity).
+                message = (
+                    f"No {slot_entity_type or 'matching'} recorded yet; the MIT "
+                    f"profile expects '{param_name}' (crate_slot {crate_slot}). "
+                    "Add one to capture it."
+                )
+                fix_hint = REPORT_ONLY
             # MIT gaps are emitted crate-level (entity_id None). They are only
             # committable when their field maps to a Root Data Entity slot; the
             # rest have no deterministic settable target and are report-only, so
             # the guidance loop surfaces them for context without burning a turn.
-            if not _is_committable(None, slot_field):
+            elif not _is_committable(None, slot_field):
+                message = (
+                    f"MIT parameter '{param_name}' is not yet captured "
+                    f"(crate_slot {crate_slot})."
+                )
                 fix_hint = REPORT_ONLY
             else:
+                message = (
+                    f"MIT parameter '{param_name}' is not yet captured "
+                    f"(crate_slot {crate_slot})."
+                )
                 # MIT enrichment needs content the user provides or a drafter
                 # synthesizes; it is never a deterministic auto-fix (D5).
                 fix_hint = "ask-user" if not additional else "draft"
@@ -359,10 +401,7 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
                     entity_id=None,
                     entity_type=slot_entity_type,
                     property=slot_field,
-                    message=(
-                        f"MIT parameter '{param_name}' is not yet captured "
-                        f"(crate_slot {crate_slot})."
-                    ),
+                    message=message,
                     suggestion=_mit_suggestion(param),
                     fix_hint=fix_hint,
                     auto_fixable=False,

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -877,6 +877,158 @@ class TestGuidanceLeavesD5:
         )
 
 
+# ---------------------------------------------------------------------------
+# Entity-aware phrasing (Issue #257, fix A)
+#
+# When a gap is about a CONCRETE entity, the guidance loop now threads the
+# entity's type/name/known-fields into the gap context. The phrase leaf must
+# put that NAME into the question — never a bare "this chemical/protocol/cell
+# line" — so the user knows WHICH entity is being asked about.
+# ---------------------------------------------------------------------------
+
+
+class TestPhraseGapQuestionNamesEntity:
+    """The phrased question must reference the named entity (Issue #257)."""
+
+    def test_entity_name_reaches_the_model_prompt(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel(
+            {"question": "What is the CAS Registry Number for Silychristin A?"}
+        )
+        _patch_build_chat_model["model"] = fake
+
+        leaves.phrase_gap_question(
+            {
+                "property": "cas",
+                "entity_type": "MolecularEntity",
+                "entity_name": "Silychristin A",
+                "tier": "SHOULD",
+                "message": "MolecularEntity SHOULD record a CAS number.",
+                "suggestion": "A CAS Registry Number like 103-90-2.",
+            }
+        )
+
+        # The entity NAME the loop resolved must reach the model in the prompt
+        # block, so the model can phrase a question naming the entity.
+        human_msg = fake.invoke_calls[0][-1].content
+        assert "Silychristin A" in human_msg
+
+    def test_known_fields_reach_the_model_prompt(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"question": "q"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.phrase_gap_question(
+            {
+                "property": "description",
+                "entity_type": "LabProtocol",
+                "entity_name": "OATP1C1 uptake assay",
+                "known_fields": {"name": "OATP1C1 uptake assay"},
+                "tier": "SHOULD",
+                "message": "LabProtocol SHOULD have a description.",
+            }
+        )
+
+        human_msg = fake.invoke_calls[0][-1].content
+        assert "OATP1C1 uptake assay" in human_msg
+
+
+# ---------------------------------------------------------------------------
+# extract_field_from_file — the bounded file-extraction leaf (Issue #257, fix C)
+#
+# When the user points the guidance loop at a file ("the CAS number is in
+# assay-metadata.xlsx"), the loop reads the file and asks this leaf to extract
+# the requested field value from the file text. It is a single bounded
+# structured-output call on the drafter tier; it returns a clean value or empty.
+# D5: an identifier-bearing field is never fabricated — the leaf returns nothing
+# for one, so the loop verifies via lookups instead.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFieldFromFile:
+    def test_runs_on_drafter_tier_single_call(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        rec = _patch_build_chat_model
+        fake = FakeChatModel({"value": "A viability assay protocol."})
+        rec["model"] = fake
+
+        leaves.extract_field_from_file(
+            "description",
+            "Protocol: the cells were exposed for 24h then read out.",
+            {"property": "description", "entity_type": "LabProtocol"},
+        )
+
+        assert all(c.get("role") == "drafter" for c in rec["calls"]), (
+            "extract_field_from_file must build the chat model on the drafter tier"
+        )
+        assert len(fake.structured_schemas) == 1, "exactly one structured-output bind"
+        assert len(fake.invoke_calls) == 1, "exactly one model invocation (a leaf)"
+
+    def test_extracts_a_clean_value(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {"value": "A dose-response viability assay in CHO-K1 cells."}
+        )
+
+        value = leaves.extract_field_from_file(
+            "description",
+            "file body with the description in it",
+            {"property": "description", "entity_type": "Study"},
+        )
+
+        assert value == "A dose-response viability assay in CHO-K1 cells."
+
+    def test_file_text_reaches_the_model_prompt(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({"value": "x"})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.extract_field_from_file(
+            "description",
+            "UNIQUE-FILE-MARKER-12345",
+            {"property": "description", "entity_type": "Study"},
+        )
+
+        human_msg = fake.invoke_calls[0][-1].content
+        assert "UNIQUE-FILE-MARKER-12345" in human_msg
+
+    def test_no_value_returns_empty_string(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # The file does not contain the field -> the model returns nothing usable.
+        _patch_build_chat_model["model"] = FakeChatModel({})
+
+        value = leaves.extract_field_from_file(
+            "description",
+            "an unrelated file body",
+            {"property": "description", "entity_type": "Study"},
+        )
+
+        assert value == ""
+
+    def test_identifier_field_extraction_is_refused(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        # D5: even if the model returns a CAS number, an identifier-bearing field
+        # must NOT be extracted from the file text — those come from lookups.
+        _patch_build_chat_model["model"] = FakeChatModel({"value": "103-90-2"})
+
+        value = leaves.extract_field_from_file(
+            "cas",
+            "the CAS number is 103-90-2",
+            {"property": "cas", "entity_type": "MolecularEntity"},
+        )
+
+        assert value == "", (
+            "D5: an identifier value must come from a lookup, not file text"
+        )
+
+
 def _flatten_keys(schema: Any) -> set[str]:
     """Every property key appearing anywhere in a (possibly nested) JSON schema."""
     keys: set[str] = set()

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -26,7 +26,7 @@ import pytest
 
 from builder.engine import AgentEngine
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
-from builder.tools.gap_analysis import Gap, GapReport, assess_gaps
+from builder.tools.gap_analysis import Gap, GapReport, Tier, assess_gaps
 from builder.tools.hitl import HumanResponse, InputResponse
 
 pytestmark = pytest.mark.timeout(120)
@@ -785,7 +785,7 @@ def _single_ask_gap_report(monkeypatch, gap: Gap, *, counts: dict[str, int]):
     monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
 
 
-def _study_desc_gap(tier: str = "MUST") -> Gap:
+def _study_desc_gap(tier: Tier = "MUST") -> Gap:
     return Gap(
         tier=tier,
         source="shacl",
@@ -1120,3 +1120,369 @@ class TestReportOnlyNeverAskedWithLLM:
         # The report-only gap was never offered to the user.
         assert human.inputs == []
         assert human.presented == []
+
+
+# ---------------------------------------------------------------------------
+# (Issue #257, fix A) Every question NAMES the entity it is about
+#
+# A gap with a concrete ``entity_id`` resolves to a real state entity; its TYPE,
+# NAME, KNOWN fields, and the MISSING field are threaded into the gap context the
+# phrase leaf consumes, so the phrased question references the entity BY NAME and
+# never a bare "this chemical / this protocol / this cell line".
+# ---------------------------------------------------------------------------
+
+
+def _backbone_with_compound(name: str = "Silychristin A") -> CrateState:
+    """Backbone + a MolecularEntity with a known name but no CAS recorded."""
+    state = _backbone()
+    state.add_entity(_entity("chem1", "MolecularEntity", name=name))
+    return state
+
+
+class TestQuestionNamesEntity:
+    def test_gap_context_carries_resolved_entity_name_and_type(self):
+        """``_gap_context`` resolves the entity from state and includes its name,
+        type, and known fields so the leaf can name it (Issue #257)."""
+        from builder.agents.guidance import _gap_context
+
+        engine = AgentEngine(state=_backbone_with_compound("Silychristin A"))
+        gap = Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id="chem1",
+            entity_type="MolecularEntity",
+            property="cas",
+            message="MolecularEntity SHOULD record a CAS number.",
+            suggestion="A CAS Registry Number.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+
+        ctx = _gap_context(engine, gap)
+
+        assert ctx.get("entity_name") == "Silychristin A"
+        assert ctx.get("entity_type") == "MolecularEntity"
+        # Known fields are surfaced so the leaf can ground the question.
+        known = ctx.get("known_fields") or {}
+        assert known.get("name") == "Silychristin A"
+        # The missing field being asked about is the gap's property.
+        assert ctx.get("property") == "cas"
+
+    def test_phrased_question_names_the_entity_not_this_chemical(self, monkeypatch):
+        """End-to-end: a gap on the named compound yields a question that contains
+        the NAME, never a bare 'this chemical'."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone_with_compound("Silychristin A"))
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+
+        cas_gap = Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id="chem1",
+            entity_type="MolecularEntity",
+            property="cas",
+            message="MolecularEntity SHOULD record a CAS number.",
+            suggestion="A CAS Registry Number like 103-90-2.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        _single_ask_gap_report(
+            monkeypatch,
+            cas_gap,
+            counts={"must_open": 0, "should_open": 1, "may_open": 0},
+        )
+
+        # A realistic phrase leaf: it echoes the entity name it is handed.
+        def _phrase(ctx):
+            name = ctx.get("entity_name") or "this chemical substance"
+            return f"What is the CAS Registry Number for {name}?"
+
+        monkeypatch.setattr(guidance, "phrase_gap_question", _phrase)
+        # An identifier gap: the user's prose can never become the value (D5).
+        monkeypatch.setattr(
+            guidance, "interpret_gap_reply", lambda _q, _r, _c: {"action": "skip"}
+        )
+
+        human = ScriptedHuman(input_answers=[_value("dunno")])
+        run_guidance(engine, human, max_rounds=5)
+
+        assert human.inputs, "the user must be prompted"
+        prompt = human.inputs[0][0]
+        assert "Silychristin A" in prompt
+        assert "this chemical" not in prompt.lower()
+
+    def test_deterministic_prompt_names_the_entity(self):
+        """Even the no-provider deterministic prompt names the entity (Issue #257)."""
+        from builder.agents.guidance import _ask_user
+
+        engine = AgentEngine(state=_backbone_with_compound("Silychristin A"))
+        gap = Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id="chem1",
+            entity_type="MolecularEntity",
+            property="description",
+            message="MolecularEntity SHOULD have a description.",
+            suggestion="A short free-text description.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        human = ScriptedHuman(input_answers=[_value("ok")])
+        _ask_user(engine, human, gap)
+
+        assert human.inputs
+        prompt = human.inputs[0][0]
+        assert "Silychristin A" in prompt
+
+
+# ---------------------------------------------------------------------------
+# (Issue #257, fix C) 'from_file' READS the file and EXTRACTS + COMMITS the value
+#
+# When the interpret leaf returns ``from_file`` and the named/likely file is
+# under an approved scan root, the loop reads it (via file_readers) and runs a
+# bounded extraction leaf to pull the requested field value, then COMMITS it.
+# An unreadable / outside-root file gracefully skips (commits nothing).
+# ---------------------------------------------------------------------------
+
+
+class TestFromFileReadsAndExtracts:
+    def _enable_provider(self, monkeypatch):
+        from builder.agents import guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+
+    def test_from_file_reads_extracts_and_commits(self, monkeypatch, tmp_path):
+        """The headline regression: a 'look in the file' reply must READ the file,
+        EXTRACT the value, and COMMIT it — not log a hint and skip (Issue #257)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        # A real file under an approved scan root carrying the value.
+        meta = tmp_path / "Assay-metadata.csv"
+        meta.write_text(
+            "field,value\n"
+            "description,A CHO-K1 OATP1C1 uptake assay measuring transporter "
+            "activity.\n"
+        )
+
+        state = _backbone()
+        state.approved_scan_roots.add(str(tmp_path))
+        engine = AgentEngine(state=state)
+        self._enable_provider(monkeypatch)
+
+        desc_gap = Gap(
+            tier="MUST",
+            source="shacl",
+            entity_id="st1",
+            entity_type="Study",
+            property="https://schema.org/description",
+            message="Study MUST have a description.",
+            suggestion="A free-text study description.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        _single_ask_gap_report(
+            monkeypatch,
+            desc_gap,
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "Describe the study."
+        )
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _r, _c: {"action": "from_file", "filename": str(meta)},
+        )
+
+        # The extraction leaf pulls the value from the file text.
+        captured: dict[str, object] = {}
+
+        def _extract(field, file_text, ctx):
+            captured["field"] = field
+            captured["file_text"] = file_text
+            return "A CHO-K1 OATP1C1 uptake assay measuring transporter activity."
+
+        monkeypatch.setattr(guidance, "extract_field_from_file", _extract)
+
+        human = ScriptedHuman(
+            input_answers=[_value(f"look in {meta}")]
+        )
+        summary = run_guidance(engine, human, max_rounds=5)
+
+        # The value was READ from the file, extracted, and COMMITTED (not skipped).
+        applied = _get(engine, "st1")
+        assert applied.fields.get("description") == (
+            "A CHO-K1 OATP1C1 uptake assay measuring transporter activity."
+        )
+        # The extraction leaf actually saw the FILE TEXT (it was read).
+        assert "OATP1C1" in str(captured.get("file_text", ""))
+        assert captured.get("field") == "description"
+        # The gap is recorded as resolved.
+        assert any(r.get("entity_id") == "st1" for r in summary["resolved"])
+
+    def test_from_file_outside_approved_root_skips_gracefully(
+        self, monkeypatch, tmp_path
+    ):
+        """A file outside every approved scan root is NOT read — the loop skips
+        gracefully and commits nothing (sandbox honoured, Issue #257)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        # The file exists, but NO approved scan root contains it.
+        outside = tmp_path / "secret.csv"
+        outside.write_text("description,leak\n")
+
+        engine = AgentEngine(state=_backbone())  # approved_scan_roots is empty
+        original = _get(engine, "st1").fields.get("description")
+        self._enable_provider(monkeypatch)
+
+        desc_gap = Gap(
+            tier="MUST",
+            source="shacl",
+            entity_id="st1",
+            entity_type="Study",
+            property="https://schema.org/description",
+            message="Study MUST have a description.",
+            suggestion="A free-text study description.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        _single_ask_gap_report(
+            monkeypatch,
+            desc_gap,
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "Describe the study."
+        )
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _r, _c: {"action": "from_file", "filename": str(outside)},
+        )
+
+        def _boom_extract(*_a, **_k):  # pragma: no cover - must not run
+            raise AssertionError(
+                "an out-of-root file must never be read or extracted"
+            )
+
+        monkeypatch.setattr(guidance, "extract_field_from_file", _boom_extract)
+
+        human = ScriptedHuman(input_answers=[_value(f"it's in {outside}")])
+        summary = run_guidance(engine, human, max_rounds=5)
+
+        # Nothing committed — the sandbox refused the read.
+        assert _get(engine, "st1").fields.get("description") == original
+        assert not any(r.get("entity_id") == "st1" for r in summary["resolved"])
+
+    def test_from_file_unreadable_file_skips_gracefully(self, monkeypatch, tmp_path):
+        """A from_file pointing at a missing/unreadable file under an approved root
+        skips gracefully (no value extracted, nothing committed)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        state = _backbone()
+        state.approved_scan_roots.add(str(tmp_path))
+        engine = AgentEngine(state=state)
+        original = _get(engine, "st1").fields.get("description")
+        self._enable_provider(monkeypatch)
+
+        missing = tmp_path / "does-not-exist.csv"
+
+        desc_gap = Gap(
+            tier="MUST",
+            source="shacl",
+            entity_id="st1",
+            entity_type="Study",
+            property="https://schema.org/description",
+            message="Study MUST have a description.",
+            suggestion="A free-text study description.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        _single_ask_gap_report(
+            monkeypatch,
+            desc_gap,
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "Describe the study."
+        )
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _r, _c: {"action": "from_file", "filename": str(missing)},
+        )
+        # Extraction must not even be reached (no readable text).
+        monkeypatch.setattr(
+            guidance,
+            "extract_field_from_file",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("must not extract from an unreadable file")
+            ),
+        )
+
+        human = ScriptedHuman(input_answers=[_value(f"see {missing}")])
+        run_guidance(engine, human, max_rounds=5)
+
+        assert _get(engine, "st1").fields.get("description") == original
+
+    def test_from_file_identifier_field_is_not_committed_from_file(
+        self, monkeypatch, tmp_path
+    ):
+        """D5: an identifier-bearing field is never committed from file text — even
+        a from_file reply pointing at the value must not land it (lookups only)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        meta = tmp_path / "compound.csv"
+        meta.write_text("cas,103-90-2\n")
+
+        state = _backbone_with_compound("Acetaminophen")
+        state.approved_scan_roots.add(str(tmp_path))
+        engine = AgentEngine(state=state)
+        self._enable_provider(monkeypatch)
+
+        cas_gap = Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id="chem1",
+            entity_type="MolecularEntity",
+            property="cas",
+            message="MolecularEntity SHOULD record a CAS number.",
+            suggestion="A CAS Registry Number.",
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        _single_ask_gap_report(
+            monkeypatch,
+            cas_gap,
+            counts={"must_open": 0, "should_open": 1, "may_open": 0},
+        )
+
+        monkeypatch.setattr(
+            guidance, "phrase_gap_question", lambda _ctx: "What is the CAS number?"
+        )
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _r, _c: {"action": "from_file", "filename": str(meta)},
+        )
+        # Even if the leaf were to return a CAS, the loop's D5 guard refuses it.
+        monkeypatch.setattr(
+            guidance, "extract_field_from_file", lambda *_a, **_k: "103-90-2"
+        )
+
+        human = ScriptedHuman(input_answers=[_value(f"cas is in {meta}")])
+        run_guidance(engine, human, max_rounds=5)
+
+        applied = _get(engine, "chem1")
+        assert applied.fields.get("cas") != "103-90-2", (
+            "D5: an identifier must come from a lookup, not file extraction"
+        )

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -245,13 +245,25 @@ class TestReportOnlyGaps:
 
     def test_committable_mit_keeps_ask_or_draft(self):
         """A crate-level MIT gap whose field DOES map to a crate slot
-        (name / description / identifier) is still committable -> ask-user/draft."""
-        report = assess_gaps(_backbone())
+        (name / description / identifier) AND whose entity type has an instance is
+        still committable -> ask-user/draft.
+
+        Note (#257, fix B): the field mapping ALONE is not enough — the entity type
+        must also have an instance, else there is no concrete entity to ask about
+        and the gap is report-only. So we use a Study with NO description (a present
+        entity type, ``Study:description`` unfilled, crate-settable)."""
+        state = _backbone()
+        # Drop the Study description so its committable MIT slot is unfilled.
+        study = state.get_entity("st1")
+        assert study is not None
+        study.fields.pop("description", None)
+        report = assess_gaps(state)
         committable_mit = [
             g
             for g in report.gaps
             if g.source == "mit"
             and g.entity_id is None
+            and g.entity_type == "Study"
             and _local(g.property) in _CRATE_SETTABLE_FIELDS
         ]
         assert committable_mit, "expected at least one committable MIT gap"
@@ -270,6 +282,72 @@ class TestReportOnlyGaps:
             assert committable_flags == sorted(committable_flags, reverse=True), [
                 (g.fix_hint, g.source, g.property) for g in within
             ]
+
+
+# ---------------------------------------------------------------------------
+# (Issue #257, fix B) MIT gaps for an entity TYPE with no instance must not be
+# offered as if a specific entity exists — they are report-only.
+# ---------------------------------------------------------------------------
+
+
+class TestMitGapsForAbsentEntityType:
+    def test_molecular_entity_gaps_report_only_when_no_instance(self):
+        """The backbone has NO MolecularEntity, so a MIT param keyed on one (even a
+        crate-settable field like name / identifier) has no concrete entity to
+        ask about and must be report-only — not a bare 'this chemical' ask."""
+        report = assess_gaps(_backbone())
+        molecular = [
+            g
+            for g in report.gaps
+            if g.source == "mit" and g.entity_type == "MolecularEntity"
+        ]
+        assert molecular, "expected unfilled MolecularEntity MIT params"
+        assert all(g.fix_hint == "report-only" for g in molecular), [
+            (g.property, g.fix_hint) for g in molecular
+        ]
+
+    def test_present_entity_type_mit_gaps_stay_committable(self):
+        """A MIT param keyed on an entity type that HAS an instance (Study) with a
+        crate-settable field stays committable -> ask/draft; absence is the
+        discriminator, not the entity type itself."""
+        state = _backbone()
+        # Drop the Study description so its committable MIT slot is unfilled.
+        study = state.get_entity("st1")
+        assert study is not None
+        study.fields.pop("description", None)
+        report = assess_gaps(state)
+        present = [
+            g
+            for g in report.gaps
+            if g.source == "mit"
+            and g.entity_type == "Study"
+            and _local(g.property) in _CRATE_SETTABLE_FIELDS
+        ]
+        assert present, "expected committable MIT gaps for present entity types"
+        assert all(g.fix_hint in ("ask-user", "draft") for g in present), [
+            (g.entity_type, g.property, g.fix_hint) for g in present
+        ]
+
+    def test_present_molecular_entity_keeps_committable_field(self):
+        """With a MolecularEntity in state, its crate-settable MIT slots become
+        committable again — the report-only downgrade is *only* for absent types."""
+        state = _backbone()
+        state.add_entity(
+            _entity("chem1", "MolecularEntity", name="Acetaminophen")
+        )
+        report = assess_gaps(state)
+        molecular_committable = [
+            g
+            for g in report.gaps
+            if g.source == "mit"
+            and g.entity_type == "MolecularEntity"
+            and _local(g.property) in _CRATE_SETTABLE_FIELDS
+            and g.fix_hint != "report-only"
+        ]
+        assert molecular_committable, (
+            "a present MolecularEntity must make its crate-settable MIT slots "
+            "committable again"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #257

The LLM-mediated HITL guidance (#249) asked unanswerable questions because they never named WHICH entity they were about, and it ignored the user pointing at files. Three TDD fixes, all confined to the guidance lane.

## A. Name the entity in every question

When a gap has a concrete `entity_id`, `_gap_context` now resolves the entity from `engine.state` and threads its **type**, **name** (`entity_name`), and **known descriptive fields** (`known_fields`) into the gap context the phrase leaf consumes. The phrase leaf renders the entity name and is instructed to name it; the deterministic / no-provider prompt names it too.

**Before → after**

| Before (contextless) | After (names the entity) |
| --- | --- |
| "What is the CAS Registry Number for **this chemical substance**?" | "What is the CAS Registry Number for **Silychristin A**?" |
| "step-by-step description of the test method in **this protocol**?" | "…the test method in **'OATP1C1 uptake assay'** (a LabProtocol)?" |
| "official identifier for **this cell line**?" | "…identifier for **'CHO-K1'** (a CellLineSample)?" |

Deterministic prompt, before → after:
`Please provide a value for 'description' on the MolecularEntity.` → `Please provide a value for 'description' for 'Silychristin A' (a MolecularEntity).`

## B. Gaps for entity TYPES with no instance

The original run asked for "this chemical"'s CAS with **zero** MolecularEntity instances. In `_mit_gaps`, a MIT parameter keyed *only* on entity types with no instance in state (e.g. `MolecularEntity:cas` when there are no MolecularEntities) is now a **report-only creation-prompt** gap (`"No MolecularEntity recorded yet; the MIT profile expects '…'. Add one to capture it."`) instead of a per-field ask phrased as if a specific entity exists. The discriminator is **absence of an instance**, not the entity type itself: once a MolecularEntity exists, its crate-settable MIT slots become committable again. MIT slots that list multiple types (e.g. `Investigation:name;Study:name;Assay:name`) stay committable as long as *any* listed type has an instance.

## C. `from_file` actually reads + extracts (instead of "not storing prose" and skipping)

When `interpret_gap_reply` returns `from_file`, the loop now:
1. **Locates** the file — the interpret leaf's `filename` hint, resolved against `approved_scan_roots` and the scanned-file inventory by base name, plus any scanned file the user named verbatim in the reply (`_candidate_file_paths`).
2. **Reads** the first candidate **inside an approved scan root** via `file_readers.read_file` — fail-closed through `scanner._contain` (the same sandbox the engine uses), **one bounded read per gap**, size-capped to 32 KiB and never raising out (`_read_pointed_file`).
3. **Extracts** the requested field value from the file text via a new bounded drafter-tier leaf `extract_field_from_file` (single structured-output call), then **commits** it through `set_fields` (never hand-rolled JSON-LD).
4. Skips gracefully (commits nothing, clear log) when the file is outside every approved root, missing/unreadable, or yields no value.

The user's reply prose is still never stored — only a value extracted from the file's text.

**D5 (Verify, Don't Trust).** Identifier-bearing fields (CAS / InChIKey / SMILES / CID / ORCID / DOI / accession …) are never extracted from file text — they come from lookups. Guarded in **two** places: the leaf short-circuits to `""` for an identifier field, and the loop refuses an identifier `from_file` commit before it can land.

## Other

- Fixed the pre-existing ty diagnostic at `tests/test_agents_guidance.py:790` (`_study_desc_gap`'s `tier` param typed as `Tier`).

## Tests (new)

`tests/agents/test_leaves.py`
- `TestPhraseGapQuestionNamesEntity::{test_entity_name_reaches_the_model_prompt, test_known_fields_reach_the_model_prompt}`
- `TestExtractFieldFromFile::{test_runs_on_drafter_tier_single_call, test_extracts_a_clean_value, test_file_text_reaches_the_model_prompt, test_no_value_returns_empty_string, test_identifier_field_extraction_is_refused}`

`tests/test_tools_gap_analysis.py`
- `TestMitGapsForAbsentEntityType::{test_molecular_entity_gaps_report_only_when_no_instance, test_present_entity_type_mit_gaps_stay_committable, test_present_molecular_entity_keeps_committable_field}`

`tests/test_agents_guidance.py`
- `TestQuestionNamesEntity::{test_gap_context_carries_resolved_entity_name_and_type, test_phrased_question_names_the_entity_not_this_chemical, test_deterministic_prompt_names_the_entity}`
- `TestFromFileReadsAndExtracts::{test_from_file_reads_extracts_and_commits, test_from_file_outside_approved_root_skips_gracefully, test_from_file_unreadable_file_skips_gracefully, test_from_file_identifier_field_is_not_committed_from_file}`

## Gates (all green)

- `uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agents_guidance.py tests/test_tools_gap_analysis.py tests/agents/test_leaves.py` → **104 passed**
- `tests/test_agents_build.py` (guidance integration) → 19 passed
- `uv run ruff check` → All checks passed
- `uv run --extra langchain ty check` → All checks passed (incl. the :790 fix)
- No-provider deterministic fallback stays green.

## Note

The lane is strict (guidance.py / leaves.py / gap_analysis.py + tests), so AGENTS.md §14.6 was **not** updated here even though the design changed (from_file now reads+extracts; entity-named questions; type-level no-instance gaps). Worth a follow-up doc edit outside this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
