### PR TITLE
feat: opt-in OpenAI reasoning ("thinking") for gpt-5.x via VITRO_OPENAI_REASONING_EFFORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ export VITRO_OPENAI_MODEL="llama3.2"           # or OPENAI_MODEL
 export VITRO_OPENAI_DRAFTER_MODEL="gpt-4o-mini"
 
 # Optional: enable reasoning ("thinking") on reasoning-capable models
-# (o-series, gpt-5.x). Values: none (default) | low | medium | high.
-# Omit for non-reasoning models like gpt-4o. When reasoning is active the
-# builder stops sending temperature=0, which gpt-5.x rejects while reasoning.
+# (o-series, gpt-5.x). Values: low | medium | high. Default is OFF (leave
+# unset). To DISABLE reasoning, just omit this var — only gpt-5.1 accepts the
+# extra value "none" (to force its default reasoning off while keeping
+# temperature=0); o-series and gpt-4o reject "none", so leave it unset there.
+# When reasoning is active the builder stops sending temperature=0, which
+# reasoning models reject while thinking.
 export VITRO_OPENAI_REASONING_EFFORT="medium"
 ```
 
@@ -170,7 +173,8 @@ base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
 # Optional: cheap drafter model (model tiering). Omit for a single model.
 drafter_model = "gpt-4o-mini"
-# Optional: reasoning ("thinking") for gpt-5.x / o-series: none|low|medium|high.
+# Optional: reasoning ("thinking") for reasoning models (gpt-5.x / o-series):
+# low|medium|high. Omit to disable reasoning; only gpt-5.1 accepts "none".
 # reasoning_effort = "medium"
 
 [anthropic]
@@ -204,7 +208,7 @@ Environment variables (``VITRO_*``) always win over the config file:
 | ``VITRO_OPENAI_BASE_URL`` | API base URL override | ``https://api.openai.com/v1`` |
 | ``VITRO_OPENAI_MODEL`` | Model name for OpenAI | ``gpt-4o`` |
 | ``VITRO_OPENAI_DRAFTER_MODEL`` | Cheap drafter model for OpenAI (model tiering) | — (uses ``VITRO_OPENAI_MODEL``) |
-| ``VITRO_OPENAI_REASONING_EFFORT`` | Reasoning ("thinking") effort for reasoning-capable OpenAI models (o-series, gpt-5.x): ``none``/``low``/``medium``/``high`` | — (off) |
+| ``VITRO_OPENAI_REASONING_EFFORT`` | Reasoning ("thinking") effort for reasoning-capable OpenAI models (o-series, gpt-5.x): ``low``/``medium``/``high``, plus ``none`` (gpt-5.1 only) to force reasoning off. Omit to disable reasoning. | — (off) |
 | ``VITRO_ANTHROPIC_API_KEY`` | API key for Anthropic | — |
 | ``VITRO_ANTHROPIC_MODEL`` | Model name for Anthropic | ``claude-sonnet-4-20250514`` |
 | ``VITRO_ANTHROPIC_DRAFTER_MODEL`` | Cheap drafter model for Anthropic (model tiering) | — (uses ``VITRO_ANTHROPIC_MODEL``) |
@@ -373,7 +377,7 @@ This works for ``requests``, ``httpx``, ``openai``, and all other HTTP clients.
 | `VITRO_OPENAI_MODEL` | No | `gpt-4o` | Model name for OpenAI-compatible providers |
 | `OPENAI_MODEL` | Fallback | `gpt-4o` | Same, unprefixed fallback |
 | `VITRO_OPENAI_DRAFTER_MODEL` | No | — (uses `VITRO_OPENAI_MODEL`) | Cheap drafter model (model tiering). Unset → single model, unchanged behaviour |
-| `VITRO_OPENAI_REASONING_EFFORT` | No | — (off) | Reasoning ("thinking") effort for reasoning-capable OpenAI models (o-series, gpt-5.x): `none`/`low`/`medium`/`high`. Omit for non-reasoning models. When active, the builder stops sending `temperature=0` (gpt-5.x rejects it while reasoning). |
+| `VITRO_OPENAI_REASONING_EFFORT` | No | — (off) | Reasoning ("thinking") effort for reasoning-capable OpenAI models (o-series, gpt-5.x): `low`/`medium`/`high`. `none` forces reasoning off on gpt-5.1 only (o-series/gpt-4o reject the `none` value — omit the var instead). Omit for non-reasoning models. Value is normalized (trimmed + lowercased). When active, the builder stops sending `temperature=0` (reasoning models reject it while thinking). |
 | `VITRO_ANTHROPIC_API_KEY` | For Anthropic | — | Anthropic API key |
 | `ANTHROPIC_API_KEY` | Fallback | — | Same, unprefixed fallback |
 | `VITRO_ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Model name for Anthropic |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ export VITRO_OPENAI_MODEL="llama3.2"           # or OPENAI_MODEL
 # Optional: cheap drafter model for bounded extraction (model tiering).
 # Unset = single model (the drafter uses VITRO_OPENAI_MODEL).
 export VITRO_OPENAI_DRAFTER_MODEL="gpt-4o-mini"
+
+# Optional: enable reasoning ("thinking") on reasoning-capable models
+# (o-series, gpt-5.x). Values: none (default) | low | medium | high.
+# Omit for non-reasoning models like gpt-4o. When reasoning is active the
+# builder stops sending temperature=0, which gpt-5.x rejects while reasoning.
+export VITRO_OPENAI_REASONING_EFFORT="medium"
 ```
 
 #### Anthropic
@@ -164,6 +170,8 @@ base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
 # Optional: cheap drafter model (model tiering). Omit for a single model.
 drafter_model = "gpt-4o-mini"
+# Optional: reasoning ("thinking") for gpt-5.x / o-series: none|low|medium|high.
+# reasoning_effort = "medium"
 
 [anthropic]
 api_key = "sk-ant-..."
@@ -196,6 +204,7 @@ Environment variables (``VITRO_*``) always win over the config file:
 | ``VITRO_OPENAI_BASE_URL`` | API base URL override | ``https://api.openai.com/v1`` |
 | ``VITRO_OPENAI_MODEL`` | Model name for OpenAI | ``gpt-4o`` |
 | ``VITRO_OPENAI_DRAFTER_MODEL`` | Cheap drafter model for OpenAI (model tiering) | — (uses ``VITRO_OPENAI_MODEL``) |
+| ``VITRO_OPENAI_REASONING_EFFORT`` | Reasoning ("thinking") effort for reasoning-capable OpenAI models (o-series, gpt-5.x): ``none``/``low``/``medium``/``high`` | — (off) |
 | ``VITRO_ANTHROPIC_API_KEY`` | API key for Anthropic | — |
 | ``VITRO_ANTHROPIC_MODEL`` | Model name for Anthropic | ``claude-sonnet-4-20250514`` |
 | ``VITRO_ANTHROPIC_DRAFTER_MODEL`` | Cheap drafter model for Anthropic (model tiering) | — (uses ``VITRO_ANTHROPIC_MODEL``) |
@@ -364,6 +373,7 @@ This works for ``requests``, ``httpx``, ``openai``, and all other HTTP clients.
 | `VITRO_OPENAI_MODEL` | No | `gpt-4o` | Model name for OpenAI-compatible providers |
 | `OPENAI_MODEL` | Fallback | `gpt-4o` | Same, unprefixed fallback |
 | `VITRO_OPENAI_DRAFTER_MODEL` | No | — (uses `VITRO_OPENAI_MODEL`) | Cheap drafter model (model tiering). Unset → single model, unchanged behaviour |
+| `VITRO_OPENAI_REASONING_EFFORT` | No | — (off) | Reasoning ("thinking") effort for reasoning-capable OpenAI models (o-series, gpt-5.x): `none`/`low`/`medium`/`high`. Omit for non-reasoning models. When active, the builder stops sending `temperature=0` (gpt-5.x rejects it while reasoning). |
 | `VITRO_ANTHROPIC_API_KEY` | For Anthropic | — | Anthropic API key |
 | `ANTHROPIC_API_KEY` | Fallback | — | Same, unprefixed fallback |
 | `VITRO_ANTHROPIC_MODEL` | No | `claude-sonnet-4-20250514` | Model name for Anthropic |

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -921,14 +921,25 @@ def _build_chat_model(
             or os.environ.get("VITRO_OPENAI_MODEL")
             or os.environ.get("OPENAI_MODEL", "gpt-4o")
         )
+        # Opt-in reasoning ("thinking") for reasoning-capable models (o-series,
+        # gpt-5.x). Off by default (unset) so existing behaviour is unchanged.
+        reasoning_effort = os.environ.get("VITRO_OPENAI_REASONING_EFFORT") or None
 
         kwargs: dict[str, Any] = {
             "model": resolved_model,
-            "temperature": 0,
             "max_retries": max_retries,
             # "timeout" is the public alias of ChatOpenAI.request_timeout (#263).
             "timeout": timeout,
         }
+        if reasoning_effort:
+            kwargs["reasoning_effort"] = reasoning_effort
+        # Reasoning models reject a non-default temperature while reasoning is
+        # ACTIVE — gpt-5.1 only permits temperature when reasoning_effort is
+        # "none". So keep the deterministic temperature=0 ONLY when reasoning is
+        # off (unset or explicit "none"); otherwise omit it and let the model use
+        # its default (1), or the API 400s ("temperature does not support 0").
+        if not reasoning_effort or reasoning_effort.strip().lower() == "none":
+            kwargs["temperature"] = 0
         if api_key:
             kwargs["api_key"] = api_key
         if resolved_base:

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -923,7 +923,12 @@ def _build_chat_model(
         )
         # Opt-in reasoning ("thinking") for reasoning-capable models (o-series,
         # gpt-5.x). Off by default (unset) so existing behaviour is unchanged.
-        reasoning_effort = os.environ.get("VITRO_OPENAI_REASONING_EFFORT") or None
+        # Normalize once (strip + lowercase) so a capitalized/whitespaced value
+        # like "Medium" or " none " forwards as the clean lowercase enum the
+        # OpenAI API expects — and a blank value collapses to None (a no-op).
+        reasoning_effort = (
+            (os.environ.get("VITRO_OPENAI_REASONING_EFFORT") or "").strip().lower() or None
+        )
 
         kwargs: dict[str, Any] = {
             "model": resolved_model,
@@ -938,7 +943,7 @@ def _build_chat_model(
         # "none". So keep the deterministic temperature=0 ONLY when reasoning is
         # off (unset or explicit "none"); otherwise omit it and let the model use
         # its default (1), or the API 400s ("temperature does not support 0").
-        if not reasoning_effort or reasoning_effort.strip().lower() == "none":
+        if not reasoning_effort or reasoning_effort == "none":
             kwargs["temperature"] = 0
         if api_key:
             kwargs["api_key"] = api_key

--- a/builder/config.py
+++ b/builder/config.py
@@ -233,6 +233,7 @@ def merge_with_env(config: dict[str, Any]) -> dict[str, Any]:
         ("openai", "base_url"): "VITRO_OPENAI_BASE_URL",
         ("openai", "model"): "VITRO_OPENAI_MODEL",
         ("openai", "drafter_model"): "VITRO_OPENAI_DRAFTER_MODEL",
+        ("openai", "reasoning_effort"): "VITRO_OPENAI_REASONING_EFFORT",
         ("openai", "model_provider"): "VITRO_OPENAI_MODEL_PROVIDER",
         ("anthropic", "api_key"): "VITRO_ANTHROPIC_API_KEY",
         ("anthropic", "model"): "VITRO_ANTHROPIC_MODEL",

--- a/tests/test_llm_reasoning_effort.py
+++ b/tests/test_llm_reasoning_effort.py
@@ -75,6 +75,37 @@ class TestReasoningEffort:
         assert kwargs["reasoning_effort"] == "none"
         assert kwargs["temperature"] == 0
 
+    def test_capitalized_effort_is_normalized_before_forwarding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A capitalized value (``Medium``) is lowercased — the OpenAI API only
+        accepts the lowercase enum, so we must not forward it verbatim."""
+        monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", "Medium")
+        kwargs = _capture_openai_kwargs(monkeypatch)
+        assert kwargs["reasoning_effort"] == "medium"
+        assert "temperature" not in kwargs
+
+    def test_whitespace_none_normalizes_and_keeps_temperature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Surrounding whitespace / casing (`` None ``) still reads as ``none``:
+        it forwards the clean ``none`` and keeps the deterministic temperature=0,
+        instead of forwarding an invalid `` None `` that the API would reject."""
+        monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", " None ")
+        kwargs = _capture_openai_kwargs(monkeypatch)
+        assert kwargs["reasoning_effort"] == "none"
+        assert kwargs["temperature"] == 0
+
+    def test_whitespace_only_effort_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A blank/whitespace value is a no-op — unchanged default behaviour
+        (temperature=0, no ``reasoning_effort`` forwarded)."""
+        monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", "   ")
+        kwargs = _capture_openai_kwargs(monkeypatch)
+        assert kwargs["temperature"] == 0
+        assert "reasoning_effort" not in kwargs
+
 
 class TestReasoningEffortConfigMapping:
     """``merge_with_env`` surfaces the config-file knob as the env var."""

--- a/tests/test_llm_reasoning_effort.py
+++ b/tests/test_llm_reasoning_effort.py
@@ -1,0 +1,103 @@
+"""Opt-in LLM reasoning ("thinking") knob for ``_build_chat_model`` (OpenAI path).
+
+Reasoning-capable OpenAI models (o-series, gpt-5.x) do NOT accept a non-default
+temperature while reasoning is active — gpt-5.1 only permits a custom temperature
+when ``reasoning_effort`` is ``"none"``. So ``VITRO_OPENAI_REASONING_EFFORT`` must
+do two things together:
+
+* pass ``reasoning_effort`` through to ``ChatOpenAI``, and
+* drop the default ``temperature=0`` when reasoning is *active* (effort != none),
+  or the API rejects the request with
+  ``Unsupported value: 'temperature' does not support 0``.
+
+Unset preserves today's behaviour exactly (``temperature=0``, no
+``reasoning_effort``) so the deterministic default is untouched.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from builder import config
+
+
+def _capture_openai_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch ``ChatOpenAI`` and return the kwargs ``_build_chat_model`` passes it."""
+    langchain_openai = pytest.importorskip("langchain_openai")
+
+    captured: dict[str, Any] = {}
+
+    def _fake_chat_openai(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(langchain_openai, "ChatOpenAI", _fake_chat_openai)
+    monkeypatch.setenv("VITRO_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("VITRO_OPENAI_MODEL", "gpt-5.1")
+
+    from builder.agents.agent_loop import _build_chat_model
+
+    _build_chat_model(provider="openai")
+    return captured
+
+
+class TestReasoningEffort:
+    """The OpenAI branch honours ``VITRO_OPENAI_REASONING_EFFORT``."""
+
+    def test_unset_keeps_temperature_zero_and_no_reasoning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default (unset): unchanged — temperature=0, no reasoning_effort."""
+        monkeypatch.delenv("VITRO_OPENAI_REASONING_EFFORT", raising=False)
+        kwargs = _capture_openai_kwargs(monkeypatch)
+        assert kwargs["temperature"] == 0
+        assert "reasoning_effort" not in kwargs
+
+    def test_active_effort_sets_reasoning_and_drops_temperature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Active effort (e.g. ``medium``): pass it, and DROP temperature."""
+        monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", "medium")
+        kwargs = _capture_openai_kwargs(monkeypatch)
+        assert kwargs["reasoning_effort"] == "medium"
+        # Reasoning models reject temperature=0 while reasoning is active.
+        assert "temperature" not in kwargs
+
+    def test_effort_none_passes_through_and_keeps_temperature(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``none`` disables reasoning; gpt-5.1 then allows temperature=0."""
+        monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", "none")
+        kwargs = _capture_openai_kwargs(monkeypatch)
+        assert kwargs["reasoning_effort"] == "none"
+        assert kwargs["temperature"] == 0
+
+
+class TestReasoningEffortConfigMapping:
+    """``merge_with_env`` surfaces the config-file knob as the env var."""
+
+    def test_reasoning_effort_mapped_from_config(self) -> None:
+        old = os.environ.pop("VITRO_OPENAI_REASONING_EFFORT", None)
+        try:
+            config.merge_with_env({"openai": {"reasoning_effort": "high"}})
+            assert os.environ.get("VITRO_OPENAI_REASONING_EFFORT") == "high"
+        finally:
+            if old is not None:
+                os.environ["VITRO_OPENAI_REASONING_EFFORT"] = old
+            else:
+                os.environ.pop("VITRO_OPENAI_REASONING_EFFORT", None)
+
+    def test_env_var_wins_over_config(self) -> None:
+        old = os.environ.get("VITRO_OPENAI_REASONING_EFFORT")
+        os.environ["VITRO_OPENAI_REASONING_EFFORT"] = "from-env"
+        try:
+            config.merge_with_env({"openai": {"reasoning_effort": "from-config"}})
+            assert os.environ["VITRO_OPENAI_REASONING_EFFORT"] == "from-env"
+        finally:
+            if old is not None:
+                os.environ["VITRO_OPENAI_REASONING_EFFORT"] = old
+            else:
+                os.environ.pop("VITRO_OPENAI_REASONING_EFFORT", None)


### PR DESCRIPTION
## What
Adds an opt-in reasoning ("thinking") knob for the OpenAI path so reasoning-capable models (o-series, **gpt-5.x**) actually reason. Today `_build_chat_model` always builds `ChatOpenAI` with `temperature=0` and **no** reasoning parameter, so thinking is never on.

## Why it's not just "pass reasoning_effort"
GPT-5 reasoning models **reject a non-default `temperature`** while reasoning is active — `"Unsupported value: 'temperature' does not support 0"`. On gpt-5.1, `temperature` is only allowed when `reasoning_effort="none"`. So the knob has to do two things together:

- pass `reasoning_effort` through to `ChatOpenAI`, **and**
- drop the hardcoded `temperature=0` whenever reasoning is **active** (kept only when unset or `"none"`, where gpt-5.1 still permits it).

## Usage
```bash
export VITRO_OPENAI_MODEL="gpt-5.1"
export VITRO_OPENAI_REASONING_EFFORT="medium"   # none | low | medium | high
```
Or in `~/.config/vitro-crate/config.toml`:
```toml
[openai]
reasoning_effort = "medium"
```

**Default (unset) is unchanged**: `temperature=0`, no reasoning — byte-for-byte today's behaviour. Omit it for non-reasoning models like `gpt-4o`.

## Testing (TDD)
- New `tests/test_llm_reasoning_effort.py` (5 tests): active effort → `reasoning_effort` passed + `temperature` dropped; `none` → passed + `temperature=0` kept; unset → unchanged; config→env mapping + env-wins.
- Regression: `test_agent_loop` + `test_config_drafter_model` (98 tests) green; `ruff` + `ty` clean.
- Verified against the installed **langchain-openai 1.3.2** that `reasoning_effort` is a real `ChatOpenAI` field (constructs cleanly).

## Note
Anthropic extended thinking (`thinking={budget_tokens}`) is a symmetric follow-up, not included here — this PR is scoped to the OpenAI/gpt-5.x path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)