### PR TITLE
feat(pipeline): mint Organization from people affiliation in materialize (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1764,7 +1764,13 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   scaffolded BEFORE the plan is materialized, so the plan's Study name/description
   are merged onto the already-scaffolded Study (fill-don't-clobber: only when the
   field is empty or still the generic placeholder), and each `people[]` is split
-  into `givenName`/`familyName` so the Person is ISA-conformant (#232).
+  into `givenName`/`familyName` so the Person is ISA-conformant (#232). When a
+  `people[].affiliation_name` is present, an `Organization` is minted via
+  `draft_organization` (or an existing one of the same name is **reused**, so a
+  shared affiliation yields ONE Organization, not duplicates) and the Person's
+  `affiliation` reference is wired onto it via `set_fields` — the build resolves it
+  to the Organization's `@id` (`_crate_mapping._wire_reference`). D5-safe: only the
+  plan's affiliation *name* is used — no ROR/IRI is fabricated (#179 Lane 1).
   **Entity→provenance wiring (#273).** Resolving a compound / cell line MINTS the
   entity but leaves it a graph orphan unless something references it, so after the
   `compounds[]` / `cell_lines[]` sections run, `_materialize_plan` wires the

--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -524,6 +524,38 @@ def _first_entity_id(engine: AgentEngine, entity_type: str) -> str | None:
     )
 
 
+def _find_or_draft_organization(engine: AgentEngine, name: str) -> str | None:
+    """Return the entity_id of an Organization named *name*, minting one if absent.
+
+    De-dup by name: an existing in-state Organization with the same (stripped)
+    ``name`` is reused so two affiliations sharing a name yield ONE Organization
+    rather than duplicates. Otherwise a new one is minted via the ``draft_organization``
+    tool (never hand-rolled JSON-LD). D5-safe: only the plan's affiliation *name* is
+    used — no ROR / IRI is fabricated here. Returns ``None`` on an empty name or if
+    drafting fails (logged), so a failure never breaks the spine.
+    """
+    name = name.strip()
+    if not name:
+        return None
+    existing = next(
+        (
+            e.entity_id
+            for e in engine.state.list_entities()
+            if e.type == "Organization"
+            and str(e.fields.get("name") or "").strip() == name
+        ),
+        None,
+    )
+    if existing is not None:
+        return existing
+    try:
+        org = engine.run_tool("draft_organization", name=name, hints={})
+    except Exception as exc:  # noqa: BLE001 - a drafting failure must not break the spine
+        logger.warning("draft_organization failed for %r: %s", name, exc)
+        return None
+    return getattr(org, "entity_id", None)
+
+
 def _set_ref_field(
     engine: AgentEngine,
     entity_id: str,
@@ -1294,7 +1326,13 @@ def _materialize_plan(
         except Exception as exc:  # noqa: BLE001
             logger.warning("materialize_aop_subgraph failed for %r: %s", aop_id, exc)
 
-    # --- people: a Person from the name + a deterministic given/family split ---
+    # --- people: a Person from the name + a deterministic given/family split,
+    # plus an Organization minted (or reused) from `affiliation_name` and wired
+    # onto the Person's `affiliation` reference (#179 Lane 1). The plan carries a
+    # name only — no ROR/IRI — so the Organization is identifier-free (D5); the
+    # build's `_wire_reference` resolves the affiliation to the Organization's
+    # `@id`. Organizations are de-duplicated by name so two people sharing an
+    # affiliation reference ONE Organization. ---
     for person in plan.get("people") or []:
         name = str((person or {}).get("name") or "").strip()
         if not name:
@@ -1306,10 +1344,21 @@ def _materialize_plan(
         if family:
             person_hints["familyName"] = family
         try:
-            engine.run_tool("draft_person", name=name, hints=person_hints)
+            drafted = engine.run_tool("draft_person", name=name, hints=person_hints)
             result["people"] += 1
         except Exception as exc:  # noqa: BLE001
             logger.warning("draft_person failed for %r: %s", name, exc)
+            continue
+
+        affiliation_name = str((person or {}).get("affiliation_name") or "").strip()
+        person_id = getattr(drafted, "entity_id", None)
+        if not affiliation_name or not person_id:
+            continue
+        org_id = _find_or_draft_organization(engine, affiliation_name)
+        if org_id is not None:
+            # `affiliation` is resolved to the Organization `@id` at build time
+            # (_crate_mapping._wire_reference); set_fields stores the ref id.
+            _set_ref_field(engine, person_id, "affiliation", org_id)
 
     # --- publications: materialize each via resolve_publication (#219/#224), with
     # a PDF-text recovery step (#245). A plan publication carries a TITLE only

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -760,6 +760,113 @@ class TestMaterializePlan:
         }
         assert counts_1 == counts_2
 
+    @staticmethod
+    def _affiliation_ref_id(person: Entity) -> str | None:
+        """The bare entity_id a Person's ``affiliation`` field points at.
+
+        ``set_fields`` stores the reference verbatim (a bare id or an
+        ``{"@id": …}`` object), so normalize both to the leading-``#``-stripped id.
+        """
+        value = person.fields.get("affiliation")
+        ref = value.get("@id") if isinstance(value, dict) else value
+        return str(ref).lstrip("#") if ref else None
+
+    def test_person_affiliation_mints_organization_and_links(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lane 1 — a plan ``people[].affiliation_name`` mints an Organization and
+        wires the Person's ``affiliation`` onto it.
+
+        ``extract_plan`` already surfaces ``affiliation_name`` (leaves.py), but the
+        deterministic materialize people-loop previously dropped it: the crate ended
+        up with ZERO Organization entities and the Person carried no affiliation.
+        """
+        import builder.agents.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        # (a) an Organization named after the plan affiliation exists in state.
+        orgs = self._by_type(engine, "Organization")
+        analytical = [
+            o for o in orgs if o.fields.get("name") == "Analytical Engine"
+        ]
+        assert len(analytical) == 1, "exactly one Organization should be minted"
+
+        # (b) the Person's affiliation references that Organization's id.
+        ada = next(
+            p
+            for p in self._by_type(engine, "Person")
+            if p.fields.get("name") == "Ada Lovelace"
+        )
+        assert self._affiliation_ref_id(ada) == analytical[0].entity_id
+
+    def test_shared_affiliation_is_deduplicated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two people with the SAME affiliation_name produce ONE Organization,
+        both referencing it (no duplicate orgs)."""
+        import builder.agents.pipeline as pipeline_mod
+
+        plan = dict(self._PLAN)
+        plan["people"] = [
+            {"name": "Ada Lovelace", "affiliation_name": "Analytical Engine"},
+            {"name": "Charles Babbage", "affiliation_name": "Analytical Engine"},
+        ]
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch, plan)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        orgs = [
+            o
+            for o in self._by_type(engine, "Organization")
+            if o.fields.get("name") == "Analytical Engine"
+        ]
+        assert len(orgs) == 1, "shared affiliation must mint exactly one Organization"
+
+        org_id = orgs[0].entity_id
+        people = {
+            p.fields.get("name"): p for p in self._by_type(engine, "Person")
+        }
+        assert self._affiliation_ref_id(people["Ada Lovelace"]) == org_id
+        assert self._affiliation_ref_id(people["Charles Babbage"]) == org_id
+
+    def test_person_without_affiliation_mints_no_organization(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A person with no affiliation_name mints no Organization and gets no
+        affiliation field — no regression, no fabrication (D5)."""
+        import builder.agents.pipeline as pipeline_mod
+
+        plan = dict(self._PLAN)
+        plan["people"] = [{"name": "Ada Lovelace"}]
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch, plan)
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        assert self._by_type(engine, "Organization") == []
+        ada = next(
+            p
+            for p in self._by_type(engine, "Person")
+            if p.fields.get("name") == "Ada Lovelace"
+        )
+        assert not ada.fields.get("affiliation")
+
     def test_run_pipeline_with_plan_reaches_conformance(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Lane 1 (epic #179 follow-on) — affiliations were dropped on the deterministic materialize path

### Problem
`extract_plan` already returns `people[].affiliation_name` (`builder/agents/leaves.py`), but the people loop in `_materialize_plan` (`builder/agents/pipeline.py`) only set `givenName`/`familyName` and **never minted an `Organization`** or set the Person's `affiliation`. So affiliations extracted from source documents were silently lost and the deterministic path produced **zero** Organization entities.

### Fix
In the people loop, when `affiliation_name` is present:
- mint an `Organization` via the existing `draft_organization` tool — or **reuse** an already-minted Organization of the same name (de-dup, no duplicates);
- wire the Person's `affiliation` reference onto that Organization via `set_fields`. At build time `_crate_mapping._wire_reference` resolves it to the Organization's `@id`.

A small `_find_or_draft_organization` helper does the find-or-mint with name de-dup. No new minting path is invented — it uses `draft_organization` + `set_fields` only.

**D5-safe:** only the plan's affiliation *name* is used; no ROR/IRI is fabricated (ROR resolution is a separate future lane).

### Tests (TDD — failing first, confirmed)
- `test_person_affiliation_mints_organization_and_links` — an `Organization` named after the affiliation exists and the Person's `affiliation` references its id.
- `test_shared_affiliation_is_deduplicated` — two people, same affiliation → **one** Organization, both referencing it.
- `test_person_without_affiliation_mints_no_organization` — no affiliation_name → no Organization, no `affiliation` field (no regression, no fabrication).

### Gate
- `tests/test_agents_pipeline.py` + `tests/test_pipeline_e2e.py` + `tests/test_tools_drafters.py`: **125 passed, 1 xpassed**.
- `uv run ruff check`: clean.
- `uv run --extra langchain ty check builder/agents/pipeline.py`: zero new diagnostics.

### Lane boundaries
Touched only `builder/agents/pipeline.py` (the people loop in `_materialize_plan` + a helper), `tests/test_agents_pipeline.py`, and the §14 materialize region of `AGENTS.md`. Did **not** touch `composites.py`, `_crate_mapping.py`, `repair.py`, `gap_analysis.py`, `build.py`, `main.py`, or `guidance.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)