### PR TITLE
feat(report): make graph-topology orphan/dangling counts actionable (#310)

### DIFF
--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -101,6 +101,15 @@
 .mat .disc summary { cursor:pointer; font-size:.82rem; color:var(--ink-2); font-weight:560; }
 .mat .disc ul.ind { list-style:none; margin:.6rem 0 0; padding:0; display:grid; gap:.28rem; }
 .mat .disc ul.ind li { display:flex; gap:.5rem; align-items:flex-start; font-size:.82rem; color:var(--ink-2); }
+/* Actionable orphan/dangling disclosure (#310). */
+.mat .topo-detail-h { margin:.7rem 0 .1rem; font-size:.76rem; font-weight:640; color:var(--ink); }
+.mat .topo-detail-h:first-of-type { margin-top:.55rem; }
+.mat .topo-detail code,
+.mat .disc ul.ind li code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.76rem;
+  background:var(--surface-2); border:1px solid var(--border); border-radius:3px;
+  padding:.02rem .32rem; color:var(--ink); }
+.mat .disc ul.ind li .ty { color:var(--muted); }
+.mat .disc ul.ind li.more { color:var(--muted); font-style:italic; padding-left:1.65rem; }
 
 /* MIT */
 .mat .mit { display:grid; gap:.5rem; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -506,6 +506,72 @@ def _render_repro_section(checks: list[tuple[str, bool, str]]) -> str:
     )
 
 
+# Cap the actionable orphan/dangling lists so a pathological crate can't blow up
+# the page; anything beyond is summarised as "+N more" (#310).
+_TOPO_LIST_CAP = 10
+
+
+def _render_topology_detail(nodes: list[dict[str, Any]]) -> str:
+    """Make the topology strip's orphan/dangling counts actionable (#310).
+
+    A count alone ("2 orphans") isn't fixable — the reader can't see *which*
+    entities are disconnected. This renders a bounded ``<details>`` naming the
+    orphaned entities (id + label + type) and the dangling reference targets, read
+    straight from the deterministic :func:`build_crate_graph` node model (each node
+    carries an ``orphan`` flag and a ``dangling`` status). Pure/cheap — no
+    re-validation, no new graph analysis. Returns ``""`` for a clean crate so
+    nothing empty is rendered.
+    """
+    esc = html.escape
+    orphans = [n for n in nodes if n.get("orphan")]
+    dangling = [n for n in nodes if n.get("status") == "dangling"]
+    if not orphans and not dangling:
+        return ""
+
+    def _rows(items: list[dict[str, Any]], *, with_type: bool) -> str:
+        # Node labels are pre-escaped by build_crate_graph; ids/types are raw.
+        rows = []
+        for n in items[:_TOPO_LIST_CAP]:
+            ty = str(n.get("type") or "")
+            tail = f' <span class="ty">{esc(ty)}</span>' if with_type and ty else ""
+            rows.append(
+                f'<li>{_mk("no")} <code>{esc(str(n["id"]))}</code>'
+                f'<span>{n.get("label") or ""}{tail}</span></li>'
+            )
+        extra = len(items) - _TOPO_LIST_CAP
+        if extra > 0:
+            rows.append(f'<li class="more">+{extra} more</li>')
+        return "".join(rows)
+
+    groups = []
+    if orphans:
+        groups.append(
+            '<p class="topo-detail-h">Orphaned entities — not reachable from the '
+            "crate root; link each via <code>hasPart</code>, <code>result</code>, "
+            f'or <code>about</code></p><ul class="ind">{_rows(orphans, with_type=True)}</ul>'
+        )
+    if dangling:
+        groups.append(
+            '<p class="topo-detail-h">Dangling references — a referenced '
+            "<code>@id</code> with no matching entity; add the entity or drop the "
+            f'reference</p><ul class="ind">{_rows(dangling, with_type=False)}</ul>'
+        )
+
+    def _n(count: int, one: str) -> str:
+        return f"{count} {one}" + ("" if count == 1 else "s")
+
+    bits = []
+    if orphans:
+        bits.append(_n(len(orphans), "orphan"))
+    if dangling:
+        bits.append(_n(len(dangling), "dangling ref"))
+    summary = " · ".join(bits) + " — which entities"
+    return (
+        f'<details class="disc topo-detail"><summary>{summary}</summary>'
+        f'{"".join(groups)}</details>'
+    )
+
+
 def _render_topology_strip(counts: dict[str, int]) -> str:
     """The graph-topology metrics strip (relocated into the Provenance section).
 
@@ -547,7 +613,12 @@ def _render_provenance_section(graph: dict[str, Any] | list[dict[str, Any]]) -> 
     from builder.writers.provenance_dag import build_crate_graph, render_provenance_svg
 
     svg = render_provenance_svg(graph)
-    counts = build_crate_graph(graph).get("counts", {})
+    # all_edges=True so every dangling stub (incl. those referenced only via
+    # secondary relations) is present in the node list — the counts are identical
+    # either way, but this lets the actionable disclosure name each one (#310).
+    model = build_crate_graph(graph, all_edges=True)
+    counts = model.get("counts", {})
+    nodes = model.get("nodes", [])
     if svg:
         body = (
             '<p class="prov-cap">The derivation chain a receiving lab follows to trace an '
@@ -579,6 +650,7 @@ def _render_provenance_section(graph: dict[str, Any] | list[dict[str, Any]]) -> 
         '<span class="sec-meta">how the result was produced</span></div>\n'
         f"  {body}\n"
         f"  {_render_topology_strip(counts)}\n"
+        f"  {_render_topology_detail(nodes)}\n"
         "</section>\n"
     )
 

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -185,6 +185,95 @@ class TestProvenanceSection:
         assert "Graph topology" in page
 
 
+class TestActionableTopology:
+    """The topology strip's orphan/dangling counts are made *actionable* (#310):
+    a bounded ``<details>`` lists which entities are orphaned and which references
+    dangle, so a reader can fix them — not just a bare count. Read straight off the
+    existing ``build_crate_graph`` node model (pure/cheap, no re-validation)."""
+
+    def _messy_graph(self) -> dict:
+        # One orphan (#orphan, unreachable from root) and one dangling ref
+        # (#ghost, referenced by #p2 but has no entity). The chain #in→#p→#out is
+        # reachable and clean.
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "hasPart": [{"@id": "#p"}, {"@id": "#out"}, {"@id": "#p2"}],
+                },
+                {"@id": "#in", "@type": "Sample", "name": "Input sample"},
+                {
+                    "@id": "#p",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "object": {"@id": "#in"},
+                    "result": {"@id": "#out"},
+                },
+                {"@id": "#out", "@type": "File", "name": "result.csv"},
+                {
+                    "@id": "#p2",
+                    "@type": "LabProcess",
+                    "additionalType": "DataAnalysis",
+                    "object": {"@id": "#out"},
+                    "result": {"@id": "#ghost"},
+                },
+                {"@id": "#orphan", "@type": "File", "name": "loose.csv"},
+            ]
+        }
+
+    def test_lists_orphan_entities(self) -> None:
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._messy_graph())
+        # The count still renders in the strip…
+        assert "1 orphan" in page
+        # …and now the disclosure names the orphan (id + label + type).
+        assert 'class="disc topo-detail"' in page
+        assert "#orphan" in page
+        assert "loose.csv" in page
+
+    def test_lists_dangling_reference_targets(self) -> None:
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._messy_graph())
+        assert "1 dangling ref" in page
+        assert "#ghost" in page
+
+    def test_no_disclosure_when_topology_clean(self) -> None:
+        # A clean crate (no orphans, no dangling refs) renders the strip but no
+        # actionable disclosure — nothing empty to open.
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#d"}]},
+                {"@id": "#d", "@type": "File", "name": "result.csv"},
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "Graph topology" in page
+        assert 'class="disc topo-detail"' not in page
+
+    def test_orphan_list_is_bounded_with_more_marker(self) -> None:
+        # 12 orphaned files → only the first 10 listed, then "+2 more" (nothing
+        # silently dropped).
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#kept"}]},
+                {"@id": "#kept", "@type": "File", "name": "kept.csv"},
+            ]
+        }
+        for i in range(12):
+            graph["@graph"].append(
+                {"@id": f"#loose{i}", "@type": "File", "name": f"loose{i}.csv"}
+            )
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "12 orphans" in page
+        assert "+2 more" in page
+        # First 10 are listed; the 11th/12th are folded into the "+N more".
+        assert "#loose0" in page
+        assert "#loose9" in page
+        assert "#loose11" not in page
+
+
 class TestSeverityTiers:
     """Profile adherence reported across Required / Recommended / Optional (#306).
 


### PR DESCRIPTION
## What

Makes the maturity report's **Provenance & graph** topology strip *actionable*. Until now it showed a bare count — e.g. `✗ 2 orphans · 1 dangling ref` — with no way to act on it: the reader couldn't see *which* entities were disconnected from the Root Data Entity or *which* references dangled.

The information already existed in the deterministic `build_crate_graph` node model (each node carries an `orphan` flag; every stub carries a `dangling` status) — it just wasn't surfaced.

## How

- New `_render_topology_detail(nodes)` renders a bounded `<details>` disclosure under the topology strip when (and only when) there are orphans or dangling refs. It names:
  - **Orphaned entities** — `@id` + label + type, with a hint to link via `hasPart` / `result` / `about`.
  - **Dangling references** — the referenced `@id` with no matching entity, with a hint to add the entity or drop the reference.
- Capped at the first **10** per list, then a `+N more` marker so a pathological crate can't blow up the page and **nothing is silently dropped**.
- `_render_provenance_section` now reads the node model with `all_edges=True` so every dangling stub is present in the node list (the counts are identical either way — they're computed over the full model regardless).
- Light-mode only and **glyph + label** (not colour-only), consistent with the rest of the report.
- **Pure/cheap contract kept** (#85): reads the existing node model, no re-validation and no new graph analysis.

Real render (S-VHPS21, 2 orphans / 28 entities) now lists e.g. `#Organization_org — Universiteit Utrecht (Organization)` and `#param_ORCID_… — ORCID (PropertyValue)`.

## Tests (TDD)

New `TestActionableTopology` in `tests/test_maturity_report.py`:
- lists orphan entities (id + label + type),
- lists dangling reference targets,
- no disclosure when the topology is clean (nothing empty rendered),
- the orphan list is bounded at 10 with a `+2 more` marker for a 12-orphan crate.

Existing `tests/test_maturity_report.py` stays green (22 passed).

Closes #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
