### PR TITLE
fix(mit): score OECD MIT coverage against the assembled @graph (#311)

### DIFF
--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -1,13 +1,22 @@
-"""Tool that assesses MIT coverage by comparing entity field completion against
-mit/invitro_tox.yaml.
+"""Tool that assesses OECD MIT coverage against ``mit/invitro_tox.yaml``.
 
-For each module in the MIT YAML, maps crate_slot patterns to entity fields
-and computes completion scores.
+For each module in the MIT YAML, maps ``crate_slot`` patterns to crate entities
+and computes per-module completion scores.
+
+The ``crate_slot`` vocabulary (``Investigation:author``, ``LabProcessExposure:param``,
+``CellLineSample:sampleType`` …) describes the **assembled RO-Crate** — schema.org /
+RO-Crate properties on nodes discriminated by ``@type`` + ``additionalType`` — not the
+intermediate :class:`CrateState`. So when the serialized ``@graph`` is available
+(``assess_mit_coverage(state, graph=…)``, as the maturity report passes it), coverage is
+scored by matching each slot against the graph nodes (#311). Without a graph, it falls
+back to the legacy best-effort match against ``CrateState`` fields — all the domain data
+is only synthesized at assembly, so the graph path is the accurate one.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -56,6 +65,128 @@ def _parse_crate_slots(slot_str: str) -> list[tuple[str, str]]:
     return slots
 
 
+# ---------------------------------------------------------------------------
+# Graph-based matching (#311) — the crate_slot vocabulary against the serialized
+# @graph. See builder/writers/provenance_dag.py for the sibling graph model; here
+# we only need node typing + property presence.
+# ---------------------------------------------------------------------------
+
+# crate_slot EntityType -> (accepted @type local-names, required additionalType|None).
+# ISA backbone Datasets share @type "Dataset" and are told apart by additionalType;
+# the LabProcess subtypes and the cell line likewise carry an additionalType string.
+_SLOT_TYPE_MATCH: dict[str, tuple[frozenset[str], str | None]] = {
+    "Investigation": (frozenset({"Dataset"}), "Investigation"),
+    "Study": (frozenset({"Dataset"}), "Study"),
+    "Assay": (frozenset({"Dataset"}), "Assay"),
+    "MolecularEntity": (frozenset({"MolecularEntity"}), None),
+    "CellLineSample": (frozenset({"Sample"}), "CellLine"),
+    "LabProcessCellCulture": (frozenset({"LabProcess"}), "CellCulture"),
+    "LabProcessExposure": (frozenset({"LabProcess"}), "Exposure"),
+    "LabProcessEndpointReadout": (frozenset({"LabProcess"}), "EndpointReadout"),
+    "LabProcessDataAnalysis": (frozenset({"LabProcess"}), "DataAnalysis"),
+    "LabProtocol": (frozenset({"LabProtocol"}), None),
+    "File": (frozenset({"File", "MediaObject"}), None),
+}
+
+# crate_slot field -> the actual property key on the assembled node.
+_SLOT_FIELD_ALIAS: dict[str, str] = {"param": "parameter"}
+
+
+def _local(token: str) -> str:
+    """Local name of a type/IRI token (last path/hash/CURIE segment)."""
+    return token.rsplit("/", 1)[-1].rsplit("#", 1)[-1].rsplit(":", 1)[-1]
+
+
+def _type_localnames(node: dict[str, Any]) -> set[str]:
+    t = node.get("@type")
+    return {_local(x) for x in (t if isinstance(t, list) else [t]) if isinstance(x, str)}
+
+
+def _additional_type_of(node: dict[str, Any]) -> str | None:
+    v = node.get("additionalType")
+    if isinstance(v, dict):
+        v = v.get("@id")
+    return _local(v) if isinstance(v, str) else None
+
+
+def _nonempty(value: Any) -> bool:
+    """A property counts as filled when it carries a non-empty value (a bare
+    ``{"@id": …}`` reference or a list of them counts)."""
+    if value is None:
+        return False
+    if isinstance(value, (str, list, dict)):
+        return len(value) > 0
+    return True
+
+
+def _node_matches_slot_type(node: dict[str, Any], entity_type: str) -> bool:
+    rule = _SLOT_TYPE_MATCH.get(entity_type)
+    if rule is None:
+        return False
+    bases, add = rule
+    if not (bases & _type_localnames(node)):
+        return False
+    return add is None or _additional_type_of(node) == add
+
+
+def _iter_property_values(node: dict[str, Any], key: str) -> list[Any]:
+    v = node.get(key)
+    return v if isinstance(v, list) else [] if v is None else [v]
+
+
+def _has_characteristic(node: dict[str, Any], index: dict[str, dict[str, Any]]) -> bool:
+    """True if *node* carries an ISA Characteristic — realized only as an
+    ``additionalProperty`` PropertyValue with ``additionalType == CharacteristicValue``
+    (built for CellLineSample from organ/tissue/passage/growth)."""
+    for item in _iter_property_values(node, "additionalProperty"):
+        target = index.get(item["@id"]) if isinstance(item, dict) and "@id" in item else item
+        if isinstance(target, dict) and _additional_type_of(target) == "CharacteristicValue":
+            return True
+    return False
+
+
+def _graph_slot_filled(
+    entity_type: str,
+    field: str,
+    nodes: list[dict[str, Any]],
+    index: dict[str, dict[str, Any]],
+) -> bool:
+    """True if any assembled node of *entity_type* has *field* filled.
+
+    ``param`` aliases to the ``parameter`` key; ``char`` is a characteristic
+    traversal; everything else is a direct property-key presence check.
+    ``conditionsOfAccess`` is deliberately *not* aliased to the always-present
+    default ``license`` — crediting it would be a trivial false pass.
+    """
+    matched = [n for n in nodes if _node_matches_slot_type(n, entity_type)]
+    if not matched:
+        return False
+    if field == "char":
+        return any(_has_characteristic(n, index) for n in matched)
+    key = _SLOT_FIELD_ALIAS.get(field, field)
+    return any(_nonempty(n.get(key)) for n in matched)
+
+
+def _assemble_graph(state: CrateState) -> list[dict[str, Any]]:
+    """Serialize *state* into an RO-Crate ``@graph`` in memory (no disk write)."""
+    import tempfile
+
+    from rocrate.rocrate import ROCrate
+
+    from builder.tools._crate_mapping import populate_crate
+    from profiles.context import ISA_TOX_CONTEXT
+
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    with tempfile.TemporaryDirectory() as tmp:
+        populate_crate(state, crate, Path(tmp), materialize_payload=False)
+        graph = crate.metadata.generate().get("@graph", [])
+    return [n for n in graph if isinstance(n, dict) and "@id" in n]
+
+
+# ---------------------------------------------------------------------------
+# Legacy CrateState field matching (fallback when no @graph is available)
+# ---------------------------------------------------------------------------
 def _count_filled_fields(state: CrateState) -> dict[tuple[str, str], bool]:
     """Count filled/verified fields across all entities in state.
 
@@ -67,74 +198,50 @@ def _count_filled_fields(state: CrateState) -> dict[tuple[str, str], bool]:
             fc = entity.get_field_status(field_name)
             if fc is not None and fc.status in ("filled", "verified"):
                 filled[(entity.type, field_name)] = True
-            else:
-                # Field exists but status is missing or unset
-                pass
     return filled
 
 
-def assess_mit_coverage(state: CrateState) -> MITReport:
-    """Assess MIT coverage by comparing entity field completion against MIT YAML.
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+def _unique_module_params(module: dict[str, Any]) -> list[dict[str, Any]]:
+    """The module's parameters (sections + top-level), deduplicated by id."""
+    all_params: list[dict[str, Any]] = []
+    for section in module.get("sections", []):
+        all_params.extend(section.get("parameters", []))
+    all_params.extend(module.get("parameters", []))
 
-    For each module in the MIT YAML, maps crate_slot patterns to entity fields
-    and computes completion scores per module.
+    seen: set[str] = set()
+    unique: list[dict[str, Any]] = []
+    for param in all_params:
+        pid = param.get("id", "")
+        if pid and pid not in seen:
+            seen.add(pid)
+            unique.append(param)
+    return unique
 
-    Args:
-        state: The current CrateState to assess.
 
-    Returns:
-        An MITReport with per-module scores and overall score.
-    """
-    mit_data = _load_mit_yaml()
-
-    if mit_data is None:
-        return MITReport(module_scores={}, overall_score=0.0)
-
-    filled_fields = _count_filled_fields(state)
-    modules = mit_data.get("modules", [])
-
+def _score_modules(
+    mit_data: dict[str, Any],
+    slot_filled: Callable[[str, str], bool],
+) -> MITReport:
+    """Roll the MIT YAML into per-module scores using *slot_filled* to decide,
+    for each ``(EntityType, field)`` crate_slot, whether it is covered."""
     module_scores: dict[str, dict[str, int]] = {}
     total_completed = 0
     total_required = 0
 
-    for module in modules:
+    for module in mit_data.get("modules", []):
         module_name = module.get("name", module.get("id", "unknown"))
-        sections = module.get("sections", [])
         module_completed = 0
         module_total = 0
 
-        # A module may have parameters directly or within sections
-        all_params: list[dict[str, Any]] = []
-        for section in sections:
-            all_params.extend(section.get("parameters", []))
-        # Also include top-level parameters (sections with id=None name=None)
-        all_params.extend(module.get("parameters", []))
-
-        # Deduplicate by parameter id
-        seen_param_ids: set[str] = set()
-        unique_params: list[dict[str, Any]] = []
-        for param in all_params:
-            pid = param.get("id", "")
-            if pid and pid not in seen_param_ids:
-                seen_param_ids.add(pid)
-                unique_params.append(param)
-
-        for param in unique_params:
-            crate_slot = param.get("crate_slot", "")
-            if not crate_slot:
+        for param in _unique_module_params(module):
+            slots = _parse_crate_slots(param.get("crate_slot", ""))
+            if not slots:
                 continue
-
-            slots = _parse_crate_slots(crate_slot)
             module_total += 1
-
-            # Check if any of the slots has a filled field
-            is_filled = False
-            for entity_type, field_name in slots:
-                if (entity_type, field_name) in filled_fields:
-                    is_filled = True
-                    break
-
-            if is_filled:
+            if any(slot_filled(et, field) for et, field in slots):
                 module_completed += 1
 
         if module_total > 0:
@@ -146,11 +253,46 @@ def assess_mit_coverage(state: CrateState) -> MITReport:
             total_required += module_total
 
     overall_score = total_completed / total_required if total_required > 0 else 0.0
+    return MITReport(module_scores=module_scores, overall_score=overall_score)
 
-    return MITReport(
-        module_scores=module_scores,
-        overall_score=overall_score,
-    )
+
+def assess_mit_coverage(
+    state: CrateState,
+    *,
+    graph: dict[str, Any] | list[dict[str, Any]] | None = None,
+) -> MITReport:
+    """Assess OECD MIT coverage of *state* against the MIT YAML checklist.
+
+    Args:
+        state: The current CrateState.
+        graph: The assembled crate ``@graph`` (or the full metadata document).
+            When provided, each ``crate_slot`` is matched against the serialized
+            nodes — the accurate path, since the MIT vocabulary describes the
+            assembled crate. When ``None``, falls back to a best-effort match
+            against ``CrateState`` fields (used by callers that don't hold an
+            assembled crate, e.g. the in-loop score floor).
+
+    Returns:
+        An MITReport with per-module scores and an overall score.
+    """
+    mit_data = _load_mit_yaml()
+    if mit_data is None:
+        return MITReport(module_scores={}, overall_score=0.0)
+
+    if graph is not None:
+        nodes = graph.get("@graph", []) if isinstance(graph, dict) else graph
+        nodes = [n for n in nodes if isinstance(n, dict) and "@id" in n]
+        index = {n["@id"]: n for n in nodes}
+
+        def slot_filled(entity_type: str, field: str) -> bool:
+            return _graph_slot_filled(entity_type, field, nodes, index)
+    else:
+        filled_fields = _count_filled_fields(state)
+
+        def slot_filled(entity_type: str, field: str) -> bool:
+            return (entity_type, field) in filled_fields
+
+    return _score_modules(mit_data, slot_filled)
 
 
 # ---------------------------------------------------------------------------

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -618,7 +618,11 @@ def build_maturity_html(
     title = state.metadata.title or "RO-Crate"
     accession = state.metadata.accession or ""
     fair = assess_fair_maturity(state)
-    mit = assess_mit_coverage(state)
+    # When the crate's assembled @graph is available (the export path passes it),
+    # score MIT against it — the crate_slot vocabulary describes the serialized
+    # crate, not CrateState (#311). Without a graph, the assessor's own fallback
+    # keeps this cheap.
+    mit = assess_mit_coverage(state, graph=graph)
     val = validation if validation is not None else state.validation
 
     tiers = _severity_tiers(val) if _validation_has_signal(val) else None

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -146,6 +146,34 @@ class TestProvenanceSection:
         assert 'class="prov"' not in page
         assert "no derivation chain" in page.lower()
 
+    def test_graph_gives_nonzero_mit_coverage(self, tmp_path: Path) -> None:
+        # MIT coverage is scored against the assembled @graph (crate_slot vocab
+        # describes the serialized crate, not CrateState), so a real crate reports
+        # non-zero coverage in the report — not the old 0% (#311).
+        from rocrate.rocrate import ROCrate
+
+        from builder.tools._crate_mapping import populate_crate
+        from profiles.context import ISA_TOX_CONTEXT
+
+        state = vhps_fixture_state("S-VHPS21")
+        crate = ROCrate()
+        crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+        populate_crate(state, crate, tmp_path, materialize_payload=False)
+        graph = crate.metadata.generate()["@graph"]
+
+        def _mit_pct(page: str) -> int:
+            import re
+
+            m = re.search(
+                r'OECD MIT coverage.*?<b>(\d+)</b><span class="den">%', page, re.S
+            )
+            assert m, "MIT KPI tile not found"
+            return int(m.group(1))
+
+        assert _mit_pct(build_maturity_html(state, graph=graph)) > 0
+        # Without the graph the report falls back (cheap) and this fixture scores 0.
+        assert _mit_pct(build_maturity_html(state)) == 0
+
     def test_export_embeds_provenance_from_crate_graph(self, tmp_path: Path) -> None:
         # End-to-end: the embedded report is built with the crate's real @graph,
         # so the topology strip travels with the written crate.

--- a/tests/test_tools_mit_assessment.py
+++ b/tests/test_tools_mit_assessment.py
@@ -2,8 +2,23 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from rocrate.rocrate import ROCrate
+
 from builder.state import CrateState, Entity, EntityProvenance, MITReport
+from builder.tools._crate_mapping import populate_crate
 from builder.tools.mit_assessment import assess_mit_coverage
+from profiles.context import ISA_TOX_CONTEXT
+from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+
+def _assembled_graph(state: CrateState, tmp_path: Path) -> list[dict]:
+    """Serialize *state* to an RO-Crate ``@graph`` (the assessment's real input)."""
+    crate = ROCrate()
+    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+    populate_crate(state, crate, tmp_path, materialize_payload=False)
+    return crate.metadata.generate()["@graph"]
 
 
 class TestAssessMITCoverage:
@@ -96,6 +111,36 @@ class TestAssessMITCoverage:
         assert result.overall_score > 0.0
         # But less than 1.0 since many modules have zero coverage
         assert result.overall_score < 1.0
+
+    def test_real_assembled_crate_has_nonzero_coverage(self, tmp_path):
+        """A real golden crate scores non-zero MIT coverage when assessed against
+        its assembled @graph — the crate_slot vocabulary describes the serialized
+        crate (schema.org properties + additionalType), not the CrateState (#311)."""
+        state = vhps_fixture_state("S-VHPS21")
+        graph = _assembled_graph(state, tmp_path)
+        result = assess_mit_coverage(state, graph=graph)
+        assert result.overall_score > 0.0
+        assert any(sc["completed"] > 0 for sc in result.module_scores.values())
+
+    def test_graph_path_credits_domain_slots(self, tmp_path):
+        """The graph matcher credits real ISA-Tox slots: the Exposure LabProcess's
+        `parameter` (crate_slot `LabProcessExposure:param`) and the cell line's
+        `sampleType` (`CellLineSample:sampleType`) are counted from the @graph."""
+        state = vhps_fixture_state("S-VHPS21")
+        graph = _assembled_graph(state, tmp_path)
+        by_graph = assess_mit_coverage(state, graph=graph)
+        by_state = assess_mit_coverage(state)  # legacy fallback, unchanged
+        # The graph path finds domain coverage the state-field path cannot.
+        assert by_graph.overall_score > by_state.overall_score
+
+    def test_module_totals_stable_across_paths(self, tmp_path):
+        """Switching to graph matching must not change the checklist size — only
+        how many slots are credited. Per-module `total` stays identical."""
+        state = vhps_fixture_state("S-VHPS21")
+        graph = _assembled_graph(state, tmp_path)
+        g = assess_mit_coverage(state, graph=graph).module_scores
+        s = assess_mit_coverage(state).module_scores
+        assert {k: v["total"] for k, v in g.items()} == {k: v["total"] for k, v in s.items()}
 
     def test_produces_correct_module_scores(self):
         """Verify module scores structure is correct."""


### PR DESCRIPTION
## What & why

`assess_mit_coverage` scored the intermediate **CrateState**, but the MIT `crate_slot`
vocabulary (`Investigation:author`, `LabProcessExposure:param`, `CellLineSample:sampleType`
…) describes the **assembled RO-Crate** — schema.org / RO-Crate properties on nodes
discriminated by `@type` + `additionalType`, plus data that only exists after assembly
(authors, parameters, characteristics). So it matched **0/41** and every crate reported
**0% MIT coverage** in the maturity report.

## Change

`assess_mit_coverage(state, *, graph=None)`:
- **With a graph** (the report/export path now passes `crate.metadata.generate()`), each
  `crate_slot` is matched against the serialized nodes: `_SLOT_TYPE_MATCH` maps
  `EntityType → (@type, additionalType)`; `param` aliases to the `parameter` key; `char`
  traverses `additionalProperty → CharacteristicValue`. `conditionsOfAccess` is
  deliberately **not** credited via the always-present default `license` (would be a
  trivial false pass); the 4 hard `char` gaps + 7 soft gaps stay uncredited — honest.
- **Without a graph**, the legacy CrateState field match is kept as a fallback, so
  in-loop callers (the agent-loop score floor, e2e) are unchanged.
- Per-module `total`s are unchanged; only `completed` moves.

The mapping was derived from the ISA-Tox context + entity models + real assembled crates
(both a minimal fixture and the real S-VHPS26 crate), not guesswork.

## Result (honest, real crates)

| Crate | Before | After |
|---|---|---|
| S-VHPS21 (minimal fixture) | 0.0% | **14.8%** |
| S-VHPS26 (real) | 0.0% | **46.6%** (Exposure 18/21, Endpoint 33/57, Analysis 7/7) |

## Test plan
- `uv run pytest tests/test_tools_mit_assessment.py tests/test_maturity_report.py`
- `uv run pytest` (full suite) — including the e2e `test_mit_coverage_floor`, which
  exercises the state-only fallback and stays green.

## Scope / follow-ups
- This is the **MIT half of #311**. The **FAIR DSM** half (level stuck at 0) is a separate
  change in `fair_assessment.py`.
- #313 — source the MIT indicators from the canonical `tox-maturity-indicators` package
  instead of the drifted local `mit/invitro_tox.yaml` (private-repo auth to settle).

Refs #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
