### PR TITLE
feat(repair): add symmetric missing_process_input repair rule (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -935,12 +935,16 @@ this closes that gap. It runs `build_and_validate`, dispatches each issue throug
 small, ordered table of issue-shape → repair rules (`builder/tools/repair.py`,
 `RepairRule`), then **re-validates** to confirm what actually cleared (it trusts the
 validator's verdict, not a rule's optimism). A repair runs **only when the correct
-value is already determined by state** — e.g. an `EndpointReadout`/`DataAnalysis`
-missing its `result` where exactly **one** un-wired `File` already exists in state
-is auto-wired via `link` (the §14.3 "no output fallback" trap). Anything needing
-**new content, a new entity, or a fabricated identifier — or a genuinely ambiguous
-target (2+ candidates) — is out of scope (D5)** and returned under `remaining` for a
-bounded LLM leaf. It is **idempotent and side-effect-safe**: if nothing is
+value is already determined by state**. Two symmetric rules are wired today:
+`missing_process_output` — an `EndpointReadout`/`DataAnalysis` missing its `result`
+where exactly **one** un-wired `File` already exists in state is auto-wired as its
+`result` via `link` (the §14.3 "no output fallback" trap); and
+`missing_process_input` — a `DataAnalysis` missing its required `schema:object`
+(input) where exactly **one** free-floating `Sample`/`File` (one wired as no
+process input or output) already exists is auto-wired as its `object`. Anything
+needing **new content, a new entity, or a fabricated identifier — or a genuinely
+ambiguous target (2+ candidates) — is out of scope (D5)** and returned under
+`remaining` for a bounded LLM leaf. It is **idempotent and side-effect-safe**: if nothing is
 deterministically fixable it mutates nothing and returns every issue in `remaining`.
 It maps a validation focus-node `@id` (e.g. `./#LabProcess_er1`) back to its state
 entity by inverting `_crate_mapping._mint_id`. Each `fixed` item carries
@@ -2013,14 +2017,17 @@ always reaches the gaps it can act on first.
 `fix_required_issues` can clear the gap deterministically from state alone. The
 engine decides this by re-using the repair loop's **own** rule predicates
 (`builder/tools/repair.py` `_RULES`, `_resolve_state_entity`,
-`_unique_unwired_file`) read-only, so the gap engine and the repair loop can
-never drift on what "deterministically fixable" means: today the single
-`missing_process_output` rule makes an `EndpointReadout`/`DataAnalysis` missing
-its `result`/`output` auto-fixable **iff exactly one un-wired `File` is in state**
-(unambiguous target); two-or-more (ambiguous) or zero (needs new content, D5)
-files, and every non-SHACL or non-REQUIRED gap, are `auto_fixable=False` →
-`"ask-user"`/`"draft"`. The Auto-resolve stage runs `fix_required_issues`; what
-remains is exactly the `auto_fixable=False` set the Guidance stage works through.
+`_unique_unwired_file`, `_unique_unwired_input`) read-only, so the gap engine and
+the repair loop can never drift on what "deterministically fixable" means: the two
+symmetric rules make a process-edge gap auto-fixable **iff its target is the single
+unambiguous candidate in state** — `missing_process_output` (an
+`EndpointReadout`/`DataAnalysis` missing its `result`/`output`) iff exactly one
+un-wired `File` exists, and `missing_process_input` (a `DataAnalysis` missing its
+`schema:object`) iff exactly one free-floating `Sample`/`File` exists. Two-or-more
+(ambiguous) or zero (needs new content, D5) candidates, and every non-SHACL or
+non-REQUIRED gap, are `auto_fixable=False` → `"ask-user"`/`"draft"`. The
+Auto-resolve stage runs `fix_required_issues`; what remains is exactly the
+`auto_fixable=False` set the Guidance stage works through.
 
 ---
 

--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -174,6 +174,7 @@ def _shacl_auto_fixable(state: CrateState, issue: dict[str, Any]) -> bool:
             _RULES,
             _resolve_state_entity,
             _unique_unwired_file,
+            _unique_unwired_input,
         )
     except ImportError:  # pragma: no cover — repair is a sibling module
         return False
@@ -182,11 +183,15 @@ def _shacl_auto_fixable(state: CrateState, issue: dict[str, Any]) -> bool:
     for rule in _RULES:
         if not rule.applies(issue, entity):
             continue
-        # The sole rule today (missing_process_output) is fixable iff a single
-        # un-wired File exists. Mirror that "would the repair decline?" check
-        # without mutating state, rather than re-deriving each rule's internals.
+        # Mirror each rule's "would the repair decline?" check without mutating
+        # state, rather than re-deriving each rule's internals:
+        # missing_process_output is fixable iff a single un-wired File exists;
+        # missing_process_input (its symmetric counterpart) iff a single
+        # free-floating Sample/File candidate exists.
         if rule.name == "missing_process_output":
             return _unique_unwired_file(state) is not None
+        if rule.name == "missing_process_input":
+            return _unique_unwired_input(state) is not None
         # An unknown future rule that owns the shape is treated as auto-fixable;
         # the repair loop is the source of truth and re-validates after.
         return True

--- a/builder/tools/repair.py
+++ b/builder/tools/repair.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from builder.state import CrateState, Entity
 from builder.tools._crate_mapping import _mint_id
-from builder.tools.provenance import _OUTPUT_FIELDS, _ref_ids
+from builder.tools.provenance import _INPUT_FIELDS, _OUTPUT_FIELDS, _ref_ids
 from builder.tools.provenance import link as _link
 
 logger = logging.getLogger(__name__)
@@ -104,6 +104,13 @@ def _resolve_state_entity(state: CrateState, focus_id: str | None) -> Entity | N
 # TOX REQUIRED violation, not a benign gap the build would synthesize.
 _OUTPUT_REQUIRED_TYPES = frozenset({"EndpointReadout", "DataAnalysis"})
 
+# Domain process types whose TOX shape REQUIRES a schema:object (input). Only
+# DataAnalysis declares the missing-input Violation (profiles/shapes/tox/
+# 5_lab_process_data_analysis.ttl: schema:object sh:minCount 1); EndpointReadout
+# requires only a result. A missing object on a DataAnalysis is therefore the
+# symmetric counterpart of the missing-output Violation.
+_INPUT_REQUIRED_TYPES = frozenset({"DataAnalysis"})
+
 
 def _process_type(entity: Entity) -> str:
     return entity.fields.get("process_type") or entity.fields.get("additionalType") or ""
@@ -155,6 +162,74 @@ def _repair_missing_process_output(
     return f"link({entity.entity_id!r}, 'result', {target.entity_id!r})"
 
 
+# Sample/File are the entity types eligible to be wired as a process input
+# (schema:object): a Sample is the canonical material input, a File the canonical
+# data input. Other types (MolecularEntity, CellLineSample, …) are external
+# starting materials the bundled isa-ro-crate shape forbids as a process object.
+_INPUT_CANDIDATE_TYPES = ("Sample", "File")
+
+
+def _already_roled(state: CrateState) -> set[str]:
+    """entity_ids already wired as some process's input OR output.
+
+    An input repair only ever wires a *free-floating* entity (one with no
+    structural role yet); an entity already consumed or produced by a process —
+    notably the process's own ``result`` File — is never a candidate input, so it
+    is excluded here.
+    """
+    roled: set[str] = set()
+    for proc in state.list_entities("LabProcess"):
+        for fld in (*_INPUT_FIELDS, *_OUTPUT_FIELDS):
+            roled |= _ref_ids(proc.fields.get(fld))
+    return roled
+
+
+def _unique_unwired_input(state: CrateState) -> Entity | None:
+    """The single free-floating Sample/File eligible as a process input, or None.
+
+    Mirrors :func:`_unique_unwired_file`: returns ``None`` when zero (needs new
+    content) or 2+ (ambiguous) such candidates exist — both are deferred to the
+    LLM rather than guessed (D5). A candidate is a Sample/File not yet wired as any
+    process input or output, so a process's own ``result`` is never mis-wired as
+    its input.
+    """
+    roled = _already_roled(state)
+    candidates = [
+        e
+        for t in _INPUT_CANDIDATE_TYPES
+        for e in state.list_entities(t)
+        if e.entity_id not in roled
+    ]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _applies_missing_process_input(issue: dict[str, Any], entity: Entity | None) -> bool:
+    """A REQUIRED missing-input (schema:object) issue on a DataAnalysis."""
+    if entity is None or entity.type != "LabProcess":
+        return False
+    if _process_type(entity) not in _INPUT_REQUIRED_TYPES:
+        return False
+    return _local_property(issue.get("property")) in _INPUT_FIELDS
+
+
+def _repair_missing_process_input(
+    state: CrateState, issue: dict[str, Any], entity: Entity | None
+) -> str | None:
+    """Wire the unique free-floating Sample/File as this process's ``object`` input.
+
+    The symmetric counterpart of :func:`_repair_missing_process_output`. Declines
+    (returns ``None``, no mutation) when the target is not unambiguous — zero
+    candidates (new content needed) or 2+ (genuine ambiguity) — so the LLM leaf
+    decides. Never creates an entity and never fabricates an id (D5).
+    """
+    assert entity is not None  # guarded by _applies_missing_process_input
+    target = _unique_unwired_input(state)
+    if target is None:
+        return None
+    _link(state, entity.entity_id, "object", target.entity_id)
+    return f"link({entity.entity_id!r}, 'object', {target.entity_id!r})"
+
+
 # The ordered dispatch table. First rule whose ``applies`` is true and whose
 # ``repair`` does not decline wins; the rest are skipped for that issue.
 _RULES: tuple[RepairRule, ...] = (
@@ -162,6 +237,11 @@ _RULES: tuple[RepairRule, ...] = (
         name="missing_process_output",
         applies=_applies_missing_process_output,
         repair=_repair_missing_process_output,
+    ),
+    RepairRule(
+        name="missing_process_input",
+        applies=_applies_missing_process_input,
+        repair=_repair_missing_process_input,
     ),
 )
 

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -86,6 +86,42 @@ def _endpoint_readout_missing_result(n_files: int = 1) -> CrateState:
     return state
 
 
+def _data_analysis_missing_object(n_inputs: int = 1) -> CrateState:
+    """Backbone + a DataAnalysis with no ``object`` (input) + ``n_inputs`` free Samples.
+
+    The TOX MUST issue 'DataAnalysis MUST have a schema:object' is auto-fixable iff
+    exactly one free-floating Sample/File candidate exists (the symmetric
+    deterministic-repair rule's predicate). The DataAnalysis already satisfies its
+    other two TOX requirements (a ``result`` File and an ``additionalProperty``)
+    so the missing-``object`` MUST gap is isolated.
+    """
+    state = _backbone()
+    state.add_entity(
+        _entity("pv1", "PropertyValue", name="Computational Tool", value="Python")
+    )
+    state.add_entity(
+        _entity("da_out", "File", name="processed.csv", dest_path="data/processed.csv")
+    )
+    state.add_entity(
+        _entity(
+            "da1",
+            "LabProcess",
+            process_type="DataAnalysis",
+            name="Analysis",
+            assay_id="as1",
+            result="da_out",
+            additionalProperty="pv1",
+            data_processing="mean",
+            software="Python",
+        )
+    )
+    for i in range(n_inputs):
+        state.add_entity(
+            _entity(f"s{i}", "Sample", name=f"raw input {i}", additionalType="Sample")
+        )
+    return state
+
+
 # ---------------------------------------------------------------------------
 # Return shape
 # ---------------------------------------------------------------------------
@@ -404,6 +440,43 @@ class TestAutoFixable:
         assert ident
         assert all(g.auto_fixable is False for g in ident)
         assert all(g.fix_hint == "ask-user" for g in ident)
+
+    def test_deterministically_repairable_input_must_is_auto_fixable(self):
+        """A missing DataAnalysis object with ONE free Sample is auto-fixable."""
+        report = assess_gaps(_data_analysis_missing_object(n_inputs=1))
+        object_gaps = [
+            g
+            for g in report.gaps
+            if g.tier == "MUST" and (g.property or "").endswith("object")
+        ]
+        assert object_gaps, "the missing-object MUST gap should be present"
+        assert all(g.auto_fixable for g in object_gaps), [
+            (g.message, g.auto_fixable) for g in object_gaps
+        ]
+        assert all(g.fix_hint == "fix_required_issues" for g in object_gaps)
+
+    def test_ambiguous_missing_object_is_not_auto_fixable(self):
+        """TWO candidate Samples == ambiguous: the repair loop declines -> ask-user."""
+        report = assess_gaps(_data_analysis_missing_object(n_inputs=2))
+        object_gaps = [
+            g
+            for g in report.gaps
+            if g.tier == "MUST" and (g.property or "").endswith("object")
+        ]
+        assert object_gaps
+        assert all(g.auto_fixable is False for g in object_gaps)
+        assert all(g.fix_hint == "ask-user" for g in object_gaps)
+
+    def test_no_candidate_missing_object_is_not_auto_fixable(self):
+        """No free Sample/File == needs NEW content (D5): not auto-fixable."""
+        report = assess_gaps(_data_analysis_missing_object(n_inputs=0))
+        object_gaps = [
+            g
+            for g in report.gaps
+            if g.tier == "MUST" and (g.property or "").endswith("object")
+        ]
+        assert object_gaps
+        assert all(g.auto_fixable is False for g in object_gaps)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools_repair.py
+++ b/tests/test_tools_repair.py
@@ -73,6 +73,47 @@ def _endpoint_readout_missing_result(n_files: int = 1) -> CrateState:
     return state
 
 
+def _data_analysis_missing_object(n_inputs: int = 1) -> CrateState:
+    """A backbone + a DataAnalysis with no ``object`` (input) + ``n_inputs`` free Samples.
+
+    The DataAnalysis already satisfies its other two TOX requirements (a ``result``
+    File and an ``additionalProperty`` PropertyValue) so the ONLY remaining REQUIRED
+    Violation is the missing ``schema:object`` (input). That issue is the symmetric
+    counterpart of the missing-output Violation, and is deterministically fixable
+    iff exactly one un-wired Sample/File candidate exists (unambiguous target).
+    """
+    state = _backbone()
+    # The DataAnalysis's own produced output (so the missing-result Violation does
+    # not also fire) and a PropertyValue (so the missing-additionalProperty
+    # Violation does not also fire) — isolating the missing-``object`` Violation.
+    state.add_entity(
+        _entity("pv1", "PropertyValue", name="Computational Tool", value="Python")
+    )
+    state.add_entity(
+        _entity("da_out", "File", name="processed.csv", dest_path="data/processed.csv")
+    )
+    state.add_entity(
+        _entity(
+            "da1",
+            "LabProcess",
+            process_type="DataAnalysis",
+            name="Analysis",
+            assay_id="as1",
+            result="da_out",
+            additionalProperty="pv1",
+            data_processing="mean",
+            software="Python",
+        )
+    )
+    # The free, un-roled Sample(s) that are candidate inputs. (The DataAnalysis's
+    # own result File is wired as an OUTPUT, so it is never a candidate input.)
+    for i in range(n_inputs):
+        state.add_entity(
+            _entity(f"s{i}", "Sample", name=f"raw input {i}", additionalType="Sample")
+        )
+    return state
+
+
 class TestReturnShape:
     def test_returns_ok_fixed_remaining(self):
         result = fix_required_issues(CrateState())
@@ -227,3 +268,97 @@ class TestRegistered:
         from builder.agents.tools_spec import TOOL_SPECS
 
         assert any(s["name"] == "fix_required_issues" for s in TOOL_SPECS)
+
+
+class TestDeterministicInputRepair:
+    """The symmetric counterpart of TestDeterministicLinkRepair (#179, Lane 2).
+
+    A DataAnalysis missing its required ``object`` (input) whose UNIQUE un-wired
+    Sample/File already exists in state is auto-wired as that process's input —
+    mirroring the existing missing-output rule.
+    """
+
+    def test_links_unique_sample_as_process_object(self):
+        """A missing process input with exactly one free Sample is auto-linked."""
+        state = _data_analysis_missing_object(n_inputs=1)
+
+        result = fix_required_issues(state)
+
+        # The Sample is now wired as the DataAnalysis's object (input) in state.
+        da = state.get_entity("da1")
+        assert da is not None
+        wired = da.fields.get("object") or da.fields.get("input")
+        wired_ids = wired if isinstance(wired, list) else [wired]
+        assert "s0" in wired_ids, da.fields
+
+        # The tox REQUIRED issue is gone and recorded under ``fixed`` with the
+        # new rule name (re-validation inside fix_required_issues confirms ``ok``).
+        assert result["ok"] is True, result
+        assert result["remaining"] == [], result["remaining"]
+        assert any(
+            item["rule"] == "missing_process_input"
+            and (item["issue"]["property"] or "").endswith("object")
+            for item in result["fixed"]
+        ), result["fixed"]
+
+    def test_each_fixed_item_records_what_was_done(self):
+        state = _data_analysis_missing_object(n_inputs=1)
+        result = fix_required_issues(state)
+        assert result["fixed"], result
+        item = result["fixed"][0]
+        assert item["rule"] == "missing_process_input"
+        assert item.get("action"), "a fixed item must record the repair action taken"
+
+
+class TestAmbiguousAndNewContentInputDeferred:
+    def test_ambiguous_input_left_in_remaining(self):
+        """Two candidate Samples == ambiguous: NOT auto-linked, left for the LLM (D5)."""
+        state = _data_analysis_missing_object(n_inputs=2)
+        da_before = state.get_entity("da1")
+        assert da_before is not None
+        before_fields = dict(da_before.fields)
+
+        result = fix_required_issues(state)
+
+        # No deterministic repair could be made: object/input untouched.
+        da = state.get_entity("da1")
+        assert da is not None
+        assert da.fields.get("object") == before_fields.get("object")
+        assert da.fields.get("input") == before_fields.get("input")
+
+        assert result["ok"] is False
+        assert any(
+            (item["issue"]["property"] or "").endswith("object")
+            for item in result["remaining"]
+        ), result["remaining"]
+
+    def test_new_content_input_not_fabricated(self):
+        """A missing object with NO candidate Sample/File needs NEW content -> remaining.
+
+        ``fix_required_issues`` must NOT fabricate an input entity or any id (D5).
+        """
+        state = _data_analysis_missing_object(n_inputs=0)
+        sample_count_before = len(state.list_entities("Sample"))
+
+        result = fix_required_issues(state)
+
+        assert len(state.list_entities("Sample")) == sample_count_before, (
+            "must not fabricate an input entity"
+        )
+        assert result["ok"] is False
+        assert any(
+            (item["issue"]["property"] or "").endswith("object")
+            for item in result["remaining"]
+        ), result["remaining"]
+        for item in result["remaining"]:
+            assert item.get("reason"), "a remaining item must record why it deferred"
+
+    def test_input_repair_is_idempotent(self):
+        """Running twice yields the same end-state (second run is a no-op)."""
+        state = _data_analysis_missing_object(n_inputs=1)
+        fix_required_issues(state)
+        after_first = state.to_json()
+        second = fix_required_issues(state)
+        assert state.to_json() == after_first
+        assert second["ok"] is True
+        assert second["fixed"] == []


### PR DESCRIPTION
## Lane 2 (epic #179 follow-on)

The deterministic repair loop (`builder/tools/repair.py`) had **exactly one** rule, `missing_process_output`, so every other REQUIRED issue routed to `ask-user` even when deterministically resolvable. This adds the **symmetric** rule, `missing_process_input`.

### What it does
A `DataAnalysis` missing its required `schema:object` (input) — the SHACL `Violation` from `profiles/shapes/tox/5_lab_process_data_analysis.ttl` (`schema:object sh:minCount 1`) — is auto-fixed by wiring its `object` to the **unique free-floating** `Sample`/`File` already in state, exactly mirroring the existing output rule. (`EndpointReadout` requires only a `result`, not an input, so `DataAnalysis` is the sole input-required type.)

### Changes (mirrors the existing output rule precisely)
- **`builder/tools/repair.py`**: new `RepairRule` `missing_process_input` with `_applies_missing_process_input` predicate + `_unique_unwired_input` helper. A candidate is a `Sample`/`File` wired as **no** process input or output — so a process's own `result` File is never mis-wired as its input. Declines (no mutation) on 0 candidates (needs new content) or 2+ (ambiguous) — **D5: never fabricate, decline when ambiguous**. Registered in `_RULES`.
- **`builder/tools/gap_analysis.py`**: explicit `missing_process_input` branch in `_shacl_auto_fixable` for auto-fixability parity (mirrors `_unique_unwired_input is not None`).
- **`AGENTS.md`**: updated the §5 repair-loop and gap-engine `auto_fixable` paragraphs (repair region only; validator section untouched).

### TDD
- `tests/test_tools_repair.py`: positive (unique `Sample` auto-wired as `object`, recorded under `fixed` with rule `missing_process_input`, re-validation clears the Violation), negative (2+ candidates declines → `remaining`; 0 candidates not fabricated → `remaining`), idempotence. Confirmed RED first (issue landed in `remaining` with no rule), then GREEN.
- `tests/test_tools_gap_analysis.py`: symmetric `auto_fixable` parity tests (unique candidate → auto-fixable + `fix_required_issues`; ambiguous/none → `ask-user`).
- Existing `missing_process_output` tests unchanged and still pass.

### Gate
- `tests/test_tools_repair.py` + `tests/test_tools_gap_analysis.py`: **47 passed**.
- `uv run ruff check`: clean.
- `uv run --extra langchain ty check`: All checks passed (zero new diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)