### PR TITLE
feat(pipeline): live progress spinner for the interactive build (#266)

### DIFF
--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -29,9 +29,11 @@ from __future__ import annotations
 
 import inspect
 import logging
+from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from builder.agents.progress_spinner import ProgressSpinner
 from builder.tools.hitl import is_interactive
 from builder.tools.session import save_session
 
@@ -139,8 +141,81 @@ def run_interactive_build(
     Raises:
         CrateExportError: If the final on-disk export fails (surfaced first).
     """
-    emit: OutputChannel = output or (lambda _msg: None)
+    base_emit: OutputChannel = output or (lambda _msg: None)
+    human: HumanInterface | None = getattr(engine, "human_interface", None)
+    interactive = is_interactive(human)
 
+    # Live progress spinner (#266): only on the REAL interactive path (an
+    # interactive HumanInterface — the CLI's ConsoleHumanInterface), so the
+    # headless / simulated path (the A/B eval, batch, tests) stays completely
+    # silent — no spinner, no daemon thread, no stdout noise — and the built
+    # @graph hash is unperturbed (the spinner is pure UI). When active it:
+    #   * subscribes to engine.on_tool_event so the live region shows the
+    #     currently-running deterministic tool (the pipeline runs tools via
+    #     engine.run_tool, not LangChain, so this is the only per-tool signal), and
+    #   * receives the existing #253 phase-progress strings via set_current.
+    # The prior engine.on_tool_event hook is restored afterwards.
+    spinner: ProgressSpinner | None = ProgressSpinner() if interactive else None
+    emit = _spinner_emit(base_emit, spinner)
+    prior_tool_event = engine.on_tool_event
+    if spinner is not None:
+        engine.on_tool_event = lambda tool, _phase: (
+            spinner.set_current(tool) if _phase == "start" else None
+        )
+
+    spinner_ctx = spinner if spinner is not None else nullcontext()
+    try:
+        with spinner_ctx:
+            return _run_build_body(
+                engine,
+                human=human,
+                interactive=interactive,
+                emit=emit,
+                pipeline_runner=pipeline_runner,
+                guidance_runner=guidance_runner,
+                exporter=exporter,
+            )
+    finally:
+        # Restore the prior tool-event hook even if the build raised (#266).
+        engine.on_tool_event = prior_tool_event
+
+
+def _spinner_emit(base_emit: OutputChannel, spinner: ProgressSpinner | None) -> OutputChannel:
+    """Wrap *base_emit* so each progress line also drives the spinner (#266).
+
+    With no spinner this is exactly *base_emit* (a strict pass-through — the
+    headless path is unchanged). With a spinner, every emitted line is fed into
+    ``spinner.set_current`` (the live region shows the latest phase, e.g. the
+    #253 ``Scaffolding ISA backbone…`` strings) **and** still forwarded to
+    *base_emit* so persistent lines (``Scanning ✓``, the guidance summary, the
+    final ``Crate written to <path>``) print above the spinner as before.
+    """
+    if spinner is None:
+        return base_emit
+
+    def emit(msg: str) -> Any:
+        spinner.set_current(msg)
+        return base_emit(msg)
+
+    return emit
+
+
+def _run_build_body(
+    engine: AgentEngine,
+    *,
+    human: HumanInterface | None,
+    interactive: bool,
+    emit: OutputChannel,
+    pipeline_runner: PipelineRunner | None,
+    guidance_runner: GuidanceRunner | None,
+    exporter: Exporter | None,
+) -> dict[str, Any]:
+    """Run the pipeline → (guidance) → export → save sequence (#266 spinner body).
+
+    Split out of :func:`run_interactive_build` so the spinner context manager can
+    wrap the whole build (pipeline + guidance) with the wiring decisions made once
+    by the caller. Behaviour is identical to the pre-#266 inline body.
+    """
     # Progress (#241): the input is already scanned by engine.initialize(); lead
     # with a concise inventory line so the user sees the build picking up.
     scanned = len(getattr(engine.state, "scanned_files", []) or [])
@@ -150,8 +225,7 @@ def run_interactive_build(
     pipeline_runner = pipeline_runner or _default_pipeline_runner()
     pipeline_result = _run_pipeline_with_progress(pipeline_runner, engine, emit)
 
-    human: HumanInterface | None = getattr(engine, "human_interface", None)
-    if not is_interactive(human):
+    if not interactive:
         # Headless / simulated: run the automated pipeline ALONE so the A/B stays
         # a clean automated-vs-automated comparison. No guidance, no summary —
         # but the build is still completed, so it must still be written to disk.

--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -1,0 +1,211 @@
+"""A live progress spinner for the deterministic interactive build (#266).
+
+The DEFAULT ``--interactive`` (pipeline) build prints static phase lines (#253),
+so the ~tens-of-seconds deterministic spine looked frozen. :class:`ProgressSpinner`
+gives it a live Rich spinner like the legacy ReAct loop's ``_ThinkingSpinner``
+(``builder/agents/agent_loop.py``): an animated dots spinner with a rotating funny
+toxicology-themed phrase, the currently-running tool/phase, and elapsed seconds,
+all updating in place.
+
+It is a reusable context manager driven by a daemon tick thread, rendering::
+
+    <funny phrase>… (<elapsed>s) · <current op>
+
+**HITL safety.** The guidance tail asks the user questions via ``input()`` mid-build;
+a Rich ``Live`` repaint would clobber that prompt. The spinner registers itself as the
+active console animation (``builder.tools.hitl.register_console_animation``) on enter and
+unregisters on exit, so a console HITL prompt — which wraps its ``input()`` in
+``suspend_console_animation`` (#239) — calls :meth:`pause` (tear down the Live region,
+stop ticking) for the duration of the prompt and :meth:`resume` afterwards. The tick
+thread skips while paused.
+
+This module deliberately defines its OWN fresh :data:`TOX_SPINNER_PHRASES` list (same
+vibe as the legacy one) rather than importing from ``agent_loop.py``, which is owned by
+another lane.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import threading
+from time import monotonic
+from typing import Any
+
+from builder.tools.hitl import (
+    register_console_animation,
+    unregister_console_animation,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ProgressSpinner", "TOX_SPINNER_PHRASES"]
+
+
+# A FRESH toxicology-themed phrase list (defined here, NOT imported from
+# agent_loop.py). Same playful lab/FAIR vibe as the legacy loop's list.
+TOX_SPINNER_PHRASES: list[str] = [
+    "intoxicating",
+    "ro-crating",
+    "FAIR-ifying",
+    "culturing the cells",
+    "calibrating the dose",
+    "annotating ontologies",
+    "resolving compounds",
+    "reticulating gels",
+    "buffering the buffer",
+    "negotiating with reviewer 2",
+    "summoning the IC50",
+    "vortexing thoughtfully",
+    "rehydrating the lyophilate",
+    "titrating responsibly",
+    "resuspending the pellet",
+    "autoclaving doubt",
+    "thawing the -80",
+    "centrifuging the chaos",
+    "pipetting precisely",
+    "decoding the SDS",
+    "labelling 'compound X'",
+    "counting colonies, twice",
+    "manifesting p<0.05",
+    "consulting the FAIR gods",
+    "interoperating",
+    "double-gloving",
+    "minting identifiers",
+    "validating the pyramid",
+    "wrangling SHACL shapes",
+    "linking provenance",
+]
+
+
+class ProgressSpinner:
+    """A Rich status spinner that ticks elapsed seconds and shows the current op.
+
+    Used as a context manager around the deterministic interactive build. A daemon
+    thread refreshes the rendered line (so the elapsed-seconds counter advances even
+    while a long phase runs); :meth:`set_current` swaps in the currently-running
+    tool/phase. On enter it registers with the hitl animation registry so a HITL
+    prompt can :meth:`pause`/:meth:`resume` it via ``suspend_console_animation``.
+
+    Colour convention mirrors the legacy ``_ThinkingSpinner``: green = working,
+    dim = elapsed/meta, cyan = the current op.
+    """
+
+    def __init__(
+        self,
+        console: Any | None = None,
+        phrase: str | None = None,
+        *,
+        tick_interval: float = 0.5,
+    ) -> None:
+        """Build a spinner.
+
+        Args:
+            console: A Rich ``Console`` (or a compatible object exposing
+                ``status(...)``). Defaults to a fresh ``rich.console.Console``.
+            phrase: The funny phrase to show. Defaults to a random pick from
+                :data:`TOX_SPINNER_PHRASES`.
+            tick_interval: Seconds between elapsed-time repaints by the daemon
+                thread. Kept configurable so tests can tick quickly.
+        """
+        if console is None:
+            from rich.console import Console
+
+            console = Console()
+        self._console = console
+        self._phrase = phrase or random.choice(TOX_SPINNER_PHRASES)
+        self._current: str | None = None
+        self._tick_interval = tick_interval
+        self._start = monotonic()
+        self._stop = threading.Event()
+        # Set while a HITL prompt owns the terminal: the tick thread must not
+        # repaint the Rich Live region over the prompt (else stdin is unusable).
+        self._paused = threading.Event()
+        self._status = console.status(
+            self._render(), spinner="dots", spinner_style="green"
+        )
+        self._thread = threading.Thread(target=self._tick, daemon=True)
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _render(self) -> str:
+        """Render the spinner line: phrase, elapsed seconds, and the current op."""
+        elapsed = int(monotonic() - self._start)
+        line = f"[green]{self._phrase}…[/green] [dim]({elapsed}s)[/dim]"
+        if self._current:
+            line += f"  [dim]·[/dim] [cyan]{self._current}[/cyan]"
+        return line
+
+    def _tick(self) -> None:
+        """Daemon loop: repaint the elapsed time roughly every tick_interval.
+
+        Skips entirely while paused (a HITL prompt owns the terminal). A repaint
+        failure (e.g. the status was torn down) stops the loop cleanly.
+        """
+        while not self._stop.wait(self._tick_interval):
+            if self._paused.is_set():
+                continue
+            try:
+                self._status.update(self._render())
+            except Exception:  # noqa: BLE001 — a torn-down Live must not crash the thread
+                break
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_current(self, text: str | None) -> None:
+        """Show (or clear, with ``None``) the currently-running tool/phase.
+
+        Records the op and repaints immediately — unless paused, in which case the
+        op is remembered but the Live region is left alone so a HITL prompt stays
+        readable (the next resume/tick picks it up).
+        """
+        self._current = text
+        if self._paused.is_set():
+            return
+        try:
+            self._status.update(self._render())
+        except Exception:  # noqa: BLE001 — UI chrome must never break the build
+            logger.debug("spinner set_current: status.update failed", exc_info=True)
+
+    def pause(self) -> None:
+        """Tear down the Live region and stop ticking so a HITL prompt is clean.
+
+        Called (via :func:`builder.tools.hitl.suspend_console_animation`) when the
+        guidance tail needs ``input()`` mid-build. Best-effort and idempotent.
+        """
+        self._paused.set()
+        try:
+            self._status.stop()
+        except Exception:  # noqa: BLE001
+            logger.debug("spinner pause: status.stop failed", exc_info=True)
+
+    def resume(self) -> None:
+        """Restart the Live region after a HITL prompt completes."""
+        try:
+            self._status.start()
+        except Exception:  # noqa: BLE001
+            logger.debug("spinner resume: status.start failed", exc_info=True)
+        self._paused.clear()
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "ProgressSpinner":
+        self._status.__enter__()
+        self._thread.start()
+        register_console_animation(self)
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        unregister_console_animation(self)
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        try:
+            self._status.__exit__(*exc)
+        except Exception:  # noqa: BLE001 — teardown must never raise on exit
+            logger.debug("spinner exit: status.__exit__ failed", exc_info=True)

--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -89,6 +89,18 @@ class ProgressSpinner:
 
     Colour convention mirrors the legacy ``_ThinkingSpinner``: green = working,
     dim = elapsed/meta, cyan = the current op.
+
+    **Non-TTY safety (CI / piped).** A live animation only makes sense on a real
+    terminal. When the console is NOT a terminal (``console.is_terminal`` is
+    falsey — CI, a pipe, a captured/redirected stream), the spinner is built in a
+    *silent* mode: it opens **no** Rich ``Live`` region (so no Rich background
+    refresh thread) and starts **no** daemon tick thread, and every public method
+    (:meth:`set_current` / :meth:`pause` / :meth:`resume` / :meth:`__enter__` /
+    :meth:`__exit__`) is a cheap, safe no-op. This keeps the headless / CI path
+    free of background threads to start, stop and join under a ``--timeout``
+    thread-dumper, so it can never hang there; on a real TTY it animates exactly
+    as before. A console without an ``is_terminal`` attribute (e.g. a test fake)
+    defaults to the animated path.
     """
 
     def __init__(
@@ -121,10 +133,21 @@ class ProgressSpinner:
         # Set while a HITL prompt owns the terminal: the tick thread must not
         # repaint the Rich Live region over the prompt (else stdin is unusable).
         self._paused = threading.Event()
-        self._status = console.status(
-            self._render(), spinner="dots", spinner_style="green"
-        )
-        self._thread = threading.Thread(target=self._tick, daemon=True)
+        # Only animate on a real terminal. A non-terminal output (CI, a pipe, a
+        # captured stream) gets the silent no-op mode: no Live region, no Rich
+        # refresh thread, no daemon tick thread — nothing to hang on teardown.
+        # A console missing ``is_terminal`` (a test fake) defaults to animated.
+        self._active: bool = bool(getattr(console, "is_terminal", True))
+        if self._active:
+            self._status: Any | None = console.status(
+                self._render(), spinner="dots", spinner_style="green"
+            )
+            self._thread: threading.Thread | None = threading.Thread(
+                target=self._tick, daemon=True
+            )
+        else:
+            self._status = None
+            self._thread = None
 
     # ------------------------------------------------------------------
     # Rendering
@@ -147,8 +170,11 @@ class ProgressSpinner:
         while not self._stop.wait(self._tick_interval):
             if self._paused.is_set():
                 continue
+            status = self._status
+            if status is None:  # silent mode never starts this thread; belt-and-braces
+                break
             try:
-                self._status.update(self._render())
+                status.update(self._render())
             except Exception:  # noqa: BLE001 — a torn-down Live must not crash the thread
                 break
 
@@ -161,9 +187,12 @@ class ProgressSpinner:
 
         Records the op and repaints immediately — unless paused, in which case the
         op is remembered but the Live region is left alone so a HITL prompt stays
-        readable (the next resume/tick picks it up).
+        readable (the next resume/tick picks it up). On a non-TTY (silent mode)
+        the op is still remembered but there is no Live region to repaint.
         """
         self._current = text
+        if not self._active or self._status is None:
+            return  # silent mode: remember the op, paint nothing
         if self._paused.is_set():
             return
         try:
@@ -175,16 +204,25 @@ class ProgressSpinner:
         """Tear down the Live region and stop ticking so a HITL prompt is clean.
 
         Called (via :func:`builder.tools.hitl.suspend_console_animation`) when the
-        guidance tail needs ``input()`` mid-build. Best-effort and idempotent.
+        guidance tail needs ``input()`` mid-build. Best-effort and idempotent. A
+        no-op in silent mode (there is no Live region owning the terminal).
         """
         self._paused.set()
+        if not self._active or self._status is None:
+            return
         try:
             self._status.stop()
         except Exception:  # noqa: BLE001
             logger.debug("spinner pause: status.stop failed", exc_info=True)
 
     def resume(self) -> None:
-        """Restart the Live region after a HITL prompt completes."""
+        """Restart the Live region after a HITL prompt completes.
+
+        A no-op in silent mode (there was no Live region to restart).
+        """
+        if not self._active or self._status is None:
+            self._paused.clear()
+            return
         try:
             self._status.start()
         except Exception:  # noqa: BLE001
@@ -196,15 +234,24 @@ class ProgressSpinner:
     # ------------------------------------------------------------------
 
     def __enter__(self) -> "ProgressSpinner":
-        self._status.__enter__()
-        self._thread.start()
+        # In silent mode (non-TTY) there is no Live region and no tick thread to
+        # start — just register so a HITL prompt's suspend/resume stays valid.
+        if self._active and self._status is not None and self._thread is not None:
+            self._status.__enter__()
+            self._thread.start()
         register_console_animation(self)
         return self
 
     def __exit__(self, *exc: Any) -> None:
         unregister_console_animation(self)
+        # Silent mode: nothing was started, so nothing to stop or join.
+        if not self._active:
+            return
         self._stop.set()
-        self._thread.join(timeout=1.0)
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+        if self._status is None:
+            return
         try:
             self._status.__exit__(*exc)
         except Exception:  # noqa: BLE001 — teardown must never raise on exit

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -211,6 +212,14 @@ class AgentEngine:
         self.human_interface = human_interface
         self._running = False
         self.profiler: ProfilingLogger | None = None
+        # Optional tool-event observer (#266): invoked at the start and end of
+        # every ``run_tool`` call with ``(tool_name, "start"|"end")``. Default
+        # ``None`` is a strict no-op (no behavior change). The deterministic
+        # pipeline runs tools via ``run_tool`` (not LangChain), so this is the
+        # single hook the interactive build's progress spinner subscribes to in
+        # order to show the currently-running tool. A callback that raises must
+        # never break ``run_tool`` (it is UI chrome).
+        self.on_tool_event: Callable[[str, str], None] | None = None
         # Per-session memo of build_and_validate results keyed on
         # (validation-input hash, profile, severity) so consecutive validations
         # of an unchanged crate skip the ~3.7s SHACL re-run (#155).
@@ -451,12 +460,33 @@ class AgentEngine:
         )
         return None
 
+    def _fire_tool_event(self, tool_name: str, phase: str) -> None:
+        """Notify the optional ``on_tool_event`` observer (#266).
+
+        Best-effort: a ``None`` observer is a no-op, and an observer that raises
+        is logged but never propagated — the callback is UI chrome (the interactive
+        build's progress spinner) and must never break a tool call.
+        """
+        cb = self.on_tool_event
+        if cb is None:
+            return
+        try:
+            cb(tool_name, phase)
+        except Exception:  # noqa: BLE001 — a UI callback must never break run_tool
+            logger.debug("on_tool_event(%s, %s) raised", tool_name, phase, exc_info=True)
+
     def run_tool(self, tool_name: str, **kwargs) -> Any:
         """Execute a tool by name with kwargs.
 
         Looks up the tool function from the registry and calls it.
         Records the call in the reasoning log and the profiling log
         (if a profiler is active).
+
+        Fires the optional ``on_tool_event`` observer with ``(tool_name, "start")``
+        before and ``(tool_name, "end")`` after the call (#266) — the "end" event
+        fires even when the tool raises (``finally``-guarded), and a raising
+        observer never breaks the call. The observer defaults to ``None`` (a strict
+        no-op), so behaviour is unchanged when it is unset.
 
         Args:
             tool_name: Name of the tool to execute.
@@ -468,6 +498,14 @@ class AgentEngine:
         Raises:
             ValueError: If the tool name is not recognised.
         """
+        self._fire_tool_event(tool_name, "start")
+        try:
+            return self._run_tool_impl(tool_name, **kwargs)
+        finally:
+            self._fire_tool_event(tool_name, "end")
+
+    def _run_tool_impl(self, tool_name: str, **kwargs) -> Any:
+        """The actual tool dispatch (wrapped by :meth:`run_tool` for events)."""
         import time as _time
 
         _start = _time.perf_counter()

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -506,3 +506,136 @@ class TestProgressOutput:
             guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
         )
         assert result["export"]["success"] is True
+
+
+class TestProgressSpinner:
+    """#266 — the DEFAULT interactive build drives a live progress spinner.
+
+    The spinner is created only on the REAL interactive path (an interactive
+    ``HumanInterface``), so headless / simulated runs (the A/B eval, batch, tests)
+    stay completely silent — no spinner, no daemon thread, no stdout noise — and
+    the built ``@graph`` hash is unperturbed. When the spinner runs it subscribes
+    to the engine's ``on_tool_event`` hook (set during the build, restored after)
+    and feeds the #253 phase-progress strings into ``set_current``.
+    """
+
+    def test_no_spinner_on_non_interactive_build(self, tmp_path, monkeypatch) -> None:
+        """A simulated (headless) build creates NO spinner — no thread, no noise."""
+        import builder.agents.build as build_mod
+        from builder.agents.build import run_interactive_build
+
+        created: list[Any] = []
+
+        class _SpySpinner:
+            def __init__(self, *a: Any, **k: Any) -> None:
+                created.append(self)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a: Any) -> None:
+                pass
+
+            def set_current(self, _text: str) -> None:
+                pass
+
+        monkeypatch.setattr(build_mod, "ProgressSpinner", _SpySpinner, raising=False)
+
+        out_dir = tmp_path / "headless-ro-crate"
+        engine = _engine(SimulatedHumanInterface())
+        engine.state.metadata.output_path = str(out_dir)
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=[].append,
+        )
+
+        assert created == [], "no spinner may be created on a headless build"
+
+    def test_spinner_created_on_interactive_build(self, tmp_path, monkeypatch) -> None:
+        """A real interactive build creates the spinner and drives set_current."""
+        import builder.agents.build as build_mod
+        from builder.agents.build import run_interactive_build
+
+        ops: list[str] = []
+        created: list[Any] = []
+
+        class _SpySpinner:
+            def __init__(self, *a: Any, **k: Any) -> None:
+                created.append(self)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a: Any) -> None:
+                pass
+
+            def set_current(self, text: str) -> None:
+                ops.append(text)
+
+        monkeypatch.setattr(build_mod, "ProgressSpinner", _SpySpinner, raising=False)
+
+        out_dir = tmp_path / "interactive-ro-crate"
+        engine = _engine(_InteractiveHuman())
+        engine.state.metadata.output_path = str(out_dir)
+
+        def fake_pipeline(eng, *, progress=None, **kw):
+            if progress is not None:
+                progress("Scaffolding ISA backbone…")
+            return dict(_PIPELINE_RESULT)
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=fake_pipeline,
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=[].append,
+        )
+
+        assert len(created) == 1, "the interactive build must create one spinner"
+        # The #253 phase string was fed into the spinner's current-op display.
+        assert any("scaffold" in op.lower() for op in ops)
+
+    def test_on_tool_event_restored_after_build(self, tmp_path) -> None:
+        """The engine's on_tool_event hook is restored to its prior value after."""
+        from builder.agents.build import run_interactive_build
+
+        out_dir = tmp_path / "restore-ro-crate"
+        engine = _engine(_InteractiveHuman())
+        engine.state.metadata.output_path = str(out_dir)
+        sentinel = lambda _n, _p: None  # noqa: E731
+        engine.on_tool_event = sentinel
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            output=[].append,
+        )
+
+        assert engine.on_tool_event is sentinel, "the prior hook must be restored"
+
+    def test_spinner_path_does_not_perturb_graph_hash(self, tmp_path) -> None:
+        """Determinism: the spinner path yields the same built @graph hash as the
+        headless path (the spinner is pure UI — it never touches the crate)."""
+        from builder.agents.build import run_interactive_build
+        from builder.agents.pipeline import run_pipeline
+        from eval.metrics import crate_graph_hash
+
+        # Headless path (no spinner) — the reference hash.
+        e1 = _engine(SimulatedHumanInterface())
+        e1.state.metadata.output_path = str(tmp_path / "a-ro-crate")
+        run_interactive_build(e1, output=[].append)
+        h1 = crate_graph_hash(e1.state)
+
+        # Interactive path (spinner active) — must match.
+        e2 = _engine(_InteractiveHuman())
+        e2.state.metadata.output_path = str(tmp_path / "b-ro-crate")
+        run_interactive_build(e2, output=[].append)
+        h2 = crate_graph_hash(e2.state)
+
+        # Sanity: the real run_pipeline produced a non-trivial crate.
+        ref = _engine(SimulatedHumanInterface())
+        run_pipeline(ref)
+        assert h1 == h2

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -618,24 +618,36 @@ class TestProgressSpinner:
 
     def test_spinner_path_does_not_perturb_graph_hash(self, tmp_path) -> None:
         """Determinism: the spinner path yields the same built @graph hash as the
-        headless path (the spinner is pure UI — it never touches the crate)."""
+        headless path (the spinner is pure UI — it never touches the crate).
+
+        Both paths run the REAL deterministic pipeline (so the comparison is
+        meaningful); only the interactive path drives the spinner. The HITL
+        guidance tail is stubbed with a graph-neutral no-op so the test isolates
+        the spinner's effect on the built ``@graph`` WITHOUT paying for a second
+        full SHACL guidance run — which made the test run three heavy real builds
+        and blow the CI per-test ``--timeout`` (#266).
+        """
         from builder.agents.build import run_interactive_build
-        from builder.agents.pipeline import run_pipeline
+        from builder.state import CrateState
         from eval.metrics import crate_graph_hash
 
-        # Headless path (no spinner) — the reference hash.
+        # A guidance runner that touches NOTHING (the interactive _InteractiveHuman
+        # approves/skips every gap, so real guidance is a graph no-op here anyway).
+        noop_guidance = lambda eng, human, **kw: {}  # noqa: E731
+
+        # Headless path (no spinner) — runs the real pipeline; the reference hash.
         e1 = _engine(SimulatedHumanInterface())
         e1.state.metadata.output_path = str(tmp_path / "a-ro-crate")
         run_interactive_build(e1, output=[].append)
         h1 = crate_graph_hash(e1.state)
 
-        # Interactive path (spinner active) — must match.
+        # Interactive path (spinner ACTIVE) — same real pipeline, must match.
         e2 = _engine(_InteractiveHuman())
         e2.state.metadata.output_path = str(tmp_path / "b-ro-crate")
-        run_interactive_build(e2, output=[].append)
+        run_interactive_build(e2, guidance_runner=noop_guidance, output=[].append)
         h2 = crate_graph_hash(e2.state)
 
-        # Sanity: the real run_pipeline produced a non-trivial crate.
-        ref = _engine(SimulatedHumanInterface())
-        run_pipeline(ref)
         assert h1 == h2
+        # Sanity: the real pipeline produced a non-trivial crate (not the empty
+        # default), so the equality above is a real signal, not two empty hashes.
+        assert h1 != crate_graph_hash(CrateState())

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -501,3 +501,70 @@ class TestScanRootApproval:
         r = engine.run_tool("scan_files", path=str(sub))
         assert isinstance(r, list) and len(r) == 1
         assert human.present_calls == [], "already-approved path must not prompt"
+
+
+class TestOnToolEvent:
+    """The optional ``on_tool_event`` callback lets the pipeline spinner show the
+    currently-running tool (#266). The deterministic pipeline runs tools via
+    ``engine.run_tool`` (not LangChain), so without this hook there is no
+    per-tool signal. It must default to ``None`` (no behavior change when unset)
+    and must never let a callback exception break ``run_tool``.
+    """
+
+    def test_default_on_tool_event_is_none(self) -> None:
+        """A fresh engine has no tool-event callback (strict no-op by default)."""
+        engine = AgentEngine()
+        assert engine.on_tool_event is None
+
+    def test_callback_fires_start_then_end_when_set(self) -> None:
+        """The callback receives (tool_name, 'start') then (tool_name, 'end')."""
+        engine = AgentEngine()
+        engine.initialize()
+        events: list[tuple[str, str]] = []
+        engine.on_tool_event = lambda name, phase: events.append((name, phase))
+
+        engine.run_tool("draft_investigation", hints={"name": "Inv"})
+
+        assert events == [
+            ("draft_investigation", "start"),
+            ("draft_investigation", "end"),
+        ]
+
+    def test_end_fires_even_when_tool_raises(self) -> None:
+        """The 'end' event still fires when the tool body raises (finally-guarded)."""
+        import pytest
+
+        engine = AgentEngine()
+        engine.initialize()
+        events: list[tuple[str, str]] = []
+        engine.on_tool_event = lambda name, phase: events.append((name, phase))
+
+        with pytest.raises(ValueError):
+            engine.run_tool("nonexistent_tool_xyz")
+
+        # start fired before the lookup; end still fired despite the raise.
+        assert ("nonexistent_tool_xyz", "start") in events
+        assert ("nonexistent_tool_xyz", "end") in events
+
+    def test_unset_callback_no_calls_no_error(self) -> None:
+        """With no callback set, run_tool behaves exactly as before (no error)."""
+        engine = AgentEngine()
+        engine.initialize()
+        # No callback set; must run cleanly and return the entity.
+        result = engine.run_tool("draft_investigation", hints={"name": "X"})
+        assert result is not None
+        assert result.type == "Investigation"
+
+    def test_raising_callback_does_not_break_run_tool(self) -> None:
+        """A callback that raises must not abort the tool call (#266)."""
+        engine = AgentEngine()
+        engine.initialize()
+
+        def _boom(_name: str, _phase: str) -> None:
+            raise RuntimeError("spinner blew up")
+
+        engine.on_tool_event = _boom
+        # The tool still runs and returns its result despite the bad callback.
+        result = engine.run_tool("draft_investigation", hints={"name": "Y"})
+        assert result is not None
+        assert result.fields.get("name") == "Y"

--- a/tests/test_progress_spinner.py
+++ b/tests/test_progress_spinner.py
@@ -1,0 +1,216 @@
+"""Tests for builder/agents/progress_spinner.py — the pipeline build spinner (#266).
+
+The DEFAULT ``--interactive`` (deterministic pipeline) build only printed static
+phase lines (#253), so the ~tens-of-seconds spine looked frozen. :class:`ProgressSpinner`
+gives it a live Rich spinner like the legacy ReAct loop's ``_ThinkingSpinner``: an
+animated dots spinner with a rotating funny toxicology-themed phrase, the currently
+running tool/phase, and elapsed seconds, updating in place.
+
+The spinner registers itself as the active console animation (``register_console_animation``)
+so a guidance HITL prompt (which calls ``suspend_console_animation``) can pause it and
+own the terminal. These tests use a fake console/status (no real terminal) — the same
+pattern as ``TestThinkingSpinnerPause`` in test_agent_loop.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _FakeStatus:
+    """A fake Rich ``console.status`` recording start/stop/update calls."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.renders: list[str] = []
+
+    def start(self) -> None:
+        self.events.append("start")
+
+    def stop(self) -> None:
+        self.events.append("stop")
+
+    def update(self, renderable: Any = None, **_k: Any) -> None:
+        if renderable is not None:
+            self.renders.append(str(renderable))
+
+    def __enter__(self) -> "_FakeStatus":
+        self.start()
+        return self
+
+    def __exit__(self, *_a: Any) -> None:
+        self.stop()
+
+
+class _FakeConsole:
+    """A fake Rich ``Console`` that hands back a fixed ``_FakeStatus``."""
+
+    def __init__(self, status: _FakeStatus) -> None:
+        self._status = status
+
+    def status(self, *_a: Any, **_k: Any) -> _FakeStatus:
+        return self._status
+
+
+class TestPhraseList:
+    """A FRESH toxicology-themed phrase list lives in this module (not imported)."""
+
+    def test_phrase_list_is_nonempty(self) -> None:
+        from builder.agents.progress_spinner import TOX_SPINNER_PHRASES
+
+        assert isinstance(TOX_SPINNER_PHRASES, list)
+        assert len(TOX_SPINNER_PHRASES) >= 5
+        assert all(isinstance(p, str) and p for p in TOX_SPINNER_PHRASES)
+
+    def test_phrase_list_is_module_level(self) -> None:
+        """The list is defined fresh in THIS module (not imported from agent_loop)."""
+        from builder.agents import progress_spinner
+
+        assert hasattr(progress_spinner, "TOX_SPINNER_PHRASES")
+
+
+class TestRender:
+    """The spinner renders the phrase, elapsed seconds, and the current op."""
+
+    def test_render_includes_phrase_and_elapsed(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        sp = ProgressSpinner(console=_FakeConsole(_FakeStatus()), phrase="intoxicating")
+        text = sp._render()
+        assert "intoxicating" in text
+        assert "s)" in text  # elapsed seconds, e.g. "(0s)"
+
+    def test_render_includes_current_op_when_set(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        sp = ProgressSpinner(console=_FakeConsole(_FakeStatus()), phrase="vortexing")
+        sp.set_current("scaffold_isa_backbone")
+        assert "scaffold_isa_backbone" in sp._render()
+
+    def test_set_current_updates_the_live_region(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="titrating")
+        sp.set_current("Materializing 12 entities…")
+        assert any("Materializing 12 entities" in r for r in st.renders)
+
+
+class TestRegistration:
+    """The spinner registers with the hitl registry on enter, unregisters on exit."""
+
+    def test_enter_registers_and_exit_unregisters(self) -> None:
+        import builder.tools.hitl as hitl
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="culturing")
+        with sp:
+            assert hitl._active_animation is sp
+        assert hitl._active_animation is None
+
+    def test_enter_starts_status_and_exit_stops_it(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="centrifuging")
+        with sp:
+            assert "start" in st.events
+        assert "stop" in st.events
+
+
+class TestPause:
+    """suspend_console_animation must pause the spinner so a HITL prompt is clean."""
+
+    def test_pause_sets_flag_and_stops_status(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x")
+        sp.pause()
+        assert sp._paused.is_set() is True
+        assert "stop" in st.events
+
+    def test_resume_clears_flag_and_starts_status(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x")
+        sp.pause()
+        sp.resume()
+        assert sp._paused.is_set() is False
+        assert "start" in st.events
+
+    def test_suspend_console_animation_pauses_then_resumes(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+        from builder.tools.hitl import (
+            register_console_animation,
+            suspend_console_animation,
+            unregister_console_animation,
+        )
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x")
+        register_console_animation(sp)
+        try:
+            with suspend_console_animation():
+                paused_in_body = sp._paused.is_set()
+        finally:
+            unregister_console_animation(sp)
+
+        assert paused_in_body is True  # paused for the duration of the prompt
+        assert sp._paused.is_set() is False  # resumed after
+
+    def test_set_current_while_paused_does_not_repaint(self) -> None:
+        """A set_current while paused records the op but does NOT touch the status."""
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x")
+        sp.pause()
+        st.renders.clear()
+        sp.set_current("draft_person")
+        assert st.renders == []  # no repaint over the prompt
+        assert "draft_person" in sp._render()  # but the op is remembered
+
+
+class TestTickThread:
+    """The daemon tick thread refreshes elapsed time and skips while paused."""
+
+    def test_thread_is_daemon_and_joins_on_exit(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x", tick_interval=0.01)
+        with sp:
+            assert sp._thread is not None
+            assert sp._thread.daemon is True
+            assert sp._thread.is_alive() is True
+        assert sp._thread.is_alive() is False  # joined cleanly on exit
+
+    def test_tick_repaints_while_running(self) -> None:
+        import time
+
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x", tick_interval=0.01)
+        with sp:
+            time.sleep(0.05)
+        assert len(st.renders) >= 1  # the daemon thread repainted at least once
+
+    def test_tick_skips_while_paused(self) -> None:
+        import time
+
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        st = _FakeStatus()
+        sp = ProgressSpinner(console=_FakeConsole(st), phrase="x", tick_interval=0.01)
+        with sp:
+            sp.pause()
+            time.sleep(0.03)
+            renders_while_paused = len(st.renders)
+            time.sleep(0.03)
+            # No new repaints accumulated while paused.
+            assert len(st.renders) == renders_while_paused
+            sp.resume()

--- a/tests/test_progress_spinner.py
+++ b/tests/test_progress_spinner.py
@@ -43,13 +43,39 @@ class _FakeStatus:
 
 
 class _FakeConsole:
-    """A fake Rich ``Console`` that hands back a fixed ``_FakeStatus``."""
+    """A fake Rich ``Console`` that hands back a fixed ``_FakeStatus``.
+
+    Reports ``is_terminal=True`` (the animated path) so the spinner behaves as
+    it does on a real TTY. The CI / piped (non-terminal) case is modelled by
+    :class:`_NonTTYConsole`.
+    """
+
+    is_terminal = True
 
     def __init__(self, status: _FakeStatus) -> None:
         self._status = status
 
     def status(self, *_a: Any, **_k: Any) -> _FakeStatus:
         return self._status
+
+
+class _NonTTYConsole:
+    """A fake Rich ``Console`` that reports a NON-terminal output (CI / piped).
+
+    Models the CI / non-interactive case: ``console.is_terminal`` is ``False``.
+    Records whether :meth:`status` was ever called — on a non-TTY the spinner
+    must NOT create a Live status at all (no Rich ``Live`` region, no Rich
+    refresh thread), so ``status_calls`` must stay ``0``.
+    """
+
+    is_terminal = False
+
+    def __init__(self) -> None:
+        self.status_calls = 0
+
+    def status(self, *_a: Any, **_k: Any) -> _FakeStatus:
+        self.status_calls += 1
+        return _FakeStatus()
 
 
 class TestPhraseList:
@@ -214,3 +240,65 @@ class TestTickThread:
             # No new repaints accumulated while paused.
             assert len(st.renders) == renders_while_paused
             sp.resume()
+
+
+class TestNonTTY:
+    """On a NON-terminal console (CI / piped) the spinner is a cheap no-op (#266).
+
+    Rich's ``console.status`` opens a ``Live`` region backed by a background
+    refresh thread; on a non-TTY that animation is invisible noise that, under
+    CI's ``--timeout`` thread-dumper, only adds threads to start, stop and join.
+    So when ``console.is_terminal`` is ``False`` the spinner must NOT open the
+    Live region or start its own daemon tick thread, and every public method
+    (``set_current`` / ``pause`` / ``resume`` / ``__enter__`` / ``__exit__``)
+    must be a fast, safe no-op. On a real TTY it animates exactly as before.
+    """
+
+    def test_non_tty_never_opens_a_status(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        console = _NonTTYConsole()
+        ProgressSpinner(console=console, phrase="x")
+        assert console.status_calls == 0  # no Live region opened on a non-TTY
+
+    def test_non_tty_starts_no_tick_thread(self) -> None:
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        sp = ProgressSpinner(console=_NonTTYConsole(), phrase="x", tick_interval=0.01)
+        with sp:
+            # No daemon tick thread on a non-TTY (nothing to repaint).
+            assert sp._thread is None or sp._thread.is_alive() is False
+
+    def test_non_tty_methods_are_safe_noops(self) -> None:
+        """All public methods complete instantly and never raise on a non-TTY."""
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        sp = ProgressSpinner(console=_NonTTYConsole(), phrase="x", tick_interval=0.01)
+        with sp:
+            sp.set_current("scaffold_isa_backbone")  # no-op, no status to touch
+            sp.pause()
+            sp.resume()
+        # Still rendarable / queryable after exit (pure UI helper).
+        assert "x" in sp._render()
+
+    def test_non_tty_registers_with_hitl_registry(self) -> None:
+        """Even silenced, it registers so suspend_console_animation stays valid."""
+        import builder.tools.hitl as hitl
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        sp = ProgressSpinner(console=_NonTTYConsole(), phrase="x")
+        with sp:
+            assert hitl._active_animation is sp
+        assert hitl._active_animation is None
+
+    def test_non_tty_exit_does_not_hang(self) -> None:
+        """A non-TTY enter/exit completes well within a tight bound (CI guard)."""
+        import time
+
+        from builder.agents.progress_spinner import ProgressSpinner
+
+        sp = ProgressSpinner(console=_NonTTYConsole(), phrase="x", tick_interval=0.01)
+        t0 = time.monotonic()
+        with sp:
+            sp.set_current("phase")
+        assert time.monotonic() - t0 < 1.0  # instant: no Live, no thread to join


### PR DESCRIPTION
Closes #266

The default `--interactive` (deterministic pipeline) build only printed static phase lines (#253), so the ~tens-of-seconds spine looked frozen. This gives it a live Rich spinner like the legacy ReAct loop's `_ThinkingSpinner`: an animated dots spinner with a rotating funny toxicology-themed phrase, the currently-running tool/phase, and elapsed seconds, all updating in place.

## Spinner API — `builder/agents/progress_spinner.py` (new)

`ProgressSpinner(console=None, phrase=None, *, tick_interval=0.5)` — a reusable context manager backed by `console.status` + a daemon tick thread, rendering:

```
<funny phrase>… (<elapsed>s) · <current op>
```

- `set_current(text)` — show (or clear, with `None`) the currently-running tool/phase; repaints immediately unless paused.
- `pause()` — tear down the Live region + stop ticking (idempotent).
- `resume()` — restart the Live region.
- `__enter__` / `__exit__` — start/stop the status + daemon thread; on enter calls `register_console_animation(self)`, on exit `unregister_console_animation(self)`.
- `TOX_SPINNER_PHRASES` — a FRESH toxicology-themed phrase list defined in this module (not imported from `agent_loop.py`).

## Engine hook — `builder/engine.py`

`AgentEngine.on_tool_event: Callable[[str, str], None] | None = None` (default `None`). `run_tool` now wraps its dispatch and fires the observer with `(tool_name, "start")` before and `(tool_name, "end")` after the call. The deterministic pipeline runs tools via `engine.run_tool` (not LangChain), so this is the single per-tool signal the spinner subscribes to.

- Default `None` → strict no-op, no behavior change.
- The `"end"` event fires even when the tool raises (`finally`-guarded around `_run_tool_impl`).
- A raising callback is caught + logged, never breaking `run_tool` (it is UI chrome).

## How it pauses for HITL

The guidance tail asks the user questions via `input()` mid-build; a Rich `Live` repaint would clobber that prompt. The spinner registers itself as the active console animation on `__enter__`, so the console HITL prompt — which wraps its `input()` in `suspend_console_animation()` (#239) — calls `pause()` (sets the paused flag, stops the Live region, halts ticking) for the duration of the prompt and `resume()` afterwards. The tick thread skips entirely while paused, and `set_current` records the op without repainting while paused.

## Driving it from `run_interactive_build` (`builder/agents/build.py`)

The spinner is created **only on the REAL interactive path** (an interactive `HumanInterface`, i.e. the CLI's `ConsoleHumanInterface`). It subscribes the engine's `on_tool_event` hook to `set_current(tool)` (restored to its prior value in a `finally`), wraps the pipeline + guidance run in the spinner context, and feeds the existing #253 phase-progress strings into `set_current` via a wrapped emit (persistent lines still print above the spinner). Headless / simulated runs (the A/B eval, batch, tests) get **no spinner, no daemon thread, no stdout noise** and an unperturbed built `@graph` hash.

## Tests

- `tests/test_progress_spinner.py` (new): phrase list, render (phrase/elapsed/current op), hitl registry register/unregister on enter/exit, `suspend_console_animation` pause/resume, set-current-while-paused no-repaint, daemon thread join + tick + skip-while-paused.
- `tests/test_engine.py::TestOnToolEvent`: default `None`, start/end firing, end-fires-on-raise, unset = no calls/no error, raising callback doesn't break `run_tool`.
- `tests/test_agents_build.py::TestProgressSpinner`: no spinner on headless build, spinner created + driven on interactive build, `on_tool_event` restored after, determinism (graph hash unchanged across the spinner path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)