### PR TITLE
fix(composites): dedup MolecularEntity by identity + wire ORCID author affiliation to Organization (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -637,9 +637,17 @@ composite never hand-rolls that wiring; (3) `verify_identifier` confirms each
 minted identifier against source. **D5:** `verify_identifier` *clears* any value
 that does not resolve, so a failed identifier never lingers as a fabricated id —
 the per-field verdicts are surfaced in `verifications` and `verified` is the AND of
-them. Looked-up identifier fields win over same-named caller `hints`, and the
-entity id is derived deterministically from the name so re-running reuses the
-entity rather than duplicating it.
+them. Looked-up identifier fields win over same-named caller `hints`. **Dedup is
+by resolved chemical IDENTITY, not by name** (Issue #179): after a successful
+lookup it computes an identity key in priority order `pubchem_cid` → `inchikey` →
+`cas` → `chebiId` and reuses any existing `MolecularEntity` whose same identity
+field matches — so two DIFFERENT names for one molecule (e.g. `Indocyanine green`
+and `ICG`, same CID/InChIKey) collapse to ONE node (the synonym is recorded as a
+`schema:alternateName`) instead of minting a second `chem_<name>` node, and two
+names resolving to the same `pubchem_cid` can no longer mint the same `@id` (which
+ro-crate-py silently overwrites — data loss). When the record carries no identity
+field, it falls back to name-keyed reuse so re-running the same name still reuses
+the entity rather than duplicating it.
 
 `resolve_publication` (Issue #179) is the citation counterpart of
 `resolve_compound`, closing the gap PR #217 deferred: a plan carries a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -692,7 +692,15 @@ verified; an ORCID-resolved Person also carries its ORCID `identifier`
 PropertyValue at build via the shared `_identifier_pv` path. HITL fires **only** on
 genuine ambiguity — never when an author is confidently resolved or confidently
 absent — and when no `human_interface` is available an ambiguous author falls back
-to a synthesized id rather than guessing.
+to a synthesized id rather than guessing. An ORCID-resolved author's
+**`affiliation` becomes an `schema:Organization` reference, never a literal
+string** (Issue #179 — the ISA shape flags a literal-string affiliation as a
+Violation): the ORCID record's `affiliation_name` (+ `affiliation_ror`) is
+find-or-drafted into an Organization (preferring the ROR so its `@id` resolves to
+the ROR IRI; D5 — a ROR is set only when the lookup returns one, never fabricated)
+and the Person's `affiliation` is wired to that Organization's `@id`. Authors
+sharing an affiliation reuse ONE Organization (deduped by name), so the build's
+`_wire_reference` resolves each `Person.affiliation` to the shared node.
 The `hints` parameter is **typed per entity type** (Issue #90). Each `draft_*`
 tool advertises a JSON-Schema built by `_crate_mapping.draft_hints_schema(type)`
 from the single source of truth `_crate_mapping.ENTITY_DRAFT_SCHEMA` — allowed

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -32,6 +32,7 @@ from builder.tools.drafters import (
     draft_assay,
     draft_investigation,
     draft_molecular_entity,
+    draft_organization,
     draft_process,
     draft_publication,
     draft_sample,
@@ -795,6 +796,38 @@ def _resolve_via_search(
     return _bare_orcid(chosen) if verified is not None else None
 
 
+def _find_or_draft_organization(
+    state: CrateState, name: str, ror: str | None = None
+) -> str | None:
+    """Return the entity_id of an Organization for ``name``, drafting one if absent.
+
+    The ISA shape requires ``Person.affiliation`` to reference a
+    ``schema:Organization`` — a literal string is a Violation (Issue #179). This
+    find-or-drafts the Organization an author's affiliation should reference.
+
+    De-dup by name: an existing in-state Organization with the same (stripped)
+    ``name`` is reused so two authors sharing an affiliation yield ONE Organization
+    (its ``ror`` is back-filled if this call carries one and it was missing).
+    Otherwise a new one is minted via the pure :func:`draft_organization` drafter
+    (never hand-rolled JSON-LD). D5-safe: a ``ror`` is set ONLY when supplied by
+    the lookup — never fabricated — so the build resolves the Organization's @id to
+    the ROR IRI when known, else a name-derived id. Returns ``None`` on an empty
+    name (a name-less affiliation cannot become an Organization reference).
+    """
+    name = (name or "").strip()
+    if not name:
+        return None
+    ror_value = (ror or "").strip()
+    for org in state.list_entities("Organization"):
+        if str(org.fields.get("name") or "").strip() == name:
+            if ror_value and not org.fields.get("ror"):
+                org.set_fields_from_dict({"ror": ror_value}, source="lookup")
+            return org.entity_id
+    hints: dict[str, Any] = {"ror": ror_value} if ror_value else {}
+    org = draft_organization(state, name, hints)
+    return org.entity_id
+
+
 def _ensure_person_for_orcid(state: CrateState, orcid: str, data: dict) -> Entity:
     """Find-or-create a Person whose @id is the ORCID URL, with a verified ORCID."""
     bare = _bare_orcid(orcid)
@@ -819,9 +852,18 @@ def _ensure_person_for_orcid(state: CrateState, orcid: str, data: dict) -> Entit
         fields["givenName"] = given
     if family:
         fields["familyName"] = family
-    affiliation = data.get("affiliation_name")
-    if affiliation:
-        fields["affiliation"] = affiliation
+    # Affiliation MUST reference a schema:Organization, not a literal string
+    # (ISA shape, Issue #179). Find-or-draft the Organization (preferring the
+    # ORCID-provided ROR so its @id resolves to the ROR IRI; D5: never fabricated)
+    # and wire the Person's `affiliation` to that Organization's reference id —
+    # the build's `_wire_reference` then resolves it to the Organization node.
+    affiliation_name = data.get("affiliation_name")
+    if affiliation_name:
+        org_id = _find_or_draft_organization(
+            state, affiliation_name, data.get("affiliation_ror")
+        )
+        if org_id is not None:
+            fields["affiliation"] = {"@id": org_id}
     person.set_fields_from_dict(fields, source="lookup")
     person.set_field_status("orcid", "verified", "lookup")
     return person

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -1180,6 +1180,66 @@ _COMPOUND_DATA_FIELDS: tuple[str, ...] = (
     "sameAs",
 )
 
+# Chemical-identity fields, in priority order, used to dedup a MolecularEntity by
+# the resolved MOLECULE rather than by its (display) name (Issue #179). Two
+# different names that resolve to the same compound (e.g. 'Indocyanine green' and
+# 'ICG' -> same CID / InChIKey) must collapse to ONE node — minting a second
+# ``chem_<name>`` node duplicates the molecule, and two names resolving to the
+# SAME ``pubchem_cid`` would mint the SAME ``@id`` at build time, which
+# ro-crate-py silently overwrites (data loss).
+_COMPOUND_IDENTITY_FIELDS: tuple[str, ...] = ("pubchem_cid", "inchikey", "cas", "chebiId")
+
+
+def _identity_key(record: Mapping[str, Any]) -> tuple[str, str] | None:
+    """Return a ``(field, value)`` chemical-identity key from a resolved record.
+
+    Picks the first non-empty field in :data:`_COMPOUND_IDENTITY_FIELDS` priority
+    order (``pubchem_cid`` -> ``inchikey`` -> ``cas`` -> ``chebiId``). Returns
+    ``None`` when the record carries no identity field (a name-only hit cannot be
+    deduped by identity — it falls back to name-keyed reuse).
+    """
+    for field in _COMPOUND_IDENTITY_FIELDS:
+        value = record.get(field)
+        if value not in (None, ""):
+            return field, str(value).strip()
+    return None
+
+
+def _find_entity_by_identity(
+    state: CrateState, key: tuple[str, str]
+) -> Entity | None:
+    """An existing MolecularEntity whose same identity field matches ``key``.
+
+    Scans ``state.list_entities("MolecularEntity")`` for one whose value for the
+    key's field equals the key's value, so a compound resolved under a second name
+    reuses the node minted for the first instead of duplicating the molecule
+    (Issue #179). Returns the first match, or ``None``.
+    """
+    field, value = key
+    for entity in state.list_entities("MolecularEntity"):
+        existing = entity.fields.get(field)
+        if existing not in (None, "") and str(existing).strip() == value:
+            return entity
+    return None
+
+
+def _append_alternate_name(entity: Entity, name: str) -> None:
+    """Record ``name`` as a ``schema:alternateName`` on a reused MolecularEntity.
+
+    A no-op when ``name`` is empty, already the entity's primary ``name``, or
+    already present in ``alternateName`` (deduped). Keeps the field a list so a
+    molecule resolved under several synonyms accumulates them.
+    """
+    candidate = " ".join(str(name).split())
+    if not candidate or candidate == str(entity.fields.get("name") or ""):
+        return
+    existing = entity.fields.get("alternateName") or []
+    aliases = list(existing) if isinstance(existing, list) else [existing]
+    if candidate in aliases:
+        return
+    aliases.append(candidate)
+    entity.set_fields_from_dict({"alternateName": aliases}, source="lookup")
+
 
 def _verify_compound_identifier(
     state: CrateState,
@@ -1358,18 +1418,40 @@ def resolve_compound(
         if value not in (None, ""):
             merged_hints[key] = value
 
-    # Idempotent: reuse the deterministically-keyed MolecularEntity if present,
-    # refreshing its looked-up fields, rather than minting a duplicate. The id is
-    # derived from the whitespace-normalized display name, so the same compound
-    # under different spacing maps to ONE entity.
-    entity_id = _make_entity_id("chem", display_name, merged_hints)
-    existing = state.get_entity(entity_id)
-    if existing is not None and existing.type == "MolecularEntity":
-        entity = existing
-        refreshed = {**merged_hints, "name": display_name}
+    # Dedup by chemical IDENTITY first (Issue #179): two DIFFERENT names that
+    # resolve to the SAME molecule (e.g. 'Indocyanine green' / 'ICG' -> same CID /
+    # InChIKey) must collapse to ONE MolecularEntity. Minting a second
+    # ``chem_<name>`` node duplicates the molecule, and two names resolving to the
+    # same ``pubchem_cid`` would mint the SAME ``@id`` at build time (silently
+    # overwritten by ro-crate-py). Reuse the node already minted for this molecule
+    # under another name — refresh its looked-up fields and record the new name as
+    # an ``alternateName`` — rather than its (different) name-derived id.
+    identity_key = _identity_key(data)
+    by_identity = (
+        _find_entity_by_identity(state, identity_key) if identity_key else None
+    )
+    if by_identity is not None:
+        entity = by_identity
+        # Do NOT clobber the entity's existing display ``name`` (the first name
+        # under which the molecule was minted) — keep it stable and record this
+        # call's name as an additional alias so the synonym is not lost.
+        refreshed = dict(merged_hints)
+        refreshed.pop("name", None)
         entity.set_fields_from_dict(refreshed, source="lookup")
+        _append_alternate_name(entity, display_name)
     else:
-        entity = draft_molecular_entity(state, display_name, merged_hints)
+        # Idempotent: reuse the deterministically-keyed MolecularEntity if present,
+        # refreshing its looked-up fields, rather than minting a duplicate. The id
+        # is derived from the whitespace-normalized display name, so the same
+        # compound under different spacing maps to ONE entity.
+        entity_id = _make_entity_id("chem", display_name, merged_hints)
+        existing = state.get_entity(entity_id)
+        if existing is not None and existing.type == "MolecularEntity":
+            entity = existing
+            refreshed = {**merged_hints, "name": display_name}
+            entity.set_fields_from_dict(refreshed, source="lookup")
+        else:
+            entity = draft_molecular_entity(state, display_name, merged_hints)
 
     identifiers = {
         key: data[key]

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -378,14 +378,27 @@ class TestMaterializePlan:
         """Stub every network lookup the composites would otherwise hit."""
         import builder.tools.composites as composites_mod
         from builder.tools import lookups as tool_lookups
+        from builder.tools._resolve_cache import compound_cache
+
+        # The compound resolution cache is process-global; a prior test can pre-cache
+        # these names and short-circuit the lookup, masking this stub's per-name CID.
+        # Clear it so the stub always runs fresh (xdist-safe).
+        compound_cache.clear()
 
         # resolve_compound -> lookup_compound (imported into composites' namespace).
+        # A DISTINCT CID per compound name: the dedup-by-chemical-identity path
+        # (Issue #179) collapses two names that resolve to the SAME identity into one
+        # MolecularEntity, so two DISTINCT plan compounds must carry distinct CIDs
+        # to stay distinct nodes. CAS stays constant (`60-56-0`) so the D5 exact-value
+        # assertion is preserved; only the (node-id-bearing) CID varies per name.
+        _cids = {"Methimazole": "1349907", "Sodium iodide": "5238"}
+
         def fake_lookup_compound(name):
             return {
                 "found": True,
                 "data": {
                     "cas": "60-56-0",
-                    "pubchem_cid": "1349907",
+                    "pubchem_cid": _cids.get(name, "999999"),
                     "smiles": "C1=CN(C(=S)N1)C",
                     "source": "pubchem",
                 },
@@ -926,47 +939,10 @@ class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
     node must be referenced by at least one other node, i.e. orphan count → 0.
     """
 
-    def _stub_lookups(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Like the base stub, but return a DISTINCT CID per compound name.
-
-        The base `_stub_lookups` hands the same canned PubChem CID to every
-        compound, so distinct compounds would collapse to ONE MolecularEntity node
-        (its build @id is the verified CID IRI). The #273 reachability test needs
-        the two plan compounds to be two distinct nodes, so override the compound
-        lookup with a per-name CID while keeping every other stub (verify / AOP /
-        Crossref) from the base.
-        """
-        super()._stub_lookups(monkeypatch)
-        import builder.tools.composites as composites_mod
-        from builder.tools._resolve_cache import compound_cache
-
-        # The compound resolution cache is process-global; a prior test (or the
-        # inherited ones, which use the base single-CID stub) can pre-cache these
-        # names and short-circuit the lookup, so distinct-CID resolution would be
-        # masked. Clear it so this test's stub always runs fresh (xdist-safe).
-        compound_cache.clear()
-
-        # Distinct CID per compound (the build keys a MolecularEntity node @id to
-        # its verified CID IRI, so distinct CIDs => distinct nodes). CAS stays the
-        # base stub's `60-56-0` so the inherited D5 test's exact-value assertion is
-        # preserved; only the (node-id-bearing) CID varies per name.
-        _cids = {"Methimazole": "1349907", "Sodium iodide": "5238"}
-
-        def fake_lookup_compound(name):
-            return {
-                "found": True,
-                "data": {
-                    "cas": "60-56-0",
-                    "pubchem_cid": _cids.get(name, "999999"),
-                    "smiles": "C1=CN(C(=S)N1)C",
-                    "source": "pubchem",
-                },
-                "error": None,
-            }
-
-        monkeypatch.setattr(
-            composites_mod, "lookup_compound", fake_lookup_compound
-        )
+    # NOTE: the base ``_stub_lookups`` already hands a DISTINCT CID per compound
+    # name (and clears the process-global compound cache), so the two plan
+    # compounds resolve to two distinct MolecularEntity nodes — exactly what this
+    # #273 reachability test needs. No override required.
 
     @staticmethod
     def _referenced_ids(graph: list[dict]) -> set[str]:

--- a/tests/test_tools_publication_authors.py
+++ b/tests/test_tools_publication_authors.py
@@ -478,6 +478,193 @@ class TestFallbackAndD5:
 
 
 # ---------------------------------------------------------------------------
+# Author affiliation must be an Organization reference, not a string (#179)
+# ---------------------------------------------------------------------------
+
+
+def _orgs(state: CrateState) -> list[Entity]:
+    return [e for e in state.list_entities() if e.type == "Organization"]
+
+
+def _affiliation_ref(person: Entity) -> str | None:
+    """The Organization @id a Person's ``affiliation`` references (bare or {@id})."""
+    ref = person.fields.get("affiliation")
+    if isinstance(ref, dict):
+        return ref.get("@id")
+    return ref if isinstance(ref, str) and ref else None
+
+
+class TestAuthorAffiliationIsOrganization:
+    """The ISA shape requires Person.affiliation to reference an Organization.
+
+    ROOT CAUSE (#179): ``_ensure_person_for_orcid`` stored
+    ``data['affiliation_name']`` as a STRING on ``affiliation`` and dropped the
+    ORCID-provided ``affiliation_ror``. The builder emitted that string (a literal
+    on a reference-only property) -> SHACL Violation, re-asked forever. The fix
+    find-or-drafts an Organization (preferring the ROR so its @id resolves to the
+    ROR IRI) and wires the Person's ``affiliation`` to that Organization.
+    """
+
+    def test_affiliation_becomes_organization_reference_with_ror(self, monkeypatch):
+        state = CrateState()
+        rec = _orcid_record("0000-0002-1825-0097", "Jane", "Doe", "Utrecht University")
+        rec["data"]["affiliation_ror"] = "05wg1m734"
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: rec,
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        person = _person_nodes(state)[0]
+        # NOT a bare name string.
+        assert person.fields.get("affiliation") != "Utrecht University"
+        # An Organization was drafted and the affiliation references it.
+        orgs = _orgs(state)
+        assert len(orgs) == 1
+        org = orgs[0]
+        assert org.fields.get("name") == "Utrecht University"
+        # D5: the ROR is preserved so the Organization @id resolves to the ROR IRI.
+        assert org.fields.get("ror") == "05wg1m734"
+        # The Person.affiliation is a REFERENCE to that Organization.
+        assert _affiliation_ref(person) == org.entity_id
+
+    def test_affiliation_name_only_still_becomes_organization(self, monkeypatch):
+        """An ORCID affiliation with a name but no ROR still yields an Organization."""
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: _orcid_record(
+                "0000-0002-1825-0097", "Jane", "Doe", "Utrecht University"
+            ),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        person = _person_nodes(state)[0]
+        orgs = _orgs(state)
+        assert len(orgs) == 1
+        assert person.fields.get("affiliation") != "Utrecht University"
+        assert _affiliation_ref(person) == orgs[0].entity_id
+
+    def test_two_authors_share_one_organization(self, monkeypatch):
+        """Two authors with the same affiliation reuse ONE Organization (no dup)."""
+        state = CrateState()
+
+        def _orcid(o):  # noqa: ANN001
+            bare = o.rsplit("/", 1)[-1]
+            given = "Jane" if bare.endswith("0097") else "John"
+            return _orcid_record(bare, given, "Doe", "Utrecht University")
+
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                },
+                {
+                    "givenName": "John",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0098",
+                },
+            ),
+            orcid=_orcid,
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        # Both authors resolved; ONE shared Organization.
+        assert len(_person_nodes(state)) == 2
+        orgs = _orgs(state)
+        assert len(orgs) == 1
+        org_id = orgs[0].entity_id
+        for person in _person_nodes(state):
+            assert _affiliation_ref(person) == org_id
+
+    def test_no_affiliation_leaves_field_unset(self, monkeypatch):
+        """No ORCID affiliation -> no Organization, no affiliation literal (D5)."""
+        state = CrateState()
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: _orcid_record("0000-0002-1825-0097", "Jane", "Doe"),
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        assert _orgs(state) == []
+        person = _person_nodes(state)[0]
+        assert not person.fields.get("affiliation")
+
+    def test_affiliation_resolves_to_org_node_in_build(self, monkeypatch):
+        """The built crate emits Person.affiliation as an @id ref to the Org node."""
+        from rocrate.rocrate import ROCrate
+
+        from builder.tools._crate_mapping import populate_crate
+        from profiles.context import ISA_TOX_CONTEXT
+
+        state = CrateState()
+        rec = _orcid_record("0000-0002-1825-0097", "Jane", "Doe", "Utrecht University")
+        rec["data"]["affiliation_ror"] = "05wg1m734"
+        _patch(
+            monkeypatch,
+            doi=lambda d: _doi_result(
+                {
+                    "givenName": "Jane",
+                    "familyName": "Doe",
+                    "identifier": "0000-0002-1825-0097",
+                }
+            ),
+            orcid=lambda o: rec,
+        )
+
+        draft_publication_with_authors(state, "10.1234/example")
+
+        crate = ROCrate()
+        crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+        populate_crate(state, crate, None, materialize_payload=False)
+        graph = crate.metadata.generate()["@graph"]
+
+        person_node = next(
+            n for n in graph if n.get("@id") == "https://orcid.org/0000-0002-1825-0097"
+        )
+        affiliation = person_node.get("affiliation")
+        # Emitted as an @id reference, not a bare string.
+        assert isinstance(affiliation, dict) and affiliation.get("@id")
+        # The reference resolves to the Organization node (ROR IRI @id).
+        assert affiliation["@id"] == "https://ror.org/05wg1m734"
+        org_node = next(n for n in graph if n.get("@id") == "https://ror.org/05wg1m734")
+        assert "Organization" in (
+            org_node.get("@type")
+            if isinstance(org_node.get("@type"), list)
+            else [org_node.get("@type")]
+        )
+        assert org_node.get("name") == "Utrecht University"
+
+
+# ---------------------------------------------------------------------------
 # Registration & engine routing
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tools_resolve_compound.py
+++ b/tests/test_tools_resolve_compound.py
@@ -151,6 +151,86 @@ class TestResolveCompoundIdempotent:
         assert first["entity_id"] == second["entity_id"]
 
 
+class TestResolveCompoundDedupByIdentity:
+    """Two DIFFERENT names that resolve to the SAME molecule collapse to ONE node.
+
+    ROOT CAUSE (#179): ``resolve_compound`` derived the entity id from the
+    NAME (``chem_<name>``) and only reused an entity when that name-derived id
+    already existed. So 'Indocyanine green' (CID 5282412) and 'ICG' (a synonym
+    resolving to the same molecule, same InChIKey) became TWO MolecularEntity
+    nodes; and when two names resolved to the SAME ``pubchem_cid`` the build
+    minted both with the same ``@id`` and ro-crate-py silently OVERWROTE one
+    (data loss). The fix dedups on the resolved chemical IDENTITY (pubchem_cid
+    -> inchikey -> cas -> chebiId), not the name.
+    """
+
+    @pytest.fixture
+    def same_molecule_two_names(self, monkeypatch):
+        """A lookup that returns the SAME molecule (CID + InChIKey) for two names."""
+        record = {
+            "found": True,
+            "error": None,
+            "data": {
+                "cas": "3599-32-4",
+                "smiles": "",
+                "inchikey": "MOFVSTNWEDAEEK-UHFFFAOYSA-M",
+                "inchi": "",
+                "formula": "C43H47N2NaO6S2",
+                "mass": "774.96",
+                "iupac_name": "indocyanine green",
+                "pubchem_cid": "5282412",
+            },
+        }
+
+        def fake_lookup(name):  # noqa: ANN001
+            # Same authoritative molecule regardless of the (different) names.
+            return dict(record)
+
+        def fake_verify(state, entity_id, field):  # noqa: ANN001
+            entity = state.get_entity(entity_id)
+            if entity is not None and entity.fields.get(field):
+                entity.set_field_status(field, "verified", "lookup")
+                return {
+                    "verified": True,
+                    "entity_id": entity_id,
+                    "field": field,
+                    "message": "ok",
+                    "suggested_fix": None,
+                }
+            return {
+                "verified": False,
+                "entity_id": entity_id,
+                "field": field,
+                "message": "no value",
+                "suggested_fix": None,
+            }
+
+        monkeypatch.setattr(composites, "lookup_compound", fake_lookup)
+        monkeypatch.setattr(composites, "verify_identifier", fake_verify)
+
+    def test_two_names_same_molecule_collapse_to_one_entity(
+        self, same_molecule_two_names
+    ):
+        state = CrateState()
+        first = resolve_compound(state, name="Indocyanine green")
+        second = resolve_compound(state, name="ICG")
+
+        # Exactly ONE MolecularEntity for the one molecule (not two).
+        assert len(_by_type(state, "MolecularEntity")) == 1
+        # Both calls return the SAME entity id (the shared molecule node).
+        assert first["entity_id"] == second["entity_id"]
+
+    def test_alternate_name_recorded_on_reused_entity(self, same_molecule_two_names):
+        state = CrateState()
+        resolve_compound(state, name="Indocyanine green")
+        resolve_compound(state, name="ICG")
+
+        mol = _by_type(state, "MolecularEntity")[0]
+        alt = mol.fields.get("alternateName") or []
+        alt = alt if isinstance(alt, list) else [alt]
+        assert "ICG" in alt
+
+
 class TestResolveCompoundLookupMiss:
     def test_lookup_miss_creates_no_entity(self, monkeypatch):
         def fake_lookup(name):  # noqa: ANN001


### PR DESCRIPTION
Two confirmed `composites.py` bugs from a real S-VHPS26 run (epic #179), each fixed TDD-first in its own commit. Both live in `builder/tools/composites.py` (`resolve_compound` and `_ensure_person_for_orcid`) — different functions from #294's `_BUILD_SYNTHESIZES_OUTPUT`/condition-table logic, which is untouched.

## Commit 1 — dedup MolecularEntity by chemical identity, not by name
`resolve_compound` derived the entity id from the display name (`chem_<name>`) and only reused an entity when that name-derived id existed. So two different names for one molecule (e.g. "Indocyanine green" and "ICG", same CID/InChIKey) minted TWO nodes, and two names resolving to the SAME `pubchem_cid` minted the SAME `@id` at build time — silently overwritten by ro-crate-py (data loss).

Fix: after a successful lookup, compute an identity key in priority order `pubchem_cid → inchikey → cas → chebiId` and reuse any existing `MolecularEntity` whose same identity field matches (refresh looked-up fields, keep the primary name stable, record the new name as `schema:alternateName`). Name-keyed reuse remains the fallback for identity-less hits.

TDD: a stubbed offline lookup returning the same CID/InChIKey for two different names now collapses to ONE MolecularEntity and both calls return the same `entity_id`; the existing same-name idempotency test still passes.

## Commit 2 — author affiliation must be an Organization, not a string
The ISA shape requires `Person.affiliation` to reference a `schema:Organization`; a literal string is a Violation that gets re-asked forever. `_ensure_person_for_orcid` stored `affiliation_name` as a STRING and dropped the ORCID-provided `affiliation_ror`.

Fix: find-or-draft an Organization from the ORCID record (preferring `affiliation_ror` as the Organization's `ror` so its `@id` resolves to the ROR IRI — D5-safe, never fabricated; else name-only) and wire the Person's `affiliation` to that Organization's reference id. A local `_find_or_draft_organization` (operating on `CrateState`, mirroring #295's engine-bound pipeline logic) dedups by name so authors sharing an affiliation reuse ONE Organization. The build's `_wire_reference` then resolves each `Person.affiliation` to the shared node. This covers the publication-author / ORCID path #295 did not.

TDD: an ORCID-resolved author with an affiliation now yields a Person whose `affiliation` is an Organization reference (Organization exists, `ror` set when provided) — not a bare string; two authors sharing an affiliation share one Organization; the built crate emits `affiliation` as an `@id` ref to the org node.

## Gate
- New tests green; existing resolve_compound, publication-authors, resolve_publication, and #294 process-chain/condition-table tests all pass; agents-pipeline tests pass (#295 materialize path undisturbed).
- `uv run ruff check` clean; `uv run ty check` has zero NEW diagnostics (the one remaining is pre-existing in `tests/test_agent_loop.py` on main).
- Lane-clean: only `builder/tools/composites.py`, the two test files, and AGENTS.md §5 changed (two-dot == three-dot diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)