### PR TITLE
test(perf): give heavy double-validation its own 120s timeout (#278)

### DIFF
--- a/tests/test_validator_perf.py
+++ b/tests/test_validator_perf.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import pathlib
 
+import pytest
 from rocrate.rocrate import ROCrate
 
 from profiles.context import ISA_TOX_CONTEXT
@@ -139,6 +140,11 @@ class TestResultsUnchanged:
         base = next(r for r in results if r.profile == "base")
         assert base.passed_required is True
 
+    # Two full SHACL sweeps (patched vs unpatched, profile="all", severity="optional")
+    # sit right at the 30s edge on CI's 2-vCPU runner, intermittently tripping the
+    # global --timeout=30 (Issue #278). Give this intentionally-heavy comparison its
+    # own budget; the rest of the suite keeps the tight 30s default.
+    @pytest.mark.timeout(120)
     def test_patched_results_byte_identical_to_unpatched(self, monkeypatch):
         """Issue sets at every severity are identical with and without the patch.
 


### PR DESCRIPTION
Fixes #278.

## Problem

`tests/test_validator_perf.py::TestResultsUnchanged::test_patched_results_byte_identical_to_unpatched` runs **two full SHACL sweeps** (patched vs unpatched, `profile="all"`, `severity="optional"`) to prove the #115 no-walk speedup is byte-identical to the original CWD-walking path. On CI's 2-vCPU runner under sharded pytest it sits right at the global `--timeout=30` edge and intermittently trips it (`+++ Timeout +++` on PR #269 shard 5), flaking unrelated PRs whose `pytest-split` lands this test in a loaded shard.

## Fix (smallest)

Add a per-test `@pytest.mark.timeout(120)` marker, which overrides the global `--timeout=30` for just this intentionally-expensive comparison. The other four tests in the file each do at most a single validation and keep the tight 30s default, so the suite-wide budget is unchanged.

- Only the genuinely heavy double-validation test is marked.
- `pytest-timeout` is already a dev dependency (`pytest-timeout>=2.4.0`) and `--timeout` is already passed by the suite.
- No source, workflow, or other test changes.

## Verify

- `uv run --extra langchain pytest -n0 tests/test_validator_perf.py --timeout=30` → all 5 pass; the heavy test ran ~30s of work and was **not** killed at 30s (got its 120s budget), the other four respect 30s.
- `uv run ruff check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)