### PR TITLE
test(pipeline): fix ty invalid-return-type in _ref_ids helper

### DIFF
--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -974,11 +974,8 @@ class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
 
         def _ref_ids(prop: object) -> set[str]:
             items = prop if isinstance(prop, list) else [prop]
-            return {
-                (m.get("@id") if isinstance(m, dict) else m)
-                for m in items
-                if m is not None
-            }
+            ids = (m.get("@id") if isinstance(m, dict) else m for m in items)
+            return {ref for ref in ids if isinstance(ref, str)}
 
         compound_node_ids = {n["@id"] for n in domain_nodes if _is_compound(n)}
         cell_node_ids = {n["@id"] for n in domain_nodes if _is_cell_line(n)}


### PR DESCRIPTION
Pre-existing ty diagnostic introduced by #273; test-only return-type fix in `_ref_ids` (filter to `str` so the comprehension genuinely yields `set[str]`), behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)