### PR TITLE
fix(guidance): persist root citation answers + ground entity-less MIT gaps (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1824,11 +1824,18 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   The loop **advances over un-progressable gaps** rather than aborting on the
   first one (#230): each round it draws the next *actionable* gap (`report-only`
   gaps are never drawn — see below), and a gap it cannot progress (e.g. the user
-  skips it) is added to a **per-report skip-set** so the loop moves on to the gap
-  behind it. It only stops once the whole report is exhausted with no progress —
-  one cryptic, uncommittable gap can no longer abandon the 200 behind it — and is
-  still hard-bounded by `max_rounds`. The skip-set is cleared on every commit (the
-  re-assessed report is fresh).
+  skips it) is added to a **per-report skip-set** (indices into the current report)
+  so the loop moves on to the gap behind it. It only stops once the whole report is
+  exhausted with no progress — one cryptic, uncommittable gap can no longer abandon
+  the 200 behind it — and is still hard-bounded by `max_rounds`. The per-report
+  index skip-set is cleared on every commit (the re-assessed report is fresh).
+  Alongside it the loop keeps a **per-RUN skip-set keyed by gap IDENTITY**
+  (`(source, entity_id, property, message)`, #179): a gap surfaced/answered but not
+  progressed is recorded here and **never re-drawn for the rest of the run**, even
+  after a *different* gap commits and clears the per-report index set and a fresh
+  re-assess re-emits it. This stops the always-highest-priority root citation MUST
+  gap (which re-emits every round until a `ScholarlyArticle` is wired) from being
+  re-asked 6+ times — the #179 re-ask loop.
 
   **The per-gap LLM exchange (#244).** When a provider is configured (gated on
   `config.get_provider()`, like the pipeline leaves), each ask-user gap runs a
@@ -1867,6 +1874,34 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
       Committing such a field as a literal string would leave the "creator MUST be
       of type Person" SHACL shape unsatisfied, so the gap would re-emit every
       round and `isa=fail` — the #275 re-ask loop this fixes.
+    - **The root `citation` gap is resolved through the publication composites,
+      not stored as a string (#179).** The Root Data Entity's `citation`
+      requirement (BASE: the auto-wired root `citation` `@id` must be an absolute
+      URI; ISA: a `ScholarlyArticle` with an identifier) surfaces with
+      `entity_id == "./"`, which `_resolve_entity_id` cannot map to a state entity
+      and which is not a crate-metadata slot — so a string commit dropped the
+      answer and the always-highest-priority gap was re-asked every round. So
+      `_apply_value` routes a root `citation` answer to `_apply_citation_value`:
+      an answer carrying a DOI → `draft_publication_with_authors(doi=…)`, otherwise
+      it is treated as a title → `resolve_publication(title=…)` (both via
+      `engine.run_tool`, never hand-rolled JSON-LD). The builder auto-wires the
+      resulting `ScholarlyArticle` onto `root_dataset.citation`. D5: the DOI is
+      re-looked-up and a title only commits on a confident Crossref match.
+
+  **Entity-less MIT gaps are grounded in the real instance name (#179).** An MIT
+  gap is emitted crate-level with `entity_id=None` carrying only `entity_type`
+  (e.g. `CellLineSample`). `_resolve_entity_id` short-circuits to `None` for any
+  falsy `entity_id`, so without grounding the phrase leaf saw a bare TYPE and no
+  name and the model invented the stock example ("HepG2") — which also produced the
+  spurious "what is the correct UTF-8 file name (replace %2B with +)" question (no
+  such gap rule exists; it was hallucinated phrasing). `_gap_context` now, when
+  `_resolve_entity_id` is `None` but `entity_type` is set, looks the type's
+  instances up via `state.list_entities(entity_type)` and threads the REAL name in
+  (`entity_name` / `known_fields`); with several instances it surfaces their names
+  for disambiguation, so the leaf is **never** handed a bare type with no name.
+  The `_PHRASE_SYSTEM_PROMPT` reinforces this: with no entity name it must ask
+  generically about "the &lt;entity type&gt;" and is explicitly forbidden from
+  inventing a specific name, identifier, or example value (D5: no fabrication).
 
   **Offline / no-provider determinism.** With no provider configured the exchange
   degrades to the original deterministic ask-and-set: phrase = the human-readable

--- a/builder/agents/guidance.py
+++ b/builder/agents/guidance.py
@@ -693,6 +693,54 @@ def _known_fields(entity: Any) -> dict[str, str]:
     return known
 
 
+def _ground_entityless_gap(engine: AgentEngine, gap: Gap, context: dict[str, Any]) -> None:
+    """Ground a typed-but-entity-less gap in the real in-state instance (Commit 2).
+
+    MIT gaps are emitted crate-level with ``entity_id=None`` carrying only an
+    ``entity_type`` (e.g. ``"CellLineSample"``). Without grounding, the phrase leaf
+    sees a bare TYPE and no name, so the model invents the stock example ("HepG2").
+    Here, for such a gap, we look up the type's instances in state and thread the
+    REAL name(s) into ``context`` so the leaf NEVER receives a bare type with no
+    name (D5: no fabrication):
+
+    * exactly one instance -> set ``entity_name`` (and ``known_fields``) from it;
+    * several instances -> surface their display names in a disambiguating
+      ``known_fields["instances"]`` entry (the leaf must phrase generically about
+      *the named instances*, never invent one).
+
+    Mutates ``context`` in place; a no-op when there is no type or no named
+    instance (the prompt-side D5 guard then forbids inventing a name).
+    """
+    entity_type = gap.entity_type
+    if not entity_type:
+        return
+    try:
+        instances = engine.state.list_entities(entity_type)
+    except (KeyError, ValueError) as exc:  # pragma: no cover — unknown type is rare
+        logger.debug("guidance: cannot list %s instances: %s", entity_type, exc)
+        return
+    named = [
+        (entity, name)
+        for entity in instances
+        if (name := _entity_display_name(entity))
+    ]
+    if not named:
+        return
+    if len(named) == 1:
+        entity, name = named[0]
+        context["entity_name"] = name
+        known = _known_fields(entity)
+        if known:
+            context["known_fields"] = known
+        return
+    # Several instances: surface their names for disambiguation rather than
+    # leaving the leaf with a bare nameless type.
+    names = [name for _entity, name in named]
+    known = dict(context.get("known_fields") or {})
+    known["instances"] = "; ".join(names)
+    context["known_fields"] = known
+
+
 def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
     """Assemble the per-gap context dict the guidance leaves consume (#244, #257).
 
@@ -708,6 +756,12 @@ def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
     the entity BY NAME — never a bare "this chemical / this protocol / this cell
     line". The entity's own type takes precedence over the gap's coarser
     ``entity_type`` when they differ.
+
+    When the gap is **entity-less but typed** (an MIT gap with ``entity_id=None``
+    carrying only ``entity_type``, Commit 2 / #179), the type's in-state instances
+    are looked up and the REAL instance name(s) threaded in
+    (:func:`_ground_entityless_gap`) so the leaf is never handed a bare type with
+    no name — which is what made the model invent the stock "HepG2" example.
     """
     field = _local_name(gap.property) or (gap.property or "")
     context: dict[str, Any] = {
@@ -729,6 +783,10 @@ def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
             known = _known_fields(entity)
             if known:
                 context["known_fields"] = known
+    else:
+        # (Commit 2, #179) An entity-less but typed gap (MIT, entity_id=None):
+        # ground it in the type's real in-state instance(s).
+        _ground_entityless_gap(engine, gap, context)
     title = (engine.state.metadata.title or "").strip()
     if title:
         context["crate_title"] = title

--- a/builder/agents/guidance.py
+++ b/builder/agents/guidance.py
@@ -195,6 +195,34 @@ def _is_person_field(field: str) -> bool:
     return field in _PERSON_FIELDS
 
 
+# (Commit 1, #179) Citation-typed fields whose ISA/BASE value MUST be a
+# ``ScholarlyArticle`` ENTITY REFERENCE (with an absolute-URI ``@id``), never a
+# literal string. The root Data Entity's ``citation`` MUST gap surfaces with
+# ``entity_id == "./"``, which ``_resolve_entity_id`` cannot map to a state entity
+# and which is not a crate-metadata slot — so committing the prose as a string did
+# nothing and the always-highest-priority gap was re-asked every round. These are
+# instead routed to the publication composites (see :func:`_apply_citation_value`).
+_CITATION_FIELDS: frozenset[str] = frozenset({"citation"})
+
+
+def _is_citation_field(field: str) -> bool:
+    """Whether ``field`` (a local property name) is a citation-typed field."""
+    return field in _CITATION_FIELDS
+
+
+def _gap_is_root(engine: AgentEngine, gap: Gap) -> bool:
+    """Whether ``gap`` targets the Root Data Entity (``./`` / no state entity).
+
+    A root/crate-level gap is one whose ``entity_id`` is ``None`` or the literal
+    ``"./"``, or one that ``_resolve_entity_id`` cannot map back to a real state
+    entity (the build's root ``./`` node folds the Investigation and has no
+    separate state node — see :func:`builder.tools.repair._resolve_state_entity`).
+    """
+    if gap.entity_id is None or gap.entity_id == "./":
+        return True
+    return _resolve_entity_id(engine, gap) is None
+
+
 # An ORCID iD anywhere in free text — the 16-digit, dash-grouped form (final
 # group may end in X), with an optional ``https://orcid.org/`` URL prefix so the
 # whole token (URL and all) is captured and can be stripped from the name.
@@ -208,6 +236,10 @@ _ORCID_LABEL_RE = re.compile(
     r"\b[,;]?\s*orcid(?:\s*id)?\s*[:=]?\s*",
     re.IGNORECASE,
 )
+# A DOI anywhere in free text — the ``10.<registrant>/<suffix>`` form (mirrors the
+# pipeline's ``_DOI_RE``). Used to route a root citation answer to the DOI-based
+# publication composite rather than a title search (Commit 1, #179).
+_DOI_RE = re.compile(r"10\.\d{4,9}/[^\s\"'<>]+", re.IGNORECASE)
 # An affiliation introduced by a leading "(" or an "@"/"affiliation:" marker.
 _AFFILIATION_RE = re.compile(
     r"(?:\baffiliation\s*[:=]\s*|\s+@\s*|\s*\(\s*)(?P<aff>[^()]+?)\s*\)?$",
@@ -231,6 +263,20 @@ def _local_name(iri: str | None) -> str:
     if not iri:
         return ""
     return iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+
+
+# A gap's stable IDENTITY, used by the per-RUN skip-set (Commit 1, #179). Two gaps
+# from different reports are "the same gap" when these four fields match — the
+# loop keys un-progressable gaps by identity (NOT by report index, which is reset
+# on every commit) so an already-tried gap (e.g. the always-highest-priority root
+# citation MUST gap) is never re-drawn even after a different gap commits and a
+# fresh re-assess re-emits it.
+GapIdentity = tuple[str | None, str | None, str | None, str]
+
+
+def _gap_identity(gap: Gap) -> GapIdentity:
+    """A stable identity tuple ``(source, entity_id, property, message)`` for ``gap``."""
+    return (gap.source, gap.entity_id, gap.property, gap.message)
 
 
 def _resolve_entity_id(engine: AgentEngine, gap: Gap) -> str | None:
@@ -378,6 +424,49 @@ def _apply_person_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
     return True
 
 
+def _apply_citation_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
+    """Resolve a root ``citation`` answer to a ``ScholarlyArticle`` (Commit 1, #179).
+
+    The root Data Entity's ``citation`` requirement (BASE: the auto-wired root
+    ``citation`` ``@id`` must be an absolute URI; ISA: a ``ScholarlyArticle`` with
+    an identifier) cannot be satisfied by committing the user's prose as a literal
+    string — ``set_fields`` has no resolvable state target for the ``./`` root, and
+    ``citation`` is not a crate-metadata slot, so the OLD path silently dropped the
+    answer and the always-highest-priority gap was re-asked every round.
+
+    Instead the answer is routed to the existing publication composites (never
+    hand-rolled JSON-LD, AGENTS.md §4.7), mirroring how :func:`_apply_person_value`
+    special-cases person fields. The builder auto-wires the resulting
+    ``ScholarlyArticle`` onto ``root_dataset.citation``:
+
+    * an answer carrying a **DOI** (or a DOI inside a URL) -> ``draft_publication_
+      with_authors(doi=…)`` — the DOI is re-looked-up, so an unresolvable DOI mints
+      nothing (D5);
+    * otherwise the answer is treated as a **title** ->
+      ``resolve_publication(title=…)`` — which commits a DOI-backed
+      ``ScholarlyArticle`` ONLY on a confident Crossref match (D5).
+
+    Returns ``True`` iff a publication entity was created so the gap clears, else
+    ``False`` (no usable answer, or no confident match — committing nothing).
+    """
+    text = (value or "").strip()
+    if not text:
+        return False
+
+    doi_match = _DOI_RE.search(text)
+    try:
+        if doi_match:
+            result = engine.run_tool(
+                "draft_publication_with_authors", doi=doi_match.group(0)
+            )
+            return isinstance(result, dict) and bool(result.get("publication_id"))
+        result = engine.run_tool("resolve_publication", title=text)
+        return isinstance(result, dict) and bool(result.get("ok"))
+    except Exception as exc:  # noqa: BLE001 — a flaky lookup must not break the loop
+        logger.warning("guidance: citation resolution failed for %r: %s", text, exc)
+        return False
+
+
 def _apply_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
     """Commit ``value`` for ``gap`` via the existing set tools. Returns success.
 
@@ -393,6 +482,11 @@ def _apply_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
     "creator MUST be of type Person" SHACL shape unsatisfied and the gap would
     re-emit every round (the #275 re-ask loop). Drafting a Person and linking it
     by reference closes the gap properly.
+
+    The root ``citation`` field (Commit 1, #179) is likewise routed to
+    :func:`_apply_citation_value`: its value must be a ``ScholarlyArticle``
+    reference resolved through the publication composites, not a literal string,
+    so a string commit dropped the answer and the gap was re-asked every round.
     """
     field = _local_name(gap.property) or (gap.property or "")
     if not field:
@@ -401,6 +495,10 @@ def _apply_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
     # (#275) Person/agent fields need a Person reference, not a literal string.
     if _is_person_field(field):
         return _apply_person_value(engine, gap, value)
+
+    # (#179) The root citation gap needs a resolved ScholarlyArticle, not a string.
+    if _is_citation_field(field) and _gap_is_root(engine, gap):
+        return _apply_citation_value(engine, gap, value)
 
     state_id = _resolve_entity_id(engine, gap)
     if state_id is not None:
@@ -1042,9 +1140,16 @@ def run_guidance(
     # advances to the next actionable gap instead of re-offering the same one; the
     # set is cleared whenever a commit invalidates the report (a fresh re-assess).
     skipped: set[int] = set()
+    # (Commit 1, #179) The per-RUN skip-set, keyed by gap IDENTITY (not report
+    # index). A gap the loop surfaced/answered but could NOT progress is recorded
+    # here and never re-drawn, even after a different gap commits and resets the
+    # per-report ``skipped`` index set above. This stops the always-highest-
+    # priority root citation MUST gap (which re-emits every round when its answer
+    # cannot be applied) from being re-asked 6+ times.
+    tried_identities: set[GapIdentity] = set()
 
     for _ in range(max(0, max_rounds)):
-        index = _next_actionable_index(report, skipped)
+        index = _next_actionable_index(report, skipped, tried_identities)
 
         # --- termination: the whole report is exhausted -----------------------
         # No actionable gap remains that we have not already tried this round —
@@ -1064,17 +1169,23 @@ def run_guidance(
         )
 
         if progressed:
-            # State changed: re-assess from scratch and forget the skip-set (the
-            # gap indices no longer refer to the same gaps).
+            # State changed: re-assess from scratch and forget the per-report
+            # index skip-set (the gap indices no longer refer to the same gaps).
+            # The per-RUN identity skip-set persists so an already-tried gap that
+            # re-emits is not re-drawn.
             report = assess_gaps(engine.state)
             skipped = set()
         else:
-            # This one gap is not resolvable right now (e.g. skipped); skip it and
-            # let the next round draw the next actionable gap in the SAME report.
+            # This one gap is not resolvable right now (e.g. skipped or its answer
+            # could not be applied). Skip it BOTH by report index (so the next
+            # round draws the next actionable gap in the SAME report) AND by
+            # identity (so it is not re-drawn even after a later commit clears the
+            # index set and a fresh re-assess re-emits it — the #179 re-ask fix).
             # The loop only stops once EVERY gap in the report is exhausted, so a
             # single un-progressable gap never abandons the ones behind it. Still
             # bounded by ``max_rounds``.
             skipped.add(index)
+            tried_identities.add(_gap_identity(gap))
 
     return {
         "resolved": resolved,
@@ -1085,13 +1196,25 @@ def run_guidance(
     }
 
 
-def _next_actionable_index(report: GapReport, skipped: set[int]) -> int | None:
+def _next_actionable_index(
+    report: GapReport,
+    skipped: set[int],
+    tried_identities: set[GapIdentity] | None = None,
+) -> int | None:
     """Index of the highest-priority *actionable, not-yet-skipped* gap, or ``None``.
 
     The report is already sorted MUST -> SHOULD -> MAY (committable before
     ``report-only`` within a tier), so we walk it in order and return the index of
-    the first gap that is BOTH actionable and not in ``skipped`` (indices into
-    ``report.gaps`` the loop has already tried and could not progress this round).
+    the first gap that is actionable and not yet excluded. A gap is excluded when
+    it is either:
+
+    * in ``skipped`` — indices into THIS report's ``gaps`` the loop has tried and
+      could not progress this round (reset on every commit); or
+    * in ``tried_identities`` (Commit 1, #179) — the per-RUN set of gap IDENTITIES
+      (``_gap_identity``) the loop surfaced/answered but could NOT progress, kept
+      across re-assessments so an un-appliable / already-answered gap (e.g. the
+      always-highest-priority root citation MUST gap) is not re-drawn even after a
+      different gap commits and clears the per-report index ``skipped`` set.
 
     A gap is **actionable** when it has a resolution route the loop can drive:
     ``auto_fixable``, or a ``fix_hint`` of ``fix_required_issues`` / ``draft`` /
@@ -1102,6 +1225,8 @@ def _next_actionable_index(report: GapReport, skipped: set[int]) -> int | None:
     """
     for index, gap in enumerate(report.gaps):
         if index in skipped:
+            continue
+        if tried_identities is not None and _gap_identity(gap) in tried_identities:
             continue
         if gap.fix_hint == REPORT_ONLY:
             continue

--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -522,7 +522,12 @@ _PHRASE_SYSTEM_PROMPT = (
     "an entity name is given, the question MUST name that specific entity (e.g. "
     "'What is the CAS Registry Number for Silychristin A?'), never a vague 'this "
     "chemical', 'this protocol', or 'this cell line' — the user must know WHICH "
-    "entity you mean."
+    "entity you mean. When NO entity name is given, ask GENERICALLY about 'the "
+    "<entity type>' (e.g. 'the cell line', 'the compound') and you are EXPLICITLY "
+    "FORBIDDEN from inventing a specific name, identifier, accession, or example "
+    "value to fill the blank — never make up a concrete cell-line / compound name "
+    "or a code the data does not provide. D5: never fabricate a specific name, "
+    "identifier, or value the data does not provide."
 )
 
 _INTERPRET_SYSTEM_PROMPT = (

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -1034,6 +1034,39 @@ class TestPhraseGapQuestionNamesEntity:
 
 
 # ---------------------------------------------------------------------------
+# (Commit 2, #179) No entity name => ask generically, NEVER fabricate one.
+#
+# An MIT/crate-level gap can reach the phrase leaf with an entity_type but NO
+# entity_name (the gap is emitted with entity_id=None). The OLD prompt only
+# forbade vague phrasing "when an entity name is given" — with none given, the
+# model invented the stock example "HepG2" (which also spawned the spurious
+# "what is the correct UTF-8 file name (replace %2B with +)" question). The
+# prompt must now, when NO name is given, tell the model to ask generically
+# about "the <entity_type>" and EXPLICITLY forbid inventing a specific name,
+# identifier, or example value (D5: no fabrication).
+# ---------------------------------------------------------------------------
+
+
+class TestPhraseGapQuestionForbidsFabricatedName:
+    """When no entity name is provided the prompt must forbid inventing one."""
+
+    def test_prompt_forbids_inventing_a_name_when_none_given(self) -> None:
+        prompt = leaves._PHRASE_SYSTEM_PROMPT.lower()
+        # The prompt must address the NO-name case (ask generically about the type)
+        # and explicitly forbid fabricating a specific name / identifier / example.
+        assert "no" in prompt and "name" in prompt, prompt
+        # It must forbid INVENTING / FABRICATING / MAKING UP a specific value.
+        assert any(
+            word in prompt for word in ("invent", "fabricat", "make up", "made-up")
+        ), "the phrase prompt must forbid fabricating a name/identifier (D5)"
+
+    def test_no_name_prompt_does_not_seed_a_specific_example_name(self) -> None:
+        # D5 regression: the prompt must not seed a concrete entity NAME the model
+        # could parrot when none is given (the 'HepG2' fabrication).
+        assert "hepg2" not in leaves._PHRASE_SYSTEM_PROMPT.lower()
+
+
+# ---------------------------------------------------------------------------
 # extract_field_from_file — the bounded file-extraction leaf (Issue #257, fix C)
 #
 # When the user points the guidance loop at a file ("the CAS number is in

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -1696,3 +1696,198 @@ class TestPersonFieldMintsPersonEntity:
         assert not isinstance(creator, str), (
             "the regression: a creator must never be committed as a literal string"
         )
+
+
+# ---------------------------------------------------------------------------
+# (Commit 1, #179) The root ``./`` citation MUST gap: its answer is persisted
+# via the publication composites and the gap is NEVER re-asked.
+#
+# ROOT CAUSE the test pins:
+#   * the root citation MUST gap surfaces with ``entity_id == "./"`` and
+#     ``property == "http://schema.org/citation"``;
+#   * ``_resolve_entity_id`` returns ``None`` (``state.get_entity("./")`` is None,
+#     repair strips ``"./"`` -> ``""``), and ``citation`` is not a crate-metadata
+#     slot, so the OLD ``_apply_value`` silently dropped the answer (returned
+#     False) -> the always-highest-priority citation MUST gap was re-drawn and
+#     re-asked after ANY other commit (the per-report skip-set is reset on every
+#     commit), so the user was asked 6+ times and the answer never landed.
+#
+# FIX: route the root citation answer to the publication composites
+# (``draft_publication_with_authors`` for a DOI/URL, else ``resolve_publication``
+# for a title) and add a per-RUN persistent skip-set keyed by gap IDENTITY so an
+# un-appliable / already-answered gap is not re-drawn even after a commit clears
+# the per-report index set.
+# ---------------------------------------------------------------------------
+
+
+def _root_citation_gap(tier: Tier = "MUST") -> Gap:
+    """The root Data Entity ``citation`` MUST gap as the gap engine emits it."""
+    return Gap(
+        tier=tier,
+        source="shacl",
+        entity_id="./",
+        entity_type=None,
+        property="http://schema.org/citation",
+        message="The Root Data Entity SHOULD reference a citation.",
+        suggestion="A publication DOI or title.",
+        fix_hint="ask-user",
+        auto_fixable=False,
+    )
+
+
+class TestRootCitationGapPersistsAndIsNotReAsked:
+    def _record_run_tool(self, engine, monkeypatch):
+        """Record ``engine.run_tool`` calls and stub the publication composites.
+
+        The composites make network calls (Crossref / ORCID), so they are stubbed
+        to a deterministic success; every call is recorded so the test can assert
+        the citation answer was routed to them.
+        """
+        calls: list[tuple[str, dict]] = []
+        real_run_tool = engine.run_tool
+
+        def _spy(tool_name, **kwargs):
+            calls.append((tool_name, dict(kwargs)))
+            if tool_name == "draft_publication_with_authors":
+                return {"publication_id": "pub1", "doi": kwargs.get("doi"), "authors": []}
+            if tool_name == "resolve_publication":
+                return {"ok": True, "doi": "10.1/x", "entity_id": "pub1"}
+            return real_run_tool(tool_name, **kwargs)
+
+        monkeypatch.setattr(engine, "run_tool", _spy)
+        return calls
+
+    def test_doi_answer_routes_to_draft_publication_with_authors(self, monkeypatch):
+        """A DOI answer for the root citation gap calls
+        ``draft_publication_with_authors`` (the answer is persisted, not dropped)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        calls = self._record_run_tool(engine, monkeypatch)
+
+        _single_ask_gap_report(
+            monkeypatch,
+            _root_citation_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        human = ScriptedHuman(input_answers=[_value("10.1016/j.tox.2021.152898")])
+        summary = run_guidance(engine, human, max_rounds=5)
+
+        pub_calls = [c for c in calls if c[0] == "draft_publication_with_authors"]
+        assert pub_calls, (
+            "a DOI answer to the root citation gap must call "
+            "draft_publication_with_authors (#179)"
+        )
+        assert pub_calls[0][1].get("doi") == "10.1016/j.tox.2021.152898"
+        # The gap was recorded as resolved (the answer landed, not silently dropped).
+        assert any(
+            "citation" in (r.get("property") or "") for r in summary["resolved"]
+        ), "the citation answer must be recorded as resolved, never dropped"
+
+    def test_title_answer_routes_to_resolve_publication(self, monkeypatch):
+        """A non-DOI (title) answer routes to ``resolve_publication``."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        calls = self._record_run_tool(engine, monkeypatch)
+
+        _single_ask_gap_report(
+            monkeypatch,
+            _root_citation_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        title = "Adverse outcome pathway-based assessment of TPO inhibition in vitro"
+        human = ScriptedHuman(input_answers=[_value(title)])
+        run_guidance(engine, human, max_rounds=5)
+
+        resolve_calls = [c for c in calls if c[0] == "resolve_publication"]
+        assert resolve_calls, (
+            "a title answer to the root citation gap must call resolve_publication (#179)"
+        )
+        assert resolve_calls[0][1].get("title") == title
+        assert not any(c[0] == "draft_publication_with_authors" for c in calls)
+
+    def test_citation_gap_is_asked_at_most_once_across_the_run(self, monkeypatch):
+        """The headline regression: the always-highest-priority root citation MUST
+        gap must be asked AT MOST ONCE even when other gaps keep committing and
+        re-assessment keeps re-emitting it (the per-RUN skip-set, #179)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+
+        # The citation gap stays UN-progressable from the loop's POV: the stubbed
+        # DOI lookup finds no confident match (the common live case — a title /
+        # unresolvable DOI), so ``_apply_citation_value`` returns False and the
+        # same citation gap re-emits every re-assess. A SECOND, progress-making gap
+        # commits each round, which CLEARS the per-report index skip-set — so
+        # without a per-RUN identity skip-set the citation gap would be re-drawn
+        # and re-asked every round.
+        calls: list[tuple[str, dict]] = []
+        real_run_tool = engine.run_tool
+
+        def _spy(tool_name, **kwargs):
+            calls.append((tool_name, dict(kwargs)))
+            if tool_name == "draft_publication_with_authors":
+                return {"ok": False, "error": "DOI did not resolve"}
+            if tool_name == "resolve_publication":
+                return {"ok": False, "reason": "no confident DOI match"}
+            return real_run_tool(tool_name, **kwargs)
+
+        monkeypatch.setattr(engine, "run_tool", _spy)
+
+        citation_gap = _root_citation_gap()
+        # A distinct committable gap on the Study, re-emitted with a FRESH value
+        # each round so committing it always makes progress (re-assess returns a
+        # report that still contains the citation gap).
+        round_n = {"i": 0}
+
+        def _assess(_state):
+            round_n["i"] += 1
+            i = round_n["i"]
+            if i > 6:
+                # Eventually the Study desc is satisfied; only the citation remains
+                # and it is now in the per-RUN skip-set -> the loop terminates.
+                return GapReport(
+                    gaps=[citation_gap],
+                    counts={"must_open": 1, "should_open": 0, "may_open": 0},
+                )
+            study_gap = Gap(
+                tier="MUST",
+                source="shacl",
+                entity_id="st1",
+                entity_type="Study",
+                property=f"https://schema.org/keywords#round{i}",
+                message="Study needs another keyword.",
+                suggestion="A keyword.",
+                fix_hint="ask-user",
+                auto_fixable=False,
+            )
+            return GapReport(
+                gaps=[citation_gap, study_gap],
+                counts={"must_open": 2, "should_open": 0, "may_open": 0},
+            )
+
+        monkeypatch.setattr(guidance, "assess_gaps", _assess)
+
+        # Always-available answers: a DOI for the citation, a keyword for the Study.
+        human = ScriptedHuman(
+            input_answers=[_value("10.1/citation")] + [_value("kw") for _ in range(20)]
+        )
+        run_guidance(engine, human, max_rounds=15)
+
+        # Count how many times the CITATION question was put to the user.
+        citation_prompts = [
+            p for (p, _ftype) in human.inputs if "citation" in p.lower()
+        ]
+        assert len(citation_prompts) <= 1, (
+            f"the root citation gap must be asked at most once, got "
+            f"{len(citation_prompts)} prompts: {citation_prompts}"
+        )

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -1238,6 +1238,112 @@ class TestQuestionNamesEntity:
 
 
 # ---------------------------------------------------------------------------
+# (Commit 2, #179) MIT gaps (entity_id=None) are GROUNDED in the real instance.
+#
+# MIT gaps are emitted crate-level with ``entity_id=None``, carrying only
+# ``entity_type`` (e.g. "CellLineSample"). ``_resolve_entity_id`` short-circuits
+# to None for any falsy entity_id, so the OLD ``_gap_context`` left the phrase
+# leaf with a bare TYPE and NO name -> the model invented "HepG2" (the stock
+# example). FIX: when ``_resolve_entity_id`` is None but ``entity_type`` is set,
+# look the instance(s) up via ``engine.state.list_entities(entity_type)`` and
+# thread the real display name into ``entity_name`` / ``known_fields``.
+# ---------------------------------------------------------------------------
+
+
+def _backbone_with_cell_line(name: str = "CHO-K1 OATP1C1") -> CrateState:
+    """Backbone + a single CellLineSample with a known instance name."""
+    state = _backbone()
+    state.add_entity(_entity("cl1", "CellLineSample", name=name))
+    return state
+
+
+def _mit_cell_line_gap() -> Gap:
+    """An MIT-style gap: crate-level (entity_id=None), carrying only the TYPE."""
+    return Gap(
+        tier="SHOULD",
+        source="mit",
+        entity_id=None,
+        entity_type="CellLineSample",
+        property="passage",
+        message="Record the cell line passage number.",
+        suggestion="The passage number at the time of the assay.",
+        fix_hint="ask-user",
+        auto_fixable=False,
+    )
+
+
+class TestMITGapGroundedInInstanceName:
+    def test_gap_context_grounds_entityless_mit_gap_in_the_instance(self):
+        """``_gap_context`` for an entity_id=None MIT gap resolves the single
+        in-state instance and threads its NAME in (#179, Commit 2)."""
+        from builder.agents.guidance import _gap_context
+
+        engine = AgentEngine(state=_backbone_with_cell_line("CHO-K1 OATP1C1"))
+        ctx = _gap_context(engine, _mit_cell_line_gap())
+
+        assert ctx.get("entity_name") == "CHO-K1 OATP1C1", (
+            "an entity_id=None MIT gap must be grounded in the real instance name"
+        )
+        known = ctx.get("known_fields") or {}
+        assert known.get("name") == "CHO-K1 OATP1C1"
+        assert ctx.get("entity_type") == "CellLineSample"
+
+    def test_phrased_question_names_the_real_cell_line_never_hepg2(self, monkeypatch):
+        """End-to-end: a phrased question for the MIT gap names the REAL cell line
+        ("CHO-K1") and never the fabricated stock example "HepG2" (#179)."""
+        from builder.agents import guidance
+        from builder.agents.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone_with_cell_line("CHO-K1 OATP1C1"))
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+        _single_ask_gap_report(
+            monkeypatch,
+            _mit_cell_line_gap(),
+            counts={"must_open": 0, "should_open": 1, "may_open": 0},
+        )
+
+        # A realistic phrase leaf: it grounds on the name it is handed, else it
+        # would invent the stock "HepG2" example (the bug).
+        def _phrase(ctx):
+            name = ctx.get("entity_name") or "HepG2"
+            return f"What passage number was {name} at during the assay?"
+
+        monkeypatch.setattr(guidance, "phrase_gap_question", _phrase)
+        monkeypatch.setattr(
+            guidance, "interpret_gap_reply", lambda _q, _r, _c: {"action": "skip"}
+        )
+
+        human = ScriptedHuman(input_answers=[_value("dunno")])
+        run_guidance(engine, human, max_rounds=5)
+
+        assert human.inputs, "the user must be prompted"
+        prompt = human.inputs[0][0]
+        assert "CHO-K1" in prompt
+        assert "hepg2" not in prompt.lower()
+
+    def test_multiple_instances_surface_their_names_not_a_bare_type(self):
+        """When several instances of the type exist, the gap context must surface
+        their names (disambiguation) rather than a bare nameless type (#179)."""
+        from builder.agents.guidance import _gap_context
+
+        state = _backbone()
+        state.add_entity(_entity("cl1", "CellLineSample", name="CHO-K1 OATP1C1"))
+        state.add_entity(_entity("cl2", "CellLineSample", name="HepaRG"))
+        engine = AgentEngine(state=state)
+
+        ctx = _gap_context(engine, _mit_cell_line_gap())
+
+        # The leaf must never receive a bare type with no name: the candidate
+        # instance names are surfaced somewhere in the grounding context.
+        blob = " ".join(
+            str(v) for v in (ctx.get("known_fields") or {}).values()
+        ) + " " + str(ctx.get("entity_name") or "")
+        assert "CHO-K1 OATP1C1" in blob and "HepaRG" in blob, (
+            "multiple instances must surface their names for disambiguation (#179)"
+        )
+
+
+# ---------------------------------------------------------------------------
 # (Issue #257, fix C) 'from_file' READS the file and EXTRACTS + COMMITS the value
 #
 # When the interpret leaf returns ``from_file`` and the named/likely file is


### PR DESCRIPTION
Two confirmed guidance-loop bugs in `builder/agents/guidance.py` (+ `leaves.py` for fix 2), root-caused by a read-only diagnosis. One branch, two clearly-separated TDD commits.

## Commit 1 — persist root-level citation answers + stop the infinite re-ask

**Root cause.** The Root Data Entity `./` citation requirement surfaces as a SHACL MUST gap with `entity_id == "./"` and `property == "http://schema.org/citation"`. In `_apply_value`: `_is_person_field("citation")` is False; `_resolve_entity_id` returns `None` (no `./` state entity; `repair._resolve_state_entity` strips `"./"` → `""`); the crate-level branch never fired (`citation` is not in `_CRATE_METADATA_FIELDS`, and the guard required `entity_id is None`, not the string `"./"`). So the answer was silently dropped (returned False). And the per-report skip-set is a `set[int]` reset on every commit, so the always-highest-priority citation MUST gap was re-drawn and re-asked after ANY other gap committed → asked 6+ times, never landed.

**Fix (confined to `guidance.py`):**
- (A) `_apply_value` detects the root citation gap and routes the answer to the publication composites — `draft_publication_with_authors(doi=…)` for a DOI/URL, else `resolve_publication(title=…)` — via `engine.run_tool` (never hand-rolled JSON-LD). The builder auto-wires the resulting `ScholarlyArticle` onto `root_dataset.citation`. Mirrors `_apply_person_value`.
- (B) A **per-RUN skip-set keyed by gap IDENTITY** (`(source, entity_id, property, message)`), populated when a gap was surfaced/answered but could not progress, and consulted in `_next_actionable_index` so an un-appliable / already-answered gap is not re-drawn even after a later commit clears the per-report index set.

TDD: 3 failing tests first (DOI routing, title routing, citation asked ≤1× across a run), then the fix.

## Commit 2 — ground MIT (entity_id=None) gaps in the real instance name; forbid name fabrication

**Root cause.** MIT gaps are emitted crate-level with `entity_id=None`, carrying only `entity_type` (e.g. `CellLineSample`). `_resolve_entity_id` short-circuits to None for any falsy `entity_id`, so `_gap_context` left the PHRASE leaf with a bare TYPE and no name; `_PHRASE_SYSTEM_PROMPT` only forbade vague phrasing "when an entity name is given" — with none given, the model invented "HepG2" (the stock example), which also produced the spurious "what is the correct UTF-8 file name (replace %2B with +)" question (no such gap rule — hallucinated phrasing).

**Fix (`guidance.py` + `leaves.py`):**
- `_gap_context`: when `_resolve_entity_id` is None but `entity_type` is set, look up instances via `engine.state.list_entities(entity_type)` and thread the REAL name into `entity_name` / `known_fields` (one instance), or surface the names for disambiguation (several). The leaf is never handed a bare type with no name.
- `_PHRASE_SYSTEM_PROMPT`: with no entity name, ask generically about "the &lt;entity type&gt;" and explicitly forbid inventing a specific name/identifier/example value (D5).

TDD: failing tests first (guidance grounds the entity-less `CellLineSample` gap in "CHO-K1 OATP1C1"; the phrased question names "CHO-K1" never "HepG2"; multi-instance disambiguation; the leaves phrase prompt forbids fabrication), then the fix.

## Gate
- `uv run ruff check` clean; `uv run --extra langchain ty check` clean (no new diagnostics).
- `tests/agents/test_leaves.py`: 50 passed. `tests/test_agents_guidance.py`: 41 passed (35 existing + 6 new).
- Branch rebased on current `origin/main`; two-dot and three-dot `git diff --stat` are identical (only my 5 files; no phantom deletions).

## Lane boundaries
Touched ONLY `builder/agents/guidance.py`, `builder/agents/leaves.py`, their test files, and the §14.6 region of `AGENTS.md`. No edits to `gap_analysis.py`, `repair.py`, `pipeline.py`, `composites.py`, `build.py`, or `main.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)