### PR TITLE
feat(report): fold provenance chain + graph topology into maturity report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ eval_reports/
 
 # local maturity-report design scratch (kept locally, never committed)
 maturity_report_prototype.html
+docs/ab-and-harmonization-handoff.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1414,7 +1414,7 @@ Embedding is automatic (no separate agent tool — a free byproduct of building 
 turned off with `export_crate(..., embed_graph=False)`. Inline-rendering the Mermaid in the #86
 `ro-crate-preview.html` is the natural next step.
 
-**Maturity report (`ro-crate-maturity.html`, #85).** `export_crate` also embeds a human-readable
+**Maturity report (`ro-crate-metadata-maturity.html`, #85).** `export_crate` also embeds a human-readable
 maturity report as a `File` + `CreativeWork` `about` `./` (same mechanism as the graph). It is
 rendered by `builder/writers/maturity_report.py` (`build_maturity_html`) as a light-mode evaluation
 dashboard — a KPI row over four detail sections — and covers four axes: profile adherence (rendered
@@ -1431,6 +1431,16 @@ renders as an explicit **"not assessed"** neutral state (glyph + label, never co
 a green zero; REQUIRED/RECOMMENDED issue text is still surfaced as `Must fix` / `Recommended`
 suggestions. Rendering this from `state.validation` alone (no new validation machinery) keeps the
 pure/cheap contract.
+
+When `export_crate` embeds the report it passes the crate's serialized `@graph`
+(`build_maturity_html(state, graph=crate.metadata.generate())`), which folds in a **Provenance &
+graph** section: the LabProcess derivation chain drawn as a self-contained inline SVG
+(`render_provenance_svg` in `builder/writers/provenance_dag.py` — a finished `<svg>`, no mermaid.js,
+no external assets, so it prints offline), plus the relocated graph-topology strip (entity
+composition by paper layer + orphan/dangling flags, from `build_crate_graph` counts). The `graph`
+argument is optional — omitting it (e.g. a bare `build_maturity_html(state)`) simply skips that
+section, so the report stays useful without a serialized crate. The embedded file is named
+`ro-crate-metadata-maturity.html` (sharing the `ro-crate-metadata` stem of the crate's main file).
 
 The page is **self-contained** (inline CSS, no external assets) so it renders offline. The styling
 and document shell live in sibling assets — `maturity_report.css` and `maturity_report.html` (with

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -264,7 +264,7 @@ def _embed_crate_graph(crate: ROCrate) -> None:
 def _embed_maturity_report(crate: ROCrate, state: CrateState) -> None:
     """Embed the maturity report into the crate and register it (#85).
 
-    Renders ``ro-crate-maturity.html`` — profile adherence (computed in-memory
+    Renders ``ro-crate-metadata-maturity.html`` — profile adherence (computed in-memory
     from the crate's current ``@graph``), FAIR + DSM, OECD MIT coverage, and
     reproducibility readiness — and adds it as a ``File`` + ``CreativeWork``
     ``about`` ``./`` (the HTML is the File's in-memory source, materialised by
@@ -275,7 +275,9 @@ def _embed_maturity_report(crate: ROCrate, state: CrateState) -> None:
     from builder.writers.maturity_report import REPORT_FILENAME, build_maturity_html
 
     # Renders from state.validation (no re-validate) so export stays cheap (#85).
-    page = build_maturity_html(state)
+    # Pass the crate's current @graph so the report can fold in the provenance
+    # chain + graph-topology strip drawn from real serialized entities.
+    page = build_maturity_html(state, graph=crate.metadata.generate())
     crate.add(
         File(
             crate,
@@ -320,7 +322,7 @@ def export_crate(
             ``sessions/<session_id>/working_crate/``.
         embed_graph: Write the entity-graph diagram into the crate (default
             True). Set False to skip the visualization artifact.
-        embed_report: Write the maturity report (ro-crate-maturity.html, #85)
+        embed_report: Write the maturity report (ro-crate-metadata-maturity.html, #85)
             into the crate (default True). Set False to skip it.
 
     Returns:
@@ -355,7 +357,7 @@ def export_crate(
             except Exception as graph_err:  # noqa: BLE001 — never fail export on the viz
                 logger.warning("Could not embed crate graph: %s", graph_err)
 
-        # Embed the maturity report (ro-crate-maturity.html, a CreativeWork about
+        # Embed the maturity report (ro-crate-metadata-maturity.html, a CreativeWork about
         # ./, #85). Best-effort: a reporting failure must not fail the export.
         if embed_report:
             try:

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -6,6 +6,8 @@
   --good:#0ca30c; --good-ink:#0a7d0a; --warn:#fab219; --warn-ink:#8a6500;
   --low:#d03b3b; --low-ink:#b3261e; --na-a:#e6ebeb; --na-b:#f3f6f6; --na-ink:#7a8688;
   --cov:#0e7c86; --track:#e6ebeb;
+  --cat-process:#2a78d6; --cat-material:#008300; --cat-data:#c0407a;
+  --edge-object:#8a9698; --edge-result:#0e7c86;
   color-scheme: light;
   background:var(--page); color:var(--ink);
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
@@ -140,6 +142,44 @@
 .mat ul.repro li { display:flex; gap:.6rem; align-items:flex-start; }
 .mat ul.repro .rl { font-weight:550; font-size:.9rem; }
 .mat ul.repro .hint { display:block; font-size:.78rem; color:var(--muted); margin-top:.1rem; }
+
+/* provenance chain (#85) */
+.mat .prov-cap { font-size:.85rem; color:var(--ink-2); margin:0 0 .8rem; max-width:60ch; }
+.mat .prov-scroll { overflow-x:auto; padding-bottom:.3rem; }
+.mat svg.prov { display:block; width:100%; min-width:44rem; height:auto; }
+.mat .prov .n { stroke-width:1.7; }
+.mat .prov .n-process { fill:var(--accent-soft); stroke:var(--cat-process); }
+.mat .prov .n-material { fill:var(--surface-2); stroke:var(--cat-material); }
+.mat .prov .n-data { fill:var(--surface-2); stroke:var(--cat-data); }
+.mat .prov .n-ctx { fill:var(--surface-2); stroke:var(--muted); }
+.mat .prov .fold { fill:color-mix(in srgb,var(--cat-data) 22%,transparent); stroke:none; }
+.mat .prov .name { fill:var(--ink); font-size:11.5px; text-anchor:middle; font-weight:520; }
+.mat .prov .tag { font-size:8px; text-anchor:middle; font-weight:700; letter-spacing:.04em; }
+.mat .prov .tag-process { fill:var(--cat-process); }
+.mat .prov .tag-material { fill:var(--cat-material); }
+.mat .prov .tag-data { fill:var(--cat-data); }
+.mat .prov .tag-ctx { fill:var(--muted); }
+.mat .prov .e { fill:none; stroke-width:1.6; }
+.mat .prov .e-object { stroke:var(--edge-object); stroke-dasharray:4 3; }
+.mat .prov .e-result { stroke:var(--edge-result); }
+.mat .prov .mk-object { fill:var(--edge-object); }
+.mat .prov .mk-result { fill:var(--edge-result); }
+.mat .prov-legend { display:flex; flex-wrap:wrap; gap:.5rem 1.1rem; margin-top:.7rem;
+  font-size:.8rem; color:var(--ink-2); }
+.mat .prov-legend .lg { display:inline-flex; align-items:center; gap:.4rem; }
+.mat .prov-legend .gl { width:1.5rem; height:0; border-top:2px solid var(--edge-result); }
+.mat .prov-legend .gl.obj { border-top:2px dashed var(--edge-object); }
+
+/* graph-topology strip (relocated here from the header) */
+.mat .comp { display:flex; flex-wrap:wrap; gap:.5rem .9rem; align-items:center;
+  font-size:.82rem; color:var(--ink-2); }
+.mat .comp .c { display:inline-flex; align-items:center; gap:.35rem; }
+.mat .comp .sw { width:.62rem; height:.62rem; border-radius:2px; }
+.mat .comp .warnflag { color:var(--low-ink); }
+.mat .comp .warnflag .mk { width:1rem; height:1rem; font-size:.6rem; }
+.mat .comp.topo { margin:1rem 0 0; padding-top:.75rem; border-top:1px solid var(--hairline); }
+.mat .topo-label { font-size:.68rem; text-transform:uppercase; letter-spacing:.08em;
+  color:var(--muted); font-weight:650; margin-right:.15rem; }
 
 .mat footer { color:var(--muted); font-size:.75rem; margin-top:1.4rem; padding-top:.9rem;
   border-top:1px solid var(--hairline); display:flex; justify-content:space-between; flex-wrap:wrap; gap:.5rem; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1,4 +1,4 @@
-"""RO-Crate maturity report (``ro-crate-maturity.html``), embedded in the crate (#85).
+"""RO-Crate maturity report (``ro-crate-metadata-maturity.html``), embedded in the crate (#85).
 
 Renders a self-contained, light-mode evaluation dashboard (inline CSS, no external
 assets) covering the four axes from the issue:
@@ -37,7 +37,7 @@ from builder.state import CrateState, FAIRReport, MITReport, ValidationReport
 from builder.tools.fair_assessment import assess_fair_maturity
 from builder.tools.mit_assessment import assess_mit_coverage
 
-REPORT_FILENAME = "ro-crate-maturity.html"
+REPORT_FILENAME = "ro-crate-metadata-maturity.html"
 
 # FAIR dimension letters (as emitted by fair/indicators.yaml) → display names.
 _DIM_NAMES = {"F": "Findable", "A": "Accessible", "I": "Interoperable", "R": "Reusable"}
@@ -227,7 +227,7 @@ def _load_css() -> str:
 
     Kept in a sibling ``maturity_report.css`` so the styling lives apart from the
     Python that assembles the markup; it is embedded (not linked) so the exported
-    ``ro-crate-maturity.html`` renders offline with no external assets.
+    ``ro-crate-metadata-maturity.html`` renders offline with no external assets.
     """
     return _CSS_PATH.read_text(encoding="utf-8").strip("\n")
 
@@ -506,10 +506,88 @@ def _render_repro_section(checks: list[tuple[str, bool, str]]) -> str:
     )
 
 
+def _render_topology_strip(counts: dict[str, int]) -> str:
+    """The graph-topology metrics strip (relocated into the Provenance section).
+
+    Renders the crate's entity composition by paper layer (packaging / ISA
+    structural / ISA-Tox domain) plus any orphan/dangling-reference flags, from
+    the deterministic :func:`build_crate_graph` counts.
+    """
+    total = counts.get("layer1", 0) + counts.get("layer2", 0) + counts.get("layer3", 0)
+    parts = [
+        '<span class="topo-label">Graph topology</span>',
+        f'<span class="c"><b>{total}</b>&nbsp;entities</span>',
+        '<span class="c"><span class="sw" style="background:var(--muted)"></span>'
+        f'{counts.get("layer1", 0)} packaging</span>',
+        '<span class="c"><span class="sw" style="background:var(--cat-process)"></span>'
+        f'{counts.get("layer2", 0)} ISA structural</span>',
+        '<span class="c"><span class="sw" style="background:var(--cat-data)"></span>'
+        f'{counts.get("layer3", 0)} ISA-Tox domain</span>',
+    ]
+    flags: list[str] = []
+    n_orphan = counts.get("orphan", 0)
+    n_dangling = counts.get("dangling", 0)
+    if n_orphan:
+        flags.append(f"{n_orphan} orphan" + ("" if n_orphan == 1 else "s"))
+    if n_dangling:
+        flags.append(f"{n_dangling} dangling ref" + ("" if n_dangling == 1 else "s"))
+    if flags:
+        parts.append(f'<span class="c warnflag">{_mk("no")}&nbsp;{" · ".join(flags)}</span>')
+    return f'<div class="comp topo">{"".join(parts)}</div>'
+
+
+def _render_provenance_section(graph: dict[str, Any] | list[dict[str, Any]]) -> str:
+    """Fold the provenance chain + graph topology into the report (#85).
+
+    Draws the LabProcess derivation chain as a self-contained inline SVG (offline,
+    no script) with a shape legend, and appends the graph-topology strip. When the
+    crate records no derivation chain, the SVG is replaced by a note but the
+    topology strip still renders. Called only when a crate ``@graph`` is supplied.
+    """
+    from builder.writers.provenance_dag import build_crate_graph, render_provenance_svg
+
+    svg = render_provenance_svg(graph)
+    counts = build_crate_graph(graph).get("counts", {})
+    if svg:
+        body = (
+            '<p class="prov-cap">The derivation chain a receiving lab follows to trace an '
+            "output back to its inputs — materials, the processes applied, and the files "
+            "each step produced.</p>\n"
+            f'  <div class="prov-scroll">{svg}</div>\n'
+            '  <div class="prov-legend">'
+            '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
+            '<polygon points="4,1 14,1 18,7 14,13 4,13 1,7" fill="var(--accent-soft)" '
+            'stroke="var(--cat-process)" stroke-width="1.6"/></svg> Process</span>'
+            '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+            '<rect x="1" y="2" width="20" height="10" rx="5" fill="var(--surface-2)" '
+            'stroke="var(--cat-material)" stroke-width="1.6"/></svg> Sample / material</span>'
+            '<span class="lg"><svg width="18" height="14" aria-hidden="true">'
+            '<rect x="1" y="1" width="15" height="12" rx="2" fill="var(--surface-2)" '
+            'stroke="var(--cat-data)" stroke-width="1.6"/></svg> File / table</span>'
+            '<span class="lg"><span class="gl obj"></span> consumes (object)</span>'
+            '<span class="lg"><span class="gl"></span> produces (result)</span>'
+            "</div>"
+        )
+    else:
+        body = (
+            '<p class="lead">No derivation chain recorded — this crate has no LabProcess '
+            "input/output edges to trace.</p>"
+        )
+    return (
+        "<section>\n"
+        '  <div class="sec-h"><h2>Provenance &amp; graph</h2>'
+        '<span class="sec-meta">how the result was produced</span></div>\n'
+        f"  {body}\n"
+        f"  {_render_topology_strip(counts)}\n"
+        "</section>\n"
+    )
+
+
 def build_maturity_html(
     state: CrateState,
     *,
     validation: ValidationReport | None = None,
+    graph: dict[str, Any] | list[dict[str, Any]] | None = None,
 ) -> str:
     """Render the maturity report HTML for *state*.
 
@@ -522,10 +600,19 @@ def build_maturity_html(
     three severity tiers Required / Recommended / Optional (#306); an unevaluated
     SHOULD/MAY tier renders as "not assessed", never a false green zero.
 
+    When a crate ``graph`` (the ``@graph`` from ``crate.metadata.generate()``) is
+    supplied, the report also folds in a Provenance & graph section: the LabProcess
+    derivation chain drawn as a self-contained inline SVG, plus a graph-topology
+    strip (entity composition by paper layer, orphan/dangling flags). Omitting
+    ``graph`` skips that section — the report is still complete without it.
+
     Args:
         state: The crate state being reported on.
         validation: Validation results to render. Defaults to
             ``state.validation``.
+        graph: The crate's serialized ``@graph`` (or the full metadata document)
+            used to render the provenance chain and topology strip. When ``None``
+            the Provenance & graph section is omitted.
     """
     esc = html.escape
     title = state.metadata.title or "RO-Crate"
@@ -540,16 +627,20 @@ def build_maturity_html(
 
     header = _render_header(title, accession, tiers)
     kpis = _render_kpis(tiers, fair, mit, repro_ready, len(checks))
+    prov_section = _render_provenance_section(graph) if graph is not None else ""
     prof_section = _render_profile_section(val, tiers)
     fair_section = _render_fair_section(fair)
     mit_section = _render_mit_section(mit)
     repro_section = _render_repro_section(checks)
 
     footer = (
-        "<footer><span>Generated by vitro-crate · ro-crate-maturity.html</span>"
+        "<footer><span>Generated by vitro-crate · ro-crate-metadata-maturity.html</span>"
         "<span>Self-contained · offline · print-friendly</span></footer>\n"
     )
-    body = header + kpis + prof_section + fair_section + mit_section + repro_section + footer
+    body = (
+        header + kpis + prov_section + prof_section + fair_section
+        + mit_section + repro_section + footer
+    )
 
     # Fill the shell placeholders. STYLE and BODY first (neither can contain a
     # sentinel), TITLE last so crate-controlled text can never re-trigger a

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -428,6 +428,217 @@ def render_provenance_mermaid(
     return out
 
 
+# ---------------------------------------------------------------------------
+# Inline-SVG provenance chain (#85) — a self-contained, offline diagram of the
+# derivation chain for embedding in the maturity report. Unlike
+# ``render_provenance_mermaid`` (which needs mermaid.js to render), this emits a
+# finished ``<svg>`` element: no script, no external assets, prints as-is.
+# ---------------------------------------------------------------------------
+_SVG_NODE_W = 138
+_SVG_NODE_H = 48
+_SVG_COL_DX = 160  # left-edge spacing between columns
+_SVG_ROW_DY = 96  # top-edge spacing between rows
+_SVG_X0 = 18
+_SVG_Y0 = 22
+_SVG_FOLD = 11  # folded-corner size on the "File" node shape
+# _node_class() bucket → (node CSS class, tag CSS class).
+_SVG_CLASS = {
+    "proc": ("n-process", "tag-process"),
+    "mat": ("n-material", "tag-material"),
+    "data": ("n-data", "tag-data"),
+    "ctx": ("n-ctx", "tag-ctx"),
+}
+
+
+def _svg_trunc(text: str, limit: int = 18) -> str:
+    """Single-line ellipsised label (the SVG has no text wrapping)."""
+    text = text.replace("\n", " ").replace("\r", " ").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _svg_node_shape(cls: str, x: int, y: int) -> str:
+    """The node's outline path/polygon for style bucket *cls* at ``(x, y)``."""
+    w, h = _SVG_NODE_W, _SVG_NODE_H
+    if cls == "proc":  # hexagon (chevron ends read as "a step")
+        pts = (
+            f"{x},{y + h // 2} {x + 13},{y} {x + w - 13},{y} "
+            f"{x + w},{y + h // 2} {x + w - 13},{y + h} {x + 13},{y + h}"
+        )
+        return f'<polygon class="n n-process" points="{pts}"/>'
+    if cls == "mat":  # stadium (rounded ends) — a sample/material
+        return (
+            f'<rect class="n n-material" x="{x}" y="{y}" width="{w}" height="{h}" '
+            f'rx="{h // 2}" ry="{h // 2}"/>'
+        )
+    if cls == "data":  # document with a folded corner — a File/Table
+        f = _SVG_FOLD
+        body = (
+            f"M{x + 4},{y} H{x + w - f} L{x + w},{y + f} V{y + h - 4} "
+            f"Q{x + w},{y + h} {x + w - 4},{y + h} H{x + 4} "
+            f"Q{x},{y + h} {x},{y + h - 4} V{y + 4} Q{x},{y} {x + 4},{y} Z"
+        )
+        fold = f"M{x + w - f},{y} V{y + f} H{x + w} Z"
+        return f'<path class="n n-data" d="{body}"/><path class="fold" d="{fold}"/>'
+    # ctx — a plain rounded rectangle for anything off the material/data axis.
+    return (
+        f'<rect class="n n-ctx" x="{x}" y="{y}" width="{w}" height="{h}" rx="8" ry="8"/>'
+    )
+
+
+def render_provenance_svg(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> str:
+    """Render the LabProcess derivation chain as a self-contained inline ``<svg>``.
+
+    Reads the same derivation subgraph as :func:`render_provenance_mermaid` — each
+    ``LabProcess`` and the entities it consumes (``object``/``input``) and produces
+    (``result``/``output``) — and lays it out left-to-right by longest-path depth,
+    so a receiving lab can read how a result was produced. Materials render as
+    rounded "stadiums", processes as hexagons, files/tables as folded documents;
+    ``object`` edges are dashed ("consumes"), ``result`` edges solid ("produces").
+
+    Unlike the Mermaid renderer, the output is a finished SVG element (markers,
+    node shapes, edge paths, labels) with **no script and no external assets**, so
+    it embeds directly in the offline maturity report and prints as-is. All
+    crate-controlled text (entity names/tags) is HTML-escaped (#169).
+
+    Args:
+        metadata: A parsed ``ro-crate-metadata.json`` dict, the ``@graph`` list, or
+            the ``crate.metadata.generate()`` document.
+
+    Returns:
+        The ``<svg>…</svg>`` markup, or ``""`` when the crate records no
+        derivation chain (no in-crate process input/output edges to draw).
+    """
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    nodes: dict[str, dict[str, Any]] = {
+        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
+    }
+
+    # Directed derivation edges, both pointing "downstream": material --object-->
+    # process, process --result--> data. Only edges whose endpoints are both
+    # in-crate nodes are drawn (off-graph refs have nothing to attach to).
+    edges: list[tuple[str, str, str]] = []  # (src, dst, kind)
+    for nid, node in nodes.items():
+        if not _is_process(node):
+            continue
+        for src in _refs(node, _INPUT_KEYS):
+            if src in nodes:
+                edges.append((src, nid, "object"))
+        for dst in _refs(node, _OUTPUT_KEYS):
+            if dst in nodes:
+                edges.append((nid, dst, "result"))
+    if not edges:
+        return ""
+
+    drawn = {e[0] for e in edges} | {e[1] for e in edges}
+
+    # Predecessors/successors over the drawn subgraph.
+    preds: dict[str, list[str]] = {n: [] for n in drawn}
+    has_succ: dict[str, bool] = {n: False for n in drawn}
+    for src, dst, _ in edges:
+        preds[dst].append(src)
+        has_succ[src] = True
+
+    # Column = longest path from any source (memoised depth; back-edges → 0 so a
+    # pathological cycle can't recurse forever).
+    col: dict[str, int] = {}
+    inprog: set[str] = set()
+
+    def _depth(n: str) -> int:
+        if n in col:
+            return col[n]
+        if n in inprog:
+            return 0
+        inprog.add(n)
+        d = 0
+        for p in preds[n]:
+            d = max(d, _depth(p) + 1)
+        inprog.discard(n)
+        col[n] = d
+        return d
+
+    for n in sorted(drawn):
+        _depth(n)
+
+    # Row assignment, column by column left→right. Within a column, nodes that
+    # continue the chain (have a successor) are placed first so the "spine" stays
+    # on a straight row; a node inherits a placed predecessor's row when free,
+    # else the lowest free row — which cleanly steps branch outputs onto new rows.
+    by_col: dict[int, list[str]] = {}
+    for n in drawn:
+        by_col.setdefault(col[n], []).append(n)
+    row: dict[str, int] = {}
+    for c in sorted(by_col):
+        used: set[int] = set()
+        ordered = sorted(by_col[c], key=lambda n: (0 if has_succ[n] else 1, n))
+        for n in ordered:
+            placed_pred_rows = [row[p] for p in preds[n] if p in row]
+            desired = min(placed_pred_rows) if placed_pred_rows else None
+            if desired is not None and desired not in used:
+                r = desired
+            else:
+                r = 0
+                while r in used:
+                    r += 1
+            row[n] = r
+            used.add(r)
+
+    pos: dict[str, tuple[int, int]] = {
+        n: (_SVG_X0 + col[n] * _SVG_COL_DX, _SVG_Y0 + row[n] * _SVG_ROW_DY)
+        for n in drawn
+    }
+    vb_w = max(x + _SVG_NODE_W for x, _ in pos.values()) + 18
+    vb_h = max(y + _SVG_NODE_H for _, y in pos.values()) + 22
+
+    # Edges: draw results (solid) then objects (dashed), each deterministically.
+    mid = _SVG_NODE_H // 2
+    edge_svg: list[str] = []
+    for kind in ("result", "object"):
+        for src, dst, k in sorted(edges):
+            if k != kind:
+                continue
+            x1, y1 = pos[src][0] + _SVG_NODE_W, pos[src][1] + mid
+            x2, y2 = pos[dst][0], pos[dst][1] + mid
+            dx = (x2 - x1) // 2 if y1 == y2 else max((x2 - x1) // 2, 30)
+            path = f"M{x1},{y1} C{x1 + dx},{y1} {x2 - dx},{y2} {x2},{y2}"
+            edge_svg.append(
+                f'<path class="e e-{kind}" d="{path}" '
+                f'marker-end="url(#prov-ar-{kind})"/>'
+            )
+
+    # Nodes: shape + type tag (above) + name (inside). Labels are escaped.
+    node_svg: list[str] = []
+    for n in sorted(drawn, key=lambda n: (col[n], row[n], n)):
+        node = nodes[n]
+        cls = _node_class(node)
+        node_cls, tag_cls = _SVG_CLASS[cls]
+        x, y = pos[n]
+        cx = x + _SVG_NODE_W // 2
+        name = _escape(_svg_trunc(_name(node)))
+        tag = _escape(_svg_trunc(_tag(node), 22)).upper()
+        node_svg.append(
+            f"<g><title>{_escape(_name(node))} — {_escape(_tag(node))}</title>"
+            f"{_svg_node_shape(cls, x, y)}"
+            f'<text class="tag {tag_cls}" x="{cx}" y="{y - 6}">{tag}</text>'
+            f'<text class="name" x="{cx}" y="{y + 28}">{name}</text></g>'
+        )
+
+    marker = (
+        '<marker id="prov-ar-{k}" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+        '<path d="M0,0 L10,5 L0,10 z" class="mk-{k}"/></marker>'
+    )
+    return (
+        f'<svg viewBox="0 0 {vb_w} {vb_h}" width="{vb_w}" height="{vb_h}" '
+        'role="img" aria-label="Provenance derivation chain" class="prov">'
+        "<title>Provenance derivation chain</title>"
+        f'<defs>{marker.format(k="object")}{marker.format(k="result")}</defs>'
+        f'<g class="edges">{"".join(edge_svg)}</g>'
+        f'<g class="nodes">{"".join(node_svg)}</g></svg>'
+    )
+
+
 # Relation key sets for the full crate graph. Each tuple is
 # (json_keys, label, reversed): reversed=True means the referenced node points
 # INTO the holder (process inputs), so the drawn edge is ref --> holder.

--- a/tests/test_html_xss.py
+++ b/tests/test_html_xss.py
@@ -15,7 +15,7 @@ Covers the three generators that embed crate data:
 
 * ``builder/writers/provenance_dag.py`` — the Mermaid DAG, the full crate graph,
   and the self-contained ``render_mermaid_html`` page;
-* ``builder/writers/maturity_report.py`` — ``ro-crate-maturity.html``;
+* ``builder/writers/maturity_report.py`` — ``ro-crate-metadata-maturity.html``;
 * the bundled ``ro-crate-preview.html`` written by ``export_crate``.
 """
 

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -11,6 +11,15 @@ from builder.writers.maturity_report import REPORT_FILENAME, build_maturity_html
 from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
 
+class TestReportFilename:
+    """The report filename shares the crate's ``ro-crate-metadata`` stem."""
+
+    def test_report_filename_is_metadata_stemmed(self) -> None:
+        # Consistency with the crate's main file (ro-crate-metadata.json); still
+        # an .html document because build_maturity_html renders HTML.
+        assert REPORT_FILENAME == "ro-crate-metadata-maturity.html"
+
+
 class TestBuildMaturityHtml:
     """build_maturity_html renders the four report axes (pure, no validator)."""
 
@@ -51,7 +60,7 @@ class TestBuildMaturityHtml:
 
 
 class TestEmbeddedInCrate:
-    """export_crate embeds ro-crate-maturity.html as a CreativeWork about ./."""
+    """export_crate embeds ro-crate-metadata-maturity.html as a CreativeWork about ./."""
 
     def test_export_writes_maturity_report(self, tmp_path: Path) -> None:
         state = vhps_fixture_state("S-VHPS21")
@@ -86,6 +95,66 @@ class TestEmbeddedInCrate:
         res = export_crate(state, str(out), embed_report=False)
         assert res["success"], res["error"]
         assert not (out / REPORT_FILENAME).exists()
+
+
+class TestProvenanceSection:
+    """When a crate ``@graph`` is supplied, the report folds in a Provenance &
+    graph section: the derivation-chain SVG plus a graph-topology strip (#85)."""
+
+    def _chain_graph(self) -> dict:
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#d"}]},
+                {"@id": "#s", "@type": "Sample", "name": "Input sample"},
+                {
+                    "@id": "#p",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "object": {"@id": "#s"},
+                    "result": {"@id": "#d"},
+                },
+                {"@id": "#d", "@type": "File", "name": "result.csv"},
+            ]
+        }
+
+    def test_graph_renders_provenance_and_topology(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        page = build_maturity_html(state, graph=self._chain_graph())
+        assert "Provenance" in page
+        assert 'class="prov"' in page  # the inline derivation-chain SVG
+        assert "result.csv" in page
+        assert "Graph topology" in page  # the relocated topology strip
+        assert "entities" in page
+
+    def test_no_graph_omits_provenance_section(self) -> None:
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
+        assert "Graph topology" not in page
+        assert 'class="prov"' not in page
+
+    def test_graph_without_chain_shows_topology_note(self) -> None:
+        # Entities but no LabProcess I/O → topology strip, but no chain SVG.
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset"},
+                {"@id": "#f", "@type": "File", "name": "orphan.csv"},
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "Graph topology" in page
+        assert 'class="prov"' not in page
+        assert "no derivation chain" in page.lower()
+
+    def test_export_embeds_provenance_from_crate_graph(self, tmp_path: Path) -> None:
+        # End-to-end: the embedded report is built with the crate's real @graph,
+        # so the topology strip travels with the written crate.
+        state = vhps_fixture_state("S-VHPS21")
+        out = tmp_path / "crate"
+        state.metadata.output_path = str(out)
+        build_crate(state)
+        page = (out / REPORT_FILENAME).read_text(encoding="utf-8")
+        assert "Graph topology" in page
 
 
 class TestSeverityTiers:

--- a/tests/test_provenance_dag.py
+++ b/tests/test_provenance_dag.py
@@ -15,6 +15,7 @@ from builder.tools._crate_mapping import populate_crate
 from builder.writers.provenance_dag import (
     render_mermaid_html,
     render_provenance_mermaid,
+    render_provenance_svg,
 )
 from profiles.context import ISA_TOX_CONTEXT
 
@@ -176,6 +177,81 @@ def test_render_mermaid_html_escapes_label_markup_safely() -> None:
     html = render_mermaid_html(render_provenance_mermaid(_full_chain_graph()))
     # json.dumps escapes the source into a quoted literal containing <br/>.
     assert "<br/>" in html
+
+
+class TestRenderProvenanceSvg:
+    """``render_provenance_svg`` draws the derivation chain as a self-contained,
+    offline inline ``<svg>`` (no external assets, no script) for embedding in the
+    maturity report."""
+
+    def test_returns_inline_svg_element(self) -> None:
+        svg = render_provenance_svg(_full_chain_graph())
+        assert svg.startswith("<svg")
+        assert svg.rstrip().endswith("</svg>")
+        assert "viewBox" in svg
+
+    def test_chain_nodes_and_edges_present(self) -> None:
+        svg = render_provenance_svg(_full_chain_graph())
+        # Every material/data label on the derivation chain is drawn.
+        for label in ("HepG2", "Cultured cells", "Condition table", "Figures"):
+            assert label in svg, f"{label} missing from provenance SVG"
+        # Process discriminators appear as node tags (uppercased).
+        assert "EXPOSURE" in svg.upper()
+        # Both edge kinds are drawn (object = input, result = output).
+        assert "e-object" in svg and "e-result" in svg
+
+    def test_no_process_chain_returns_empty(self) -> None:
+        # A graph with data but no LabProcess has no derivation chain to draw.
+        svg = render_provenance_svg(
+            {"@graph": [{"@id": "#f", "@type": "File", "name": "orphan.csv"}]}
+        )
+        assert svg == ""
+
+    def test_escapes_crate_controlled_names(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "#s", "@type": "Sample", "name": "<script>alert(1)</script>"},
+                {
+                    "@id": "#p",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "object": {"@id": "#s"},
+                    "result": {"@id": "#d"},
+                },
+                {"@id": "#d", "@type": "File", "name": "out.csv"},
+            ]
+        }
+        svg = render_provenance_svg(graph)
+        assert "<script>alert(1)</script>" not in svg
+        assert "&lt;script&gt;" in svg
+
+    def test_self_contained_no_external_assets(self) -> None:
+        svg = render_provenance_svg(_full_chain_graph())
+        assert "http://" not in svg and "https://" not in svg
+        assert "<script" not in svg.lower()
+
+    def test_branching_second_output_is_drawn(self) -> None:
+        # One process with two results (a branch) — both outputs must be drawn.
+        graph = {
+            "@graph": [
+                {"@id": "#s", "@type": "Sample", "name": "Input sample"},
+                {
+                    "@id": "#p",
+                    "@type": "LabProcess",
+                    "additionalType": "EndpointReadout",
+                    "object": {"@id": "#s"},
+                    "result": [{"@id": "#d1"}, {"@id": "#d2"}],
+                },
+                {"@id": "#d1", "@type": "File", "name": "result.csv"},
+                {"@id": "#d2", "@type": ["File", "csvw:Table"], "name": "raw.csv"},
+            ]
+        }
+        svg = render_provenance_svg(graph)
+        assert "result.csv" in svg and "raw.csv" in svg
+
+    def test_accepts_bare_graph_list(self) -> None:
+        svg = render_provenance_svg(_full_chain_graph()["@graph"])
+        assert svg.startswith("<svg")
 
 
 def _exposure_state() -> CrateState:


### PR DESCRIPTION
## What & why

Folds the **provenance chain** and **graph-topology** into the embedded maturity report
(the "fold provenance in" step from the report redesign), and renames the artifact for
consistency with the crate's main file.

### 1. Rename → `ro-crate-metadata-maturity.html`
`REPORT_FILENAME` now shares the `ro-crate-metadata` stem of `ro-crate-metadata.json`
(still an HTML document). Updated across the constant, docstrings, footer, `builder.py`,
tests, and AGENTS.md.

### 2. `render_provenance_svg` (`builder/writers/provenance_dag.py`)
A **self-contained inline SVG** of the LabProcess derivation chain — unlike the Mermaid
renderer it needs no `mermaid.js`, so it embeds and prints offline:
- longest-path layered layout; hexagon **processes**, stadium **materials**, folded-doc
  **files/tables**; dashed `object` ("consumes") + solid `result` ("produces") edges,
  with automatic branching onto extra rows;
- no script, no external assets; all crate-controlled text HTML-escaped (#169);
- returns `""` when the crate records no derivation chain.

### 3. Fold into the report (`builder/writers/maturity_report.py`)
`build_maturity_html` gains an optional `graph=` param. When supplied it renders a
**Provenance & graph** section: the chain SVG + a shape legend + the relocated
graph-topology strip (entity composition by paper layer, orphan/dangling flags, from
`build_crate_graph` counts). `_embed_maturity_report` passes `crate.metadata.generate()`.
Omitting `graph` cleanly skips the section, so existing pure calls are unaffected.

## Verification
- New + existing tests pass; full suite green.
- Cross-checked the generated HTML against a **real** crate `@graph` (S-VHPS21): topology
  entity count matches exactly (28 = 28), layer counts sum, every LabProcess appears in the
  chain, FAIR indicators reflect the real assessment. The elaborate real **S-VHPS26** crate
  renders its full 4-process branched chain.
- `ruff` + `ty` clean; light-mode only (deliberate), self-contained/offline.

## Test plan
- `uv run pytest tests/test_maturity_report.py tests/test_provenance_dag.py tests/test_html_xss.py`
- `uv run pytest` (full suite)

## Follow-ups surfaced (separate assessor/robustness track, not this PR)
- #310 — make graph-topology orphan/dangling counts actionable (list the entities).
- #311 — maturity metrics under-report: MIT coverage 0% and FAIR DSM stuck at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
