### PR TITLE
feat(composites): make the Exposure output the CSVW condition table (#285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -802,10 +802,20 @@ have **no build-time output fallback**, so a process with no explicit `result`
 (and, for DataAnalysis, no `object`) fires a tox REQUIRED Violation. The composite
 **synthesizes** the missing output — a placeholder `Sample` (via `draft_sample`)
 for a material producer (CellCulture) or a placeholder `File` (via `draft_file`)
-for a data producer (Exposure/EndpointReadout/DataAnalysis) — and `link`s it, so
-the chain never dangles. **Requires:** an existing `assay_id` + each step's
+for a data producer (EndpointReadout/DataAnalysis) — and `link`s it, so
+the chain never dangles. **The Exposure is the deliberate exception (#285):** it is
+NOT given a generic placeholder result here, because its build-time fallback
+(`_crate_mapping._synth_condition_table`) is the *semantically-correct* output — the
+CSVW **condition table** that `schema:about`-references the test MolecularEntities
+(the substances + doses the cells were exposed to). Synthesizing a generic result
+File would populate `result` and pre-empt that `table --about--> MolecularEntity`
+link, demoting the compounds to the weaker Study `schema:mentions` backstop. So the
+Exposure step is left output-less in state and the build emits the condition table
+as its result; the material flow still passes downstream via the step's inputs.
+**Requires:** an existing `assay_id` + each step's
 `process_type`. **Synthesizes (only when not supplied/derivable):** the produced
-output entity (and a DataAnalysis input `File` when it has no upstream step).
+output entity for EndpointReadout/DataAnalysis (and a DataAnalysis input `File`
+when it has no upstream step); the Exposure's output is the build's condition table.
 **Respects:** any explicit `object`/`result` you pass — those win over synthesis.
 Placeholders carry only structural metadata (name, crate path, role); they
 **never fabricate measurement values or identifiers** (D5) — they are header-less
@@ -1781,7 +1791,13 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   `biologicalModels` aliases) so every resolved entity — PubChem- AND ChEBI-backed
   compounds alike — is reachable from the backbone at a glance (orphan count → 0).
   Idempotent: `set_fields` writes the same deterministic ids, so re-running mints
-  no duplicates.
+  no duplicates. **Condition-table link now fires (#285).** `draft_process_chain`
+  no longer pre-empts the Exposure's build-time output with a generic placeholder
+  File (see §5), so the `chemicals` set here actually build into the Exposure's
+  CSVW condition table (`table --about--> MolecularEntity`): the compounds attach
+  as the *true conditions of the exposure process*, and the Study `mentions` edge
+  is a redundant backstop (still load-bearing for a compound the table cannot reach,
+  e.g. one resolved with no Exposure in the chain) rather than the primary link.
 - **Assess** (`assess_gaps`, the gap engine #215, this section) — one
   prioritized `GapReport` unifying SHACL + MIT + FAIR.
 - **Auto-resolve** (`fix_required_issues`, §5, the keystone) — clears every

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -176,6 +176,20 @@ _CHAIN_ORDER: tuple[str, ...] = (
 # the whole derivation chain connected and referenceable.
 _SAMPLE_PRODUCERS = frozenset({"CellCulture"})
 
+# Subtypes whose build-time output fallback is the *semantically-correct* output
+# entity, so synthesizing a generic placeholder here would PRE-EMPT it (Issue
+# #285). The Exposure's build fallback (``_crate_mapping._synth_condition_table``)
+# is the CSVW **condition table** — the per-well design table that
+# ``schema:about``-references the test MolecularEntities (the substances + doses
+# the cells were exposed to). That ``table --about--> MolecularEntity`` edge is
+# the TRUE ISA-Tox link, but it only fires when the Exposure has NO explicit
+# ``result``. If ``draft_process_chain`` eagerly synthesized a generic result
+# File, ``result`` would be populated, the condition table would never build, and
+# the compounds would ride only on the weaker Study ``schema:mentions`` backstop.
+# So we leave these steps' output to the build: the chain still flows downstream
+# via the step's inputs (``upstream_output = outputs or inputs``).
+_BUILD_SYNTHESIZES_OUTPUT = frozenset({"Exposure"})
+
 
 def _ref_ids(value: Any) -> set[str]:
     """Normalize a reference value (id / {@id} / list thereof) to bare ids."""
@@ -327,9 +341,13 @@ def draft_process_chain(
         # closed. Every producing step gets a real output entity in state (a
         # Sample for a material producer, a File for a data producer) — so the
         # next step can consume it by id and EndpointReadout / DataAnalysis never
-        # dangle into a tox Violation. ---
+        # dangle into a tox Violation. The EXCEPTION is a subtype whose build-time
+        # fallback is the semantically-correct output (the Exposure's CSVW
+        # condition table; #285): synthesizing a generic placeholder there would
+        # pre-empt the ``table --about--> MolecularEntity`` link, so we leave its
+        # output to the build (the chain still flows downstream via its inputs). ---
         outputs = _explicit_ids(step, "result", "output")
-        if not outputs:
+        if not outputs and ptype not in _BUILD_SYNTHESIZES_OUTPUT:
             placeholder = _synthesize_output(
                 state, proc, ptype, draft_sample, draft_file
             )

--- a/tests/test_tools_process_chain.py
+++ b/tests/test_tools_process_chain.py
@@ -108,14 +108,21 @@ class TestChainCreation:
         assert cc_out, "CellCulture must have an output to feed the Exposure"
         assert cc_out & exp_in, "Exposure must consume the CellCulture output"
 
-        # Exposure output feeds the EndpointReadout input.
-        exp_out = _ref_ids(exp.fields.get("result")) | _ref_ids(exp.fields.get("output"))
+        # The material flow continues into the EndpointReadout. The Exposure has
+        # NO in-state output of its own (#285): its output is the build-time CSVW
+        # condition table, so the chain hands its consumed material (the cultured
+        # Sample) downstream — the EndpointReadout must consume it.
+        assert not (
+            _ref_ids(exp.fields.get("result")) | _ref_ids(exp.fields.get("output"))
+        ), "Exposure must rely on the build's condition table, not an in-state output"
         er_in = (
             _ref_ids(er.fields.get("object"))
             | _ref_ids(er.fields.get("input"))
             | _ref_ids(er.fields.get("samples"))
         )
-        assert exp_out & er_in, "EndpointReadout must consume the Exposure output"
+        assert exp_in & er_in, (
+            "EndpointReadout must consume the material flowing through the Exposure"
+        )
 
         # EndpointReadout output feeds the DataAnalysis object.
         er_out = _ref_ids(er.fields.get("result")) | _ref_ids(er.fields.get("output"))
@@ -270,6 +277,167 @@ class TestChainPassesValidation:
             state2, assay_id2, chain=_FULL_CHAIN, validate_after=None
         )
         assert "validation" not in result2
+
+
+def _types(node: dict) -> set[str]:
+    """The @type(s) of a built graph node as a set of strings."""
+    t = node.get("@type")
+    if isinstance(t, list):
+        return {str(x) for x in t}
+    return {str(t)} if t is not None else set()
+
+
+def _node_ref_ids(value: object) -> set[str]:
+    """Bare @ids referenced by a built node property (scalar / list / {@id})."""
+    items = value if isinstance(value, list) else [value]
+    out: set[str] = set()
+    for v in items:
+        ref = v.get("@id") if isinstance(v, dict) else v
+        if isinstance(ref, str):
+            out.add(ref)
+    return out
+
+
+class TestExposureOutputIsConditionTable:
+    """Issue #285 — the Exposure's synthesized output must BE the CSVW condition
+    table that ``about``-references the test compounds (the substances the cells
+    were exposed to), NOT a generic placeholder result File.
+
+    Before #285, ``draft_process_chain`` eagerly synthesized a *generic* result
+    File for the Exposure (it is not a sample-producer and had no explicit
+    ``result``). That populated the Exposure's ``result``, so the build's
+    ``_synth_condition_table`` fallback — the ONLY path that wires
+    ``table --about--> MolecularEntity`` — never fired. Compound reachability then
+    rode solely on the Study ``schema:mentions`` edge: the compounds were modelled
+    as "mentioned by the study" rather than "the conditions of the exposure
+    process", semantically weaker than the ISA-Tox intent.
+
+    The fix makes the Exposure's output the condition table, so the compounds
+    attach as TRUE exposure conditions while the Study ``mentions`` becomes a
+    redundant backstop. Orphan count must stay 0 (#273) and validation unchanged.
+    """
+
+    def _exposure_chain_state(self) -> tuple[CrateState, list[str]]:
+        """A backbone + chain whose Exposure carries two resolved compounds.
+
+        Returns ``(state, compound_entity_ids)``. Mirrors the real materialize
+        flow: the chain is drafted first, then the compounds are wired onto the
+        Exposure via the ``chemicals`` ref field (as ``_materialize_plan`` does).
+        """
+        from builder.tools.drafters import draft_molecular_entity
+
+        state, assay_id = _scaffold()
+        chem1 = draft_molecular_entity(state, "Methimazole", {"pubchem_cid": "1349907"})
+        chem2 = draft_molecular_entity(state, "Sodium iodide", {"pubchem_cid": "5238"})
+        draft_process_chain(state, assay_id, chain=_FULL_CHAIN)
+
+        exp = _processes_by_subtype(state)["Exposure"][0]
+        exp.set_fields_from_dict(
+            {"chemicals": [{"@id": chem1.entity_id}, {"@id": chem2.entity_id}]},
+            source="llm",
+        )
+        return state, [chem1.entity_id, chem2.entity_id]
+
+    @staticmethod
+    def _built_graph(state: CrateState) -> list[dict]:
+        from builder.tools.builder import assemble_crate
+
+        crate = assemble_crate(
+            state,
+            output_dir=None,
+            materialize_payload=False,
+            include_all_scanned=False,
+        )
+        return crate.metadata.generate()["@graph"]
+
+    def test_exposure_output_is_condition_table_about_compounds(self) -> None:
+        state, compound_ids = self._exposure_chain_state()
+        graph = self._built_graph(state)
+        by_id = {n.get("@id"): n for n in graph}
+
+        # The Exposure's output node must be a CSVW condition table, not a plain
+        # generic File. (An Exposure builds as @type LabProcess discriminated by
+        # additionalType="Exposure".)
+        exposure = next(
+            n
+            for n in graph
+            if "LabProcess" in _types(n) and n.get("additionalType") == "Exposure"
+        )
+        out_ids = _node_ref_ids(exposure.get("output")) | _node_ref_ids(
+            exposure.get("result")
+        )
+        assert out_ids, "Exposure has no output node"
+        out_nodes = [by_id[i] for i in out_ids if i in by_id]
+        condition_tables = [n for n in out_nodes if "csvw:Table" in _types(n)]
+        assert condition_tables, (
+            "Exposure output must be a CSVW condition table (csvw:Table), not a "
+            f"generic placeholder File; got: {[n.get('@type') for n in out_nodes]}"
+        )
+
+        # The condition table's `about` must list BOTH resolved MolecularEntities
+        # — the compounds ARE the conditions of this exposure (the substances the
+        # cells were exposed to), connected THROUGH the table (ISA forbids a
+        # MolecularEntity as a process object).
+        compound_node_ids = {
+            n.get("@id") for n in graph if "MolecularEntity" in _types(n)
+        }
+        assert len(compound_node_ids) == 2, (
+            f"expected 2 MolecularEntity nodes, got {compound_node_ids}"
+        )
+        about_ids: set[str] = set()
+        for table in condition_tables:
+            about_ids |= _node_ref_ids(table.get("about"))
+        assert compound_node_ids <= about_ids, (
+            "condition table's `about` must list every compound (the exposure "
+            f"conditions); table about={about_ids}, compounds={compound_node_ids}"
+        )
+
+        # No generic `proc_exposure_result.csv` placeholder File is the Exposure's
+        # output — the condition table replaced it.
+        assert not any(
+            "csvw:Table" not in _types(n) for n in out_nodes
+        ), f"Exposure still has a generic placeholder output: {out_nodes}"
+
+    def test_compounds_are_not_orphaned(self) -> None:
+        """Wiring compounds through the condition table keeps orphan count 0 (#273)."""
+        state, _ = self._exposure_chain_state()
+        graph = self._built_graph(state)
+
+        referenced: set[str] = set()
+
+        def _collect(value: object) -> None:
+            if isinstance(value, dict):
+                ref = value.get("@id")
+                if isinstance(ref, str):
+                    referenced.add(ref)
+                else:
+                    for v in value.values():
+                        _collect(v)
+            elif isinstance(value, list):
+                for item in value:
+                    _collect(item)
+
+        for node in graph:
+            for key, value in node.items():
+                if key in ("@id", "@type"):
+                    continue
+                _collect(value)
+
+        compounds = [n for n in graph if "MolecularEntity" in _types(n)]
+        assert compounds, "no MolecularEntity in built graph — test setup is wrong"
+        orphans = [n["@id"] for n in compounds if n["@id"] not in referenced]
+        assert orphans == [], f"orphaned compounds: {orphans}"
+
+    @pytest.mark.timeout(120)
+    def test_conformance_unchanged_with_condition_table(self) -> None:
+        """The condition-table output must not regress ISA / ISA-Tox conformance."""
+        state, _ = self._exposure_chain_state()
+        report = build_and_validate(state)
+        assert "error" not in report, report
+        assert report["conformance"]["base"] is True, report
+        assert report["conformance"]["isa"] is True, report
+        assert report["conformance"]["tox"] is True, report
+        assert report["ok"] is True, report
 
 
 class TestNoPydanticShadowWarning:


### PR DESCRIPTION
## Summary

Closes #285. Makes the Exposure process's synthesized output **be** the CSVW condition table that `schema:about`-references the test `MolecularEntities` (the substances + doses the cells were exposed to), instead of a generic placeholder result File.

## Before → after (the semantic model)

**Before.** `_crate_mapping._synth_condition_table` — the only path that wires the `table --about--> MolecularEntity` edge — fires in `_build_process` *only when the Exposure has no explicit `result`*:

```python
out = result or [_synth_condition_table(crate, output_dir, pid, cells, chems, ...)]
```

But `draft_process_chain` (#268) eagerly synthesized a **generic placeholder result File** for the Exposure (it is neither a sample producer nor — until now — a build-fallback subtype). That populated `result`, so the condition table never built. Compound reachability therefore rode solely on the Study `schema:mentions` backstop: the compounds were modelled as *"mentioned by the study"* rather than *"the conditions of the exposure process"* — semantically weaker than the ISA-Tox intent. Orphans were already 0 and the crate valid, but the link was the wrong one.

**After.** A new `_BUILD_SYNTHESIZES_OUTPUT = frozenset({"Exposure"})` in `draft_process_chain` marks subtypes whose **build-time fallback is the semantically-correct output**. The Exposure step is left output-less in state, so the build emits the CSVW condition table as its result and wires `table --about--> MolecularEntity` (+ the `compound` column's `valueUrl`). The chain still flows downstream via the step's inputs (the existing `upstream_output = outputs or inputs` already anticipated "a bare Exposure relying on the build's typed-table fallback").

Net effect: compounds attach as **true exposure conditions**; the Study `mentions` edge becomes a redundant backstop (still load-bearing for a compound the table cannot reach, e.g. one resolved with no Exposure in the chain).

## Scope

- `builder/tools/composites.py` — the fix (one new constant + one guard in the output-synthesis loop). **No `_crate_mapping.py` change needed** — the existing condition-table fallback now fires and reads the `chemicals` set during materialize.
- `tests/test_tools_process_chain.py` — new `TestExposureOutputIsConditionTable` (TDD: written failing first), plus an updated connectivity assertion in `test_wires_sequential_provenance_edges` reflecting that the Exposure's output is now the build-time condition table.
- `AGENTS.md` — section-local notes in §5 (`draft_process_chain`) and §14.6 (materialize). Validator section untouched.

## Orphans + validation

- **Orphans stay 0 (#273):** new `test_compounds_are_not_orphaned`, and the full `_materialize_plan` end-to-end test `test_compounds_and_cell_line_are_wired_not_orphaned` both green.
- **SHACL unchanged:** new `test_conformance_unchanged_with_condition_table` asserts base/isa/tox all `True`; existing `test_run_pipeline_with_links_preserves_conformance` green.

## Gate

- `tests/test_tools_process_chain.py` (20) ✓, `tests/test_agents_pipeline.py` (71, incl. #273) ✓, composites / condition-table / csvw / crate-mapping / provenance / builder-domain / leaves / agent-loop / data-content / build-and-validate ✓
- `uv run ruff check .` — clean
- `uv run --extra langchain ty check` on changed files — clean (zero new diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)