### PR TITLE
fix(fair): stop DSM collapsing at L1; decouple mit_coverage from unpopulated state (#311)

### DIFF
--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from builder.state import CrateState, FAIRReport
+from builder.state import CrateState, FAIRReport, MITReport
 
 logger = logging.getLogger(__name__)
 
@@ -130,9 +130,20 @@ def _check_conforms_to_profile(state: CrateState) -> bool:
     return has_isa_types
 
 
+def _mit_has_coverage(report: MITReport) -> bool:
+    """True when a MIT report records actual (non-empty, non-zero) coverage."""
+    return report.module_scores != {} and report.overall_score > 0
+
+
 def _check_mit_coverage_indicator(state: CrateState) -> bool:
-    """Check that MIT coverage is tracked (report present)."""
-    return state.mit_assessment.module_scores != {} and state.mit_assessment.overall_score > 0
+    """Check that MIT coverage is tracked (report present).
+
+    Reads ``state.mit_assessment`` — the back-compat path. On the report/export
+    path that field is never populated, so callers pass the freshly-computed report
+    to :func:`assess_fair_maturity` instead (``mit=``), which is scored against the
+    assembled ``@graph`` (#311).
+    """
+    return _mit_has_coverage(state.mit_assessment)
 
 
 # DSM indicator checks
@@ -152,8 +163,22 @@ def _check_dataset_metadata(state: CrateState) -> bool:
 
 
 def _check_access_info(state: CrateState) -> bool:
-    """Dataset Descriptor contains access information."""
-    return bool(state.metadata.output_path or state.metadata.input_path)
+    """Dataset Descriptor contains access information.
+
+    A self-contained RO-Crate carries its access information intrinsically: the
+    data is reached through the crate, and the descriptor states how — a resolvable
+    identity, explicit reuse terms, included data files, or a known location.
+    Reading *only* the incidental build-time ``output_path`` / ``input_path`` (unset
+    on the report and fixture paths) collapsed the whole DSM ladder at L1 even for
+    complete crates (#311). Credit crate content instead; a crate with none of these
+    genuinely lacks access information and still fails.
+    """
+    md = state.metadata
+    has_location = bool(md.output_path or md.input_path)
+    has_identity = bool(md.accession or state.session_id)
+    has_license = any(e.fields.get("license") for e in state.list_entities())
+    has_data = bool(state.list_entities("File"))
+    return has_location or has_identity or has_license or has_data
 
 
 def _check_has_descriptor(state: CrateState) -> bool:
@@ -321,7 +346,7 @@ DSM_CHECKS: dict[str, Any] = {
 }
 
 
-def assess_fair_maturity(state: CrateState) -> FAIRReport:
+def assess_fair_maturity(state: CrateState, *, mit: MITReport | None = None) -> FAIRReport:
     """Assess FAIR maturity from CrateState metadata.
 
     Checks basic FAIR indicators from fair/indicators.yaml and computes
@@ -329,12 +354,21 @@ def assess_fair_maturity(state: CrateState) -> FAIRReport:
 
     Args:
         state: The current CrateState to assess.
+        mit: An already-computed MIT report to score the ``mit_coverage`` indicator
+            (RDA-R1.3-01D) against. The report/export path computes MIT against the
+            assembled ``@graph`` and passes it here, because ``state.mit_assessment``
+            is never populated on that path (#311). When ``None`` the indicator falls
+            back to ``state.mit_assessment`` (back-compat).
 
     Returns:
         A FAIRReport with indicator_results and dsm_level.
     """
     indicators_data = _load_yaml(FAIR_INDICATORS_PATH)
     dsm_data = _load_yaml(DSM_INDICATORS_PATH)
+
+    # The mit_coverage indicator is scored from the caller-supplied report when
+    # given (graph-based), else from the state's own (possibly empty) assessment.
+    mit_report = mit if mit is not None else state.mit_assessment
 
     indicator_results: list[dict[str, Any]] = []
 
@@ -357,7 +391,12 @@ def assess_fair_maturity(state: CrateState) -> FAIRReport:
                     }
                 )
             elif check_name in FAIR_CHECKS:
-                passed = FAIR_CHECKS[check_name](state)
+                # mit_coverage is scored from the (graph-based) report, not the
+                # never-populated state.mit_assessment (#311).
+                if check_name == "mit_coverage":
+                    passed = _mit_has_coverage(mit_report)
+                else:
+                    passed = FAIR_CHECKS[check_name](state)
                 indicator_results.append(
                     {
                         "id": indicator.get("id", ""),

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -617,12 +617,15 @@ def build_maturity_html(
     esc = html.escape
     title = state.metadata.title or "RO-Crate"
     accession = state.metadata.accession or ""
-    fair = assess_fair_maturity(state)
     # When the crate's assembled @graph is available (the export path passes it),
     # score MIT against it — the crate_slot vocabulary describes the serialized
     # crate, not CrateState (#311). Without a graph, the assessor's own fallback
     # keeps this cheap.
     mit = assess_mit_coverage(state, graph=graph)
+    # Feed that MIT result into FAIR so the mit_coverage indicator (RDA-R1.3-01D)
+    # reflects the graph-based coverage — state.mit_assessment is never populated
+    # on this path (#311).
+    fair = assess_fair_maturity(state, mit=mit)
     val = validation if validation is not None else state.validation
 
     tiers = _severity_tiers(val) if _validation_has_signal(val) else None

--- a/tests/test_tools_fair_assessment.py
+++ b/tests/test_tools_fair_assessment.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from builder.state import CrateState, Entity, EntityProvenance, FAIRReport
-from builder.tools.fair_assessment import assess_fair_maturity
+from builder.state import CrateState, Entity, EntityProvenance, FAIRReport, MITReport
+from builder.tools.fair_assessment import _check_access_info, assess_fair_maturity
+from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
 
 class TestAssessFairMaturity:
@@ -101,3 +102,74 @@ class TestAssessFairMaturity:
             for ind in license_indicators:
                 if "out_of_scope" not in str(ind.get("scope", "")):
                     assert ind["passed"] is True
+
+
+class TestDsmLevelNotCollapsed:
+    """The DSM ladder must reflect the indicators actually met, not collapse to 0
+    because one brittle L1 check reads incidental build-time state (#311).
+
+    ``access_info`` (DSM-1-C3) previously gated only on ``output_path`` /
+    ``input_path`` — unset on the report/fixture paths — so a single L1 miss
+    zeroed the whole ladder even for a conformant crate. It now credits crate
+    content (a resolvable identity, reuse terms, included data, or a known
+    location).
+    """
+
+    def test_conformant_crate_reaches_non_collapsed_dsm_level(self) -> None:
+        # S-VHPS21 passes every assessable L1 + L2 indicator; only L3 has real
+        # gaps (resolvable_terms / standard_license / controlled_values). So the
+        # honest level is 2 — not 0 collapsed by access_info.
+        level = assess_fair_maturity(vhps_fixture_state("S-VHPS21")).dsm_level
+        assert level >= 2, f"DSM collapsed to {level}; expected >= 2"
+
+    def test_access_info_credits_resolvable_accession(self) -> None:
+        # A dataset with a resolvable accession carries access information even
+        # when the incidental build paths are unset.
+        state = CrateState()
+        state.metadata.accession = "S-VHPS21"
+        assert state.metadata.output_path is None
+        assert state.metadata.input_path is None
+        assert _check_access_info(state) is True
+
+    def test_access_info_still_true_for_known_location(self) -> None:
+        # Back-compat: an output/input path still counts.
+        state = CrateState()
+        state.metadata.output_path = "/tmp/out"
+        assert _check_access_info(state) is True
+
+    def test_access_info_false_without_any_access_signal(self) -> None:
+        # A crate with no identity, no location, no license and no data has no
+        # access information — a real gap, correctly failed (not always-true).
+        state = CrateState()
+        assert not state.session_id
+        assert _check_access_info(state) is False
+
+
+class TestMitCoverageIndicatorCoupling:
+    """The FAIR RDA-R1.3-01D (``mit_coverage``) indicator read the never-populated
+    ``state.mit_assessment`` on the report/export path, so it could never pass even
+    when MIT coverage was fine. It now honours a MIT report passed by the caller
+    (which scores against the assembled @graph), falling back to
+    ``state.mit_assessment`` for back-compat (#311)."""
+
+    def _mit_indicator(self, result: FAIRReport) -> dict:
+        ind = next(
+            (i for i in result.indicator_results if i.get("id") == "RDA-R1.3-01D"), None
+        )
+        assert ind is not None, "mit_coverage indicator (RDA-R1.3-01D) not found"
+        return ind
+
+    def test_indicator_uses_passed_mit_report(self) -> None:
+        state = CrateState()
+        state.metadata.title = "T"
+        mit = MITReport(module_scores={"m": {"completed": 1, "total": 2}}, overall_score=0.5)
+        # state.mit_assessment stays the empty default; the passed report wins.
+        result = assess_fair_maturity(state, mit=mit)
+        assert self._mit_indicator(result)["passed"] is True
+
+    def test_indicator_falls_back_to_state_when_no_mit_passed(self) -> None:
+        # No mit passed and the default empty state.mit_assessment → not covered.
+        state = CrateState()
+        state.metadata.title = "T"
+        result = assess_fair_maturity(state)
+        assert self._mit_indicator(result)["passed"] is False


### PR DESCRIPTION
## What

Fixes the **FAIR DSM level stuck at 0** half of #311 (the MIT-coverage half shipped in #314). The maturity report was faithful — it rendered exactly what the assessors returned — so the fix is in `builder/tools/fair_assessment.py`.

Two independent root causes:

### 1. DSM ladder collapsed at L1 (`access_info`)

`_check_access_info` (DSM-1-C3, level 1) gated **only** on `state.metadata.output_path` / `input_path` — incidental build-time fields that are unset on the report and fixture paths. The DSM ladder is cumulative, so that single L1 miss zeroed the whole thing even when every other L1/L2 indicator passed.

Now it credits crate **content**: a resolvable identity (`accession` / `session_id`), explicit reuse terms (a `license` on an entity), included data files, or a known location. A crate with **none** of these genuinely lacks access information and still fails (not an always-true credit).

For the `S-VHPS21` golden fixture this yields an honest **DSM level 2** — every assessable L1 + L2 indicator passes; its L3 gaps (`resolvable_terms` / `standard_license` / `controlled_values`) remain real failures — instead of a collapsed 0.

### 2. `mit_coverage` FAIR indicator read never-populated state

`_check_mit_coverage_indicator` (RDA-R1.3-01D, Reusable) read `state.mit_assessment`, which is **never populated** on the report/export path, so it could never pass even when MIT coverage was fine.

- Extract a `_mit_has_coverage(report)` predicate.
- `assess_fair_maturity(state, *, mit=None)` now scores the indicator from a caller-supplied MIT report; `build_maturity_html` passes the graph-based MIT result it already computes (the crate_slot vocabulary describes the assembled `@graph`, per #314). Without `mit` it falls back to `state.mit_assessment` (back-compat).

End-to-end on `S-VHPS21`: DSM `0 → 2`; the `mit_coverage` indicator flips `False → True` (real coverage ≈ 0.15).

## Tests (TDD)

`tests/test_tools_fair_assessment.py`:
- `TestDsmLevelNotCollapsed` — conformant crate reaches DSM ≥ 2; `access_info` credits a resolvable accession / known location; still fails with no access signal at all.
- `TestMitCoverageIndicatorCoupling` — the indicator honours a passed MIT report; falls back to state when none passed.

Existing FAIR / maturity-report / gap-analysis tests stay green (60 passed in the targeted run).

## Notes

- Keyword-only `mit=` is additive; the two existing callers (`gap_analysis.py`, `maturity_report.py`) are unaffected.
- The `access_info` fix touches only `fair_assessment.py`; the `maturity_report.py` change is a 2-line reorder (compute MIT before FAIR, pass it in) in `build_maturity_html`, a different region from PR #317 (#310) — the two merge cleanly.

Closes the DSM half of #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
