### PR TITLE
fix(pipeline): wire resolved compounds + cell line into provenance (#273)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1693,6 +1693,23 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   are merged onto the already-scaffolded Study (fill-don't-clobber: only when the
   field is empty or still the generic placeholder), and each `people[]` is split
   into `givenName`/`familyName` so the Person is ISA-conformant (#232).
+  **Entity→provenance wiring (#273).** Resolving a compound / cell line MINTS the
+  entity but leaves it a graph orphan unless something references it, so after the
+  `compounds[]` / `cell_lines[]` sections run, `_materialize_plan` wires the
+  collected ids deterministically through `set_fields` (never hand-rolled JSON-LD)
+  using the canonical ISA-Tox reference fields: each resolved `MolecularEntity` →
+  the **Exposure** LabProcess via `chemicals` (ISA forbids a MolecularEntity as a
+  process object — objects MUST be File/Sample/BioSample — so the build connects
+  the compound THROUGH the Exposure's CSVW condition table, `schema:about` →
+  MolecularEntity + the `compound` column's `valueUrl`; `_crate_mapping
+  ._build_process`/`_synth_condition_table`); the resolved `CellLineSample` → the
+  **CellCulture** LabProcess via `cell_line` (its consumed input, replacing the
+  synthesized generic `..._input` placeholder); and BOTH are surfaced on the
+  scaffolded Study via `schema:mentions` (the `chemicals` / `cell_lines`→
+  `biologicalModels` aliases) so every resolved entity — PubChem- AND ChEBI-backed
+  compounds alike — is reachable from the backbone at a glance (orphan count → 0).
+  Idempotent: `set_fields` writes the same deterministic ids, so re-running mints
+  no duplicates.
 - **Assess** (`assess_gaps`, the gap engine #215, this section) — one
   prioritized `GapReport` unifying SHACL + MIT + FAIR.
 - **Auto-resolve** (`fix_required_issues`, §5, the keystone) — clears every

--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -524,6 +524,28 @@ def _first_entity_id(engine: AgentEngine, entity_type: str) -> str | None:
     )
 
 
+def _set_ref_field(
+    engine: AgentEngine,
+    entity_id: str,
+    field: str,
+    value: str | list[str],
+) -> None:
+    """Set a single reference *field* on *entity_id* via the ``set_fields`` tool.
+
+    Thin wrapper used by the #273 entity→process/Study wiring: *field* is one of
+    the crate mapping's reference fields (``chemicals`` / ``cell_line`` /
+    ``cell_lines``) so the build resolves it to ``{"@id"}`` reference(s) rather than
+    a literal. Goes through the consolidated mutation tool (never hand-rolled
+    JSON-LD); a wiring failure is logged and never breaks the spine.
+    """
+    try:
+        engine.run_tool("set_fields", entity_id=entity_id, fields={field: value})
+    except Exception as exc:  # noqa: BLE001 - a wiring failure must not break the spine
+        logger.warning(
+            "linking %s=%r onto %r failed: %s", field, value, entity_id, exc
+        )
+
+
 # The generic placeholder names the scaffold leaves on a backbone layer when no
 # title was available (kept in sync with the `_DEFAULT_*` constants above). A
 # field still carrying its layer's placeholder is treated as "empty" by the
@@ -968,6 +990,20 @@ def _materialize_plan(
     * each ``cell_lines[]`` → ``draft_cell_line_sample`` (a ``CellLineSample``
       from the name only; the Cellosaurus accession is a later lookup, not the
       plan).
+    * **entity→provenance wiring (#273).** Resolving a compound / cell line MINTS
+      the entity but leaves it a graph ORPHAN unless something references it, so the
+      collected ids are wired deterministically via ``set_fields`` (never
+      hand-rolled JSON-LD) with the canonical ISA-Tox reference fields: every
+      resolved ``MolecularEntity`` → the **Exposure** LabProcess via ``chemicals``
+      (ISA forbids a MolecularEntity as a process object, so the build connects the
+      compound THROUGH the Exposure's CSVW condition table — ``schema:about`` →
+      MolecularEntity + the compound column ``valueUrl``), the resolved
+      ``CellLineSample`` → the **CellCulture** LabProcess via ``cell_line`` (its
+      consumed input, replacing the synthesized generic ``..._input``), and BOTH
+      onto the scaffolded Study via ``schema:mentions`` (``chemicals`` /
+      ``cell_lines``→``biologicalModels``) so every resolved entity — PubChem- AND
+      ChEBI-backed — is reachable from the backbone (orphan count → 0). Idempotent:
+      ``set_fields`` writes the same deterministic ids, so re-running mints no dups.
     * each ``protocols[]`` → ``draft_protocol`` (a ``LabProtocol`` from the
       name/description only — D5: no identifier) which is then linked to the
       ``LabProcess`` it governs via the ``labprotocol`` reference field (resolved
@@ -1110,27 +1146,87 @@ def _materialize_plan(
             logger.warning("merge plan study name failed: %s", exc)
 
     # --- compounds: resolve_compound mints the MolecularEntity + verified ids ---
+    # Collect each resolved MolecularEntity id so the test compounds can be WIRED
+    # into the Exposure below (#273) — without this they are graph orphans.
+    compound_ids: list[str] = []
     for compound in plan.get("compounds") or []:
         name = str((compound or {}).get("name") or "").strip()
         if not name:
             continue
         try:
             # D5: only the NAME is passed; identifiers come from the lookup.
-            engine.run_tool("resolve_compound", name=name)
+            resolved = engine.run_tool("resolve_compound", name=name)
             result["compounds"] += 1
         except Exception as exc:  # noqa: BLE001
             logger.warning("resolve_compound failed for %r: %s", name, exc)
+            continue
+        # resolve_compound returns {"entity_id", ...} on a hit and {"ok": False}
+        # on a miss (which mints no entity, so there is nothing to wire). Capture
+        # the id (PubChem AND ChEBI hits alike) for the Exposure/Study linking.
+        cid = resolved.get("entity_id") if isinstance(resolved, dict) else None
+        if cid:
+            compound_ids.append(str(cid))
 
     # --- cell lines: a CellLineSample from the name only (accession is a lookup) ---
+    # Collect each minted CellLineSample id so the cell line can be wired into the
+    # CellCulture (and Study) below (#273) rather than left orphaned.
+    cell_line_ids: list[str] = []
     for cell_line in plan.get("cell_lines") or []:
         name = str((cell_line or {}).get("name") or "").strip()
         if not name:
             continue
         try:
-            engine.run_tool("draft_cell_line_sample", name=name, hints={})
+            cell = engine.run_tool("draft_cell_line_sample", name=name, hints={})
             result["cell_lines"] += 1
         except Exception as exc:  # noqa: BLE001
             logger.warning("draft_cell_line_sample failed for %r: %s", name, exc)
+            continue
+        # draft_cell_line_sample returns the Entity it created/reused.
+        cid = getattr(cell, "entity_id", None)
+        if cid:
+            cell_line_ids.append(str(cid))
+
+    # --- wire resolved compounds + cell line into the provenance (#273) ---------
+    # The resolver/drafter above MINT the right domain entities, but they are
+    # orphans until something references them. Wire them deterministically with the
+    # canonical ISA-Tox reference fields (NEVER hand-rolled JSON-LD):
+    #   * each MolecularEntity → the Exposure LabProcess via `chemicals`. ISA
+    #     forbids a MolecularEntity as a process object (objects MUST be
+    #     File/Sample/BioSample), so the build connects the compound THROUGH the
+    #     Exposure's CSVW condition table (schema:about → MolecularEntity), with the
+    #     compound column's valueUrl resolving to its id (_crate_mapping
+    #     ._build_process / _synth_condition_table).
+    #   * the CellLineSample → the CellCulture LabProcess via `cell_line` (its
+    #     consumed input), replacing the synthesized generic `..._input` placeholder.
+    #   * both also surface on the Study via schema:mentions (`chemicals` /
+    #     `cell_lines`→biologicalModels) so every resolved entity is reachable at a
+    #     glance even when (e.g. a ChEBI-only compound) it is not the condition
+    #     table's first valueUrl column. Idempotent: `set_fields` overwrites the ref
+    #     field with the same deterministic ids, so re-running mints no duplicates.
+    chain_by_type = {
+        str(s.get("process_type") or ""): s for s in chain_steps_summary
+    }
+    if compound_ids:
+        exposure_step = chain_by_type.get("Exposure")
+        exposure_id = exposure_step.get("process_id") if exposure_step else None
+        if exposure_id:
+            _set_ref_field(engine, str(exposure_id), "chemicals", compound_ids)
+    if cell_line_ids:
+        culture_step = chain_by_type.get("CellCulture")
+        culture_id = culture_step.get("process_id") if culture_step else None
+        if culture_id:
+            # CellCulture consumes ONE cell line; use the first resolved one.
+            _set_ref_field(engine, str(culture_id), "cell_line", cell_line_ids[0])
+
+    # Surface both on the scaffolded Study via schema:mentions so every resolved
+    # entity is reachable from the backbone (no orphan), regardless of which
+    # condition-table column resolves to which id.
+    study_mention_id = _first_entity_id(engine, "Study")
+    if study_mention_id:
+        if compound_ids:
+            _set_ref_field(engine, study_mention_id, "chemicals", compound_ids)
+        if cell_line_ids:
+            _set_ref_field(engine, study_mention_id, "cell_lines", cell_line_ids)
 
     # NOTE: the process chain is now drafted unconditionally ABOVE (#262) — the
     # standard 4-step chain with the plan's step names overlaid — so there is no

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -786,6 +786,226 @@ class TestMaterializePlan:
         assert result["materialized"]["compounds"] >= 2
 
 
+def _types(node: dict) -> set[str]:
+    """The @type(s) of a graph node as a set of strings."""
+    t = node.get("@type")
+    if isinstance(t, list):
+        return {str(x) for x in t}
+    return {str(t)} if t is not None else set()
+
+
+class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
+    """Issue #273 — resolved compounds and the cell line must be WIRED into the
+    provenance, not left as orphans.
+
+    The materialize path already RESOLVES the right MolecularEntity / CellLineSample
+    entities, but before #273 it never linked them into the process chain, so the
+    exported crate flagged them all as ``⚠ orphan``. The fix wires them with the
+    canonical ISA-Tox reference fields:
+
+    * each resolved ``MolecularEntity`` → the Exposure LabProcess via the
+      ``chemicals`` ref field. ISA forbids a MolecularEntity as a process object
+      (objects MUST be File/Sample/BioSample), so the compound is connected THROUGH
+      the Exposure's CSVW condition table (``schema:about`` → MolecularEntity) and,
+      at a glance, on the Study via ``schema:mentions`` (the ``chemicals`` Study
+      mention).
+    * the resolved ``CellLineSample`` → the CellCulture LabProcess via the
+      ``cell_line`` ref field (its consumed input), replacing the synthesized
+      generic ``..._input`` placeholder; also surfaced on the Study via
+      ``cell_lines`` (``biologicalModels``, an alias of ``schema:mentions``).
+
+    Reachability is asserted against the *built* ``@graph`` (the exact assembly
+    ``build_and_validate`` uses): every resolved MolecularEntity / CellLineSample
+    node must be referenced by at least one other node, i.e. orphan count → 0.
+    """
+
+    def _stub_lookups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Like the base stub, but return a DISTINCT CID per compound name.
+
+        The base `_stub_lookups` hands the same canned PubChem CID to every
+        compound, so distinct compounds would collapse to ONE MolecularEntity node
+        (its build @id is the verified CID IRI). The #273 reachability test needs
+        the two plan compounds to be two distinct nodes, so override the compound
+        lookup with a per-name CID while keeping every other stub (verify / AOP /
+        Crossref) from the base.
+        """
+        super()._stub_lookups(monkeypatch)
+        import builder.tools.composites as composites_mod
+        from builder.tools._resolve_cache import compound_cache
+
+        # The compound resolution cache is process-global; a prior test (or the
+        # inherited ones, which use the base single-CID stub) can pre-cache these
+        # names and short-circuit the lookup, so distinct-CID resolution would be
+        # masked. Clear it so this test's stub always runs fresh (xdist-safe).
+        compound_cache.clear()
+
+        # Distinct CID per compound (the build keys a MolecularEntity node @id to
+        # its verified CID IRI, so distinct CIDs => distinct nodes). CAS stays the
+        # base stub's `60-56-0` so the inherited D5 test's exact-value assertion is
+        # preserved; only the (node-id-bearing) CID varies per name.
+        _cids = {"Methimazole": "1349907", "Sodium iodide": "5238"}
+
+        def fake_lookup_compound(name):
+            return {
+                "found": True,
+                "data": {
+                    "cas": "60-56-0",
+                    "pubchem_cid": _cids.get(name, "999999"),
+                    "smiles": "C1=CN(C(=S)N1)C",
+                    "source": "pubchem",
+                },
+                "error": None,
+            }
+
+        monkeypatch.setattr(
+            composites_mod, "lookup_compound", fake_lookup_compound
+        )
+
+    @staticmethod
+    def _referenced_ids(graph: list[dict]) -> set[str]:
+        """Every @id referenced by ANY node in *graph*.
+
+        Walks each node's property values for ``{"@id": ...}`` references (scalar,
+        list, or nested) EXCEPT the node's own ``@id``/``@type``, so a node that
+        only "references" itself is not counted as referenced.
+        """
+        referenced: set[str] = set()
+
+        def _collect(value: object) -> None:
+            if isinstance(value, dict):
+                ref = value.get("@id")
+                if isinstance(ref, str):
+                    referenced.add(ref)
+                else:
+                    for v in value.values():
+                        _collect(v)
+            elif isinstance(value, list):
+                for item in value:
+                    _collect(item)
+
+        for node in graph:
+            for key, value in node.items():
+                if key in ("@id", "@type"):
+                    continue
+                _collect(value)
+        return referenced
+
+    def _built_graph(self, engine: AgentEngine) -> list[dict]:
+        """The built crate's ``@graph`` — the same assembly build_and_validate uses."""
+        from builder.tools.builder import assemble_crate
+
+        crate = assemble_crate(
+            engine.state,
+            output_dir=None,
+            materialize_payload=False,
+            include_all_scanned=False,
+        )
+        return crate.metadata.generate()["@graph"]
+
+    def test_compounds_and_cell_line_are_wired_not_orphaned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        # The Exposure carries the resolved MolecularEntity ids in `chemicals`.
+        procs = self._by_type(engine, "LabProcess")
+        exposure = next(p for p in procs if p.fields.get("process_type") == "Exposure")
+        chem_ids = {c.entity_id for c in self._by_type(engine, "MolecularEntity")}
+        assert chem_ids, "no MolecularEntity resolved — test setup is wrong"
+        wired_chems = exposure.fields.get("chemicals")
+        wired_chem_ids = {
+            (c.get("@id") if isinstance(c, dict) else c)
+            for c in (wired_chems if isinstance(wired_chems, list) else [wired_chems])
+        }
+        wired_chem_ids = {str(c).lstrip("#") for c in wired_chem_ids if c}
+        assert wired_chem_ids == {c.lstrip("#") for c in chem_ids}
+
+        # The CellCulture references the actual cell-line Sample via `cell_line`
+        # (not a synthesized generic `_input`).
+        cell_culture = next(
+            p for p in procs if p.fields.get("process_type") == "CellCulture"
+        )
+        cell_ids = {c.entity_id for c in self._by_type(engine, "CellLineSample")}
+        assert cell_ids, "no CellLineSample resolved — test setup is wrong"
+        wired_cell = cell_culture.fields.get("cell_line")
+        wired_cell_id = (
+            wired_cell.get("@id") if isinstance(wired_cell, dict) else wired_cell
+        )
+        assert str(wired_cell_id).lstrip("#") in {c.lstrip("#") for c in cell_ids}
+
+        # No resolved MolecularEntity / CellLineSample is an orphan in the BUILT
+        # graph: every one is referenced by at least one other node (#273).
+        graph = self._built_graph(engine)
+        referenced = self._referenced_ids(graph)
+        node_ids = {n.get("@id") for n in graph}
+
+        # A CellLineSample builds as @type Sample discriminated by
+        # additionalType="CellLine" (its intermediate derived samples are plain
+        # Samples), so detect it via that discriminator, not the state class name.
+        def _is_compound(n: dict) -> bool:
+            return "MolecularEntity" in _types(n)
+
+        def _is_cell_line(n: dict) -> bool:
+            return n.get("additionalType") == "CellLine"
+
+        domain_nodes = [n for n in graph if _is_compound(n) or _is_cell_line(n)]
+        # Both MolecularEntity (the two plan compounds) AND the CellLineSample must
+        # be present in the built graph (the resolver mints them; the compound node
+        # @id is the verified identifier IRI, not the state entity_id).
+        assert len([n for n in domain_nodes if _is_compound(n)]) == 2
+        assert any(_is_cell_line(n) for n in domain_nodes)
+        # …and NONE of them is an orphan: every one is referenced by another node.
+        orphans = [n["@id"] for n in domain_nodes if n["@id"] not in referenced]
+        assert orphans == [], f"orphaned resolved domain entities: {orphans}"
+        # The Study surfaces every compound + the cell line via schema:mentions
+        # (emitted under the context-aliased `chemicals` / `biologicalModels`
+        # keys), so each is reachable from the backbone at a glance (#273).
+        study_node = next(
+            n for n in graph if str(n.get("@id", "")).startswith("#Study_")
+        )
+
+        def _ref_ids(prop: object) -> set[str]:
+            items = prop if isinstance(prop, list) else [prop]
+            return {
+                (m.get("@id") if isinstance(m, dict) else m)
+                for m in items
+                if m is not None
+            }
+
+        compound_node_ids = {n["@id"] for n in domain_nodes if _is_compound(n)}
+        cell_node_ids = {n["@id"] for n in domain_nodes if _is_cell_line(n)}
+        assert compound_node_ids <= _ref_ids(study_node.get("chemicals"))
+        assert cell_node_ids <= _ref_ids(study_node.get("biologicalModels"))
+        assert node_ids  # graph is non-empty
+
+    def test_run_pipeline_with_links_preserves_conformance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Wiring the compounds/cell line must NOT regress ISA + Tox conformance."""
+        from builder.agents.pipeline import run_pipeline
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch)
+        self._stub_lookups(monkeypatch)
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "draft_entity_fields", lambda *a, **k: {})
+
+        engine = _engine(self._titled_state())
+        result = run_pipeline(engine)
+
+        assert result["conformance"] == {"base": True, "isa": True, "tox": True}
+        assert result["ok"] is True
+
+
 class TestPublicationFromPDF:
     """Issue #245 — when a plan publication's "title" is actually a PDF FILENAME,
     `_materialize_plan` must recover the real DOI/title from the PDF *text* and


### PR DESCRIPTION
Closes #273.

## Problem
The deterministic materialize path (`_materialize_plan`) already RESOLVES the right domain entities — the test-chemical `MolecularEntity`s (PubChem CID + CAS verified, plus the ChEBI-only ones) and the `CellLineSample` (CHO-K1 OATP1C1) — but never WIRED them into the process graph. On a real S-VHPS26 export the Mermaid graph flagged every one as `⚠ orphan`: the Exposure referenced only the cell-culture sample + a CSV, and the CellCulture used a generic `..._input` Sample instead of the actual cell line.

## Fix (in `builder/agents/pipeline.py`, materialize path only)
After the `compounds[]` / `cell_lines[]` sections run, collect the minted entity ids and wire them deterministically via the `set_fields` tool (never hand-rolled JSON-LD) using the canonical ISA-Tox **reference fields**:

- each resolved `MolecularEntity` → the **Exposure** LabProcess via **`chemicals`**. ISA forbids a MolecularEntity as a process object (objects MUST be File/Sample/BioSample), so the build connects the compound THROUGH the Exposure's CSVW condition table (`schema:about` → MolecularEntity + the `compound` column `valueUrl`), exactly as `_crate_mapping._build_process`/`_synth_condition_table` document.
- the resolved `CellLineSample` → the **CellCulture** LabProcess via **`cell_line`** (its consumed input), replacing the synthesized generic `..._input` placeholder.
- both also surfaced on the scaffolded **Study** via `schema:mentions` (the **`chemicals`** / **`cell_lines`→`biologicalModels`** aliases) so every resolved entity — PubChem- AND ChEBI-backed compounds alike — is reachable from the backbone (orphan count → 0).

The CAS/CID identifier PropertyValues remain attached to each MolecularEntity via the existing `_identifier_pv` build path (unchanged — verified by the inherited D5 test).

## Properties / invariants
- **Idempotent** — `set_fields` writes the same deterministic ids, so re-running mints no duplicates.
- **Provider-gated** — runs only on the plan-driven path, so the no-provider graph-hash determinism contract is untouched.
- **Lane discipline** — only `builder/agents/pipeline.py`, its tests, and `AGENTS.md §14.6` changed; no forbidden files touched.

## Tests (TDD, failing-first)
New `TestMaterializeLinksResolvedEntities` (subclasses `TestMaterializePlan`) asserts, against the **built `@graph`** (same assembly `build_and_validate` uses):
- the Exposure carries every resolved compound id in `chemicals`; the CellCulture references the cell-line Sample via `cell_line`;
- NO resolved MolecularEntity/CellLineSample is an orphan (every one referenced by another node);
- the Study mentions every compound + the cell line;
- `run_pipeline` still reaches `{base, isa, tox}` conformance (no regression).

```
uv run --extra langchain pytest -n 2 --maxprocesses=2 tests/test_agents_pipeline.py tests/test_pipeline_e2e.py
# 77 passed, 1 xpassed
```
`uv run ruff check` and `uv run --extra langchain ty check builder/agents/pipeline.py` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)