### PR TITLE
fix(pipeline): metadata-first context for the extract leaf (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1537,6 +1537,19 @@ INPUT (dir / zip / conversation)
   default names; now document titles/abstracts/SOP headings reach the leaf. The
   empty-context path is still a strict no-op (`""` ⇒ no provider call), preserving
   the no-provider determinism guarantee.
+  - **Metadata-first, fair per-file budget (#179, real S-VHPS26 run).** The first
+    `_gather_context` (#231) used ONE shared `_MAX_CONTEXT_CHARS` pool and a
+    `min(remaining, _MAX_CONTEXT_CHARS)` per-file cap, with files in plain scan
+    order — so the FIRST file read could consume the whole budget and the richest
+    structured metadata (a BioStudies `<acc>.json` export, an assay-metadata
+    `.xlsx`, a SOP `.docx`/README), read later, got only its filename. The fix:
+    (a) the inventory is sorted **metadata-first** by `_metadata_read_priority`
+    (`*metadata*` → structured `*.json` → README/SOP/`.docx` docs → bulk data;
+    stable within ties) so high-signal files lead both the reads and the emitted
+    digest; (b) each file gets at most a FAIR per-file slice
+    (`_per_file_cap = max(_MIN_PER_FILE_CHARS, _MAX_CONTEXT_CHARS // n)`) so an
+    early large file can no longer starve the rest. The total budget is still the
+    binding ceiling.
 - **Fix loop = deterministic.** `build_and_validate` already returns issues pre-routed to
   `{entity_id, property, fix, severity, profile}`; a code loop dispatches each to a
   lookup / `set_fields` / `link`, calling the LLM only for "draft new content" repairs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1549,7 +1549,12 @@ INPUT (dir / zip / conversation)
     digest; (b) each file gets at most a FAIR per-file slice
     (`_per_file_cap = max(_MIN_PER_FILE_CHARS, _MAX_CONTEXT_CHARS // n)`) so an
     early large file can no longer starve the rest. The total budget is still the
-    binding ceiling.
+    binding ceiling. Complementarily, the scanner now populates `first_rows` for
+    genuinely tabular office formats (`.xlsx`/`.xls`) via the proper Excel reader
+    (`scanner._excel_preview` → `file_readers.read_excel`) instead of the raw-bytes
+    sampler the NUL-byte binary guard (Issue #51) correctly rejects — so a real
+    `.xlsx` takes the cheap-preview path rather than the budget-consuming body read.
+    The binary guard for truly binary files is unchanged.
 - **Fix loop = deterministic.** `build_and_validate` already returns issues pre-routed to
   `{entity_id, property, fix, severity, profile}`; a code loop dispatches each to a
   lookup / `set_fields` / `link`, calling the LLM only for "draft new content" repairs.

--- a/builder/agents/pipeline.py
+++ b/builder/agents/pipeline.py
@@ -270,12 +270,23 @@ _DEFAULT_ASSAY_NAME = "Assay"
 # file BODIES (`.json` / `.docx` / `.pdf` …) — not just filenames — so it must
 # cap how much disk content reaches the leaf so the one bounded call stays
 # affordable. The cap is applied BOTH per-file (each body excerpt is truncated to
-# `_MAX_CONTEXT_CHARS`) AND to the total accumulated body content (the running sum
-# of body excerpts never exceeds `_MAX_CONTEXT_CHARS`), so a folder of many large
-# files cannot blow the budget. ~8k chars is roughly a couple thousand tokens —
-# enough for a study title / abstract / SOP heading to survive, small enough to
-# stay cheap.
+# a FAIR per-file slice, see `_per_file_cap`) AND to the total accumulated body
+# content (the running sum of body excerpts never exceeds `_MAX_CONTEXT_CHARS`),
+# so a folder of many large files cannot blow the budget and no single early file
+# can starve the rest. ~8k chars is roughly a couple thousand tokens — enough for
+# a study title / abstract / SOP heading to survive, small enough to stay cheap.
 _MAX_CONTEXT_CHARS = 8000
+
+# Fair per-file floor for the body excerpt (Issue #179 / real S-VHPS26 run). The
+# pre-fix bug: one shared 8000-char pool + a `min(remaining, _MAX_CONTEXT_CHARS)`
+# per-file cap let the FIRST scanned file consume the WHOLE budget, so the richest
+# structured metadata (a BioStudies `<acc>.json`, an assay-metadata `.xlsx`, a SOP
+# `.docx`) — read later — got only its filename. We now read across files fairly:
+# each file gets at most `max(_MIN_PER_FILE_CHARS, _MAX_CONTEXT_CHARS // n)` chars
+# (`n` = files to read), so an early large file cannot zero the budget while still
+# leaving generous headroom when there are few files. A small floor guarantees
+# even a long inventory yields a usable slice per file.
+_MIN_PER_FILE_CHARS = 1500
 
 
 def _backbone_hints(engine: AgentEngine) -> dict[str, dict[str, str]]:
@@ -311,6 +322,47 @@ def _scaffold_backbone(engine: AgentEngine) -> dict[str, Any]:
     """
     hints = _backbone_hints(engine)
     return engine.run_tool("scaffold_isa_backbone", **hints)
+
+
+def _metadata_read_priority(filename: str) -> int:
+    """Read-ordering rank for *filename* — lower sorts FIRST (Issue #179).
+
+    The real S-VHPS26 run showed a large early *bulk-data* file starved the body
+    budget so the structured metadata files read later got only their filename.
+    Rank metadata-bearing files ahead of bulk data so they reach the leaf even
+    under a tight budget. Ties keep the caller's original (stable) scan order.
+
+    Ranks (case-insensitive on the basename):
+
+    * ``0`` — an explicit ``*metadata*`` file (highest signal);
+    * ``1`` — a BioStudies-style accession export / structured ``*.json``;
+    * ``2`` — a README / SOP / protocol document or any ``.docx``/``.md``/``.txt``;
+    * ``3`` — everything else (bulk data: ``.xlsx``/``.csv``/binary/…).
+    """
+    name = filename.lower()
+    if "metadata" in name:
+        return 0
+    if name.endswith(".json"):
+        return 1
+    doc_suffixes = (".docx", ".md", ".txt", ".rtf", ".odt")
+    doc_stems = ("readme", "sop", "protocol")
+    if name.endswith(doc_suffixes) or any(stem in name for stem in doc_stems):
+        return 2
+    return 3
+
+
+def _per_file_cap(n_files_to_read: int) -> int:
+    """Fair per-file body-excerpt cap given *n_files_to_read* files (Issue #179).
+
+    Each file gets at most an equal share of the total budget, with a floor so a
+    long inventory still yields a usable slice per file. This is the per-file
+    half of the fix — combined with the metadata-first ordering it guarantees the
+    high-signal metadata files get a fair slice instead of one early file eating
+    the whole 8000-char pool.
+    """
+    if n_files_to_read <= 0:
+        return _MAX_CONTEXT_CHARS
+    return max(_MIN_PER_FILE_CHARS, _MAX_CONTEXT_CHARS // n_files_to_read)
 
 
 def _read_body_excerpt(path: str, approved_roots: set[str], remaining: int) -> str | None:
@@ -370,17 +422,27 @@ def _gather_context(engine: AgentEngine) -> str:
     description (``state.metadata``) and the scanned-file inventory
     (``state.scanned_files``). For each scanned file it prefers the cheap tabular
     ``first_rows`` preview the scanner already captured; for non-tabular rich files
-    that lack a preview (``.json`` / ``.docx`` / ``.pdf`` …) it now reads a
+    that lack a preview (``.json`` / ``.docx`` / ``.pdf`` …) it reads a
     **bounded body excerpt** from disk via :func:`_read_body_excerpt` so document
     BODIES — study titles, abstracts, SOP headings — reach the single bounded leaf
     rather than filenames alone. Without this the leaf saw only filenames + tiny
     previews and ``extract_plan`` returned an empty plan, so the backbone fell back
     to the literal default names (#231).
 
+    **Metadata-first, fair per-file budget (Issue #179 / real S-VHPS26 run).** The
+    files whose bodies must be read are sorted by :func:`_metadata_read_priority`
+    so the structured METADATA files (``*metadata*``, BioStudies ``*.json``,
+    README/SOP/``.docx`` docs) are read BEFORE bulk data files, with the original
+    scan order preserved within each tier. Each file gets at most a FAIR slice
+    (:func:`_per_file_cap`) of the total :data:`_MAX_CONTEXT_CHARS` budget, so a
+    single large early file can no longer eat the whole pool and starve the rest
+    (the pre-fix bug). The running total is still capped at
+    :data:`_MAX_CONTEXT_CHARS`.
+
     Body reads are **fail-closed to ``state.approved_scan_roots``** and never raise
-    out of the spine (see :func:`_read_body_excerpt`). Output is bounded by
-    :data:`_MAX_CONTEXT_CHARS` per file AND in total, so the one bounded leaf call
-    stays token-safe regardless of how many large files were scanned.
+    out of the spine (see :func:`_read_body_excerpt`). Output is bounded both per
+    file AND in total, so the one bounded leaf call stays token-safe regardless of
+    how many large files were scanned.
 
     Returns ``""`` when nothing usable is available, which the caller treats as a
     strict no-op (no provider call is made) — preserving the no-context strict-noop
@@ -398,9 +460,24 @@ def _gather_context(engine: AgentEngine) -> str:
 
     if state.scanned_files:
         approved_roots = state.approved_scan_roots
-        file_lines: list[str] = []
+
+        # Order the WHOLE inventory metadata-first (stable within ties) so the
+        # highest-signal files lead both the disk reads and the emitted digest —
+        # the pre-fix bug let a large early bulk-data file eat the body budget and
+        # the structured metadata that followed got only its filename (#179).
+        ordered = sorted(
+            state.scanned_files, key=lambda f: _metadata_read_priority(f.filename)
+        )
+
+        # Files that need a disk body read = those without a cheap tabular preview.
+        # Each gets at most a FAIR per-file slice of the budget so an early large
+        # file cannot starve the later metadata.
+        n_to_read = sum(1 for f in ordered if not f.first_rows)
+        per_file_cap = _per_file_cap(n_to_read)
+
         body_budget = _MAX_CONTEXT_CHARS  # total body content across all files
-        for f in state.scanned_files:
+        file_lines: list[str] = []
+        for f in ordered:
             line = f"- {f.filename}"
             if f.first_rows:
                 # Prefer the cheap preview the scanner already captured — no disk read.
@@ -409,8 +486,10 @@ def _gather_context(engine: AgentEngine) -> str:
                     line += f": {preview}"
             elif body_budget > 0:
                 # No tabular preview: read a bounded body excerpt (fail-closed to
-                # approved roots; never raises) so the leaf sees the document body.
-                excerpt = _read_body_excerpt(f.path, approved_roots, body_budget)
+                # approved roots; never raises) under the fair per-file cap AND the
+                # running total budget, so the leaf sees the document body.
+                remaining = min(per_file_cap, body_budget)
+                excerpt = _read_body_excerpt(f.path, approved_roots, remaining)
                 if excerpt:
                     body_budget -= len(excerpt)
                     line += f":\n{excerpt}"

--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -322,6 +322,38 @@ _TABULAR_MIME_TYPES = {
 
 _TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls"}
 
+# How many tabular rows to capture for the scanner's cheap `first_rows` preview of
+# an Excel workbook — enough to show the header + a few data rows, without reading
+# the whole sheet (Issue #179, Commit 2).
+_EXCEL_PREVIEW_ROWS = 20
+
+
+def _excel_preview(path: str) -> str | None:
+    """Capture a bounded tabular preview of an Excel workbook for ``first_rows``.
+
+    Routes through the proper Excel reader (:func:`builder.tools.file_readers.read_excel`,
+    the same path :func:`read_file` uses) rather than the raw-bytes
+    :func:`read_file_sample` sampler, whose NUL-byte binary guard correctly rejects
+    the zip/OLE2 container and so left ``first_rows`` unset for every ``.xlsx``
+    (Issue #179, Commit 2). Bounded to :data:`_EXCEL_PREVIEW_ROWS` rows so the
+    preview stays cheap. Never raises: any reader/dependency error yields ``None``
+    (the caller then simply leaves ``first_rows`` unset, exactly as before).
+
+    Returns the pipe-delimited preview text, or ``None`` when nothing readable was
+    produced.
+    """
+    # Lazy import: keep the scanner importable without the optional Excel deps.
+    from builder.tools.file_readers import read_excel
+
+    try:
+        return read_excel(path, max_rows=_EXCEL_PREVIEW_ROWS)
+    except (OSError, ValueError, ImportError) as exc:
+        logger.warning("Excel preview failed for %s; leaving first_rows unset: %s", path, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 - a malformed workbook must not break the scan
+        logger.warning("Unexpected Excel-preview error for %s; skipping: %s", path, exc)
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Archive helpers
@@ -606,17 +638,23 @@ def scan_files(
         is_tabular = mime in _TABULAR_MIME_TYPES or entry.suffix.lower() in _TABULAR_SUFFIXES
         first_rows: list[str] | None = None
         if is_tabular:
-            # For binary office formats (xlsx/xls) the extension says "tabular" but
-            # the content is a zip/OLE2 container — do NOT pass already_text=True
-            # because that bypasses the NUL-byte binary guard and the raw PK\x03\x04…
-            # bytes would be read as mojibake (Issue #51 regression).
-            _is_binary_ext = entry.suffix.lower() in {".xlsx", ".xls"}
-            sample = read_file_sample(
-                str(entry),
-                lines=20,
-                precomputed_size=file_size,
-                already_text=not _is_binary_ext,
-            )
+            # Office formats (xlsx/xls) are genuinely tabular but binary (a
+            # zip/OLE2 container): the raw-bytes sampler's NUL-byte binary guard
+            # (Issue #51) rejects them, so `read_file_sample(already_text=False)`
+            # returned None and left `first_rows` unset — which forced every .xlsx
+            # down the budget-consuming body-read path in the pipeline's
+            # `_gather_context` (Issue #179, Commit 2). Read them through the proper
+            # Excel reader (the same `read_excel` path `read_file` uses) so the
+            # cheap preview is captured; CSV/TSV stay on the fast text sampler.
+            if entry.suffix.lower() in {".xlsx", ".xls"}:
+                sample = _excel_preview(str(entry))
+            else:
+                sample = read_file_sample(
+                    str(entry),
+                    lines=20,
+                    precomputed_size=file_size,
+                    already_text=True,
+                )
             if sample is not None:
                 lines = sample.splitlines()
                 if max_line_length > 0:

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -302,6 +302,137 @@ class TestDraftEntitiesWiring:
         assert result.get("fields_applied") == 0
 
 
+class TestGatherContextMetadataFirst:
+    """`_gather_context` must feed the structured METADATA files to the leaf, not
+    only filenames + the paper (Issue #179 / real S-VHPS26 run).
+
+    Root cause (pre-fix): the 8000-char body budget is ONE shared pool and the
+    per-file cap is ``min(remaining, _MAX_CONTEXT_CHARS)``, so the FIRST file read
+    can consume the whole budget. Files are processed in plain scan order with no
+    metadata prioritization, so a large early bulk-data file zeroes the budget and
+    the richest structured metadata — a BioStudies ``<acc>.json`` export, an
+    assay-metadata ``.xlsx``, a SOP ``.docx`` — never reaches ``extract_plan``.
+
+    The fix: (a) order metadata-bearing files FIRST, and (b) cap each file fairly
+    so no single early file starves the rest.
+    """
+
+    _JSON_SENTINEL = "BIOSTUDIES_ACCESSION_SENTINEL_S_VHPS26"
+    _META_XLSX_SENTINEL = "ASSAY_METADATA_SHEET_SENTINEL"
+    _DATA_SENTINEL = "BULK_DATA_FILE_BODY_SENTINEL"
+
+    def _state_with_files(self, root: Path) -> CrateState:
+        """A scanned-file inventory that reproduces the S-VHPS26 ordering trap.
+
+        A LARGE bulk-data ``.xlsx`` is listed FIRST (its stubbed body alone exceeds
+        the whole 8000-char budget), followed by the metadata-bearing files whose
+        bodies carry unique sentinels. All paths are inside *root* (an approved
+        scan root) so the fail-closed containment guard admits them.
+        """
+        from builder.agents.pipeline import _MAX_CONTEXT_CHARS
+
+        state = CrateState()
+        state.metadata.title = "S-VHPS26 metadata-first context"
+        state.approved_scan_roots = {str(root)}
+
+        names = [
+            "aaa_big_data.xlsx",  # bulk data, sorts FIRST alphabetically
+            "S-VHPS26.json",  # BioStudies accession export (metadata)
+            "assay_metadata.xlsx",  # assay-metadata sheet (metadata)
+            "protocol_SOP.docx",  # SOP doc
+            "zzz_more_data.xlsx",  # more bulk data, sorts LAST
+        ]
+        # Bodies: the FIRST file's body alone overflows the total budget; the
+        # metadata files carry unique sentinel tokens near their start.
+        self._bodies = {
+            "aaa_big_data.xlsx": (self._DATA_SENTINEL + " ") * (_MAX_CONTEXT_CHARS * 2),
+            "S-VHPS26.json": self._JSON_SENTINEL + ' {"accession": "S-VHPS26"}',
+            "assay_metadata.xlsx": self._META_XLSX_SENTINEL + " | cell line | dose",
+            "protocol_SOP.docx": "Standard operating procedure heading.",
+            "zzz_more_data.xlsx": (self._DATA_SENTINEL + " ") * (_MAX_CONTEXT_CHARS * 2),
+        }
+        for name in names:
+            p = root / name
+            p.write_text("placeholder")  # real file so _contain resolves it
+            state.scanned_files.append(
+                FileClassification(
+                    path=str(p),
+                    filename=name,
+                    size=len(self._bodies[name]),
+                    mime_type="application/octet-stream",
+                    first_rows=None,  # forces the body-read path for every file
+                )
+            )
+        return state
+
+    def _stub_reader(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub the body reader to return the sized bodies keyed by filename."""
+        import builder.tools.file_readers as fr_mod
+
+        def fake_read_file(path, *args, **kwargs):
+            return self._bodies.get(Path(path).name)
+
+        monkeypatch.setattr(fr_mod, "read_file", fake_read_file)
+
+    def test_biostudies_json_sentinel_reaches_context(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The BioStudies ``<acc>.json`` body MUST reach the gathered context even
+        though a much larger bulk-data file is scanned first.
+
+        Pre-fix this FAILS: the first file (``aaa_big_data.xlsx``) exhausts the
+        whole 8000-char budget, so the JSON sentinel never appears.
+        """
+        import builder.agents.pipeline as pipeline_mod
+
+        self._stub_reader(monkeypatch)
+        engine = _engine(self._state_with_files(tmp_path))
+
+        context = pipeline_mod._gather_context(engine)
+
+        assert self._JSON_SENTINEL in context, (
+            "the BioStudies .json metadata body must reach the leaf context"
+        )
+
+    def test_metadata_body_precedes_bulk_data_body(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A metadata-named file's body must appear BEFORE a bulk data file's body."""
+        import builder.agents.pipeline as pipeline_mod
+
+        self._stub_reader(monkeypatch)
+        engine = _engine(self._state_with_files(tmp_path))
+
+        context = pipeline_mod._gather_context(engine)
+
+        # The metadata .xlsx sentinel must appear, and before any bulk-data body.
+        meta_idx = context.find(self._META_XLSX_SENTINEL)
+        data_idx = context.find(self._DATA_SENTINEL)
+        assert meta_idx != -1, "the assay-metadata file body must reach the context"
+        if data_idx != -1:
+            assert meta_idx < data_idx, (
+                "metadata-named file body must precede a bulk data file body"
+            )
+
+    def test_total_budget_ceiling_is_respected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The overall 8000-char body budget stays the ceiling — no single file
+        (and not the fair per-file slices summed) blows it."""
+        import builder.agents.pipeline as pipeline_mod
+        from builder.agents.pipeline import _MAX_CONTEXT_CHARS
+
+        self._stub_reader(monkeypatch)
+        engine = _engine(self._state_with_files(tmp_path))
+
+        context = pipeline_mod._gather_context(engine)
+
+        # Total body content (sentinels are a proxy: the two huge data files alone
+        # would each exceed the budget if uncapped) stays bounded. Allow headroom
+        # for the non-body scaffolding (title line, filename headers).
+        assert len(context) <= _MAX_CONTEXT_CHARS + 2000
+
+
 class TestMaterializePlan:
     """Stage B (`_materialize_plan`) turns the extracted candidate plan into real
     domain entities via the deterministic composites (Issue #179 task 2b-B).

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -110,6 +110,34 @@ class TestScanFiles:
         assert fc.first_rows is not None
         assert fc.first_rows[0] == "col1\tcol2"
 
+    def test_xlsx_file_has_first_rows_populated(self, tmp_path):
+        """scan_files populates first_rows for .xlsx files (Issue #179, Commit 2).
+
+        Pre-fix this FAILS: ``.xlsx`` is a zip/OLE2 container, so the scanner's
+        ``read_file_sample(already_text=False)`` path hits the NUL-byte binary
+        guard and returns ``None``, leaving ``first_rows`` unset — which forces
+        every .xlsx down the budget-consuming body-read path in ``_gather_context``.
+        The fix routes genuinely tabular office formats through the proper Excel
+        reader so the cheap preview is captured.
+        """
+        import openpyxl
+
+        xlsx_file = tmp_path / "assay.xlsx"
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["compound", "dose", "viability"])
+        ws.append(["Methimazole", "10uM", "0.42"])
+        wb.save(xlsx_file)
+
+        result = _scan(str(tmp_path))
+
+        fc = next(f for f in result if f.filename == "assay.xlsx")
+        assert fc.first_rows is not None, ".xlsx first_rows must be populated"
+        # The Excel reader's pipe-delimited content carries the header cells.
+        joined = "\n".join(fc.first_rows)
+        assert "compound" in joined
+        assert "viability" in joined
+
     def test_nonexistent_directory_returns_empty_list(self, tmp_path):
         """scan_files on a non-existent directory should return [] gracefully."""
         nonexistent = tmp_path / "does_not_exist"


### PR DESCRIPTION
## Problem (real S-VHPS26 run)

The deterministic pipeline never fed the structured METADATA files to the plan
extractor, so it built the backbone from filenames + the paper only.

Root cause is budget starvation in `builder/agents/pipeline.py::_gather_context`:
`body_budget` is ONE shared 8000-char pool across all scanned files, the per-file
cap is `min(remaining, _MAX_CONTEXT_CHARS)`, and files are read in plain scan
order. A large early bulk-data file consumes the whole budget, so the richest
structured metadata — a BioStudies `S-VHPS26.json`, an assay-metadata `.xlsx`, a
SOP `.docx`/README, all read later — reached `extract_plan` as filenames only.

## Commit 1 — metadata-first ordering + fair per-file cap (`_gather_context`)

- Order the inventory **metadata-first** (`_metadata_read_priority`): `*metadata*`
  → structured `*.json` → README/SOP/`.docx` docs → bulk data, stable within ties,
  so high-signal files lead both the disk reads and the emitted digest.
- Give each file a **fair per-file slice** (`_per_file_cap`) of the total budget,
  so an early large file can no longer starve the rest. The total budget stays the
  binding ceiling; reads remain fail-closed to `approved_scan_roots`.

TDD: `TestGatherContextMetadataFirst` reproduces the ordering trap (large first
file whose body alone exceeds the budget + a BioStudies `.json` with a unique
sentinel) and asserts the sentinel reaches the context, a metadata body precedes
a bulk-data body, and the total budget is respected. Confirmed failing first.

## Commit 2 — populate tabular `first_rows` for `.xlsx` (scanner)

`first_rows` was null for every `.xlsx`: the scanner read office formats via
`read_file_sample(already_text=False)`, whose NUL-byte binary guard (#51)
correctly rejects the zip/OLE2 container and returns None, so `first_rows` stayed
unset and every `.xlsx` fell into the budget-consuming body-read path. Fix routes
`.xlsx`/`.xls` through the proper Excel reader (`_excel_preview` →
`file_readers.read_excel`); CSV/TSV stay on the text sampler; the #51 binary guard
for truly binary files is untouched (its mojibake regression test still passes).

## Gate

- New tests + existing pipeline (80) and scanner (82) suites pass.
- `ruff check` clean; `ty check` zero diagnostics on changed modules.
- Confined to the lane: `pipeline.py`, `scanner.py`, the two test files, and the
  AGENTS.md §14.2 doc sync. Two-dot == three-dot diffstat (no phantom deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)