### PR TITLE
feat(composites): produce EPA DTXSID in resolve_compound (#179)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -583,7 +583,7 @@ format only (D7); the ARC folder tree is materialised at export time by
 ```
 scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=False) → dict  # composite: linked Investigation→Study→Assay in one call (idempotent-WITH-merge: a reused layer's EMPTY fields are filled from the supplied hints, fill-don't-clobber), the fast path to a BASE-passing crate
 materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
-resolve_compound(name: str, hints: dict | None = None, verify=None) → {entity_id, name, identifiers, verifications, verified, source}  # composite: chemical name → lookup_compound → draft_molecular_entity → verify_identifier, in one idempotent call; carries the looked-up CAS + PubChem CID and never keeps an unverified id (D5)
+resolve_compound(name: str, hints: dict | None = None, verify=None) → {entity_id, name, identifiers, verifications, verified, source}  # composite: chemical name → lookup_compound → draft_molecular_entity → verify_identifier (+ best-effort CompTox DTXSID), in one idempotent call; carries the looked-up CAS + PubChem CID + EPA DTXSID and never keeps an unverified id (D5)
 resolve_publication(title: str, verify=None) → {ok, doi, entity_id, title, score} | {ok: False, reason, title}  # composite: publication title → Crossref title-search → confidence gate → draft_publication_with_authors(doi=…), in one idempotent call; commits a DOI only on a high-confidence match (score floor AND near-exact title) and never fabricates one (D5)
 draft_publication_with_authors(doi: str) → {publication_id, doi, authors:[{name, person_id, orcid, resolution}], hitl}  # composite (engine-routed, HITL-capable): publication + every author wired as a Person, each author's @id harmonized to their ORCID via a verify-first cascade
 draft_investigation(hints: dict) → Entity
@@ -637,7 +637,16 @@ composite never hand-rolls that wiring; (3) `verify_identifier` confirms each
 minted identifier against source. **D5:** `verify_identifier` *clears* any value
 that does not resolve, so a failed identifier never lingers as a fabricated id —
 the per-field verdicts are surfaced in `verifications` and `verified` is the AND of
-them. Looked-up identifier fields win over same-named caller `hints`. **Dedup is
+them. **DTXSID enrichment (Issue #179):** after resolution it also runs a
+best-effort CompTox `lookup_dtxsid` — querying by the strongest EXACT key
+available (`cas` → `inchikey` → name) — and stores the EPA **DTXSID** on the
+entity when found, so the build appends it as a third `DTXSID` identifier
+PropertyValue after `[CAS, PubChem CID]`. It is D5-safe (the value comes straight
+from CompTox, never fabricated) and **non-fatal** — a CompTox miss or outage never
+sinks an already-resolved compound. (Before #179 `lookup_dtxsid` had no
+deterministic-pipeline caller — it was reachable only from the legacy ReAct loop,
+so the default path silently dropped DTXSID for every compound.)
+Looked-up identifier fields win over same-named caller `hints`. **Dedup is
 by resolved chemical IDENTITY, not by name** (Issue #179): after a successful
 lookup it computes an identity key in priority order `pubchem_cid` → `inchikey` →
 `cas` → `chebiId` and reuses any existing `MolecularEntity` whose same identity
@@ -732,10 +741,11 @@ mirroring rocrate-wizard's `param_id` (`#param_<slug(name)>_<sha1("name|value")[
 and emits `propertyID` as an `{"@id": …}` node when a url is given. At build time:
 a Person carrying `orcid` gains an `ORCID` PropertyValue identifier
 (`propertyID {"@id": https://orcid.org}`); a MolecularEntity carrying
-`cas`/`casrn`/`cas_number` and/or `pubchem_cid` gains `[CAS, PubChem CID]`
-identifiers in that order (CAS has no `propertyID`; PubChem CID's is
-`{"@id": https://pubchem.ncbi.nlm.nih.gov/compound}`). These source fields are
-consumed structurally (kept off the node as raw literals). A Person's
+`cas`/`casrn`/`cas_number` and/or `pubchem_cid` and/or `dtxsid` gains
+`[CAS, PubChem CID, DTXSID]` identifiers in that order (CAS has no `propertyID`;
+PubChem CID's is `{"@id": https://pubchem.ncbi.nlm.nih.gov/compound}`; DTXSID's is
+`{"@id": https://comptox.epa.gov/dashboard/chemical/details}`). These source fields
+are consumed structurally (kept off the node as raw literals). A Person's
 `affiliation` and a Publication's `author` are resolved to `{"@id"}` references
 (via `_wire_reference` / `_resolve_many`) rather than emitted as literals, so
 `Person.affiliation` points at its Organization and `ScholarlyArticle.author`

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -344,6 +344,9 @@ _STRUCT_FIELDS = frozenset(
         "cas",
         "casrn",
         "cas_number",
+        # EPA CompTox/DSSTox substance id promoted to a DTXSID identifier
+        # PropertyValue (#179) — consumed structurally, not a stray node literal.
+        "dtxsid",
         "doi",
         "dest_path",
         "path",
@@ -448,7 +451,7 @@ def _identifier_pv(
 
 
 # Per-MolecularEntity identifier fields, in the order the gold crate lists them
-# (CAS first, then PubChem CID). Each tuple is
+# (CAS first, then PubChem CID, then the EPA DTXSID). Each tuple is
 # (field aliases, scheme name, propertyID url | None).
 _MOLECULAR_IDENTIFIERS: tuple[tuple[tuple[str, ...], str, str | None], ...] = (
     (("cas", "casrn", "cas_number"), "CAS", None),
@@ -456,6 +459,14 @@ _MOLECULAR_IDENTIFIERS: tuple[tuple[tuple[str, ...], str, str | None], ...] = (
         ("pubchem_cid",),
         "PubChem CID",
         "https://pubchem.ncbi.nlm.nih.gov/compound",
+    ),
+    # EPA CompTox/DSSTox substance id (#179). Appended AFTER CAS + PubChem CID so
+    # existing identifier order and PropertyValue ids stay byte-stable; propertyID
+    # is the CompTox chemical-details base, mirroring the PubChem-CID convention.
+    (
+        ("dtxsid",),
+        "DTXSID",
+        "https://comptox.epa.gov/dashboard/chemical/details",
     ),
 )
 

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -42,6 +42,7 @@ from builder.tools.hitl import HumanInterface
 from builder.tools.lookups import (
     lookup_compound,
     lookup_doi,
+    lookup_dtxsid,
     lookup_orcid,
     warm_compound_cache,
 )
@@ -1495,11 +1496,40 @@ def resolve_compound(
         else:
             entity = draft_molecular_entity(state, display_name, merged_hints)
 
+    # Best-effort EPA DTXSID enrichment (#179). DTXSID is a first-class ISA-Tox
+    # chemical identifier that the deterministic pipeline otherwise never
+    # produces — ``lookup_dtxsid`` had NO pipeline caller (it was reachable only
+    # from the legacy ReAct loop). Query CompTox by the strongest EXACT key
+    # available (CAS -> InChIKey -> name) so the match is unambiguous, and store
+    # the DTXSID only when the lookup returns one. D5-safe: the value comes
+    # straight from CompTox (the authority), never fabricated. A miss or outage
+    # is NON-FATAL — DTXSID is enrichment, not a precondition — so a CompTox
+    # failure never sinks an already-resolved compound (mirrors the graceful
+    # handling of the primary lookup above).
+    if not entity.fields.get("dtxsid"):
+        dtxsid_query = data.get("cas") or data.get("inchikey") or display_name
+        try:
+            dtxsid_hit = lookup_dtxsid(dtxsid_query)
+        except Exception:
+            logger.warning(
+                "DTXSID lookup errored for '%s'; skipping (non-fatal)",
+                dtxsid_query,
+                exc_info=True,
+            )
+            dtxsid_hit = {}
+        if dtxsid_hit.get("found"):
+            dtxsid = (dtxsid_hit.get("data") or {}).get("dtxsid")
+            if dtxsid:
+                entity.set_fields_from_dict({"dtxsid": dtxsid}, source="lookup")
+
     identifiers = {
         key: data[key]
         for key in _COMPOUND_IDENTIFIER_FIELDS
         if data.get(key) not in (None, "")
     }
+    # Surface the looked-up DTXSID in the return (pipeline provenance/logging).
+    if entity.fields.get("dtxsid"):
+        identifiers["dtxsid"] = entity.fields["dtxsid"]
 
     verifications: list[dict[str, Any]] = []
     do_verify = verify is None or verify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,28 @@ import pytest
 from builder.state import CrateState, Entity, EntityProvenance
 
 
+@pytest.fixture(autouse=True)
+def _stub_composites_dtxsid(monkeypatch):
+    """Keep ``resolve_compound``'s best-effort CompTox DTXSID lookup offline (#179).
+
+    ``resolve_compound`` runs a best-effort ``lookup_dtxsid`` (a live CompTox HTTP
+    call) after the primary PubChem/ChEBI resolution. Default it to a MISS across
+    the whole suite so no offline test accidentally reaches the network; tests
+    that exercise the DTXSID path re-patch ``composites.lookup_dtxsid`` with a hit
+    (a later ``monkeypatch.setattr`` in the test wins). Scoped to the symbol bound
+    in the ``composites`` namespace, so direct ``lookups`` / ``comptox`` (and
+    contract) tests are untouched. ``raising=False`` tolerates any import order.
+    """
+    from builder.tools import composites
+
+    monkeypatch.setattr(
+        composites,
+        "lookup_dtxsid",
+        lambda query: {"found": False, "data": {}, "error": "offline stub (conftest)"},
+        raising=False,
+    )
+
+
 @pytest.fixture
 def minimal_state() -> CrateState:
     """Return a CrateState with one Investigation entity."""

--- a/tests/test_crate_mapping_identifiers.py
+++ b/tests/test_crate_mapping_identifiers.py
@@ -172,6 +172,71 @@ class TestMolecularEntityIdentifiers:
         assert "cas" not in chem and "casrn" not in chem
 
 
+def _molecular_state_with_dtxsid() -> CrateState:
+    state = CrateState()
+    state.metadata.title = "Compound crate"
+    chem = Entity(
+        entity_id="chem_bpa",
+        type="MolecularEntity",
+        fields={
+            "name": "Bisphenol A",
+            "cas": "80-05-7",
+            "pubchem_cid": "6623",
+            "dtxsid": "DTXSID7020182",
+        },
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+    state.add_entity(chem)
+    return state
+
+
+class TestMolecularEntityDtxsid:
+    """A MolecularEntity carrying `dtxsid` emits a DTXSID identifier PV (#179).
+
+    DTXSID (the EPA CompTox/DSSTox substance id) is a first-class ISA-Tox chemical
+    identifier. It rounds-trips through the same ``_identifier_pv`` path as CAS /
+    PubChem CID — appended AFTER them so the existing order/ids are stable — with
+    its ``propertyID`` an ``@id`` node pointing at the CompTox Dashboard.
+    """
+
+    def _dtxsid_pv(self, graph: list[dict]) -> dict | None:
+        return next(
+            (
+                n
+                for n in graph
+                if n.get("@type") == "PropertyValue" and n.get("name") == "DTXSID"
+            ),
+            None,
+        )
+
+    def test_dtxsid_property_value_emitted(self):
+        graph = _graph(_molecular_state_with_dtxsid())
+        pv = self._dtxsid_pv(graph)
+        assert pv is not None, "a DTXSID PropertyValue node must be in the graph"
+        assert pv.get("value") == "DTXSID7020182"
+        assert pv.get("propertyID") == {
+            "@id": "https://comptox.epa.gov/dashboard/chemical/details"
+        }
+
+    def test_identifier_order_cas_cid_then_dtxsid(self):
+        graph = _graph(_molecular_state_with_dtxsid())
+        chem = _by_id(graph, "https://pubchem.ncbi.nlm.nih.gov/compound/6623")
+        assert chem is not None
+        ids = _ref_ids(chem.get("identifier"))
+        pv = self._dtxsid_pv(graph)
+        assert pv is not None
+        # CAS + PubChem CID + DTXSID, DTXSID appended last.
+        assert len(ids) == 3
+        assert ids[-1] == pv.get("@id")
+
+    def test_no_raw_dtxsid_literal_on_node(self):
+        graph = _graph(_molecular_state_with_dtxsid())
+        chem = _by_id(graph, "https://pubchem.ncbi.nlm.nih.gov/compound/6623")
+        assert chem is not None
+        # dtxsid must live in the PropertyValue, not as a bare literal on the node.
+        assert "dtxsid" not in chem
+
+
 class TestPersonAffiliation:
     def test_affiliation_resolves_to_org_reference(self):
         state = CrateState()

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -279,6 +279,8 @@ def _stub_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_search_works_by_title(title: str) -> list[dict[str, Any]]:
         return []
 
+    # NB: resolve_compound's best-effort CompTox DTXSID lookup is stubbed offline
+    # suite-wide by the ``_stub_composites_dtxsid`` autouse fixture in conftest.py.
     monkeypatch.setattr(composites_mod, "lookup_compound", fake_lookup_compound)
     monkeypatch.setattr(composites_mod, "verify_identifier", fake_verify_identifier)
     monkeypatch.setattr(

--- a/tests/test_tools_resolve_compound.py
+++ b/tests/test_tools_resolve_compound.py
@@ -142,6 +142,62 @@ class TestResolveCompoundHappyPath:
         assert mol.fields.get("description") == "a flavonolignan"
 
 
+class TestResolveCompoundDtxsid:
+    """resolve_compound enriches the MolecularEntity with its EPA DTXSID (#179).
+
+    DTXSID is a first-class ISA-Tox chemical identifier that the deterministic
+    pipeline previously never produced — ``lookup_dtxsid`` had NO pipeline caller
+    (it was reachable only from the legacy ReAct loop). resolve_compound now does
+    a best-effort CompTox lookup after the primary resolution and stores the
+    DTXSID on the entity, so the build's identifier-PV path emits it alongside
+    CAS + PubChem CID. D5-safe: the value comes straight from CompTox (the
+    authority), and a miss or outage is non-fatal.
+    """
+
+    def test_dtxsid_stored_on_entity(self, offline_lookup, monkeypatch):
+        seen: list[str] = []
+
+        def fake_dtxsid(query):  # noqa: ANN001
+            seen.append(query)
+            return {"found": True, "data": {"dtxsid": "DTXSID7020182"}, "error": None}
+
+        monkeypatch.setattr(composites, "lookup_dtxsid", fake_dtxsid)
+
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert mol.fields.get("dtxsid") == "DTXSID7020182"
+        # Queried by the strongest exact key available — the looked-up CAS.
+        assert seen and seen[0] == "33889-69-9"
+        # Surfaced in the return for pipeline provenance/logging.
+        assert result["identifiers"].get("dtxsid") == "DTXSID7020182"
+
+    def test_dtxsid_miss_leaves_no_field(self, offline_lookup, monkeypatch):
+        monkeypatch.setattr(
+            composites,
+            "lookup_dtxsid",
+            lambda q: {"found": False, "data": {}, "error": "no hit"},
+        )
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+        assert result["entity_id"]  # the compound still resolves
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert "dtxsid" not in mol.fields
+
+    def test_dtxsid_lookup_error_is_non_fatal(self, offline_lookup, monkeypatch):
+        def boom(query):  # noqa: ANN001
+            raise RuntimeError("CompTox down")
+
+        monkeypatch.setattr(composites, "lookup_dtxsid", boom)
+        state = CrateState()
+        result = resolve_compound(state, name="Silychristin A")
+        # The compound still resolves despite the CompTox failure (non-fatal).
+        assert result["entity_id"]
+        mol = _by_type(state, "MolecularEntity")[0]
+        assert "dtxsid" not in mol.fields
+
+
 class TestResolveCompoundIdempotent:
     def test_second_call_no_duplicate(self, offline_lookup):
         state = CrateState()


### PR DESCRIPTION
## What

Wire `lookup_dtxsid` into `resolve_compound` as a best-effort CompTox enrichment and emit a **DTXSID** identifier `PropertyValue` at build, appended after CAS + PubChem CID.

## Why

Closes a **cutover-fidelity gap** (part of the #179 arc): the EPA **DTXSID** is a first-class ISA-Tox chemical identifier, but the now-default deterministic pipeline never produced it. `lookup_dtxsid` shipped and was registered, yet had **no pipeline caller** — it was reachable only from the legacy ReAct loop, so the cutover silently dropped DTXSID from every tox crate with a compound.

## How

- **`builder/tools/composites.py`** — after the primary PubChem/ChEBI resolve, `resolve_compound` runs a best-effort `lookup_dtxsid` querying by the strongest exact key available (`cas` → `inchikey` → name), stores `dtxsid` on the entity, and surfaces it in the return. Wrapped in try/except so a CompTox miss or outage is **non-fatal** — it never sinks an already-resolved compound. **D5-safe:** the value comes straight from CompTox, never fabricated.
- **`builder/tools/_crate_mapping.py`** — `dtxsid` added to `_STRUCT_FIELDS` (kept off the node as a raw literal) and a `("dtxsid", "DTXSID", <comptox-details-url>)` entry appended to `_MOLECULAR_IDENTIFIERS`. Appended **after** CAS + PubChem CID so existing identifier order and PropertyValue ids stay byte-stable; the `propertyID` base matches `lookups/comptox.py`'s own `@id` convention (no drift).
- **Docs** — `AGENTS.md` `resolve_compound` signature/description and the identifier-PropertyValue note updated.

## Tests (TDD — written first, confirmed red, then green)

- `TestResolveCompoundDtxsid` — DTXSID stored on the entity + surfaced; a miss leaves no field; a lookup error is non-fatal.
- `TestMolecularEntityDtxsid` — build emits the DTXSID PV in `[CAS, PubChem CID, DTXSID]` order, `propertyID` an `@id` node, no raw literal on the node.
- `tests/conftest.py` — one suite-wide autouse stub defaults `composites.lookup_dtxsid` to a miss so the new **live** CompTox call never leaks into offline tests; scoped to the `composites` namespace, so direct lookup/contract tests are untouched.

## Verification

- Full suite green: **1492 passed, 1 xpassed, 0 failures**; affected subset re-verified on the current tree (143 passed).
- `ruff` clean, `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)