### PR TITLE
fix(tools): list child files when read_file is handed a directory (#281)

### DIFF
--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -37,16 +37,46 @@ def _format_kib(num_bytes: int) -> str:
     return f"{num_bytes / 1024:.1f} KiB"
 
 
+# How many concrete child-file paths to surface in a directory message. Enough
+# for a weak model to pick a real file to read next, capped so the tool message
+# stays compact on a large directory.
+_DIR_LISTING_LIMIT = 25
+
+
 def _directory_message(path: str) -> str:
     """Actionable message for a reader that was handed a directory (Issue #240).
 
     The LLM kept calling ``read_file``/``read_file_sample`` on a *directory* and
-    got a silent ``None`` each time, then looped. Return a clear "this is a
-    directory, browse the inventory then read a file" signal instead.
+    got a silent ``None`` each time, then looped. The abstract "use
+    list_scanned_files" hint alone still looped a weak model, so this also lists
+    the directory's immediate **readable file children** as CONCRETE paths the
+    model can read next — the most direct way to break the loop (follow-up to
+    #240). Subdirectories are excluded (they would just loop the same way); an
+    empty/unreadable directory falls back to the plain guidance.
     """
-    return (
+    base = (
         f"{path} is a directory, not a file — use list_scanned_files to browse "
         f"the inventory, then read a specific file by its path."
+    )
+    try:
+        children = sorted(
+            entry
+            for entry in Path(path).iterdir()
+            if entry.is_file() and not entry.name.startswith(".")
+        )
+    except OSError:
+        return base
+    if not children:
+        return base
+
+    shown = children[:_DIR_LISTING_LIMIT]
+    listed = "\n".join(f"  - {child}" for child in shown)
+    more = ""
+    if len(children) > len(shown):
+        more = f"\n  …and {len(children) - len(shown)} more (use list_scanned_files)."
+    return (
+        f"{base}\nReadable files in this directory — read one of these paths "
+        f"directly:\n{listed}{more}"
     )
 
 

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -1163,11 +1163,13 @@ def read_file_sample(
     if file_path.is_dir():
         # A directory handed to a file reader (e.g. read_file_sample(<dir>,
         # mode='overview')) used to return a silent None, which looped a weak
-        # model. Return a clear, actionable signal instead (Issue #240).
-        return (
-            f"{path} is a directory, not a file — use list_scanned_files to "
-            f"browse the inventory, then read a specific file by its path."
-        )
+        # model. Return a clear, actionable signal — including the directory's
+        # concrete readable file children so the model reads a real file next
+        # instead of re-calling on the directory (Issue #240). Imported lazily to
+        # avoid a scanner<->file_readers import cycle.
+        from builder.tools.file_readers import _directory_message
+
+        return _directory_message(path)
     if not file_path.is_file():
         return None
 

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -120,3 +120,29 @@ class TestDirectoryHandling:
         # A genuinely missing path stays None (the agent-loop maps that to its
         # 'unreadable' message); only a directory gets the new guidance.
         assert read_file(str(tmp_path / "does_not_exist.csv")) is None
+
+    def test_directory_message_lists_concrete_child_file_paths(self, tmp_path):
+        # A weak model kept re-calling read_file on a directory even after the
+        # abstract "use list_scanned_files" hint. Listing the directory's actual
+        # readable file children (concrete paths) gives it something to read NEXT,
+        # breaking the loop. (Follow-up to #240.)
+        (tmp_path / "Assay_Meta_data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        (tmp_path / "results.xlsx").write_bytes(b"PK\x03\x04stub")
+        (tmp_path / "nested").mkdir()  # subdir must NOT be listed as a readable file
+
+        result = read_file(str(tmp_path))
+        assert result is not None
+        assert "is a directory" in result
+        # Concrete, immediately-readable child file paths are surfaced.
+        assert str(tmp_path / "Assay_Meta_data.csv") in result
+        assert str(tmp_path / "results.xlsx") in result
+        # The subdirectory is not offered as a file to read.
+        assert str(tmp_path / "nested") not in result
+
+    def test_directory_message_handles_empty_directory(self, tmp_path):
+        # An empty directory has no children to offer; it must still return the
+        # actionable directory message (never None / never crash).
+        result = read_file(str(tmp_path))
+        assert result is not None
+        assert "is a directory" in result
+        assert "list_scanned_files" in result


### PR DESCRIPTION
## Problem

The legacy ReAct agent looped calling `read_file` on a directory path (`…/Assay_OATP1C1/Assay_Meta_data`), making no progress (`→ None` repeatedly in the dashboard). The readers already returned the #240 "is a directory, use list_scanned_files" guidance, but the abstract hint alone still loops a weak model (DeepSeek-flash) because it has no concrete next file to read.

## Fix

`_directory_message` now appends the directory's immediate **readable file children** as concrete paths the model can read directly — the most direct way to break the loop. Subdirectories and dotfiles are excluded, the listing is capped (25, with an "…and N more" tail), and an empty/unreadable directory falls back to the plain guidance. `scanner.read_file_sample` now reuses this single helper (lazy import, no scanner↔file_readers cycle) so both readers behave identically.

## Tests

TDD: new tests assert the message surfaces concrete child-file paths, excludes subdirectories, and still returns the actionable message for an empty directory. Existing #240 directory tests (file_readers + scanner) still pass. `ruff`/`ty` clean.

Fixes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)