### PR TITLE
fix(crate): resolvable @ids for real-pipeline Publications and ChEBI-only compounds (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1178,6 +1178,14 @@ cleanly under RO-Crate 1.2 (Issue #243): the ChEBI CURIE on `chebiId`
 ontology IRI on `sameAs` as an `{"@id": …}` node. The legacy bare
 `chebi_id`/`chebi_iri` keys were absent from the `@context` and failed the base
 pass (and leaked into the HITL loop as unanswerable gaps), so they are gone.
+A ChEBI-only `MolecularEntity` (no `pubchem_cid`) takes that resolvable ChEBI
+**PURL** as its `@id` (`http://purl.obolibrary.org/obo/CHEBI_<n>`, derived from
+the `sameAs` IRI or the `chebiId` CURIE by `_crate_mapping._chebi_purl`) rather
+than a `#MolecularEntity_<eid>` fragment — preferring an externally resolvable
+identifier the lookup actually produced over a local fragment (Issue #179, D5:
+never fabricated; a compound with no `pubchem_cid` and no ChEBI identity still
+falls back to the fragment). `pubchem_cid` (the PubChem compound URL) still wins
+when both are present.
 
 ### Anti-Hallucination
 The agent **never fabricates identifiers**. Every identifier is verified against its source. If verification fails, the field is cleared and the agent tries alternatives or asks the user.

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -506,6 +506,29 @@ def _bare_doi(raw: str) -> str:
     return value
 
 
+def _chebi_purl(entity: Entity) -> str | None:
+    """The resolvable ChEBI PURL for a ChEBI-fallback MolecularEntity, or None.
+
+    ``lookup_compound``'s ChEBI fallback (no PubChem CID) carries the
+    dereferenceable ontology IRI on ``sameAs`` as an ``{"@id": <PURL>}`` node and
+    the ChEBI CURIE on ``chebiId`` (the OLS ``short_form`` ``CHEBI_<n>`` or the
+    ``CHEBI:<n>`` colon form). Prefer the ``sameAs`` PURL verbatim when it is a
+    ChEBI obo IRI, else derive ``http://purl.obolibrary.org/obo/CHEBI_<n>`` from
+    the ``chebiId`` CURIE. Returns None when neither is present so the caller falls
+    back to the local fragment — never fabricating an id (D5).
+    """
+    same_as = entity.fields.get("sameAs")
+    iri = same_as.get("@id") if isinstance(same_as, dict) else same_as
+    if isinstance(iri, str) and "obo/CHEBI_" in iri:
+        return iri.strip()
+    chebi_id = entity.fields.get("chebiId")
+    if chebi_id:
+        num = str(chebi_id).strip().replace("CHEBI:", "CHEBI_")
+        if num.startswith("CHEBI_"):
+            return f"http://purl.obolibrary.org/obo/{num}"
+    return None
+
+
 def _mint_id(entity: Entity) -> str:
     """A spec-correct @id: resolvable URI when available, else `#`-fragment.
 
@@ -520,8 +543,16 @@ def _mint_id(entity: Entity) -> str:
     if t == "Organization" and f.get("ror"):
         r = str(f["ror"]).strip()
         return r if r.startswith("http") else f"https://ror.org/{r.lstrip('/')}"
-    if t == "MolecularEntity" and f.get("pubchem_cid"):
-        return f"https://pubchem.ncbi.nlm.nih.gov/compound/{f['pubchem_cid']}"
+    if t == "MolecularEntity":
+        # A PubChem CID is the preferred clean external @id. A ChEBI-fallback
+        # compound (no CID) carries a resolvable ChEBI PURL on sameAs / chebiId —
+        # use it instead of a `#MolecularEntity_<eid>` fragment so the @id is
+        # externally resolvable (#179, D5: only ids the lookup produced).
+        if f.get("pubchem_cid"):
+            return f"https://pubchem.ncbi.nlm.nih.gov/compound/{f['pubchem_cid']}"
+        chebi_purl = _chebi_purl(entity)
+        if chebi_purl:
+            return chebi_purl
     if t == "Publication":
         # Recognise a DOI on either `doi` or `identifier` in URL, CURIE, or bare
         # form. The real pipeline never sets a `doi` field — Crossref returns the

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -489,6 +489,23 @@ def _scalar_props(entity: Entity, skip: tuple[str, ...] = ()) -> dict[str, Any]:
     return {k: v for k, v in entity.fields.items() if k not in drop and not k.startswith("@")}
 
 
+def _bare_doi(raw: str) -> str:
+    """Strip a DOI's URL or CURIE prefix down to the bare ``10.xxxx/...`` form.
+
+    Recognises ``https://doi.org/`` / ``http://doi.org/`` URL forms and a ``doi:``
+    CURIE prefix (case-insensitive). Returns the input unchanged when no prefix is
+    present (it is already bare). Used to rebuild the canonical
+    ``https://doi.org/<bare>`` @id from whatever DOI form a field carries (#179).
+    """
+    value = raw.strip()
+    for prefix in ("https://doi.org/", "http://doi.org/"):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+    if value.lower().startswith("doi:"):
+        return value[len("doi:"):]
+    return value
+
+
 def _mint_id(entity: Entity) -> str:
     """A spec-correct @id: resolvable URI when available, else `#`-fragment.
 
@@ -506,11 +523,22 @@ def _mint_id(entity: Entity) -> str:
     if t == "MolecularEntity" and f.get("pubchem_cid"):
         return f"https://pubchem.ncbi.nlm.nih.gov/compound/{f['pubchem_cid']}"
     if t == "Publication":
-        ident = str(f.get("identifier", ""))
-        doi = f.get("doi") or (ident if ident.startswith("10.") else None)
-        if doi:
-            d = str(doi).strip()
-            return d if d.startswith("http") else f"https://doi.org/{d}"
+        # Recognise a DOI on either `doi` or `identifier` in URL, CURIE, or bare
+        # form. The real pipeline never sets a `doi` field — Crossref returns the
+        # DOI as the full URL `https://doi.org/10...` on `identifier` (#179).
+        # Because that value does not start with the literal `"10."`, the old
+        # branch fell through to a `#Publication_...` fragment, so the auto-wired
+        # root `citation` referenced a fragment @id and the base check
+        # ro-crate-1.2_19.1 failed ("Citation … must be an absolute URI"). Minting
+        # the absolute `https://doi.org/<bare>` URL keeps the citation @id valid.
+        raw = str(f.get("doi") or f.get("identifier") or "").strip()
+        is_doi = (
+            raw.startswith("10.")
+            or "doi.org/" in raw
+            or raw.lower().startswith("doi:")
+        )
+        if is_doi:
+            return raw if raw.startswith("http") else f"https://doi.org/{_bare_doi(raw)}"
     if eid.startswith(("#", "http://", "https://", "./")) or "://" in eid:
         return eid
     return "#" + _slug(t) + "_" + eid

--- a/tests/test_crate_mapping_identifiers.py
+++ b/tests/test_crate_mapping_identifiers.py
@@ -18,11 +18,17 @@ graph; no network and no SHACL (no `build_and_validate`) so the module is fast.
 
 from __future__ import annotations
 
+import re
+
 from rocrate.rocrate import ROCrate
 
 from builder.state import CrateState, Entity, EntityProvenance
-from builder.tools._crate_mapping import populate_crate
+from builder.tools._crate_mapping import _mint_id, populate_crate
 from profiles.context import ISA_TOX_CONTEXT
+
+# RO-Crate 1.2 absolute-URI regex (rocrate_validator should/4_data_entity_metadata.py):
+# a cited Data Entity's @id MUST match this, so a "#"-fragment fails.
+_ABSOLUTE_URI = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
 
 
 def _graph(state: CrateState) -> list[dict]:
@@ -247,3 +253,74 @@ class TestPublicationAuthors:
         assert ids == ["https://orcid.org/0000-0002-9569-7562"], (
             f"author must be an array of Person references, got {ids}"
         )
+
+
+class TestPublicationRealPipelineDoiId:
+    """The Publication @id must be the DOI URL on the REAL pipeline path (#179).
+
+    The real pipeline (``draft_publication`` via ``_ensure_publication`` /
+    Crossref) never sets a ``doi`` FIELD — it stores the DOI on ``identifier`` in
+    the FULL URL form Crossref returns (``https://doi.org/10....``). Because that
+    value does not start with the literal ``"10."``, the old ``_mint_id``
+    Publication branch fell through to a ``#Publication_...`` local fragment, so
+    the auto-wired root ``citation`` referenced a fragment @id and the base
+    validator check ``ro-crate-1.2_19.1`` failed ("Citation for Data Entity './'
+    must be an absolute URI"). The @id must be the absolute DOI URL instead.
+    """
+
+    def _state_with_url_identifier(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Publication crate"
+        # Mirror the real pipeline: ONLY identifier (full URL form), NO doi field.
+        state.add_entity(
+            Entity(
+                entity_id="pub_real",
+                type="Publication",
+                fields={
+                    "name": "A real publication",
+                    "identifier": "https://doi.org/10.1016/j.tiv.2023.105770",
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        return state
+
+    def test_url_form_identifier_mints_doi_url_id(self):
+        pub = self._state_with_url_identifier().list_entities("Publication")[0]
+        assert (
+            _mint_id(pub) == "https://doi.org/10.1016/j.tiv.2023.105770"
+        ), "DOI in URL form on `identifier` must mint the absolute DOI URL @id"
+
+    def test_minted_id_is_absolute_uri(self):
+        pub = self._state_with_url_identifier().list_entities("Publication")[0]
+        minted = _mint_id(pub)
+        assert _ABSOLUTE_URI.match(minted), (
+            f"@id {minted!r} must be an absolute URI (base check ro-crate-1.2_19.1)"
+        )
+
+    def test_node_and_root_citation_use_doi_url(self):
+        graph = _graph(self._state_with_url_identifier())
+        article = _by_id(graph, "https://doi.org/10.1016/j.tiv.2023.105770")
+        assert article is not None, "Publication node @id must be the DOI URL"
+        assert article.get("@type") == "ScholarlyArticle"
+        root = _by_id(graph, "./")
+        assert root is not None
+        citation_ids = _ref_ids(root.get("citation"))
+        assert "https://doi.org/10.1016/j.tiv.2023.105770" in citation_ids, (
+            "root citation must reference the absolute DOI URL @id, "
+            f"got {citation_ids}"
+        )
+
+    def test_bare_doi_prefixed_identifier_mints_doi_url(self):
+        """A ``doi:`` CURIE-prefixed identifier (no doi field) also mints the URL."""
+        state = CrateState()
+        state.add_entity(
+            Entity(
+                entity_id="pub_curie",
+                type="Publication",
+                fields={"name": "p", "identifier": "doi:10.1234/abc"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        pub = state.list_entities("Publication")[0]
+        assert _mint_id(pub) == "https://doi.org/10.1234/abc"

--- a/tests/test_crate_mapping_identifiers.py
+++ b/tests/test_crate_mapping_identifiers.py
@@ -324,3 +324,94 @@ class TestPublicationRealPipelineDoiId:
         )
         pub = state.list_entities("Publication")[0]
         assert _mint_id(pub) == "https://doi.org/10.1234/abc"
+
+
+class TestChebiOnlyMolecularEntityId:
+    """A ChEBI-fallback MolecularEntity gets the resolvable ChEBI PURL @id (#179).
+
+    ``lookup_compound``'s ChEBI fallback returns a ``chebiId`` CURIE (the OLS
+    ``short_form``, e.g. ``CHEBI_1378``) and a ``sameAs`` ``{"@id": <PURL>}`` but
+    NO ``pubchem_cid``. The old ``_mint_id`` only promoted ``pubchem_cid`` to a
+    clean external @id, so a ChEBI-only compound fell through to a
+    ``#MolecularEntity_<eid>`` fragment even though it carries a resolvable PURL.
+    Prefer the external resolvable @id when present (D5: only ids the lookup
+    produced — never fabricated).
+    """
+
+    def _chebi_state(self, *, with_sameas: bool = True, with_chebi_id: bool = True) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "ChEBI compound crate"
+        fields: dict = {"name": "some flavonolignan", "iupac_name": "x"}
+        if with_chebi_id:
+            fields["chebiId"] = "CHEBI_1378"
+        if with_sameas:
+            fields["sameAs"] = {"@id": "http://purl.obolibrary.org/obo/CHEBI_1378"}
+        chem = Entity(
+            entity_id="chem_chebi",
+            type="MolecularEntity",
+            fields=fields,
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        state.add_entity(chem)
+        return state
+
+    def test_mint_id_prefers_chebi_purl(self):
+        chem = self._chebi_state().list_entities("MolecularEntity")[0]
+        assert (
+            _mint_id(chem) == "http://purl.obolibrary.org/obo/CHEBI_1378"
+        ), "ChEBI-only MolecularEntity @id must be the resolvable ChEBI PURL"
+
+    def test_mint_id_not_a_fragment(self):
+        chem = self._chebi_state().list_entities("MolecularEntity")[0]
+        assert not _mint_id(chem).startswith("#"), "must not fall through to a #fragment"
+
+    def test_node_built_under_chebi_purl(self):
+        graph = _graph(self._chebi_state())
+        chem = _by_id(graph, "http://purl.obolibrary.org/obo/CHEBI_1378")
+        assert chem is not None, "MolecularEntity node @id must be the ChEBI PURL"
+        assert chem.get("@type") == "MolecularEntity"
+
+    def test_chebi_id_curie_alone_resolves_purl(self):
+        """With only the `chebiId` CURIE (no sameAs) the PURL is still derived."""
+        chem = self._chebi_state(with_sameas=False).list_entities("MolecularEntity")[0]
+        assert _mint_id(chem) == "http://purl.obolibrary.org/obo/CHEBI_1378"
+
+    def test_colon_form_chebi_id_resolves_purl(self):
+        """A `CHEBI:1378` CURIE (colon form) also derives the underscore PURL."""
+        state = CrateState()
+        chem = Entity(
+            entity_id="chem_colon",
+            type="MolecularEntity",
+            fields={"name": "c", "chebiId": "CHEBI:1378"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        state.add_entity(chem)
+        assert _mint_id(chem) == "http://purl.obolibrary.org/obo/CHEBI_1378"
+
+    def test_pubchem_cid_still_wins_over_chebi(self):
+        """A compound carrying both still prefers the PubChem compound URL."""
+        state = CrateState()
+        chem = Entity(
+            entity_id="chem_both",
+            type="MolecularEntity",
+            fields={
+                "name": "c",
+                "pubchem_cid": "441764",
+                "sameAs": {"@id": "http://purl.obolibrary.org/obo/CHEBI_1378"},
+            },
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        state.add_entity(chem)
+        assert _mint_id(chem) == "https://pubchem.ncbi.nlm.nih.gov/compound/441764"
+
+    def test_no_chebi_no_pubchem_falls_back_to_fragment(self):
+        """D5: no resolvable id present -> the local fragment, never fabricated."""
+        state = CrateState()
+        chem = Entity(
+            entity_id="chem_plain",
+            type="MolecularEntity",
+            fields={"name": "mystery compound"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        state.add_entity(chem)
+        assert _mint_id(chem) == "#MolecularEntity_chem_plain"


### PR DESCRIPTION
## Summary

Two confirmed `_mint_id` defects in `builder/tools/_crate_mapping.py` (epic #179), each fixed TDD-first as a separate commit. Both make a minted `@id` an externally-resolvable absolute URI instead of falling through to a non-resolvable `#`-fragment.

### Commit 1 — Publication `@id` is the DOI URL on the real pipeline path
The real pipeline never sets a `doi` FIELD: `draft_publication` (via `_ensure_publication` / Crossref) stores the DOI on `identifier` in the **full URL form** Crossref returns (`https://doi.org/10...`). Because that value does not start with the literal `"10."`, the old Publication branch fell through to a `#Publication_<slug>` fragment, so the auto-wired root `citation` referenced a fragment `@id` and the base check `ro-crate-1.2_19.1` failed ("Citation for Data Entity './' must be an absolute URI"). This is why the base pass stayed red even after a citation was supplied.

Now a DOI is recognised on either `doi` or `identifier` in URL, `doi:` CURIE, or bare `10.` form, and the absolute `https://doi.org/<bare>` URL is minted (bare DOI extracted via the new `_bare_doi` helper).

### Commit 2 — ChEBI-only MolecularEntity `@id` is the resolvable ChEBI PURL
`lookup_compound`'s ChEBI fallback (no PubChem CID) carries the dereferenceable ontology IRI on `sameAs` (`{"@id": <PURL>}`) and the ChEBI CURIE on `chebiId` (OLS `short_form`, e.g. `CHEBI_1378`). `_mint_id` only promoted `pubchem_cid`, so a ChEBI-only compound fell through to a `#MolecularEntity_<eid>` fragment despite carrying a resolvable PURL. Now when there is no `pubchem_cid` but a ChEBI `sameAs` PURL or `chebiId` CURIE is present, `http://purl.obolibrary.org/obo/CHEBI_<n>` is minted (via the new `_chebi_purl` helper). `pubchem_cid` still wins when both are present.

**D5 preserved:** only ids the lookup actually produced are promoted — a compound carrying neither a DOI/CID nor a ChEBI identity still falls back to the local fragment; nothing is fabricated.

## Tests (TDD, failing-first confirmed for both)
- `TestPublicationRealPipelineDoiId` — real-pipeline path (only `identifier` set to the URL form, no `doi` field); asserts the DOI-URL `@id`, the absolute-URI regex, and the root `citation` referencing it. The existing test that hand-sets a `doi` field (which masked the bug) is left intact.
- `TestChebiOnlyMolecularEntityId` — `sameAs` and `chebiId` paths, colon + underscore CURIE forms; guards that `pubchem_cid` still wins and that a compound with no resolvable identity stays a fragment.

## Gate
- `tests/test_crate_mapping_identifiers.py`: 22 passed.
- Regression: crate-mapping / builder / csvw / publication-authors / resolve-compound / resolve-publication / build-and-validate / repair / gap-analysis / validate-dict / provenance suites all green.
- `ruff check` clean; `ty check` zero new diagnostics.

AGENTS.md §10 updated to document the new ChEBI PURL minting behavior. No files outside the assigned lane (`_crate_mapping.py`, `tests/test_crate_mapping_identifiers.py`, plus the in-scope AGENTS.md §10 note) were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)