### PR TITLE
fix(pipeline): extract + materialize compound candidates so the default path resolves compounds (#258)

### DIFF
--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -197,7 +197,19 @@ _PLAN_SYSTEM_PROMPT = (
     "publications, and files. This is a PROPOSAL for the user to confirm, not "
     "committed truth. Propose ONLY what the documents support; leave any field "
     "you cannot support empty and record ambiguities or things the user should "
-    "confirm in 'notes'. Refer to compounds, cell lines, people and "
+    "confirm in 'notes'. "
+    # #258: the test/control compounds are very often named ONLY in the data
+    # FILENAMES, not in prose — direct the model to mine them from the
+    # scanned-files inventory (the legacy ReAct path inferred them this way).
+    "IMPORTANT — find the test/control compounds by reading the DATA FILENAMES "
+    "in the scanned-files inventory as well as any prose, JSON, or README "
+    "bodies. Data files are routinely named after the chemical(s) they hold, "
+    "e.g. 'S-VHPS26_P5_Silychristin+Verapamil.xlsx' or 'Diclofenac+BSP.xlsx' — "
+    "propose each chemical token (split filename stems on '+', '_', '-', and "
+    "spaces; drop plate/well/replicate/date codes and the study accession) as a "
+    "separate compound NAME. Propose the chemical names you recognise even when "
+    "they appear only in a filename. "
+    "Refer to compounds, cell lines, people and "
     "publications BY NAME ONLY. NEVER include identifiers of any kind: no CAS, "
     "PubChem CID, InChIKey, SMILES, InChI, Cellosaurus accession, ORCID, DOI, "
     "or @id. Those are resolved later by dedicated lookup services, never by you."
@@ -365,6 +377,14 @@ def extract_plan(
     people, publications, files, and free-text ``notes`` — for the user to
     confirm. It does not mutate state and does not orchestrate.
 
+    The compounds in particular are mined from the **data FILENAMES** in the
+    scanned-files inventory as well as from prose/JSON/README bodies (#258): data
+    files are routinely named after the chemical(s) they hold (e.g.
+    ``…_Silychristin+Verapamil.xlsx``), and the legacy ReAct path recovered the
+    test articles exactly that way, so the prompt directs the model to propose
+    each chemical token in a filename stem as a candidate compound NAME (D5: name
+    only — the CAS/CID come later from ``resolve_compound``).
+
     Every field is optional: the model proposes only what the context supports and
     records ambiguity in ``notes`` rather than inventing. D5: the plan names WHAT
     EXISTS — no identifiers (CAS/CID/InChIKey/SMILES/Cellosaurus accession/ORCID/
@@ -398,7 +418,9 @@ def extract_plan(
                 f"{context}\n\n"
                 "Propose the candidate plan. Fill only what the documents "
                 "support; leave the rest empty and note ambiguities in 'notes'. "
-                "Names only — no identifiers."
+                "Remember the test/control compounds are often named only in the "
+                "data FILENAMES above — read the chemical names out of those "
+                "filenames too, not just the prose. Names only — no identifiers."
             )
         ),
     ]

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -431,6 +431,104 @@ class TestExtractPlanShape:
         assert plan["notes"]
 
 
+def _prompt_text(fake: FakeChatModel) -> str:
+    """Concatenated text of every message the model was invoked with.
+
+    The leaf builds a ``[SystemMessage, HumanMessage]`` list; ``FakeChatModel``
+    records that list in ``invoke_calls``. Flattening it to one lowercase string
+    lets a test assert WHAT INSTRUCTIONS reach the model (e.g. "mine compound
+    names from the data filenames") without coupling to message ordering.
+    """
+    chunks: list[str] = []
+    for messages in fake.invoke_calls:
+        for msg in messages:
+            content = getattr(msg, "content", "")
+            if isinstance(content, str):
+                chunks.append(content)
+    return "\n".join(chunks).lower()
+
+
+class TestExtractPlanMinesCompoundsFromFilenames:
+    """#258: the bounded plan extractor must propose candidate compound NAMES
+    inferred from the DATA FILENAMES (and JSON/README bodies), not only from
+    prose — the legacy ReAct path got 22 compounds off filenames like
+    ``…_P5_Silychristin+Verapamil.xlsx`` while the bounded leaf got 0 because its
+    prompt never told the model to read names out of the filenames inventory.
+
+    These tests pin the PROMPT contract (the model is *instructed* to mine
+    compound names from filenames + bodies, names only — D5), offline, so the
+    real DeepSeek-flash call is steered the same way without any network.
+    """
+
+    # A scanned-files inventory whose ONLY compound signal is in the filenames —
+    # the S-VHPS26 shape that produced 0 compounds on the default path.
+    _FILENAME_CONTEXT = (
+        "Title: S-VHPS26 transporter interaction screen\n\n"
+        "Scanned files:\n"
+        "- S-VHPS26_P5_Silychristin+Verapamil.xlsx\n"
+        "- S-VHPS26_Diclofenac+BSP.xlsx\n"
+        "- conditions.csv"
+    )
+
+    def test_prompt_instructs_mining_compound_names_from_filenames(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        fake = FakeChatModel({})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.extract_plan(self._FILENAME_CONTEXT)
+
+        text = _prompt_text(fake)
+        # The model must be told to infer compound names from the FILENAMES …
+        assert "filename" in text, (
+            "extract_plan must instruct the model to read candidate compound "
+            "names from the data filenames (#258)"
+        )
+        # … and that the inferred items are COMPOUND candidates specifically.
+        assert "compound" in text
+
+    def test_prompt_keeps_names_only_discipline(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        """The filename-mining instruction must not weaken D5: names only."""
+        fake = FakeChatModel({})
+        _patch_build_chat_model["model"] = fake
+
+        leaves.extract_plan(self._FILENAME_CONTEXT)
+
+        text = _prompt_text(fake)
+        # The names-only / no-identifier discipline is still asserted in the prompt.
+        assert "name" in text
+        assert ("no identifier" in text) or ("never include identifiers" in text) or (
+            "identifiers of any kind" in text
+        ), "the filename-mining prompt must still forbid identifiers (D5)"
+
+    def test_filename_derived_compound_plan_round_trips(
+        self, _patch_build_chat_model: dict[str, Any]
+    ) -> None:
+        """A model that (correctly) returns filename-derived compound NAMES has
+        them preserved by the leaf (names only — no fabricated identifiers)."""
+        _patch_build_chat_model["model"] = FakeChatModel(
+            {
+                "compounds": [
+                    {"name": "Silychristin", "role": "test"},
+                    {"name": "Verapamil", "role": "test"},
+                    {"name": "Diclofenac", "role": "test"},
+                    {"name": "BSP", "role": "test"},
+                ]
+            }
+        )
+
+        plan = leaves.extract_plan(self._FILENAME_CONTEXT)
+
+        names = {c["name"] for c in plan.get("compounds", [])}
+        assert names == {"Silychristin", "Verapamil", "Diclofenac", "BSP"}
+        # D5: still no fabricated identifiers on any filename-derived compound.
+        for compound in plan["compounds"]:
+            for ident in ("cas", "pubchem_cid", "inchikey", "smiles", "@id"):
+                assert ident not in compound
+
+
 class TestExtractPlanEmptyContext:
     """An uninformative context yields an empty-but-valid plan, not fabrication."""
 

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -1006,6 +1006,183 @@ class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
         assert result["ok"] is True
 
 
+
+class TestMaterializeCompoundsFromFilenames:
+    """#258 — the DEFAULT pipeline path must end-to-end turn compound-bearing
+    DATA FILENAMES into MolecularEntities (the legacy ReAct path got 22; the
+    default path got 0). This drives the REAL ``extract_plan`` leaf (its chat
+    model faked offline to return the filename-derived compound NAMES the enriched
+    prompt steers a model toward) through ``_materialize_plan`` with the compound
+    lookups stubbed, so the whole filename → plan → ``resolve_compound`` →
+    MolecularEntity chain is exercised with NO network.
+
+    Contract:
+    * count of MolecularEntities goes 0 → N for the representative input;
+    * NAMES-ONLY (D5): only the plan NAME reaches ``resolve_compound``; the
+      MolecularEntity's CAS/CID is the LOOKED-UP value, never invented from a
+      filename or a plan field.
+    """
+
+    # The S-VHPS26 shape: compounds appear ONLY in the data filenames.
+    _COMPOUND_FILES = (
+        "S-VHPS26_P5_Silychristin+Verapamil.xlsx",
+        "S-VHPS26_Diclofenac+BSP.xlsx",
+    )
+    _EXPECTED_NAMES = {"Silychristin", "Verapamil", "Diclofenac", "BSP"}
+
+    def _enable_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+    def _state_with_compound_files(self, tmp_path: Path) -> CrateState:
+        """A titled state whose scanned data files name compounds in their stems."""
+        state = CrateState()
+        state.metadata.title = "S-VHPS26 transporter interaction screen"
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        files: list[FileClassification] = []
+        for name in self._COMPOUND_FILES:
+            path = tmp_path / name
+            path.write_bytes(b"PK\x03\x04 xlsx stub")  # body irrelevant — names in filenames
+            files.append(
+                FileClassification(
+                    path=str(path),
+                    filename=name,
+                    size=path.stat().st_size,
+                    mime_type=(
+                        "application/vnd.openxmlformats-officedocument."
+                        "spreadsheetml.sheet"
+                    ),
+                    # A tabular preview so _gather_context lists the filename
+                    # WITHOUT a disk read (the filename carries the compound names).
+                    first_rows=["well,value", "A1,1.0"],
+                )
+            )
+        state.scanned_files = files
+        return state
+
+    def _fake_extract_plan_chat_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> list[str]:
+        """Fake the REAL leaf's chat model so the genuine ``extract_plan`` code
+        path runs (its enriched prompt is built and fed the gathered context),
+        but the model deterministically returns the filename-derived compounds a
+        correctly-steered model would. Records the prompt text the model saw so a
+        test can assert the filenames actually reached the leaf."""
+        import builder.agents.leaves as leaves_mod
+
+        seen_prompts: list[str] = []
+        expected = self._EXPECTED_NAMES
+
+        class _Runnable:
+            def invoke(self, messages, *a, **k):
+                for msg in messages:
+                    content = getattr(msg, "content", "")
+                    if isinstance(content, str):
+                        seen_prompts.append(content)
+                # A steered model proposes the compound NAMES it read off the
+                # filenames — names only (D5: no identifiers).
+                return {
+                    "compounds": [
+                        {"name": n, "role": "test"} for n in sorted(expected)
+                    ]
+                }
+
+        class _Model:
+            def with_structured_output(self, schema, *, include_raw=False, **k):
+                return _Runnable()
+
+        monkeypatch.setattr(
+            leaves_mod, "_build_chat_model", lambda *a, **k: _Model()
+        )
+        return seen_prompts
+
+    # Per-name LOOKED-UP identifiers (offline) — the verified ids PubChem would
+    # have returned for these names. Distinct per name so a test can assert the
+    # right name resolved to the right (looked-up, not invented) CAS.
+    _LOOKUP_BY_NAME: dict[str, dict[str, str]] = {
+        "Silychristin": {"cas": "33889-69-9", "pubchem_cid": "441764"},
+        "Verapamil": {"cas": "52-53-9", "pubchem_cid": "2520"},
+        "Diclofenac": {"cas": "15307-86-5", "pubchem_cid": "3033"},
+        "BSP": {"cas": "71-67-0", "pubchem_cid": "9568"},
+    }
+
+    def _stub_compound_lookup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub ``resolve_compound``'s name->record lookup + verification offline,
+        so a name resolves to a VERIFIED (looked-up) identifier with no network —
+        the D5 path: the id comes from the lookup, never from the plan/filename."""
+        import builder.tools.composites as composites_mod
+
+        lookup_by_name = self._LOOKUP_BY_NAME
+
+        def fake_lookup_compound(name):
+            ids = lookup_by_name.get(str(name).strip())
+            if ids is None:
+                return {"found": False, "data": None, "error": "not found"}
+            return {"found": True, "data": {**ids, "source": "pubchem"}, "error": None}
+
+        def fake_verify_identifier(state, entity_id, field):
+            ent = state.get_entity(entity_id)
+            if ent is not None:
+                ent.set_field_status(field, "verified", "lookup")
+            return {"verified": True, "entity_id": entity_id, "field": field, "message": "ok"}
+
+        monkeypatch.setattr(composites_mod, "lookup_compound", fake_lookup_compound)
+        monkeypatch.setattr(composites_mod, "verify_identifier", fake_verify_identifier)
+
+    def _by_type(self, engine: AgentEngine, type_name: str) -> list[Entity]:
+        return [e for e in engine.state.list_entities() if e.type == type_name]
+
+    def test_default_path_materializes_compounds_from_filenames(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        seen_prompts = self._fake_extract_plan_chat_model(monkeypatch)
+        self._stub_compound_lookup(monkeypatch)
+
+        engine = _engine(self._state_with_compound_files(tmp_path))
+
+        # BEFORE: the default path has produced zero compounds.
+        assert self._by_type(engine, "MolecularEntity") == []
+
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # The real leaf actually saw the compound-bearing filenames.
+        joined = "\n".join(seen_prompts)
+        assert "Silychristin+Verapamil" in joined
+        assert "Diclofenac+BSP" in joined
+
+        # AFTER: 0 → N MolecularEntities, one per filename-derived compound name.
+        chems = self._by_type(engine, "MolecularEntity")
+        assert {c.fields.get("name") for c in chems} == self._EXPECTED_NAMES
+        assert result["compounds"] == len(self._EXPECTED_NAMES)
+
+    def test_names_only_identifiers_come_from_the_lookup(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """D5: only the NAME reaches ``resolve_compound``; each MolecularEntity's
+        CAS/CID is the LOOKED-UP value (never invented from the filename)."""
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._fake_extract_plan_chat_model(monkeypatch)
+        self._stub_compound_lookup(monkeypatch)
+
+        engine = _engine(self._state_with_compound_files(tmp_path))
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        chems = {c.fields.get("name"): c for c in self._by_type(engine, "MolecularEntity")}
+        assert set(chems) == self._EXPECTED_NAMES, "all filename compounds minted"
+        # The CAS on each entity is the name's LOOKED-UP value, not a fabrication.
+        for name, expected in self._LOOKUP_BY_NAME.items():
+            assert chems[name].fields.get("cas") == expected["cas"]
+
+
+
 class TestPublicationFromPDF:
     """Issue #245 — when a plan publication's "title" is actually a PDF FILENAME,
     `_materialize_plan` must recover the real DOI/title from the PDF *text* and


### PR DESCRIPTION
## Root cause

On `S-VHPS26_extracted` the **legacy ReAct** path inferred **22** MolecularEntities (with verified CAS) from data filenames like `…_P5_Silychristin+Verapamil.xlsx`; the **default pipeline** path produced **0** compounds.

This was **path (a)** — the bounded `extract_plan` leaf. The materialize side (`_materialize_plan` in `pipeline.py`) was already correct: it resolves `plan["compounds"]` via `resolve_compound` and mints a MolecularEntity per resolved compound (path (b), wired by earlier work and confirmed by the existing `test_materializes_plan_entities`). The bug was that the leaf's prompt only mined compounds from **prose**, never from the **filenames** inventory in the gathered context — so on filename-only inputs the leaf returned an empty `compounds` list and the materialize step had nothing to resolve.

## Fix

`builder/agents/leaves.py` only — enrich the `extract_plan` system + human prompts to direct the model to mine test/control compound **names** from the data **filenames** (split filename stems on `+`/`_`/`-`/space; drop plate/well/replicate/date codes and the study accession) as well as JSON/README bodies. **NAMES ONLY (D5):** no CAS/CID/InChIKey — identifiers still come from `resolve_compound`'s lookups, never the plan/filename. The plan **schema is unchanged**, so the D5 "no identifier field in the schema the model sees" guard stays intact.

No change to `pipeline.py` was needed: path (b) already creates the MolecularEntities.

## Tests (strict TDD, fully offline — `resolve_compound`/lookups stubbed, no network)

- `test_leaves.py::TestExtractPlanMinesCompoundsFromFilenames` — the prompt instructs filename compound-mining while keeping names-only discipline; filename-derived names round trip with no fabricated identifiers. (The prompt-instruction test was confirmed **RED** before the fix.)
- `test_agents_pipeline.py::TestMaterializeCompoundsFromFilenames` — end-to-end, the **real** `extract_plan` leaf (chat model faked offline) fed compound-bearing filenames drives `_materialize_plan` from **0 → N** MolecularEntities, each entity's CAS being the **looked-up** value, never invented.

## Gates

- `uv run --extra langchain pytest` on the touched files: 119 passed (rebased onto #273). `uv run ruff check`: clean. `uv run --extra langchain ty check`: clean (no new diagnostics).

## Scope / sequencing note

Orphan-linking (wiring the created compounds into the provenance graph) is the follow-up **#273**, which merged into `main` first; this branch has been rebased on top of it (its test file additions coexist cleanly). #273 only *links* the compounds; this PR is what *creates* them from the filenames in the first place.

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)