### PR TITLE
fix(agent-loop): export on every completed build + loop-breaker for repeated non-progress reads (#287)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,19 @@ list_scanned_files …". `read_file_sample`'s `lines` argument controls how much
 of each tool's call args (`run_tool: read_file(path='…')`) so the recorded action
 shows *which* path/hints a tool ran with, not just its result.
 
+**Repeated non-progress loop-breaker (Issue #287, legacy ReAct only):** even with
+the directory/`None` messages above, a weak model (DeepSeek-flash) re-issued the
+*same* `read_file_sample`/`read_file` call on a directory / non-existent path ~36×
+in a row, burning millions of tokens. The `_run` wrapper in `_build_langchain_tools`
+now tracks the last tool-call signature (name + sorted args) and the consecutive
+count of the **same non-progress result** (a directory message, an unreadable/`None`
+message, or an `{"error": …}` dict — `_is_non_progress_result`) on the engine. After
+`_LOOP_BREAKER_THRESHOLD` (3) identical non-progress repeats it **refuses to run the
+call again** and returns a forceful corrective message carrying the live
+`list_scanned_files` inventory (concrete file paths to read instead). Any *distinct*
+call or any *progress* result resets the counter, so legitimately-repeated different
+calls and a single normal retry never trip it.
+
 #### Entity Drafters (`builder/tools/drafters.py`)
 Generate metadata entities from files, conversation, or existing metadata.
 Each drafter collects hints, calls the LLM, and ensures identifiers come from
@@ -1822,6 +1835,19 @@ build (interactive *and* headless), so the user always gets a crate on disk and
 logged, surfaced via `output`, and re-raised as `CrateExportError` so the CLI
 signals a non-zero exit. The exporter is injectable so the wiring is unit-tested
 with no ro-crate-py / disk (`tests/test_agents_build.py`).
+
+**Legacy ReAct now mirrors this (#287).** "only the legacy ReAct loop exported,
+because the LLM chose to" was itself a bug: in a live `--legacy-react` run the weak
+model *never* chose `export_crate` while the user kept the session alive, so a
+base-valid 70+-entity crate was never written (`_finish_backstop`, #251, only runs
+on the quit/EOF exit path). The legacy loop now auto-exports on **every** completed
+in-loop build too: `_auto_export_after_build` in `builder/agents/agent_loop.py` fires
+after a `build_and_validate` that passes **base** conformance over a non-empty crate,
+calling `export_crate` with no explicit path (same destination resolution as above),
+stamping `_EXPORTED_FLAG` (so `_finish_backstop` stays a no-op — no double-export),
+and surfacing the absolute crate path. It is idempotent via an entity-count
+fingerprint: it re-exports only when the crate changed since the last auto-export, so
+the *latest* crate always lands and an unchanged repeat build is a no-op.
 
 **Progress + persistence (#241 / #242).** Before these the default `--interactive`
 (pipeline) path *felt dead*: the deterministic spine ran for ~tens of seconds with

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -230,6 +230,39 @@ _FILE_READ_TOOLS = frozenset(
 # from the agent itself or from the backstop.
 _EXPORTED_FLAG = "_crate_exported_this_session"
 
+# Attribute holding the entity-count fingerprint of the last in-loop auto-export
+# (#287 Fix A). A completed build auto-exports the crate to disk so the user
+# always gets a crate (the new deterministic pipeline already exports on every
+# completed build, #233); this fingerprint makes the auto-export idempotent —
+# it re-exports only when the crate has changed since the last auto-export
+# (so the *latest* crate always lands), never twice for the same build.
+_AUTO_EXPORT_FINGERPRINT_FLAG = "_crate_auto_export_fingerprint"
+
+# Attribute holding the optional single-arg console sink the loop installs so an
+# in-loop auto-export can surface the absolute crate path to the user (#287 Fix
+# A). Default ``None`` is a strict no-op (mirrors ``on_tool_event``, #266), so a
+# headless/test engine without a console behaves identically.
+_AUTO_EXPORT_EMIT_FLAG = "on_auto_export"
+
+# ---------------------------------------------------------------------------
+# Issue #287 Fix B: loop-breaker for repeated non-progress tool calls
+# ---------------------------------------------------------------------------
+
+# How many CONSECUTIVE identical non-progress tool calls (same tool name + same
+# args returning the same directory/None/error result) the loop tolerates before
+# it intervenes. A weak model looped ~36× on a directory/non-existent read,
+# burning millions of tokens; a small threshold breaks that fast without tripping
+# on legitimately-repeated DISTINCT calls or a single normal retry.
+_LOOP_BREAKER_THRESHOLD = 3
+
+# Attributes holding the loop-breaker's per-engine detection state: the signature
+# (tool name + sorted args) of the last call and the consecutive-repeat count of
+# the same non-progress result. Kept on the engine so the state survives across
+# the per-call tool closures and resets cleanly when a distinct/progress call
+# arrives.
+_LOOP_BREAKER_LAST_SIG_FLAG = "_loop_breaker_last_signature"
+_LOOP_BREAKER_COUNT_FLAG = "_loop_breaker_repeat_count"
+
 # ---------------------------------------------------------------------------
 # Issue #263: stall recovery (Fix A) + autonomous continuation (Fix B)
 # ---------------------------------------------------------------------------
@@ -428,6 +461,193 @@ def _unreadable_file_message(path: str, tool_name: str = "read_file_sample") -> 
     )
 
 
+# ---------------------------------------------------------------------------
+# Issue #287 Fix A: auto-export the crate on every completed in-loop build
+# ---------------------------------------------------------------------------
+
+
+def _emit_auto_export(engine: AgentEngine, message: str) -> None:
+    """Surface an in-loop auto-export status line via the engine's emit sink.
+
+    The loop installs a single-arg sink at ``engine.<_AUTO_EXPORT_EMIT_FLAG>``
+    (``console.print``); a missing/``None`` sink is a strict no-op (mirrors the
+    #266 ``on_tool_event`` pattern), so a headless/test engine without a console
+    behaves identically. A raising sink is swallowed — surfacing is UI chrome and
+    must never break a tool call.
+    """
+    sink = getattr(engine, _AUTO_EXPORT_EMIT_FLAG, None)
+    if sink is None:
+        return
+    try:
+        sink(message)
+    except Exception:  # noqa: BLE001 — a UI sink must never break a tool call.
+        logger.debug("auto-export emit sink raised", exc_info=True)
+
+
+def _auto_export_after_build(engine: AgentEngine, build_result: Any) -> None:
+    """Export the crate to disk after a successful in-loop ``build_and_validate``.
+
+    Issue #287 Fix A: the legacy ReAct loop only wrote a crate via the finish
+    backstop, which runs on the EXIT path (quit/EOF). In a live run the user kept
+    the session alive, the weak model never called ``export_crate``, and a fully
+    built, base-VALID crate (70+ entities) was NEVER written. The deterministic
+    pipeline already exports on every completed build (#233); this brings the
+    legacy loop in line.
+
+    Fires when, and only when:
+      * the crate has entities (an empty crate has nothing to write), AND
+      * the build passed BASE conformance (``build_result["conformance"]["base"]``
+        — the same gate the pipeline uses; ISA/Tox may still have gaps but a
+        base-valid crate is worth landing), AND
+      * the crate has changed since the last auto-export (entity-count
+        fingerprint) — so the *latest* crate always lands and an unchanged repeat
+        build never re-exports (idempotency).
+
+    On a successful export the ``_EXPORTED_FLAG`` is stamped (so ``_finish_backstop``
+    stays a no-op and never double-exports) and the resolved ABSOLUTE crate path is
+    surfaced via the engine's emit sink. ``export_crate`` is called with no explicit
+    path so it honors ``state.metadata.output_path`` (CLI ``--output`` / default
+    ``<input>-ro-crate/``) then the session fallback. NEVER raises: an export
+    failure is logged and surfaced but the build result still flows back to the
+    model unchanged (the finish backstop can retry on exit).
+    """
+    try:
+        if not isinstance(build_result, dict):
+            return
+        # A build error or a base-conformance miss must not export — only a
+        # base-valid, non-empty crate is worth landing.
+        if build_result.get("error"):
+            return
+        conformance = build_result.get("conformance") or {}
+        if not conformance.get("base"):
+            return
+        if not engine.state.list_entities():
+            return
+
+        # Idempotency: re-export only when the crate changed since the last
+        # auto-export, so the latest crate always lands and a repeat build of an
+        # unchanged crate is a no-op (no double-export for the same build).
+        fingerprint = len(engine.state.list_entities())
+        last = getattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, None)
+        if last == fingerprint and getattr(engine, _EXPORTED_FLAG, False):
+            return
+
+        # No explicit path → export_crate honors state.metadata.output_path
+        # (CLI --output / default <input>-ro-crate/) then the session fallback.
+        result = engine.run_tool("export_crate")
+    except Exception as exc:  # noqa: BLE001 — auto-export must never break the turn.
+        logger.warning("In-loop auto-export failed: %s", exc)
+        return
+
+    if isinstance(result, dict) and result.get("success"):
+        # Stamp BEFORE surfacing so any later backstop call is a strict no-op,
+        # and record the fingerprint so an unchanged repeat build won't re-export.
+        setattr(engine, _EXPORTED_FLAG, True)
+        setattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, fingerprint)
+        crate_path = result.get("crate_path")
+        try:
+            from pathlib import Path
+
+            resolved = str(Path(crate_path).resolve()) if crate_path else crate_path
+        except (OSError, TypeError, ValueError):
+            resolved = crate_path
+        logger.info("In-loop auto-export wrote crate to %s", resolved)
+        _emit_auto_export(engine, f"Crate written to: {resolved}")
+        return
+
+    # export_crate returned a failure dict (it never raises by contract). Do NOT
+    # stamp the flag — the finish backstop should still try on exit.
+    error = (result or {}).get("error") if isinstance(result, dict) else result
+    logger.warning("In-loop auto-export: export_crate failed: %s", error)
+    _emit_auto_export(engine, f"Could not write the crate yet: {error}")
+
+
+# ---------------------------------------------------------------------------
+# Issue #287 Fix B: loop-breaker for repeated non-progress tool calls
+# ---------------------------------------------------------------------------
+
+
+def _is_non_progress_result(result: Any) -> bool:
+    """Return True when a tool result represents NO forward progress (#287 Fix B).
+
+    A weak model loops when a tool keeps handing back the same dead-end. Three
+    shapes count as non-progress:
+
+    1. An ``error`` dict — the wrapper turns a recoverable tool-body exception
+       into ``{"error": ..., "tool": ...}`` (e.g. a non-existent path).
+    2. A directory-guidance string — a reader handed a directory returns
+       ``"<path> is a directory, not a file …"`` (#240/#281).
+    3. An unreadable/None string — a reader that could not return text returns
+       ``"<tool> could not return text …"`` (#101/#148).
+
+    Anything else (real file content, a successful build dict, a list, …) is
+    progress and resets the loop-breaker. The check is purely structural so it
+    never raises.
+    """
+    if isinstance(result, dict):
+        return "error" in result
+    if isinstance(result, str):
+        return (
+            "is a directory, not a file" in result
+            or "could not return text" in result
+        )
+    return False
+
+
+def _call_signature(tool_name: str, kwargs: dict[str, Any]) -> tuple[str, tuple]:
+    """A hashable signature for a tool call (name + sorted, stringified args).
+
+    Args are stringified before sorting so unhashable values (lists/dicts a weak
+    model may pass) can't break signature comparison — the loop-breaker only
+    needs to know whether two calls are byte-identical, not to round-trip them.
+    """
+    try:
+        items = tuple(sorted((str(k), str(v)) for k, v in kwargs.items()))
+    except Exception:  # noqa: BLE001 — signature comparison must never raise.
+        items = (("__repr__", repr(kwargs)),)
+    return (tool_name, items)
+
+
+def _loop_breaker_intervention(engine: AgentEngine, tool_name: str) -> str:
+    """Build the corrective tool message that breaks a repeated non-progress loop.
+
+    Injects the actual ``list_scanned_files`` inventory (the concrete file paths
+    the model should read instead) plus a forceful directive to stop repeating the
+    identical call and pick a real file path. The inventory is fetched via
+    ``engine.run_tool('list_scanned_files')`` so it reflects the live scan; a
+    failure degrades to the directive alone (never raises).
+    """
+    inventory_block = ""
+    try:
+        inv = engine.run_tool("list_scanned_files")
+        if isinstance(inv, dict):
+            files = inv.get("files") or []
+            paths = [f.get("path") for f in files if isinstance(f, dict) and f.get("path")]
+            if paths:
+                shown = paths[:25]
+                listed = "\n".join(f"  - {p}" for p in shown)
+                more = (
+                    f"\n  …and {len(paths) - len(shown)} more "
+                    "(call list_scanned_files to page through them)."
+                    if len(paths) > len(shown)
+                    else ""
+                )
+                inventory_block = (
+                    f"\nScanned files you can read by their EXACT path:\n{listed}{more}"
+                )
+    except Exception:  # noqa: BLE001 — the inventory is best-effort.
+        logger.debug("loop-breaker: list_scanned_files failed", exc_info=True)
+
+    return (
+        f"STOP — you have called {tool_name} with the same arguments "
+        f"{_LOOP_BREAKER_THRESHOLD} times in a row and it is not making progress "
+        f"(the path is a directory, missing, or unreadable). Do NOT call "
+        f"{tool_name} again with those arguments. Pick a CONCRETE file path from "
+        f"the inventory below, or move on to drafting/validating entities."
+        f"{inventory_block}"
+    )
+
+
 def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
     """Build LangChain BaseTool instances from the engine's tool registry.
 
@@ -449,6 +669,20 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
 
         def _make_tool(tool_name: str, tool_desc: str, tool_params: dict) -> BaseTool:
             def _run(**kwargs: Any) -> Any:
+                # Loop-breaker (#287 Fix B): if this is the Nth consecutive
+                # IDENTICAL call that has been returning a non-progress result
+                # (directory/None/error), REFUSE to repeat it — return a forceful
+                # corrective tool message with the actual scanned-file inventory so
+                # a weak model stops looping (it ignored #281's directory message
+                # and looped ~36×). Distinct calls / a single retry never trip this.
+                signature = _call_signature(tool_name, kwargs)
+                last_sig = getattr(engine, _LOOP_BREAKER_LAST_SIG_FLAG, None)
+                repeat_count = getattr(engine, _LOOP_BREAKER_COUNT_FLAG, 0)
+                if last_sig == signature and repeat_count >= _LOOP_BREAKER_THRESHOLD:
+                    # Do NOT run the tool again — the identical non-progress call
+                    # is short-circuited and the model is steered elsewhere.
+                    return _loop_breaker_intervention(engine, tool_name)
+
                 try:
                     result = engine.run_tool(tool_name, **kwargs)
                 except (ValueError, KeyError, TypeError) as exc:
@@ -463,31 +697,63 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     # otherwise escape both the ToolNode and the model loop.
                     # Genuinely fatal errors (SystemExit, KeyboardInterrupt) are
                     # intentionally NOT caught so they propagate normally.
-                    return {"error": str(exc), "tool": tool_name}
-                # scan_files returns the full list[FileClassification] (already
-                # stored in state); hand the LLM a compact summary instead of
-                # the raw blob so it gets a clear success signal and does not
-                # re-scan in a loop.
-                if tool_name == "scan_files" and isinstance(result, list):
-                    from builder.tools.scanner import summarize_scan_result
+                    result = {"error": str(exc), "tool": tool_name}
+                else:
+                    # scan_files returns the full list[FileClassification] (already
+                    # stored in state); hand the LLM a compact summary instead of
+                    # the raw blob so it gets a clear success signal and does not
+                    # re-scan in a loop.
+                    if tool_name == "scan_files" and isinstance(result, list):
+                        from builder.tools.scanner import summarize_scan_result
 
-                    return summarize_scan_result(result)
-                # The file-reading tools return None for missing/oversized/binary
-                # files; hand the LLM an actionable message so it stops re-calling
-                # them (#101, #148).
-                if tool_name in _FILE_READ_TOOLS and result is None:
-                    return _unreadable_file_message(
-                        kwargs.get("path", ""), tool_name
-                    )
-                # When the agent itself successfully exports, stamp the engine so
-                # the deterministic finish backstop (#251) does not double-export
-                # on session exit.
-                if (
-                    tool_name in ("export_crate", "build_crate")
-                    and isinstance(result, dict)
-                    and result.get("success")
-                ):
-                    setattr(engine, _EXPORTED_FLAG, True)
+                        result = summarize_scan_result(result)
+                    # The file-reading tools return None for missing/oversized/
+                    # binary files; hand the LLM an actionable message so it stops
+                    # re-calling them (#101, #148).
+                    elif tool_name in _FILE_READ_TOOLS and result is None:
+                        result = _unreadable_file_message(
+                            kwargs.get("path", ""), tool_name
+                        )
+                    # When the agent itself successfully exports, stamp the engine
+                    # so the deterministic finish backstop (#251) does not
+                    # double-export on session exit. Also record the entity-count
+                    # fingerprint so an unchanged follow-up build_and_validate does
+                    # not redundantly re-export (#287 Fix A idempotency).
+                    elif (
+                        tool_name in ("export_crate", "build_crate")
+                        and isinstance(result, dict)
+                        and result.get("success")
+                    ):
+                        setattr(engine, _EXPORTED_FLAG, True)
+                        try:
+                            setattr(
+                                engine,
+                                _AUTO_EXPORT_FINGERPRINT_FLAG,
+                                len(engine.state.list_entities()),
+                            )
+                        except Exception:  # noqa: BLE001 — fingerprint is best-effort.
+                            logger.debug("fingerprint stamp failed", exc_info=True)
+                    # Auto-export on every completed in-loop build (#287 Fix A):
+                    # the user kept the session alive and the weak model never
+                    # called export_crate, so a base-valid 70+-entity crate never
+                    # landed. Mirror the deterministic pipeline (#233) — write the
+                    # crate whenever build_and_validate passes base conformance.
+                    elif tool_name == "build_and_validate":
+                        _auto_export_after_build(engine, result)
+
+                # Update the loop-breaker detection state AFTER post-processing so
+                # it sees the same message the model sees. A repeated identical
+                # non-progress call increments the streak; any distinct call or a
+                # progress result resets it.
+                if last_sig == signature and _is_non_progress_result(result):
+                    setattr(engine, _LOOP_BREAKER_COUNT_FLAG, repeat_count + 1)
+                elif _is_non_progress_result(result):
+                    setattr(engine, _LOOP_BREAKER_LAST_SIG_FLAG, signature)
+                    setattr(engine, _LOOP_BREAKER_COUNT_FLAG, 1)
+                else:
+                    setattr(engine, _LOOP_BREAKER_LAST_SIG_FLAG, None)
+                    setattr(engine, _LOOP_BREAKER_COUNT_FLAG, 0)
+
                 return result
 
             _run.__name__ = tool_name
@@ -1537,6 +1803,15 @@ def run_interactive_agent(
 
     console = Console()
 
+    # In-loop auto-export surfacing (#287 Fix A): a completed in-loop build writes
+    # the crate to disk and reports its absolute path via this sink. The export
+    # fires deep inside ``app.invoke`` (under the Rich Live spinner), so we BUFFER
+    # the line here and flush it from ``_run_turn`` once the spinner has torn down,
+    # keeping the transcript clean. Installed on the engine like ``on_tool_event``
+    # (#266); a headless engine leaves it ``None`` (a strict no-op).
+    auto_export_lines: list[str] = []
+    setattr(engine, _AUTO_EXPORT_EMIT_FLAG, auto_export_lines.append)
+
     if max_iterations is None:
         from builder.config import get_max_iterations
 
@@ -1937,6 +2212,12 @@ def run_interactive_agent(
             outcome = "recursion"
         finally:
             root_logger.setLevel(old_root_level)
+
+        # Flush any in-loop auto-export status lines buffered during the invoke
+        # (#287 Fix A) now the spinner's Live region is gone, so "Crate written
+        # to: <abs path>" lands cleanly in the transcript.
+        while auto_export_lines:
+            console.print(auto_export_lines.pop(0))
 
         if outcome == "ok" and result:
             reply = _extract_reply(result)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1643,3 +1643,356 @@ class TestTimeoutEndsTurnGracefully:
         assert backstop_calls["n"] >= 1
 
 
+# ---------------------------------------------------------------------------
+# Issue #287: export-on-completed-build (Fix A) + repeated-non-progress
+# loop-breaker (Fix B). The engine/tools are stubbed; no SHACL / LLM / network.
+# ---------------------------------------------------------------------------
+
+
+class TestExportOnCompletedBuild:
+    """Issue #287 Fix A: a successful in-loop build_and_validate auto-exports the
+    crate to disk (no quit needed), surfaces the absolute path, stamps the
+    _EXPORTED_FLAG, and leaves the finish backstop a no-op afterward."""
+
+    def _engine_with_entities(self, *types: str):
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        engine.state.session_id = "test_export_287"
+        for i, t in enumerate(types or ("Investigation", "Study")):
+            engine.state.add_entity(Entity(entity_id=f"e{i}", type=t))
+        return engine
+
+    def _install_spy(self, engine, *, build_result, export_result):
+        """Replace engine.run_tool with a recording spy returning canned results
+        for build_and_validate / export_crate; record the call order."""
+        calls: list[str] = []
+
+        def fake_run_tool(tool_name: str, **kwargs):
+            calls.append(tool_name)
+            if tool_name == "build_and_validate":
+                return dict(build_result)
+            if tool_name in ("export_crate", "build_crate"):
+                return dict(export_result)
+            return {"ok": True}
+
+        engine.run_tool = fake_run_tool  # type: ignore[method-assign]
+        return calls
+
+    def test_successful_build_and_validate_auto_exports_once(self):
+        from builder.agents.agent_loop import (
+            _EXPORTED_FLAG,
+            _build_langchain_tools,
+            _finish_backstop,
+        )
+
+        engine = self._engine_with_entities("Investigation", "Study")
+        calls = self._install_spy(
+            engine,
+            build_result={
+                "ok": True,
+                "conformance": {"base": True, "isa": True, "tox": True},
+                "issues": [],
+            },
+            export_result={
+                "success": True,
+                "crate_path": "/tmp/S-VHPS26-ro-crate",
+                "error": None,
+            },
+        )
+
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        result = tools["build_and_validate"].invoke({"severity": None, "profile": None})
+
+        # build_and_validate ran, then export_crate was triggered exactly once.
+        assert "build_and_validate" in calls
+        assert calls.count("export_crate") == 1, f"expected one export, got {calls}"
+        # The original build result is still returned to the model.
+        assert isinstance(result, dict) and result.get("ok") is True
+        # The flag is stamped so the finish backstop is a no-op.
+        assert getattr(engine, _EXPORTED_FLAG, False) is True
+
+        # A subsequent finish backstop must NOT double-export.
+        before = calls.count("export_crate")
+        _finish_backstop(engine, emit=lambda _m: None)
+        assert calls.count("export_crate") == before, (
+            f"finish backstop must not double-export, got {calls}"
+        )
+
+    def test_crate_path_is_surfaced(self):
+        """The absolute crate path is surfaced through the loop's output channel."""
+        from builder.agents.agent_loop import _build_langchain_tools
+
+        engine = self._engine_with_entities("Investigation")
+        self._install_spy(
+            engine,
+            build_result={"ok": True, "conformance": {"base": True}, "issues": []},
+            export_result={
+                "success": True,
+                "crate_path": "/tmp/out-ro-crate",
+                "error": None,
+            },
+        )
+
+        surfaced: list[str] = []
+        # The loop installs an emit sink on the engine for in-loop exports.
+        engine.on_auto_export = surfaced.append  # type: ignore[attr-defined]
+
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        tools["build_and_validate"].invoke({})
+
+        assert any("ro-crate" in m for m in surfaced), (
+            f"the crate path must be surfaced, got {surfaced}"
+        )
+
+    def test_failed_build_does_not_export(self):
+        """A build_and_validate that does not pass base conformance never exports."""
+        from builder.agents.agent_loop import _EXPORTED_FLAG, _build_langchain_tools
+
+        engine = self._engine_with_entities("Investigation")
+        calls = self._install_spy(
+            engine,
+            build_result={
+                "ok": False,
+                "conformance": {"base": False},
+                "issues": [{"x": 1}],
+            },
+            export_result={
+                "success": True,
+                "crate_path": "/tmp/out-ro-crate",
+                "error": None,
+            },
+        )
+
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        tools["build_and_validate"].invoke({})
+
+        assert "export_crate" not in calls, f"a failed build must not export, got {calls}"
+        assert getattr(engine, _EXPORTED_FLAG, False) is False
+
+    def test_empty_crate_does_not_export(self):
+        """A successful build over an EMPTY crate (no entities) never exports."""
+        from builder.agents.agent_loop import _EXPORTED_FLAG, _build_langchain_tools
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        engine.state.session_id = "test_export_287_empty"
+        calls = self._install_spy(
+            engine,
+            build_result={"ok": True, "conformance": {"base": True}, "issues": []},
+            export_result={
+                "success": True,
+                "crate_path": "/tmp/out-ro-crate",
+                "error": None,
+            },
+        )
+
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        tools["build_and_validate"].invoke({})
+
+        assert "export_crate" not in calls, f"empty crate must not export, got {calls}"
+        assert getattr(engine, _EXPORTED_FLAG, False) is False
+
+    def test_re_export_when_state_changes_between_builds(self):
+        """A second build after the crate has grown re-exports (the latest crate
+        always lands); a second build with NO change does not re-export."""
+        from builder.agents.agent_loop import _build_langchain_tools
+
+        engine = self._engine_with_entities("Investigation")
+        calls = self._install_spy(
+            engine,
+            build_result={"ok": True, "conformance": {"base": True}, "issues": []},
+            export_result={
+                "success": True,
+                "crate_path": "/tmp/out-ro-crate",
+                "error": None,
+            },
+        )
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+
+        tools["build_and_validate"].invoke({})
+        assert calls.count("export_crate") == 1
+        # No state change → a repeat build must NOT re-export.
+        tools["build_and_validate"].invoke({})
+        assert calls.count("export_crate") == 1, f"no change → no re-export, got {calls}"
+        # The crate grows → the next build re-exports the latest crate.
+        engine.state.add_entity(Entity(entity_id="new", type="Study"))
+        tools["build_and_validate"].invoke({})
+        assert calls.count("export_crate") == 2, f"grown crate → re-export, got {calls}"
+
+    def test_failed_export_does_not_crash_or_stamp(self):
+        """When the auto-export itself fails, the build result is still returned
+        and the flag is not stamped (so the finish backstop can retry on exit)."""
+        from builder.agents.agent_loop import _EXPORTED_FLAG, _build_langchain_tools
+
+        engine = self._engine_with_entities("Investigation")
+        self._install_spy(
+            engine,
+            build_result={"ok": True, "conformance": {"base": True}, "issues": []},
+            export_result={"success": False, "crate_path": None, "error": "disk full"},
+        )
+
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        result = tools["build_and_validate"].invoke({})
+
+        assert isinstance(result, dict) and result.get("ok") is True
+        assert getattr(engine, _EXPORTED_FLAG, False) is False
+
+
+class TestRepeatedNonProgressLoopBreaker:
+    """Issue #287 Fix B: N consecutive IDENTICAL non-progress tool calls trigger
+    a loop-breaker that injects the list_scanned_files inventory and steers the
+    model to a concrete file path."""
+
+    def _engine(self):
+        from builder.engine import AgentEngine
+        from builder.state import FileClassification
+
+        engine = AgentEngine()
+        engine.state.session_id = "test_loopbreaker_287"
+        engine.state.scanned_files = [
+            FileClassification(
+                path="/data/run/Assay_OATP1C1/results.csv",
+                filename="results.csv",
+                size=1234,
+                mime_type="text/csv",
+            )
+        ]
+        return engine
+
+    def _install_dir_reader(self, engine, message):
+        """engine.run_tool returns the same directory message for every read."""
+        calls: list[tuple[str, tuple]] = []
+
+        def fake_run_tool(tool_name: str, **kwargs):
+            calls.append((tool_name, tuple(sorted(kwargs.items()))))
+            if tool_name == "read_file_sample":
+                # Mirror what file_readers does for a directory: a real string.
+                return message
+            if tool_name == "list_scanned_files":
+                from builder.tools.management import list_scanned_files
+
+                return list_scanned_files(engine.state, **kwargs)
+            return {"ok": True}
+
+        engine.run_tool = fake_run_tool  # type: ignore[method-assign]
+        return calls
+
+    def test_identical_directory_reads_trigger_intervention(self):
+        from builder.agents.agent_loop import (
+            _LOOP_BREAKER_THRESHOLD,
+            _build_langchain_tools,
+        )
+
+        engine = self._engine()
+        dir_msg = (
+            "/data/run/Assay_OATP1C1 is a directory, not a file — use "
+            "list_scanned_files to browse the inventory, then read a specific "
+            "file by its path."
+        )
+        calls = self._install_dir_reader(engine, dir_msg)
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        reader = tools["read_file_sample"]
+
+        args = {"path": "/data/run/Assay_OATP1C1"}
+        results = []
+        for _ in range(_LOOP_BREAKER_THRESHOLD + 1):
+            results.append(reader.invoke(dict(args)))
+
+        # The first calls pass through the directory message unchanged. On/after
+        # the threshold the loop-breaker injects the inventory and steers the
+        # model — the final result must NOT be the bare directory message.
+        last = str(results[-1])
+        assert last != dir_msg, "the loop-breaker must change the repeated result"
+        assert "results.csv" in last, (
+            f"the loop-breaker must inject the scanned-file inventory, got: {last}"
+        )
+        # The underlying read tool was NOT called yet again after the breaker
+        # fired (the identical non-progress call is refused/short-circuited).
+        read_calls = [c for c in calls if c[0] == "read_file_sample"]
+        assert len(read_calls) <= _LOOP_BREAKER_THRESHOLD, (
+            f"the identical read must be refused after the threshold, got {calls}"
+        )
+
+    def test_error_dict_results_trigger_intervention(self):
+        from builder.agents.agent_loop import (
+            _LOOP_BREAKER_THRESHOLD,
+            _build_langchain_tools,
+        )
+
+        engine = self._engine()
+        calls: list[tuple[str, tuple]] = []
+
+        def fake_run_tool(tool_name: str, **kwargs):
+            calls.append((tool_name, tuple(sorted(kwargs.items()))))
+            if tool_name == "read_file":
+                # A missing path raises -> the wrapper turns it into an error dict.
+                raise ValueError("Entity not found: /nope")
+            if tool_name == "list_scanned_files":
+                from builder.tools.management import list_scanned_files
+
+                return list_scanned_files(engine.state, **kwargs)
+            return {"ok": True}
+
+        engine.run_tool = fake_run_tool  # type: ignore[method-assign]
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        reader = tools["read_file"]
+
+        results = []
+        for _ in range(_LOOP_BREAKER_THRESHOLD + 1):
+            results.append(reader.invoke({"path": "/nope"}))
+
+        last = str(results[-1])
+        assert "results.csv" in last, (
+            f"repeated error results must trigger the inventory injection, got {last}"
+        )
+
+    def test_distinct_calls_do_not_trigger(self):
+        """Repeated but DISTINCT directory reads never trip the loop-breaker."""
+        from builder.agents.agent_loop import (
+            _LOOP_BREAKER_THRESHOLD,
+            _build_langchain_tools,
+        )
+
+        engine = self._engine()
+
+        def fake_run_tool(tool_name: str, **kwargs):
+            if tool_name == "read_file_sample":
+                return (
+                    f"{kwargs.get('path')} is a directory, not a file — use "
+                    "list_scanned_files."
+                )
+            return {"ok": True}
+
+        engine.run_tool = fake_run_tool  # type: ignore[method-assign]
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        reader = tools["read_file_sample"]
+
+        # Each call has a DISTINCT path → never the same non-progress result.
+        for i in range(_LOOP_BREAKER_THRESHOLD + 3):
+            res = str(reader.invoke({"path": f"/data/dir_{i}"}))
+            assert "results.csv" not in res, (
+                f"distinct calls must not trip the loop-breaker, got {res}"
+            )
+
+    def test_single_repeat_below_threshold_does_not_trigger(self):
+        """A repeat below the threshold passes the result through unchanged."""
+        from builder.agents.agent_loop import (
+            _LOOP_BREAKER_THRESHOLD,
+            _build_langchain_tools,
+        )
+
+        engine = self._engine()
+        dir_msg = "/data/d is a directory, not a file — use list_scanned_files."
+        self._install_dir_reader(engine, dir_msg)
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        reader = tools["read_file_sample"]
+
+        # Repeat one fewer than the threshold → still the bare directory message.
+        for _ in range(_LOOP_BREAKER_THRESHOLD - 1):
+            res = str(reader.invoke({"path": "/data/d"}))
+            assert "results.csv" not in res, (
+                f"below threshold must not inject the inventory, got {res}"
+            )
+
+


### PR DESCRIPTION
Fixes #287. Two robustness fixes to the **legacy ReAct loop** (`builder/agents/agent_loop.py`), both verified against a weak agent LLM (DeepSeek-flash) so neither relies on the model behaving. Lane: `agent_loop.py` + its tests (+ an AGENTS.md doc sync). No other modules touched.

## A) Export on every completed in-loop build (not only on quit)
The crate previously only landed on disk via `_finish_backstop` (#251), which runs on the **exit path** (quit/EOF). In the reported live run the user kept the session alive and the model never called `export_crate`, so a base-valid 70+-entity crate was **never written** — the user "never saw the ro-crate."

The `_run` tool wrapper now auto-exports after a `build_and_validate` that passes **BASE** conformance over a non-empty crate (mirroring the deterministic pipeline's export-on-completed-build, #233):
- calls `export_crate` with **no explicit path** so it honors `state.metadata.output_path` (CLI `--output` / default `<input>-ro-crate/`) then the session fallback;
- stamps the existing `_EXPORTED_FLAG` so `_finish_backstop` stays a **no-op** afterward (never double-exports);
- surfaces the absolute crate path through the loop's output channel.

**Idempotency:** an entity-count fingerprint means it re-exports only when the crate has changed since the last auto-export — so the *latest* crate always lands and an unchanged repeat build is a no-op. A failed/empty build never exports.

## B) Loop-breaker for repeated non-progress tool calls
A weak model re-issued the *same* `read_file_sample`/`read_file` call on a directory / non-existent path ~36× in a row (each returning the same directory/`None`/error result), burning millions of tokens. #281's directory message alone didn't stop it.

The wrapper now tracks the last call signature (tool name + sorted args) and the consecutive count of the **same non-progress result** (directory message / unreadable-`None` message / `{"error": …}` dict) on the engine. After `_LOOP_BREAKER_THRESHOLD` (3) identical non-progress repeats it **refuses to run the call again** and returns a forceful corrective message carrying the live `list_scanned_files` inventory (concrete paths to read instead). Distinct calls and a single retry below threshold never trip it; any distinct/progress result resets the counter.

## Tests (strict TDD — written failing first, then implemented)
- `TestExportOnCompletedBuild`: auto-export fires exactly once on a base-valid build, stamps the flag, surfaces the path, leaves `_finish_backstop` a no-op; failed/empty builds don't export; re-export only on state change; a failed export doesn't crash or stamp.
- `TestRepeatedNonProgressLoopBreaker`: identical directory/error reads trigger the inventory injection on/after the threshold; distinct calls and a single below-threshold repeat do not.

## Gate (all green)
- `uv run --extra langchain pytest tests/test_agent_loop.py` → 92 passed
- related suites (`test_agent_graph`, `test_engine`, `test_tool_disclosure`, `test_tools_build_and_validate`, `test_agents_build`, `test_file_readers`, `test_tools_management`) → 125 passed
- `uv run ruff check` clean; `uv run --extra langchain ty check` clean (no new diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)