### PR TITLE
fix(dashboard): event-or-timeout polling + follow-newest session (#267)

### DIFF
--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -922,83 +922,83 @@ def run_static_dashboard(session_id: str | None = None) -> None:
 def run_dashboard(session_id: str | None = None, refresh_interval: float = 2.0) -> None:
     """Run a live-updating dashboard using watchfiles.
 
-    If *session_id* is None, uses the most recent session with profile data.
+    If *session_id* is None, the dashboard *follows the newest session*: it
+    re-resolves the most recent session on every refresh, so a fresh
+    ``--interactive`` run is picked up live with no restart (#267). If an
+    explicit *session_id* is given, the dashboard stays pinned to it.
 
-    The display refreshes whenever ``profile.ndjson`` is modified — new tool
-    calls and node events appear in near-real-time.
+    The display refreshes on every filesystem change under :data:`SESSION_DIR`
+    AND at least every *refresh_interval* seconds even with no events (a poll
+    fallback that is robust against FSEvents/atomic-save quirks).
 
     Press Ctrl+C to exit.
     """
-    sessions = list_sessions_available()
-    if not sessions:
-        print("No session data found. Run the agent first to generate profile data.")
-        return
-
-    if session_id is None:
-        target = sessions[0]
-    else:
-        matches = [s for s in sessions if s["session_id"] == session_id]
-        if not matches:
+    if session_id is not None:
+        sessions = list_sessions_available()
+        if not any(s["session_id"] == session_id for s in sessions):
             print(f"Session not found: {session_id}")
             return
-        target = matches[0]
-
-    profile_path = target["profile_path"]
 
     try:
-        _run_live_dashboard(profile_path, target["session_id"], refresh_interval)
+        _run_live_dashboard(session_id=session_id, refresh_interval=refresh_interval)
     except KeyboardInterrupt:
         pass
     finally:
         print("\nDashboard closed.")
 
 
-def _change_touches(changes: Any, watched: set[str]) -> bool:
-    """Whether any watchfiles change touches one of *watched* file paths.
-
-    Watching the session DIRECTORY (see :func:`_run_live_dashboard`) also surfaces
-    churn from temp files — ``save_session`` writes ``.crate_state_tmp_*`` then
-    ``os.replace``\\ s it over ``crate_state.json`` — plus any exported payload. We
-    re-render only when ``profile.ndjson`` or ``crate_state.json`` actually changed
-    so unrelated churn doesn't thrash the display. ``changes`` is the
-    ``set[tuple[Change, str]]`` yielded by ``watchfiles.watch``.
-
-    Matching is by **basename**, not full path. ``watchfiles`` yields ABSOLUTE
-    paths, but ``watched`` is built from ``SESSION_DIR`` which is *relative*
-    (``Path("sessions")``), so a full-string ``path in watched`` never matched and
-    the dashboard stopped refreshing entirely (regression from the dir-watch
-    change). Comparing file names is robust to relative-vs-absolute and symlinked
-    paths.
-    """
-    names = {Path(p).name for p in watched}
-    try:
-        return any(Path(path).name in names for _change, path in changes)
-    except TypeError:
-        return False
-
-
 def _run_live_dashboard(
-    profile_path: Path,
-    session_id: str,
+    session_id: str | None,
     refresh_interval: float,
 ) -> None:
-    """Inner live-dashboard loop with Rich ``Live`` display and file-watching."""
+    """Inner live-dashboard loop with Rich ``Live`` display and file-watching.
+
+    Watches the :data:`SESSION_DIR` *root* (not an individual session/file) and
+    rebuilds + renders on **every wake** — both real change events and the
+    periodic timeout wake (``yield_on_timeout``). This is the #267 fix:
+
+    * The previous basename filter (``_change_touches``) discarded the atomic
+      save signal. ``save_session`` writes ``crate_state.json`` via tempfile +
+      ``os.replace``; on macOS the change batch contains ONLY the temp file
+      (``.crate_state_tmp_*``), which the filter excluded — so the render never
+      fired. Rendering on every wake (event OR timeout) removes that whole
+      failure mode.
+    * The session was pinned at startup. With *session_id* None we re-resolve
+      the newest session via :func:`list_sessions_available` on every wake, so a
+      new run is followed live. An explicit *session_id* stays pinned.
+
+    The ``profile.ndjson`` mtime cache (:func:`_read_records_cached`) is kept so
+    the profile isn't needlessly re-parsed; ``crate_state.json`` is re-read each
+    render (via :func:`format_session_summary` -> :func:`_load_cratestate`).
+    """
     from rich.console import Console
     from rich.layout import Layout
     from rich.live import Live
 
     console = Console()
-    session_path = profile_path.parent
-    crate_state_path = session_path / "crate_state.json"
-    last_mtime: float = 0.0
-    records: list[dict[str, Any]] = []
+
+    # Per-session mtime cache for profile.ndjson. Keyed by session_id so that,
+    # when following the newest session, switching sessions doesn't reuse a stale
+    # cache from a different run.
+    cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+    def _resolve_session() -> str | None:
+        """Pick the session to render this wake: pinned, or the newest one."""
+        if session_id is not None:
+            return session_id
+        sessions = list_sessions_available()
+        return sessions[0]["session_id"] if sessions else None
 
     def _build() -> Layout:
-        nonlocal last_mtime, records
-        # Re-read profile only when it changed; reuse the cache otherwise so a
-        # crate_state-only refresh doesn't blank the profile panel (#121).
+        sid = _resolve_session()
+        if sid is None:
+            # No sessions yet — render an empty placeholder and keep polling.
+            return format_session_summary("(waiting for a session…)", [])
+        profile_path = SESSION_DIR / sid / "profile.ndjson"
+        last_mtime, records = cache.get(sid, (0.0, []))
         records, last_mtime = _read_records_cached(profile_path, last_mtime, records)
-        return format_session_summary(session_id, records)
+        cache[sid] = (last_mtime, records)
+        return format_session_summary(sid, records)
 
     try:
         from watchfiles import watch
@@ -1010,20 +1010,29 @@ def _run_live_dashboard(
         console.print(_build())
         return
 
-    # Watch the session DIRECTORY, not the individual files. ``save_session``
-    # writes crate_state.json atomically (tempfile + ``os.replace``), which swaps
-    # the inode a file-path watcher holds — so a watcher bound to crate_state.json
-    # silently stopped seeing updates and the dashboard only refreshed on reload.
-    # Watching the directory catches the rename (and crate_state.json first
-    # appearing after the dashboard started). Filter to the two files we render
-    # from so unrelated temp/export churn doesn't thrash the display.
-    watched = {str(profile_path), str(crate_state_path)}
+    # SESSION_DIR may not exist yet (no run has written a session). watchfiles
+    # cannot watch a missing path, so create the root; per-session dirs appear
+    # under it as runs start and the follow-newest loop picks them up.
+    try:
+        SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.warning("Could not create session dir %s", SESSION_DIR)
 
     with Live(
         _build(), console=console, refresh_per_second=1 / refresh_interval, screen=False
     ) as live:
-        # `step` is watchfiles' debounce quiet-period (see _WATCH_STEP_MS), not
-        # the render interval — keep it small so updates aren't throttled.
-        for changes in watch(str(session_path), step=_WATCH_STEP_MS):
-            if _change_touches(changes, watched):
-                live.update(_build())
+        # Watch the SESSION_DIR ROOT with an event-OR-timeout loop:
+        #   * ``yield_on_timeout`` + ``rust_timeout`` wake the loop at least every
+        #     ``refresh_interval`` even with zero FS events (poll fallback);
+        #   * any real change also wakes it immediately.
+        # On every wake we rebuild + render unconditionally — no path filtering,
+        # so atomic-save temp churn can no longer hide the update (#267).
+        # ``step`` stays small (watchfiles' debounce quiet-period) so a steady
+        # stream of writes is surfaced promptly.
+        for _changes in watch(
+            str(SESSION_DIR),
+            step=_WATCH_STEP_MS,
+            rust_timeout=int(refresh_interval * 1000),
+            yield_on_timeout=True,
+        ):
+            live.update(_build())

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -290,59 +290,297 @@ class TestTokenSummary:
         assert "0" in output
 
 
-class TestLiveRefresh:
-    """Regression guards for the live dashboard auto-refresh (#121).
+class _DummyLive:
+    """A stand-in for ``rich.live.Live`` that records every ``update()`` call."""
 
-    The dashboard appeared to "only update on load" because watchfiles' ``step``
-    (a debounce quiet-period) was set to the render interval (2000ms), so a
-    steady stream of profiler writes never went quiet long enough to be yielded.
-    A secondary bug blanked the profile panel whenever only crate_state.json
-    changed (profile mtime unchanged -> records became []).
+    def __init__(self, *a, **k) -> None:
+        self.updates: list = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a) -> bool:
+        return False
+
+    def update(self, renderable, *a, **k) -> None:
+        self.updates.append(renderable)
+
+
+class TestLiveRefresh:
+    """Regression guards for the live dashboard auto-refresh (#267).
+
+    Two confirmed root causes, both fixed here:
+
+    1. The old ``_change_touches`` basename filter discarded the atomic-save
+       signal. ``save_session`` writes ``crate_state.json`` via tempfile +
+       ``os.replace``; on macOS the watch batch contains ONLY the temp file
+       (``.crate_state_tmp_*``), which the filter explicitly EXCLUDED — so
+       ``live.update()`` never fired. The filter is gone; we render on EVERY
+       wake (event OR timeout).
+    2. The session was pinned at startup (``sessions[0]`` once). A fresh
+       ``--interactive`` run creates a NEW session dir the dashboard never
+       followed. Now, with no explicit ``session_id``, the loop re-resolves the
+       newest session on every wake.
+
+    Earlier #121 fix retained: ``_read_records_cached`` (mtime cache) so
+    ``profile.ndjson`` isn't needlessly re-parsed.
     """
 
-    def test_watch_step_is_small_and_decoupled_from_refresh_interval(
+    def test_watch_is_called_with_session_dir_root_and_event_or_timeout(
         self, tmp_path, monkeypatch
     ) -> None:
-        """``watch()`` must be called with a small fixed ``step`` (the watchfiles
-        default), independent of ``refresh_interval`` — otherwise updates are
-        throttled to multi-second intervals and the dashboard looks frozen."""
+        """``watch()`` must poll the SESSION_DIR root with ``yield_on_timeout``
+        and a ``rust_timeout`` derived from ``refresh_interval`` — so the loop
+        wakes on every change AND at least every ``refresh_interval`` even with
+        zero events (the bulletproof poll fallback vs FSEvents quirks)."""
         import rich.live
         import watchfiles
 
-        from builder.tools.dashboard import _WATCH_STEP_MS, _run_live_dashboard
+        from builder.tools import dashboard as d
 
-        profile_path = tmp_path / "profile.ndjson"
-        profile_path.write_text(json.dumps({"event": "node_end", "node": "model"}) + "\n")
+        session_dir = tmp_path / "20260626_a"
+        session_dir.mkdir()
+        (session_dir / "profile.ndjson").write_text(
+            json.dumps({"event": "node_end", "node": "model"}) + "\n"
+        )
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)
 
         captured: dict = {}
 
         def fake_watch(*paths, **kwargs):
-            captured["step"] = kwargs.get("step")
             captured["paths"] = paths
-            return iter(())  # no changes -> loop body skipped, returns immediately
-
-        class _DummyLive:
-            def __init__(self, *a, **k) -> None:
-                pass
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a) -> bool:
-                return False
-
-            def update(self, *a) -> None:
-                pass
+            captured["rust_timeout"] = kwargs.get("rust_timeout")
+            captured["yield_on_timeout"] = kwargs.get("yield_on_timeout")
+            return iter(())  # no wakes -> loop body skipped, returns immediately
 
         monkeypatch.setattr(watchfiles, "watch", fake_watch)
         monkeypatch.setattr(rich.live, "Live", _DummyLive)
 
-        _run_live_dashboard(profile_path, "sess", refresh_interval=2.0)
+        d._run_live_dashboard(session_id=None, refresh_interval=2.0)
 
-        assert _WATCH_STEP_MS <= 100
-        assert captured["step"] == _WATCH_STEP_MS
-        # The bug was step == int(refresh_interval * 1000) == 2000.
-        assert captured["step"] != 2000
+        # Watch the SESSION_DIR ROOT, not an individual session/file.
+        assert captured["paths"] == (str(tmp_path),)
+        assert captured["yield_on_timeout"] is True
+        assert captured["rust_timeout"] == int(2.0 * 1000)
+
+    def test_renders_on_timeout_wake_with_no_events(self, tmp_path, monkeypatch) -> None:
+        """A timeout/empty wake (the poll path) must trigger a render — NOT only
+        a filtered file event. This is the core #267 fix: even when the atomic
+        save surfaces solely as temp-file churn (or no event at all), the loop
+        still rebuilds and renders."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools import dashboard as d
+
+        session_dir = tmp_path / "20260626_a"
+        session_dir.mkdir()
+        (session_dir / "profile.ndjson").write_text(
+            json.dumps({"event": "node_end", "node": "model"}) + "\n"
+        )
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)
+
+        live = _DummyLive()
+
+        def fake_watch(*paths, **kwargs):
+            # One empty (timeout) batch, then stop.
+            yield set()
+
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", lambda *a, **k: live)
+
+        d._run_live_dashboard(session_id=None, refresh_interval=2.0)
+
+        # The empty/timeout wake produced a render.
+        assert len(live.updates) >= 1
+
+    def test_renders_on_temp_file_only_event(self, tmp_path, monkeypatch) -> None:
+        """When the only change surfaced is a ``.crate_state_tmp_*`` event (the
+        macOS atomic-save signature), the loop must STILL render. The old
+        basename filter dropped this exact event — that was the bug."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools import dashboard as d
+
+        session_dir = tmp_path / "20260626_a"
+        session_dir.mkdir()
+        (session_dir / "profile.ndjson").write_text(
+            json.dumps({"event": "node_end", "node": "model"}) + "\n"
+        )
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)
+
+        live = _DummyLive()
+        tmp_evt = str(session_dir / ".crate_state_tmp_abc")
+
+        def fake_watch(*paths, **kwargs):
+            yield {(1, tmp_evt)}  # deleted/added temp churn only
+
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", lambda *a, **k: live)
+
+        d._run_live_dashboard(session_id=None, refresh_interval=2.0)
+
+        assert len(live.updates) >= 1
+
+    def test_follows_newest_session_per_wake_when_unpinned(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """With no explicit ``session_id``, the loop re-resolves the newest
+        session on EVERY wake via ``list_sessions_available`` and renders it —
+        so a fresh ``--interactive`` run is followed live, no restart (#267)."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools import dashboard as d
+
+        old = tmp_path / "20260626_old"
+        old.mkdir()
+        (old / "profile.ndjson").write_text(
+            json.dumps({"event": "node_end", "node": "model"}) + "\n"
+        )
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)
+
+        live = _DummyLive()
+        consults: list = []
+        formatted: list = []
+
+        real_list = d.list_sessions_available
+
+        def spy_list(*a, **k):
+            result = real_list(*a, **k)
+            consults.append([s["session_id"] for s in result])
+            return result
+
+        def fake_format(session_id, records):
+            formatted.append(session_id)
+            return f"render::{session_id}"
+
+        def fake_watch(*paths, **kwargs):
+            # First wake: only the old session exists.
+            yield set()
+            # Between wakes a NEW (newer) session dir appears.
+            new = tmp_path / "20260627_new"
+            new.mkdir()
+            (new / "profile.ndjson").write_text(
+                json.dumps({"event": "node_end", "node": "model"}) + "\n"
+            )
+            # Make the new dir unambiguously newer by mtime.
+            import os
+            import time
+
+            t = time.time() + 100
+            os.utime(new, (t, t))
+            yield set()
+
+        monkeypatch.setattr(d, "list_sessions_available", spy_list)
+        monkeypatch.setattr(d, "format_session_summary", fake_format)
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", lambda *a, **k: live)
+
+        d._run_live_dashboard(session_id=None, refresh_interval=2.0)
+
+        # list_sessions_available consulted on every wake (not just startup).
+        assert len(consults) >= 2
+        # The newest session was rendered after it appeared.
+        assert "20260627_new" in formatted
+        assert formatted[-1] == "20260627_new"
+
+    def test_explicit_session_id_stays_pinned(self, tmp_path, monkeypatch) -> None:
+        """An explicitly passed ``session_id`` stays pinned across wakes even if
+        a newer session dir appears — the dashboard must not wander."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools import dashboard as d
+
+        pinned = tmp_path / "20260626_pinned"
+        pinned.mkdir()
+        (pinned / "profile.ndjson").write_text(
+            json.dumps({"event": "node_end", "node": "model"}) + "\n"
+        )
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)
+
+        live = _DummyLive()
+        formatted: list = []
+
+        def fake_format(session_id, records):
+            formatted.append(session_id)
+            return f"render::{session_id}"
+
+        def fake_watch(*paths, **kwargs):
+            # A newer session appears, but we must stay pinned.
+            newer = tmp_path / "20260627_newer"
+            newer.mkdir()
+            (newer / "profile.ndjson").write_text(
+                json.dumps({"event": "node_end", "node": "model"}) + "\n"
+            )
+            import os
+            import time
+
+            t = time.time() + 100
+            os.utime(newer, (t, t))
+            yield set()
+
+        monkeypatch.setattr(d, "format_session_summary", fake_format)
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", lambda *a, **k: live)
+
+        d._run_live_dashboard(session_id="20260626_pinned", refresh_interval=2.0)
+
+        assert formatted, "should have rendered"
+        assert set(formatted) == {"20260626_pinned"}
+
+    def test_no_crash_when_session_dir_has_no_sessions(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """SESSION_DIR exists but is empty (no sessions yet) — the loop must wake,
+        render an empty state, and not crash while waiting for one to appear."""
+        import rich.live
+        import watchfiles
+
+        from builder.tools import dashboard as d
+
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)  # empty dir, no sessions
+
+        live = _DummyLive()
+
+        def fake_watch(*paths, **kwargs):
+            yield set()  # one timeout wake, then stop
+
+        monkeypatch.setattr(watchfiles, "watch", fake_watch)
+        monkeypatch.setattr(rich.live, "Live", lambda *a, **k: live)
+
+        # Must not raise.
+        d._run_live_dashboard(session_id=None, refresh_interval=2.0)
+
+    def test_static_fallback_when_watchfiles_unavailable(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """When ``watchfiles`` can't be imported, fall back to a static snapshot
+        (printed once) instead of crashing."""
+        import builtins
+
+        from builder.tools import dashboard as d
+
+        session_dir = tmp_path / "20260626_a"
+        session_dir.mkdir()
+        (session_dir / "profile.ndjson").write_text(
+            json.dumps({"event": "node_end", "node": "model"}) + "\n"
+        )
+        monkeypatch.setattr(d, "SESSION_DIR", tmp_path)
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *a, **k):
+            if name == "watchfiles":
+                raise ImportError("watchfiles not installed")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+        # Must not raise — falls back to a one-shot static render.
+        d._run_live_dashboard(session_id=None, refresh_interval=2.0)
 
     def test_records_cache_reused_when_profile_unchanged(self, tmp_path) -> None:
         """A crate_state-only refresh (profile.ndjson mtime unchanged) reuses the
@@ -380,82 +618,3 @@ class TestLiveRefresh:
         assert len(records2) == 2
         assert mtime2 != mtime
 
-    def test_watches_session_directory_so_atomic_saves_are_caught(
-        self, tmp_path, monkeypatch
-    ) -> None:
-        """save_session writes crate_state.json atomically (tempfile + os.replace),
-        which swaps the inode a file-path watcher holds — so a watcher bound to the
-        FILE silently stops seeing updates and the dashboard only refreshes on
-        reload. The fix watches the session DIRECTORY, which catches the rename
-        (and crate_state.json first appearing after startup)."""
-        import rich.live
-        import watchfiles
-
-        from builder.tools.dashboard import _run_live_dashboard
-
-        session_dir = tmp_path / "sess1"
-        session_dir.mkdir()
-        profile_path = session_dir / "profile.ndjson"
-        profile_path.write_text(json.dumps({"event": "node_end", "node": "model"}) + "\n")
-
-        captured: dict = {}
-
-        def fake_watch(*paths, **kwargs):
-            captured["paths"] = paths
-            return iter(())
-
-        class _DummyLive:
-            def __init__(self, *a, **k) -> None:
-                pass
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a) -> bool:
-                return False
-
-            def update(self, *a) -> None:
-                pass
-
-        monkeypatch.setattr(watchfiles, "watch", fake_watch)
-        monkeypatch.setattr(rich.live, "Live", _DummyLive)
-
-        _run_live_dashboard(profile_path, "sess1", refresh_interval=2.0)
-
-        # Watch the directory, NOT the individual files (the old, broken behavior
-        # watched profile.ndjson / crate_state.json paths and missed atomic renames).
-        assert captured["paths"] == (str(session_dir),)
-
-    def test_change_touches_only_relevant_files(self) -> None:
-        """The directory watch fires on temp/export churn too; only re-render when
-        profile.ndjson or crate_state.json actually changed."""
-        from builder.tools.dashboard import _change_touches
-
-        prof = "/s/profile.ndjson"
-        crate = "/s/crate_state.json"
-        watched = {prof, crate}
-        # watchfiles yields a set of (Change, path); the helper inspects only path.
-        assert _change_touches({(2, prof)}, watched) is True
-        assert _change_touches({(1, crate)}, watched) is True
-        # the atomic-save temp churn must NOT trigger a re-render
-        assert _change_touches({(1, "/s/.crate_state_tmp_abc")}, watched) is False
-        assert _change_touches(set(), watched) is False
-
-    def test_change_touches_matches_relative_watched_vs_absolute_event(self) -> None:
-        """REGRESSION: SESSION_DIR is relative ('sessions'), so `watched` holds
-        RELATIVE paths, but watchfiles yields ABSOLUTE paths. Full-string matching
-        never hit and the dashboard stopped refreshing — match by basename."""
-        from builder.tools.dashboard import _change_touches
-
-        # watched built from a relative SESSION_DIR; events arrive absolute.
-        watched = {"sessions/20260626_x/profile.ndjson", "sessions/20260626_x/crate_state.json"}
-        assert _change_touches(
-            {(2, "/Users/me/repo/sessions/20260626_x/profile.ndjson")}, watched
-        ) is True
-        assert _change_touches(
-            {(1, "/Users/me/repo/sessions/20260626_x/crate_state.json")}, watched
-        ) is True
-        # unrelated absolute churn still ignored
-        assert _change_touches(
-            {(1, "/Users/me/repo/sessions/20260626_x/.crate_state_tmp_x")}, watched
-        ) is False


### PR DESCRIPTION
Closes #267

The live dashboard **still** didn't auto-update. Two confirmed, repro-backed root causes — both in `builder/tools/dashboard.py` — are fixed here.

## Root causes
1. **The `_change_touches` basename filter discarded the save signal.** `save_session` writes `crate_state.json` atomically (tempfile → `os.replace`). A repro of `watchfiles.watch(<dir>)` + `os.replace` on macOS shows the change batch contains **only** the temp file (`.crate_state_tmp_*`), which the filter **explicitly excluded** (a test even asserted temp churn → no re-render). So `live.update()` never fired → no refresh.
2. **Session pinned at startup.** `run_dashboard` picked `sessions[0]` once and watched only that session dir. A subsequent `--interactive` run creates a *new* session dir the dashboard never followed → "must restart to see updates".

## Fix — event-OR-timeout polling + follow-newest
Rewrote the live loop (`run_dashboard` / `_run_live_dashboard`) so it:
- **Watches the `SESSION_DIR` root** with `watch(str(SESSION_DIR), step=_WATCH_STEP_MS, rust_timeout=int(refresh_interval*1000), yield_on_timeout=True)` — the loop wakes on **every** change AND at least every `refresh_interval` even with **zero** events (poll fallback, bulletproof vs FSEvents/atomic-save quirks).
- **Renders on every wake unconditionally** — no path filtering. Atomic-save temp churn (or no event at all) can no longer hide the update. `_change_touches` is deleted.
- **Follows the newest session.** With no explicit `session_id`, it re-resolves the newest session via `list_sessions_available()` on **each wake** and renders it (a fresh `--interactive` run is picked up live, no restart). An explicit `session_id` stays **pinned**.
- Keeps the `profile.ndjson` mtime cache (`_read_records_cached`, now per-session) so the profile isn't needlessly re-parsed; `crate_state.json` is re-read each render via `format_session_summary` → `_load_cratestate`.
- Handles a **missing/empty `SESSION_DIR`** gracefully (creates the root, renders an empty "waiting for a session…" state, keeps polling — no crash).
- Preserves the **static fallback** when `watchfiles` is unavailable.

## What was removed
- `_change_touches` (the filter that was itself the bug).
- Its tests, including the one asserting temp-churn → no-render, and `test_watches_session_directory_so_atomic_saves_are_caught` (encoded the old per-session-dir watch design).

## How it was verified
- TDD: wrote the new `TestLiveRefresh` tests first, confirmed 7 failed against the old code (red), then implemented the new loop (green). `watchfiles.watch` is stubbed to yield a timeout/empty batch (or a temp-file-only event) then stop; `rich.live.Live` is stubbed to capture `update()` calls.
- New tests:
  - `test_watch_is_called_with_session_dir_root_and_event_or_timeout`
  - `test_renders_on_timeout_wake_with_no_events`
  - `test_renders_on_temp_file_only_event`
  - `test_follows_newest_session_per_wake_when_unpinned`
  - `test_explicit_session_id_stays_pinned`
  - `test_no_crash_when_session_dir_has_no_sessions`
  - `test_static_fallback_when_watchfiles_unavailable`
- Gates: `uv run --extra langchain pytest -n0 tests/test_dashboard.py` (22 passed), `uv run ruff check` (clean), `uv run --extra langchain ty check builder/tools/dashboard.py tests/test_dashboard.py` (clean). `tests/test_main.py` dashboard-flag tests still pass.

## Lane
`builder/tools/dashboard.py` + `tests/test_dashboard.py` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)