### PR TITLE
fix(main): silence noisy third-party loggers under interactive INFO bump (#276)

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,10 +36,20 @@ def setup_logging(verbose: int = 0, interactive: bool = False) -> None:
     verbosity (``verbose == 0``), the effective level is raised to INFO so that
     pipeline progress is visible. A user-requested higher verbosity (``-v`` /
     ``-vv``) is never downgraded.
+
+    The interactive INFO bump is for *our* progress lines only. Promoting the
+    root logger to INFO would otherwise unleash the noisy third-party libraries
+    (notably ``httpx``, which logs every request at INFO), drowning each guidance
+    question under per-request spam. So when the bump -- and only the bump --
+    raises the level to INFO, the noisy third-party loggers are pinned to WARNING
+    while ``builder.*`` / ``__main__`` stay at INFO. A user who explicitly asked
+    for ``-v`` / ``-vv`` opted into the verbosity and those loggers are left
+    untouched.
     """
     level_map = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
     level = level_map.get(verbose, logging.WARNING)
-    if interactive and verbose == 0:
+    interactive_bump = interactive and verbose == 0
+    if interactive_bump:
         level = logging.INFO
     logging.basicConfig(
         level=level,
@@ -50,6 +60,14 @@ def setup_logging(verbose: int = 0, interactive: bool = False) -> None:
     # call in the same process), so set the level explicitly to honour the
     # interactive bump and the requested verbosity deterministically.
     logging.getLogger().setLevel(level)
+    # The interactive bump promotes the root logger to INFO; keep that for our
+    # own loggers but silence the per-request chatter from third-party HTTP/SDK
+    # libraries (httpx logs every "HTTP Request: POST .../chat/completions" at
+    # INFO, burying each guidance question). Only do this for the bump -- never
+    # when the user explicitly requested verbosity via -v / -vv.
+    if interactive_bump:
+        for noisy in ("httpx", "httpcore", "openai", "urllib3"):
+            logging.getLogger(noisy).setLevel(logging.WARNING)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -449,3 +449,58 @@ class TestInteractiveVerbosity:
             assert root.level == logging.DEBUG
         finally:
             root.setLevel(original)
+
+    def test_interactive_silences_noisy_third_party_loggers(self):
+        """The interactive INFO bump must not unleash httpx/openai request spam.
+
+        When *interactive* raises the effective level to INFO (and the user did
+        not ask for it via -v/-vv), the noisy third-party loggers are forced to
+        WARNING so each guidance question is not buried under per-request
+        ``HTTP Request: POST .../chat/completions`` INFO lines, while our own
+        ``builder.*`` progress lines stay at INFO.
+        """
+        import logging
+
+        from main import setup_logging
+
+        root = logging.getLogger()
+        noisy_names = ("httpx", "httpcore", "openai", "urllib3")
+        originals = {name: logging.getLogger(name).level for name in noisy_names}
+        original_root = root.level
+        try:
+            setup_logging(0, interactive=True)
+            for name in noisy_names:
+                assert (
+                    logging.getLogger(name).getEffectiveLevel() >= logging.WARNING
+                ), name
+            assert logging.getLogger("builder").getEffectiveLevel() == logging.INFO
+        finally:
+            root.setLevel(original_root)
+            for name, lvl in originals.items():
+                logging.getLogger(name).setLevel(lvl)
+
+    def test_explicit_verbose_does_not_raise_third_party_loggers(self):
+        """Under an explicit -vv (DEBUG) the user opted into verbosity.
+
+        The noisy third-party loggers must NOT be force-raised, so their
+        DEBUG/INFO output is honoured rather than suppressed.
+        """
+        import logging
+
+        from main import setup_logging
+
+        root = logging.getLogger()
+        noisy_names = ("httpx", "httpcore", "openai", "urllib3")
+        originals = {name: logging.getLogger(name).level for name in noisy_names}
+        original_root = root.level
+        try:
+            # Start from NOTSET so a force-raise would be observable.
+            for name in noisy_names:
+                logging.getLogger(name).setLevel(logging.NOTSET)
+            setup_logging(2, interactive=True)
+            for name in noisy_names:
+                assert logging.getLogger(name).level == logging.NOTSET, name
+        finally:
+            root.setLevel(original_root)
+            for name, lvl in originals.items():
+                logging.getLogger(name).setLevel(lvl)


### PR DESCRIPTION
## Summary

Fixes #276. In `--interactive` mode `setup_logging()` raises the root logger to INFO so our pipeline progress is visible, but that also turned on INFO for noisy third-party libraries — `httpx` logs every `HTTP Request: POST .../chat/completions` at INFO. Dozens of these scrolled between each guidance question, so the user literally could not see what was being asked.

When the INFO level comes from the interactive bump — and **only** then (not when the user explicitly requested `-v`/`-vv`) — the noisy loggers `httpx`, `httpcore`, `openai`, `urllib3` are pinned to WARNING, while our own `builder.*` / `__main__` (and the live spinner) stay at INFO.

## Behavior

- `setup_logging(0, interactive=True)`: `httpx`/`httpcore`/`openai`/`urllib3` → WARNING; `builder` stays INFO. ✅
- `setup_logging(2, interactive=True)` (explicit `-vv`/DEBUG): third-party loggers are NOT force-raised — opted-in verbosity honoured. ✅
- Non-interactive default stays WARNING.

## Tests (TDD)

Added to `TestInteractiveVerbosity` in `tests/test_main.py`:
- `test_interactive_silences_noisy_third_party_loggers` (was failing before the fix)
- `test_explicit_verbose_does_not_raise_third_party_loggers`

Both reset global logging state in `finally` to avoid leakage.

```
uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_main.py  →  30 passed
uv run ruff check  →  clean
uv run --extra langchain ty check main.py  →  clean
```

## Lane discipline

Only `main.py` and `tests/test_main.py` touched. No files under `builder/`, `pipeline*`, `dashboard*`, or `test_agents_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)