### PR TITLE
fix(agents): route OpenAI reasoning models through the Responses API (reconcile)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -555,6 +555,18 @@ invoked by the orchestration node (they make no LLM call of their own), this
 ships the *capability* and config knob; the drafter tier binds when a drafter
 path makes its own model call.
 
+**OpenAI reasoning models (`gpt-5.x`, `o`-series).** These reject a non-default
+`temperature` and cannot bind function tools on `/v1/chat/completions` (the API
+400s on tools + `reasoning_effort`), so `_build_chat_model` routes them through
+the **Responses API** (`use_responses_api=True`) and does not send a temperature.
+Detection is by model name (`_is_openai_reasoning_model`); a custom/Azure
+deployment name the heuristic can't recognise can force it with
+`VITRO_OPENAI_USE_RESPONSES_API`. Standard models keep chat/completions with a
+deterministic `temperature=0` (override via `VITRO_TEMPERATURE`).
+`VITRO_OPENAI_REASONING_EFFORT` forwards a `reasoning_effort` (a lever on
+reasoning-token spend); the explicit value `none` disables reasoning and opts
+back to the standard `temperature=0` path.
+
 **Decision gate (future work):** upgrading the *orchestrator* to a stronger
 model is a separate, profiling-gated decision. Instrument `profile.ndjson` for
 iterations-per-task, recursion-limit hits, and REQUIRED-issue fix success;

--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -839,6 +839,22 @@ def _get_request_timeout() -> float:
     return _DEFAULT_REQUEST_TIMEOUT
 
 
+_OPENAI_REASONING_PREFIXES: tuple[str, ...] = ("gpt-5", "o1", "o3", "o4")
+
+
+def _is_openai_reasoning_model(model_name: str | None) -> bool:
+    """Return True if *model_name* denotes an OpenAI reasoning model.
+
+    Reasoning models (``gpt-5.x`` and the ``o``-series) reject the ``temperature``
+    parameter and require the Responses API to bind function tools
+    (``/v1/chat/completions`` returns a 400 for tools + reasoning_effort). Custom
+    / Azure deployment names that do not match this heuristic can force
+    Responses-API routing via ``VITRO_OPENAI_USE_RESPONSES_API``.
+    """
+    m = (model_name or "").strip().lower()
+    return m.startswith(_OPENAI_REASONING_PREFIXES)
+
+
 def _build_chat_model(
     provider: str | None = None,
     model: str | None = None,
@@ -921,14 +937,30 @@ def _build_chat_model(
             or os.environ.get("VITRO_OPENAI_MODEL")
             or os.environ.get("OPENAI_MODEL", "gpt-4o")
         )
-        # Opt-in reasoning ("thinking") for reasoning-capable models (o-series,
-        # gpt-5.x). Off by default (unset) so existing behaviour is unchanged.
-        # Normalize once (strip + lowercase) so a capitalized/whitespaced value
-        # like "Medium" or " none " forwards as the clean lowercase enum the
-        # OpenAI API expects — and a blank value collapses to None (a no-op).
+        # Reasoning models (gpt-5.x, o-series) reject `temperature` and cannot
+        # bind function tools on /v1/chat/completions with reasoning_effort — the
+        # API requires the Responses API instead. Both the ReAct loop and the
+        # pipeline drafter leaves bind tools, so route reasoning models through
+        # the Responses API. Detect by name, with VITRO_OPENAI_USE_RESPONSES_API
+        # as an explicit override for custom/Azure deployment names the heuristic
+        # cannot recognise. An explicit reasoning_effort="none" turns reasoning
+        # OFF, so that call is treated as a standard (chat/completions,
+        # temperature-0) request.
+        #
+        # reasoning_effort is normalized once (strip + lowercase) so a
+        # capitalized/whitespaced value like "Medium" or " none " forwards as the
+        # clean lowercase enum the OpenAI API expects — and a blank value
+        # collapses to None (a no-op).
         reasoning_effort = (
             (os.environ.get("VITRO_OPENAI_REASONING_EFFORT") or "").strip().lower() or None
         )
+        override = os.environ.get("VITRO_OPENAI_USE_RESPONSES_API")
+        if override is not None:
+            use_responses = override.strip().lower() in ("1", "true", "yes", "on")
+        elif reasoning_effort == "none":
+            use_responses = False
+        else:
+            use_responses = _is_openai_reasoning_model(resolved_model)
 
         kwargs: dict[str, Any] = {
             "model": resolved_model,
@@ -936,15 +968,17 @@ def _build_chat_model(
             # "timeout" is the public alias of ChatOpenAI.request_timeout (#263).
             "timeout": timeout,
         }
+        if use_responses:
+            kwargs["use_responses_api"] = True
         if reasoning_effort:
             kwargs["reasoning_effort"] = reasoning_effort
-        # Reasoning models reject a non-default temperature while reasoning is
-        # ACTIVE — gpt-5.1 only permits temperature when reasoning_effort is
-        # "none". So keep the deterministic temperature=0 ONLY when reasoning is
-        # off (unset or explicit "none"); otherwise omit it and let the model use
-        # its default (1), or the API 400s ("temperature does not support 0").
-        if not reasoning_effort or reasoning_effort == "none":
-            kwargs["temperature"] = 0
+        # Keep the deterministic temperature=0 default for a standard-path model
+        # (VITRO_TEMPERATURE overrides it), but never force a temperature on a
+        # Responses-API-routed reasoning model — it only accepts the provider
+        # default (the API 400s on "temperature does not support 0").
+        if not use_responses:
+            temp_override = os.environ.get("VITRO_TEMPERATURE")
+            kwargs["temperature"] = float(temp_override) if temp_override is not None else 0
         if api_key:
             kwargs["api_key"] = api_key
         if resolved_base:

--- a/tests/test_llm_reasoning_effort.py
+++ b/tests/test_llm_reasoning_effort.py
@@ -10,8 +10,11 @@ do two things together:
   or the API rejects the request with
   ``Unsupported value: 'temperature' does not support 0``.
 
-Unset preserves today's behaviour exactly (``temperature=0``, no
-``reasoning_effort``) so the deterministic default is untouched.
+On a reasoning model, an *unset* ``VITRO_OPENAI_REASONING_EFFORT`` still routes
+through the Responses API (reasoning is on by default) and forwards no
+``reasoning_effort``; ``reasoning_effort="none"`` opts back to the standard
+chat/completions + ``temperature=0`` path. See ``test_llm_reasoning_model`` for
+the model-name routing and the standard-model default.
 """
 
 from __future__ import annotations
@@ -47,13 +50,16 @@ def _capture_openai_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 class TestReasoningEffort:
     """The OpenAI branch honours ``VITRO_OPENAI_REASONING_EFFORT``."""
 
-    def test_unset_keeps_temperature_zero_and_no_reasoning(
+    def test_unset_routes_reasoning_model_via_responses_api(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Default (unset): unchanged — temperature=0, no reasoning_effort."""
+        """Default (unset) on a reasoning model (gpt-5.1): reasoning is on by
+        default, so it routes through the Responses API and is NOT forced to
+        temperature=0 (which the API rejects); no reasoning_effort is forwarded."""
         monkeypatch.delenv("VITRO_OPENAI_REASONING_EFFORT", raising=False)
         kwargs = _capture_openai_kwargs(monkeypatch)
-        assert kwargs["temperature"] == 0
+        assert kwargs["use_responses_api"] is True
+        assert "temperature" not in kwargs
         assert "reasoning_effort" not in kwargs
 
     def test_active_effort_sets_reasoning_and_drops_temperature(
@@ -99,11 +105,13 @@ class TestReasoningEffort:
     def test_whitespace_only_effort_is_treated_as_unset(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A blank/whitespace value is a no-op — unchanged default behaviour
-        (temperature=0, no ``reasoning_effort`` forwarded)."""
+        """A blank/whitespace value is a no-op — same as unset: no
+        ``reasoning_effort`` forwarded, and (on the reasoning model gpt-5.1) the
+        Responses API route with no forced temperature."""
         monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", "   ")
         kwargs = _capture_openai_kwargs(monkeypatch)
-        assert kwargs["temperature"] == 0
+        assert kwargs["use_responses_api"] is True
+        assert "temperature" not in kwargs
         assert "reasoning_effort" not in kwargs
 
 

--- a/tests/test_llm_reasoning_model.py
+++ b/tests/test_llm_reasoning_model.py
@@ -1,0 +1,74 @@
+"""OpenAI reasoning-model support in ``_build_chat_model``.
+
+Reasoning models (gpt-5.x, o-series) reject ``temperature`` and cannot use
+function tools on ``/v1/chat/completions`` with ``reasoning_effort`` — the API
+returns::
+
+    Function tools with reasoning_effort are not supported for gpt-5.6-luna in
+    /v1/chat/completions. To use function tools, use /v1/responses or set
+    reasoning_effort to 'none'.
+
+Both the ReAct loop and the pipeline's drafter leaves bind tools, so such a
+model must be routed through the Responses API. These tests pin that behaviour
+and guarantee standard (non-reasoning) models are left exactly as before.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.agents.agent_loop import _build_chat_model
+
+
+def _openai_env(monkeypatch: pytest.MonkeyPatch, model: str) -> None:
+    monkeypatch.setenv("VITRO_OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("VITRO_OPENAI_MODEL", model)
+    for stray in (
+        "VITRO_OPENAI_USE_RESPONSES_API",
+        "VITRO_TEMPERATURE",
+        "VITRO_OPENAI_REASONING_EFFORT",
+        "VITRO_OPENAI_BASE_URL",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(stray, raising=False)
+
+
+@pytest.mark.parametrize("model", ["gpt-5.6-luna", "gpt-5.1", "o3", "o1-mini", "o4-mini"])
+def test_reasoning_model_uses_responses_api(monkeypatch: pytest.MonkeyPatch, model: str) -> None:
+    """A reasoning model routes through the Responses API and is not forced to temperature 0."""
+    _openai_env(monkeypatch, model)
+    llm = _build_chat_model(provider="openai")
+    assert llm.use_responses_api is True
+    assert llm.temperature != 0  # never force an unsupported temperature on a reasoning model
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gpt-4.1", "gpt-3.5-turbo"])
+def test_standard_model_unchanged(monkeypatch: pytest.MonkeyPatch, model: str) -> None:
+    """Standard models keep chat/completions and the deterministic temperature=0 default."""
+    _openai_env(monkeypatch, model)
+    llm = _build_chat_model(provider="openai")
+    assert not llm.use_responses_api
+    assert llm.temperature == 0
+
+
+def test_env_forces_responses_api_for_custom_deployment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A custom/Azure deployment name the heuristic can't recognise can force the Responses API."""
+    _openai_env(monkeypatch, "research-reasoner-prod")
+    # Without the override it would be treated as a standard model:
+    assert not _build_chat_model(provider="openai").use_responses_api
+    monkeypatch.setenv("VITRO_OPENAI_USE_RESPONSES_API", "1")
+    assert _build_chat_model(provider="openai").use_responses_api is True
+
+
+def test_env_reasoning_effort_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VITRO_OPENAI_REASONING_EFFORT is forwarded (a cost lever for reasoning-token spend)."""
+    _openai_env(monkeypatch, "gpt-5.6-luna")
+    monkeypatch.setenv("VITRO_OPENAI_REASONING_EFFORT", "low")
+    assert _build_chat_model(provider="openai").reasoning_effort == "low"
+
+
+def test_explicit_temperature_override_for_standard_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VITRO_TEMPERATURE overrides the 0 default on a standard model."""
+    _openai_env(monkeypatch, "gpt-4o")
+    monkeypatch.setenv("VITRO_TEMPERATURE", "0.7")
+    assert _build_chat_model(provider="openai").temperature == pytest.approx(0.7)


### PR DESCRIPTION
Reconciles the unmerged reasoning-model fix (branch `jh-openai-reasoning-support`) with the different, overlapping `reasoning_effort` handling that landed on `main` — into a single correct `_build_chat_model`.

## The problem

`main`'s `_build_chat_model` handled `VITRO_OPENAI_REASONING_EFFORT` but **never routed reasoning models through the Responses API**, so binding function tools on gpt-5.x / o-series 400s:

> Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

Both the ReAct loop and the pipeline's drafter leaves bind tools, so **main can't run reasoning models with tools at all**. It also carried a **latent bug**: an *unset* `reasoning_effort` still sent `temperature=0` to a reasoning model (which the API rejects) — main's own docstring said "gpt-5.1 only permits temperature when reasoning_effort is 'none'", yet the unset path forced `0`.

## The reconcile

One unified `_build_chat_model`, combining both approaches:
- **`_is_openai_reasoning_model`** name heuristic (`gpt-5`, `o1`/`o3`/`o4`).
- Reasoning models → **`use_responses_api=True`**; `VITRO_OPENAI_USE_RESPONSES_API` forces it for custom/Azure deployment names the heuristic can't recognise.
- **Never force temperature** on a reasoning / Responses-API model; standard models keep `temperature=0` with a `VITRO_TEMPERATURE` override.
- Keep main's **`reasoning_effort` normalization**; explicit `"none"` disables reasoning and opts back to the standard chat/completions + `temperature=0` path.

## Tests (TDD)

- Added `tests/test_llm_reasoning_model.py` (from the branch) as the failing spec → confirmed red on main → green after the fix (11 cases: routing, standard-model default, env override, effort passthrough, temperature override).
- **Corrected two assertions** in `tests/test_llm_reasoning_effort.py` that pinned the latent bug (a `gpt-5.1` build with `reasoning_effort` unset expected `temperature=0`). They now assert the correct behavior: reasoning-on-by-default → Responses API, no forced temperature. The other 6 (incl. `effort="none"` → `temperature=0`) are unchanged and green.
- 19 reasoning tests + 161 broader agent/leaf/loop tests green; `ruff` + `ty` clean.

## Docs

AGENTS.md §4.4 (Model Tiering) now documents the reasoning-model routing and the three env knobs (`VITRO_OPENAI_USE_RESPONSES_API`, `VITRO_TEMPERATURE`, `VITRO_OPENAI_REASONING_EFFORT`). Disjoint from the §11–§14 edits in #322, so no conflict.

## Why now

This is the prerequisite for the toolbox harmonization (`_build_chat_model` gets extracted into a shared `llm.py`) — better to extract the correct version. It also unblocks running gpt-5.x/o-series with tool-calling (the gpt-5.6-luna A/B path).

**Supersedes** branch `jh-openai-reasoning-support` (can be deleted after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
