### PR TITLE
fix(drafters): never persist internal entity_id/@id as an entity field (#286)

### DIFF
--- a/builder/state.py
+++ b/builder/state.py
@@ -58,6 +58,13 @@ CompletionStatus = Literal["missing", "filled", "verified"]
 CompletionSource = Literal["scanner", "llm", "user", "lookup"]
 InputType = Literal["directory", "conversation"]
 
+# Internal @id / @type handles that live on the Entity itself (the ``entity_id``
+# and ``type`` attributes), NOT as schema.org properties. They must never be
+# stored in ``Entity.fields``: a field named ``entity_id`` / ``@id`` / ``type`` /
+# ``@type`` serializes as a bare JSON-LD key absent from the RO-Crate @context
+# and fails base conformance (Issue #286). ``set_fields_from_dict`` drops them.
+_RESERVED_INTERNAL_KEYS: frozenset[str] = frozenset({"entity_id", "@id", "type", "@type"})
+
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -181,8 +188,23 @@ class Entity:
     def set_fields_from_dict(
         self, values: dict[str, Any], source: CompletionSource = "llm"
     ) -> None:
-        """Set multiple fields at once, marking each as filled."""
+        """Set multiple fields at once, marking each as filled.
+
+        Reserved internal handles (``entity_id`` / ``@id`` / ``type`` /
+        ``@type``) are silently dropped rather than stored as fields: they are
+        the entity's own ``entity_id`` / ``type`` attributes, not schema.org
+        properties, and would otherwise serialize as bare JSON-LD keys absent
+        from the RO-Crate @context, failing base validation (Issue #286).
+        """
         for field_name, value in values.items():
+            if field_name in _RESERVED_INTERNAL_KEYS:
+                logger.debug(
+                    "Dropping reserved internal key %r from fields of entity %s; "
+                    "it is an @id/@type handle, not a property.",
+                    field_name,
+                    self.entity_id,
+                )
+                continue
             self.fields[field_name] = value
             self.set_field_status(field_name, "filled", source)
 

--- a/builder/tools/drafters.py
+++ b/builder/tools/drafters.py
@@ -227,11 +227,16 @@ def draft_defined_term(state: CrateState, name: str, hints: dict) -> Entity:
     if "in_defined_term_set" in merged_hints:
         merged_hints["inDefinedTermSet"] = merged_hints.pop("in_defined_term_set")
 
-    # A looked-up term carries a dereferenceable IRI; use it as the entity_id so
-    # _mint_id keeps it as the @id (an IRI containing "://" is preserved verbatim).
+    # A looked-up term carries a dereferenceable IRI; use it as the entity's
+    # entity_id so _mint_id keeps it as the @id (an IRI containing "://" is
+    # preserved verbatim). The IRI is the entity's @id HANDLE, not a property, so
+    # the entity_id/@id keys are stripped from merged_hints before
+    # set_fields_from_dict — otherwise they would serialize as bare JSON-LD keys
+    # absent from the @context and fail base validation (Issue #286).
     iri = merged_hints.get("entity_id") or merged_hints.get("@id") or merged_hints.get("url")
-    if iri and "entity_id" not in hints:
-        merged_hints["entity_id"] = iri
+    merged_hints.pop("entity_id", None)
+    merged_hints.pop("@id", None)
+    if iri:
         entity_id = str(iri)
     else:
         entity_id = _make_entity_id("dt", name, merged_hints)

--- a/tests/test_state_reserved_keys.py
+++ b/tests/test_state_reserved_keys.py
@@ -1,0 +1,43 @@
+"""Tests for the reserved-key guard in Entity.set_fields_from_dict (#286).
+
+The keys ``entity_id`` / ``@id`` are an entity's internal @id handle (the
+``Entity.entity_id`` attribute) and ``type`` / ``@type`` are its @type handle
+(the ``Entity.type`` attribute). None of them are schema.org properties, so if
+they ever land in ``Entity.fields`` they serialize as bare JSON-LD keys absent
+from the RO-Crate @context and fail base conformance. ``set_fields_from_dict``
+must therefore refuse to store them as fields.
+"""
+
+from __future__ import annotations
+
+from builder.state import Entity
+
+
+def test_set_fields_from_dict_drops_reserved_internal_keys():
+    """entity_id/@id/type/@type passed in a fields dict never become fields."""
+    entity = Entity(entity_id="dt_x", type="DefinedTerm")
+    entity.set_fields_from_dict(
+        {
+            "name": "apoptosis",
+            "entity_id": "http://example.org/term",
+            "@id": "http://example.org/term",
+            "type": "Bogus",
+            "@type": "Bogus",
+        }
+    )
+    # Legitimate fields are kept.
+    assert entity.fields.get("name") == "apoptosis"
+    # The internal handles are NOT stored as fields.
+    for key in ("entity_id", "@id", "type", "@type"):
+        assert key not in entity.fields, f"reserved key {key!r} leaked into fields"
+    # The entity's own identity handles are untouched by the dropped keys.
+    assert entity.entity_id == "dt_x"
+    assert entity.type == "DefinedTerm"
+
+
+def test_reserved_keys_get_no_completion_status():
+    """Dropped reserved keys must not get a phantom 'filled' completion entry."""
+    entity = Entity(entity_id="dt_x", type="DefinedTerm")
+    entity.set_fields_from_dict({"name": "apoptosis", "entity_id": "http://example.org/x"})
+    assert entity.get_field_status("name") is not None
+    assert entity.get_field_status("entity_id") is None

--- a/tests/test_tools_drafters.py
+++ b/tests/test_tools_drafters.py
@@ -471,6 +471,88 @@ class TestDraftDefinedTerm:
             for n in mentioned
         ), f"a DefinedTerm should be a mentions target; got {ids}"
 
+    def test_iri_is_used_as_id_but_never_stored_as_a_field(self):
+        """The looked-up IRI sets the @id but must NOT leak as an entity field.
+
+        Regression for #286: ``draft_defined_term`` copied the IRI into
+        ``merged_hints["entity_id"]`` and then ``set_fields_from_dict`` stored
+        it as a literal ``entity_id`` field, which serialized as a bare JSON-LD
+        key not in the @context and failed base validation.
+        """
+        state = CrateState()
+        iri = "http://www.bioassayontology.org/bao#BAO_0002993"
+        entity = draft_defined_term(
+            state, "cell viability assay", {"term_code": "BAO:0002993", "url": iri}
+        )
+        # (a) the IRI is used as the entity's stable @id handle.
+        assert entity.entity_id == iri
+        # (b) but neither entity_id nor @id may exist as a literal FIELD.
+        assert "entity_id" not in entity.fields
+        assert "@id" not in entity.fields
+
+    def test_assembled_node_has_no_entity_id_key(self):
+        """The DefinedTerm @graph node must not carry a bare ``entity_id`` key.
+
+        Regression for #286: such a key is absent from the RO-Crate @context and
+        fails base conformance ("the occurrences of the JSON-LD key 'entity_id'
+        are not allowed in the compacted format").
+        """
+        state = CrateState()
+        iri = "http://www.bioassayontology.org/bao#BAO_0002993"
+        draft_defined_term(state, "cell viability assay", {"url": iri})
+        graph = _graph(state)
+        node = _node_by_id(graph, iri)
+        assert node is not None, "DefinedTerm should be in @graph under its IRI @id"
+        assert "entity_id" not in node, f"entity_id leaked onto the node: {node}"
+
+    def test_explicit_entity_id_hint_sets_id_without_leaking_field(self):
+        """An explicit ``entity_id`` hint (an IRI) still sets the @id, not a field."""
+        state = CrateState()
+        iri = "http://purl.obolibrary.org/obo/GO_0006915"
+        entity = draft_defined_term(state, "apoptosis", {"entity_id": iri})
+        assert entity.entity_id == iri
+        assert "entity_id" not in entity.fields
+        graph = _graph(state)
+        node = _node_by_id(graph, iri)
+        assert node is not None
+        assert "entity_id" not in node
+
+
+class TestDraftersDoNotLeakReservedKeys:
+    """Audit (#286): no drafter may persist internal @id/type handles as fields."""
+
+    def test_no_drafter_persists_entity_id_or_at_id_as_a_field(self):
+        """Passing entity_id/@id/type/@type to any drafter never makes a field."""
+        reserved = {
+            "entity_id": "http://example.org/x",
+            "@id": "http://example.org/x",
+            "type": "Bogus",
+            "@type": "Bogus",
+        }
+        state = CrateState()
+        inv = draft_investigation(state, {"name": "Inv", **reserved})
+        study = draft_study(state, inv.entity_id, {"name": "Study", **reserved})
+        entities = [
+            inv,
+            study,
+            draft_assay(state, study.entity_id, {"name": "Assay", **reserved}),
+            draft_molecular_entity(state, "Caffeine", dict(reserved)),
+            draft_cell_line_sample(state, "HepG2", dict(reserved)),
+            draft_process(state, study.entity_id, "CellCulture", dict(reserved)),
+            draft_defined_term(state, "apoptosis", {"term_code": "GO:0006915", **reserved}),
+            draft_property_value(state, "pH", {"value": "7", **reserved}),
+            draft_person(state, "Ada Lovelace", dict(reserved)),
+            draft_organization(state, "ACME", dict(reserved)),
+            draft_protocol(state, {"name": "Proto", **reserved}),
+            draft_sample(state, {"name": "Sample", **reserved}),
+            draft_publication(state, "10.1/x", dict(reserved)),
+        ]
+        for ent in entities:
+            for key in ("entity_id", "@id", "type", "@type"):
+                assert key not in ent.fields, (
+                    f"{ent.type} leaked reserved key {key!r} into fields: {ent.fields}"
+                )
+
 
 class TestDraftPropertyValue:
     """Tests for draft_property_value (Issue #141)."""


### PR DESCRIPTION
## Problem

`draft_defined_term` copied a looked-up term IRI into `merged_hints["entity_id"]` and then called `set_fields_from_dict`, which stored `entity_id` as a regular **field** inside `Entity.fields`. `entity_id`/`@id` are the entity's internal @id handle (the `Entity.entity_id` attribute), not schema.org properties, so on serialization the crate emitted a bare JSON-LD key `entity_id` absent from the `@context` and **failed base conformance** ("the occurrences of the JSON-LD key 'entity_id' are not allowed in the compacted format"). `set_fields(entity_id=None)` didn't fix it (the key still serialized) — the leak was structural.

## Fix

- **`draft_defined_term`**: uses the IRI as the entity's `entity_id` (@id) but strips `entity_id`/`@id` from `merged_hints` before `set_fields_from_dict`, so the IRI never becomes a field. An explicit `entity_id`/`@id` hint is now honoured as the @id (matching the docstring).
- **Belt-and-braces guard** (`builder/state.py`): `Entity.set_fields_from_dict` now drops the reserved internal keys (`entity_id`, `@id`, `type`, `@type`) with a debug log instead of storing them as fields — preventing this class of bug across every drafter and lookup caller. `_make_entity_id` still reads `entity_id` from `hints` unaffected.

Audited the sibling drafters (`draft_property_value`, `draft_person`, `draft_organization`, `draft_cell_line_sample`, `draft_molecular_entity`, etc.): none intentionally wrote `entity_id`/`@id`/`type` as a field; the guard hardens them all.

## Tests (TDD — written red first)

- `draft_defined_term` from an IRI: uses it as @id, but `fields` carry no `entity_id`/`@id`, and the assembled @graph node has no `entity_id` key.
- Audit test across all drafters: passing `entity_id`/`@id`/`type`/`@type` never creates those fields.
- Direct `set_fields_from_dict` guard test (+ no phantom completion entry).

Gate: focused + `-k "drafter or state"` all green (181 tests); `ruff` clean; `ty` adds no new diagnostics.

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)