### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jente Houweling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -412,3 +412,9 @@ from builder.tools.scanner import extract_pdf_text
 result = extract_pdf_text("/path/to/publication.pdf")
 # Returns: "[Page 1]\n[Text] Abstract\n[Text] ...\n[Table 1 (3 rows)]\n| Compound | IC50 | Cell Line |\n| --- | --- | --- |\n| ..."
 ```
+
+---
+
+## License
+
+Released under the [MIT License](LICENSE). Copyright © 2026 Jente Houweling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "vitro-crate"
 version = "0.1.0"
 description = "ISA-Tox RO-Crate Builder — LLM-assisted creation of profile-conformant RO-Crates for in vitro toxicology data"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     "rocrate>=0.15.0",


### PR DESCRIPTION
## Summary

The repo previously shipped with **no license**, which leaves reuse terms legally undefined. This adds a permissive MIT license.

- **`LICENSE`** — standard MIT License text, © 2026 Jente Houweling.
- **`pyproject.toml`** — declares `license = "MIT"` (SPDX) and `license-files = ["LICENSE"]` so package metadata matches. `uv lock --check` still resolves cleanly.
- **`README.md`** — adds a short License section linking to the file.

MIT was chosen as a permissive, low-friction license consistent with the research-Python / RO-Crate ecosystem, maximizing downstream reuse without copyleft obligations.

> **Note on copyright holder:** attributed to Jente Houweling as the individual author. If RIVM institutional copyright is required instead, only the holder line in `LICENSE` and the README needs to change — the license itself stays MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)