### PR TITLE
feat(cli): default build output to output/<name>_crate, versioned (#315)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2083,12 +2083,15 @@ in memory, #242). Both are fixed without an LLM and without perturbing the built
   `tests/test_agents_pipeline.py`).
 
 **Output location (CLI, `main.py`).** The on-disk destination is resolved at
-dispatch time with this precedence (#233):
+dispatch time with this precedence (#233, #315):
 
 1. `--output` / `-o` always wins (sets `state.metadata.output_path`);
-2. `--output` omitted **and** `--input` given => a **sibling of the input folder**,
-   `<input_parent>/<input_name>-ro-crate/`, so the crate lands next to the data it
-   describes;
+2. `--output` omitted **and** `--input` given => **`output/<name>_crate`**, versioned
+   `_v2`/`_v3`… on re-run (`_default_output_dir`), where `<name>` is the input folder
+   name with a trailing `_extracted` stripped. This keeps builds under a dedicated
+   `output/` tree instead of writing an `<input>-ro-crate` sibling (which polluted a
+   curated input tree like `input/raw/`). Payload is materialized, so each version is
+   self-contained;
 3. no `--input` (conversation mode) => leave `output_path` unset so `export_crate`
    falls back to the session `working_crate/` directory.
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,32 @@ from builder.engine import AgentEngine
 logger = logging.getLogger(__name__)
 
 
+def _default_output_dir(input_path: str | Path, output_root: str | Path = "output") -> Path:
+    """Resolve the default on-disk crate destination when no ``--output`` is given.
+
+    Lands under ``output/<name>_crate`` and versions re-runs as ``_v2`` / ``_v3`` …
+    (the first build has no suffix), matching the existing ``output/`` layout and
+    never clobbering a previous build (#315). ``<name>`` is the input folder name
+    with a trailing ``_extracted`` stripped, so an extracted archive
+    ``S-VHPS26_extracted`` maps to ``S-VHPS26_crate``.
+
+    This keeps builds out of a curated input tree (previously the crate was written
+    to an ``<input>-ro-crate`` sibling, which polluted ``input/raw/``).
+    """
+    root = Path(output_root)
+    name = Path(input_path).name
+    suffix = "_extracted"
+    if name.endswith(suffix):
+        name = name[: -len(suffix)]
+    base = root / f"{name}_crate"
+    if not base.exists():
+        return base
+    version = 2
+    while (root / f"{name}_crate_v{version}").exists():
+        version += 1
+    return root / f"{name}_crate_v{version}"
+
+
 def setup_logging(verbose: int = 0, interactive: bool = False) -> None:
     """Configure logging for the builder.
 
@@ -436,19 +462,17 @@ def main(argv: list[str] | None = None) -> int:
         logger.info("Starting with empty state (conversation mode)")
         engine.initialize()
 
-    # Resolve the on-disk output destination (#233). Precedence:
+    # Resolve the on-disk output destination (#233, #315). Precedence:
     #   1. --output / -o always wins.
-    #   2. --output omitted AND --input given => a SIBLING of the input folder:
-    #      <input_parent>/<input_name>-ro-crate/ (the deterministic default so the
-    #      built crate lands next to the data it describes).
+    #   2. --output omitted AND --input given => output/<name>_crate, versioned
+    #      _v2/_v3… (see _default_output_dir). Keeps builds out of a curated input
+    #      tree (the old <input>-ro-crate sibling polluted input/raw/).
     #   3. No --input (conversation mode) => leave output_path unset so
     #      export_crate falls back to the session working_crate/ directory.
     if args.output:
         engine.state.metadata.output_path = args.output
     elif args.input:
-        input_dir = Path(args.input)
-        sibling = input_dir.parent / f"{input_dir.name}-ro-crate"
-        engine.state.metadata.output_path = str(sibling)
+        engine.state.metadata.output_path = str(_default_output_dir(args.input))
 
     entity_count = len(engine.state.list_entities())
     logger.info(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -245,8 +245,38 @@ class TestInteractiveDispatch:
         assert seen == [True]
 
 
+class TestDefaultOutputDir:
+    """The no-``--output`` default lands under ``output/<name>_crate``, versioned
+    ``_v2`` / ``_v3`` … (#315), matching the existing ``output/`` layout. ``<name>``
+    is the input folder name with a trailing ``_extracted`` stripped."""
+
+    def test_lands_under_output_root_stripping_extracted(self, tmp_path):
+        from main import _default_output_dir
+
+        out = _default_output_dir("/data/S-VHPS26_extracted", output_root=tmp_path)
+        assert out == tmp_path / "S-VHPS26_crate"
+
+    def test_non_extracted_name_used_verbatim(self, tmp_path):
+        from main import _default_output_dir
+
+        out = _default_output_dir("/data/experiment", output_root=tmp_path)
+        assert out == tmp_path / "experiment_crate"
+
+    def test_versions_increment_without_clobber(self, tmp_path):
+        from main import _default_output_dir
+
+        (tmp_path / "S-VHPS26_crate").mkdir()
+        assert _default_output_dir("/x/S-VHPS26_extracted", output_root=tmp_path) == (
+            tmp_path / "S-VHPS26_crate_v2"
+        )
+        (tmp_path / "S-VHPS26_crate_v2").mkdir()
+        assert _default_output_dir("/x/S-VHPS26_extracted", output_root=tmp_path) == (
+            tmp_path / "S-VHPS26_crate_v3"
+        )
+
+
 class TestOutputPathDefaulting:
-    """``--output`` precedence and the sibling-of-input default (#233).
+    """``--output`` precedence and the versioned ``output/`` default (#233, #315).
 
     Decision (issue #233):
       * ``--output`` / ``-o`` always wins.
@@ -278,20 +308,22 @@ class TestOutputPathDefaulting:
         monkeypatch.setattr(build_mod, "run_interactive_build", _capture)
         return captured
 
-    def test_input_without_output_defaults_to_sibling(self, monkeypatch, tmp_path):
-        """--input <dir>, no --output => output_path is <dir>-ro-crate sibling."""
+    def test_input_without_output_defaults_to_versioned_output(self, monkeypatch, tmp_path):
+        """--input <dir>, no --output => output_path is output/<name>_crate (#315)."""
         from pathlib import Path
 
         self._stub_config(monkeypatch)
-        d = tmp_path / "experiment"
+        monkeypatch.chdir(tmp_path)  # so output/ is created under tmp, not the repo
+        d = tmp_path / "experiment_extracted"
         d.mkdir()
         (d / "test.txt").write_text("hello\n")
         captured = self._capture_output_path(monkeypatch)
 
         result = main(["--interactive", "--input", str(d)])
         assert result == 0
-        expected = d.parent / f"{d.name}-ro-crate"
-        assert captured == [str(expected)] or [Path(p) for p in captured] == [expected]
+        # Lands under ./output, '_extracted' stripped from the name.
+        expected = Path("output") / "experiment_crate"
+        assert [Path(p) for p in captured] == [expected]
 
     def test_explicit_output_wins_over_sibling_default(self, monkeypatch, tmp_path):
         """--output X overrides the sibling-of-input default."""


### PR DESCRIPTION
## What & why

Building `--input <dir>` with no `--output` wrote the crate to an `<input>-ro-crate`
**sibling of the input** (#233). When the input lives under a curated tree like
`input/raw/`, that self-pollutes it — e.g. building `input/raw/S-VHPS26_extracted/`
dropped a `ro-crate-metadata.json` + embeds + a materialized 23 MB data copy at
`input/raw/S-VHPS26_extracted-ro-crate/`.

## Change

The no-`--output` default now lands under **`output/<name>_crate`**, matching the
versioning already used there (`output/S-VHPS22_crate{,_v2..v7}`):

- `output/<name>_crate` for the first build, then `_v2`, `_v3`, … on re-run (never
  clobbers) — `_default_output_dir` in `main.py`.
- `<name>` = the input folder name with a trailing `_extracted` stripped
  (`S-VHPS26_extracted` → `S-VHPS26_crate`), reproducing the existing names.
- `--output`/`-o` still always wins; conversation mode (no `--input`) still falls back to
  the session `working_crate/`.
- Payload is already materialized (`export_crate(..., materialize_payload=True)`), so each
  version is self-contained (data travels with it).

## Test plan
- `uv run pytest tests/test_main.py tests/test_build_output_payload.py`
  (new `TestDefaultOutputDir` unit tests for versioning + `_extracted` stripping; the
  `TestOutputPathDefaulting` integration test updated to the new default).
- `uv run pytest` — full suite green (1520 passed, 1 xpassed).

## Notes
- Docs updated: AGENTS.md §"Output location" and the `main.py` precedence comment (#233 → #315).
- Existing pollution cleaned separately (not in this diff): the stale
  `input/raw/S-VHPS26_extracted-ro-crate/` build was moved to `output/S-VHPS26_crate/`, and
  the 35 stale `ro-crate-maturity.html` artifacts (old filename) were removed.

Closes #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
