### PR TITLE
refactor(agents): extract shared LLM plumbing into builder/agents/llm.py (#309 Step 1)

### DIFF
--- a/builder/agents/agent_loop.py
+++ b/builder/agents/agent_loop.py
@@ -7,7 +7,6 @@ and lets the LLM decide which tools to call based on user requests.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from time import monotonic, perf_counter
 from typing import TYPE_CHECKING, Any, Sequence, cast
@@ -23,6 +22,13 @@ try:
 except ImportError:
     from typing_extensions import Annotated as _Annotated
 
+from builder.agents.llm import (
+    _build_chat_model,
+    _extract_model_name,
+    _extract_token_usage,
+    _get_request_timeout,
+    _recursion_limit,
+)
 from builder.agents.system_prompt import SYSTEM_PROMPT
 from builder.agents.tools_spec import TOOL_SPECS
 from builder.engine import AgentEngine
@@ -220,9 +226,7 @@ def _build_args_schema(name: str, params: dict[str, Any]) -> type[BaseModel] | N
 # File-reading tools that hand back a bare ``None`` for files that are missing,
 # too large, or binary/corrupt. A bare ``None`` gives a weak model nothing to act
 # on, so it re-calls the tool forever and hits the iteration cap (#101, #148).
-_FILE_READ_TOOLS = frozenset(
-    {"read_file_sample", "read_file", "read_excel", "read_docx"}
-)
+_FILE_READ_TOOLS = frozenset({"read_file_sample", "read_file", "read_excel", "read_docx"})
 
 # Attribute stamped on the engine once the crate has been exported this session,
 # so the deterministic finish backstop (#251) is idempotent across the two exit
@@ -266,11 +270,6 @@ _LOOP_BREAKER_COUNT_FLAG = "_loop_breaker_repeat_count"
 # ---------------------------------------------------------------------------
 # Issue #263: stall recovery (Fix A) + autonomous continuation (Fix B)
 # ---------------------------------------------------------------------------
-
-# Per-request wall-clock timeout default (seconds) for the chat model when no
-# VITRO_REQUEST_TIMEOUT is set. A real --legacy-react run hung with a 349s+ model
-# invoke and no timeout, so the turn never ended and the #254 backstop never ran.
-_DEFAULT_REQUEST_TIMEOUT = 120.0
 
 # Maximum autonomous (non-prompted) re-invocations the loop will chain off a
 # single user message before checking back in with the user. Bounds the
@@ -367,10 +366,7 @@ def _crate_is_complete(engine: AgentEngine) -> bool:
             return False
         val = engine.state.validation
         return bool(
-            val.base_passed
-            and val.isa_passed
-            and val.tox_passed
-            and not val.required_issues
+            val.base_passed and val.isa_passed and val.tox_passed and not val.required_issues
         )
     except Exception:  # noqa: BLE001 — a completeness probe must never raise.
         logger.debug("completeness probe failed", exc_info=True)
@@ -587,10 +583,7 @@ def _is_non_progress_result(result: Any) -> bool:
     if isinstance(result, dict):
         return "error" in result
     if isinstance(result, str):
-        return (
-            "is a directory, not a file" in result
-            or "could not return text" in result
-        )
+        return "is a directory, not a file" in result or "could not return text" in result
     return False
 
 
@@ -711,9 +704,7 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     # binary files; hand the LLM an actionable message so it stops
                     # re-calling them (#101, #148).
                     elif tool_name in _FILE_READ_TOOLS and result is None:
-                        result = _unreadable_file_message(
-                            kwargs.get("path", ""), tool_name
-                        )
+                        result = _unreadable_file_message(kwargs.get("path", ""), tool_name)
                     # When the agent itself successfully exports, stamp the engine
                     # so the deterministic finish backstop (#251) does not
                     # double-export on session exit. Also record the entity-count
@@ -777,240 +768,6 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
 
 
 # ---------------------------------------------------------------------------
-# Iteration safety net
-# ---------------------------------------------------------------------------
-
-
-def _recursion_limit(max_iterations: int) -> int:
-    """Map the documented tool-iteration cap to LangGraph's ``recursion_limit``.
-
-    Each tool iteration is roughly two super-steps (``model`` then ``tools``),
-    so the recursion limit is ``2 * max_iterations``. Floored at 2 so the graph
-    can always complete at least one model→tools→model cycle. Without this,
-    LangGraph applies its silent default of 25 super-steps and a runaway loop
-    raises an uncaught ``GraphRecursionError`` (#56).
-    """
-    return max(2, max_iterations * 2)
-
-
-# ---------------------------------------------------------------------------
-# Provider detection
-# ---------------------------------------------------------------------------
-
-
-def _detect_provider() -> str | None:
-    """Detect which LLM provider is available based on environment variables.
-
-    Checks ``VITRO_OPENAI_API_KEY`` / ``VITRO_ANTHROPIC_API_KEY`` first,
-    then falls back to the unprefixed ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``.
-
-    Returns ``"openai"``, ``"anthropic"``, or ``None`` if neither is configured.
-    """
-    if os.environ.get("VITRO_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY"):
-        return "openai"
-    if os.environ.get("VITRO_ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"):
-        return "anthropic"
-    return None
-
-
-def _get_request_timeout() -> float:
-    """Return the per-request wall-clock timeout (seconds) for the chat model.
-
-    Issue #263: a real ``--legacy-react`` run hung when the final model invoke
-    ran 349s+ with no response and no timeout, so the turn never ended and the
-    #254 finish-backstop never exported. A finite request timeout is the first
-    line of defence (the loop's wall-clock guard in :func:`_invoke_with_timeout`
-    is the second). Precedence:
-
-        1. Environment variable ``VITRO_REQUEST_TIMEOUT`` (seconds)
-        2. Built-in default (120s)
-
-    A non-positive or unparseable value falls back to the default so the model
-    is never built without a finite timeout.
-    """
-    env_val = os.environ.get("VITRO_REQUEST_TIMEOUT")
-    if env_val is not None:
-        try:
-            parsed = float(env_val)
-            if parsed > 0:
-                return parsed
-        except (ValueError, TypeError):
-            pass
-    return _DEFAULT_REQUEST_TIMEOUT
-
-
-_OPENAI_REASONING_PREFIXES: tuple[str, ...] = ("gpt-5", "o1", "o3", "o4")
-
-
-def _is_openai_reasoning_model(model_name: str | None) -> bool:
-    """Return True if *model_name* denotes an OpenAI reasoning model.
-
-    Reasoning models (``gpt-5.x`` and the ``o``-series) reject the ``temperature``
-    parameter and require the Responses API to bind function tools
-    (``/v1/chat/completions`` returns a 400 for tools + reasoning_effort). Custom
-    / Azure deployment names that do not match this heuristic can force
-    Responses-API routing via ``VITRO_OPENAI_USE_RESPONSES_API``.
-    """
-    m = (model_name or "").strip().lower()
-    return m.startswith(_OPENAI_REASONING_PREFIXES)
-
-
-def _build_chat_model(
-    provider: str | None = None,
-    model: str | None = None,
-    base_url: str | None = None,
-    max_retries: int | None = None,
-    role: str = "orchestrator",
-    timeout: float | None = None,
-) -> Any:
-    """Build a LangChain chat model for the given or detected provider.
-
-    Supports custom endpoints (OpenAI-compatible only — Ollama, LiteLLM,
-    local proxies, etc.) via the ``OPENAI_BASE_URL`` environment variable
-    or the ``base_url`` parameter.
-
-    Model tiering (Issue #96): a single ``_build_chat_model`` centralises
-    construction so a different model can be bound per *role* without changing
-    the graph topology. The strong ``"orchestrator"`` keeps the primary model
-    (``VITRO_OPENAI_MODEL`` / ``VITRO_ANTHROPIC_MODEL``); the cheap
-    ``"drafter"`` uses ``VITRO_OPENAI_DRAFTER_MODEL`` /
-    ``VITRO_ANTHROPIC_DRAFTER_MODEL`` *when configured*. With no drafter model
-    set, the drafter resolves to the same primary model as the orchestrator —
-    a strict no-op (single model, identical to today's behaviour).
-
-    Args:
-        provider: One of ``"openai"``, ``"anthropic"``.  If ``None``, auto-detect.
-        model: Model name override (e.g. ``"gpt-4o-mini"``, ``"llama3.2"``).
-            An explicit value wins over role-based resolution. Falls back to
-            provider/role defaults.
-        base_url: Custom API base URL for OpenAI-compatible providers.
-            Falls back to ``OPENAI_BASE_URL`` env var, then provider default.
-        role: ``"orchestrator"`` (default) or ``"drafter"``. Selects the model
-            tier when ``model`` is not given explicitly.
-        timeout: Per-request wall-clock timeout in seconds wired onto the model
-            (Issue #263). Falls back to ``VITRO_REQUEST_TIMEOUT`` then a finite
-            built-in default so the model is never built without one — a silent
-            provider stall can never hang a turn forever.
-
-    Returns:
-        A LangChain ``BaseChatModel`` instance.
-
-    Raises:
-        RuntimeError: If no provider can be detected or the provider is unknown.
-    """
-    if max_retries is None:
-        env_val = os.environ.get("VITRO_MAX_RETRIES")
-        max_retries = int(env_val) if env_val is not None else 3
-
-    if timeout is None:
-        timeout = _get_request_timeout()
-
-    provider = provider or _detect_provider()
-    if provider is None:
-        raise RuntimeError(
-            "No LLM provider configured. Set VITRO_OPENAI_API_KEY "
-            "(or OPENAI_API_KEY) or VITRO_ANTHROPIC_API_KEY "
-            "(or ANTHROPIC_API_KEY) environment variable, or pass "
-            "--provider openai|anthropic."
-        )
-
-    # Model tiering: when the caller asks for the drafter role and no explicit
-    # model was given, prefer the configured drafter model. If none is set,
-    # ``model`` stays ``None`` and the provider branch resolves the primary
-    # model exactly as before (strict no-op default).
-    if model is None and role == "drafter":
-        if provider == "openai":
-            model = os.environ.get("VITRO_OPENAI_DRAFTER_MODEL") or None
-        elif provider == "anthropic":
-            model = os.environ.get("VITRO_ANTHROPIC_DRAFTER_MODEL") or None
-
-    if provider == "openai":
-        from langchain_openai import ChatOpenAI
-
-        # VITRO_ prefixed env vars take priority, fall back to unprefixed
-        api_key = os.environ.get("VITRO_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        resolved_base = (
-            base_url or os.environ.get("VITRO_OPENAI_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
-        )
-        resolved_model = (
-            model
-            or os.environ.get("VITRO_OPENAI_MODEL")
-            or os.environ.get("OPENAI_MODEL", "gpt-4o")
-        )
-        # Reasoning models (gpt-5.x, o-series) reject `temperature` and cannot
-        # bind function tools on /v1/chat/completions with reasoning_effort — the
-        # API requires the Responses API instead. Both the ReAct loop and the
-        # pipeline drafter leaves bind tools, so route reasoning models through
-        # the Responses API. Detect by name, with VITRO_OPENAI_USE_RESPONSES_API
-        # as an explicit override for custom/Azure deployment names the heuristic
-        # cannot recognise. An explicit reasoning_effort="none" turns reasoning
-        # OFF, so that call is treated as a standard (chat/completions,
-        # temperature-0) request.
-        #
-        # reasoning_effort is normalized once (strip + lowercase) so a
-        # capitalized/whitespaced value like "Medium" or " none " forwards as the
-        # clean lowercase enum the OpenAI API expects — and a blank value
-        # collapses to None (a no-op).
-        reasoning_effort = (
-            (os.environ.get("VITRO_OPENAI_REASONING_EFFORT") or "").strip().lower() or None
-        )
-        override = os.environ.get("VITRO_OPENAI_USE_RESPONSES_API")
-        if override is not None:
-            use_responses = override.strip().lower() in ("1", "true", "yes", "on")
-        elif reasoning_effort == "none":
-            use_responses = False
-        else:
-            use_responses = _is_openai_reasoning_model(resolved_model)
-
-        kwargs: dict[str, Any] = {
-            "model": resolved_model,
-            "max_retries": max_retries,
-            # "timeout" is the public alias of ChatOpenAI.request_timeout (#263).
-            "timeout": timeout,
-        }
-        if use_responses:
-            kwargs["use_responses_api"] = True
-        if reasoning_effort:
-            kwargs["reasoning_effort"] = reasoning_effort
-        # Keep the deterministic temperature=0 default for a standard-path model
-        # (VITRO_TEMPERATURE overrides it), but never force a temperature on a
-        # Responses-API-routed reasoning model — it only accepts the provider
-        # default (the API 400s on "temperature does not support 0").
-        if not use_responses:
-            temp_override = os.environ.get("VITRO_TEMPERATURE")
-            kwargs["temperature"] = float(temp_override) if temp_override is not None else 0
-        if api_key:
-            kwargs["api_key"] = api_key
-        if resolved_base:
-            kwargs["base_url"] = resolved_base
-
-        return ChatOpenAI(**kwargs)
-
-    if provider == "anthropic":
-        from langchain_anthropic import ChatAnthropic
-
-        api_key = os.environ.get("VITRO_ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
-        resolved_model = (
-            model
-            or os.environ.get("VITRO_ANTHROPIC_MODEL")
-            or os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
-        )
-        kwargs: dict[str, Any] = {
-            "model": resolved_model,
-            "temperature": 0,
-            "max_retries": max_retries,
-            # "timeout" is the public alias of ChatAnthropic
-            # .default_request_timeout (#263).
-            "timeout": timeout,
-        }
-        if api_key:
-            kwargs["api_key"] = api_key
-        return ChatAnthropic(**kwargs)
-
-    raise RuntimeError(f"Unknown provider: {provider!r}. Use openai or anthropic.")
-
-
-# ---------------------------------------------------------------------------
 # Explicit StateGraph construction (replaces create_agent)
 # ---------------------------------------------------------------------------
 
@@ -1040,49 +797,6 @@ def _tool_names_from_state(state: dict[str, Any]) -> list[str]:
         return []
     tool_calls = getattr(messages[-1], "tool_calls", None) or []
     return [tc.get("name", "") for tc in tool_calls]
-
-
-def _extract_token_usage(message: Any) -> tuple[int | None, int | None]:
-    """Extract ``(input_tokens, output_tokens)`` from a LangChain ``AIMessage``.
-
-    Provider-agnostic and the SINGLE source of truth for usage mining across the
-    ReAct model node (:func:`_wrap_model_node`) and the deterministic pipeline's
-    bounded leaves (:mod:`builder.agents.leaves`), so both arms of the eval
-    harness record token counts with identical semantics:
-
-    1. Prefer the standardised ``usage_metadata`` (langchain-core >=0.3).
-    2. Fall back to provider-specific ``response_metadata["token_usage"]`` /
-       ``["usage"]`` (``prompt_tokens`` / ``completion_tokens`` aliases).
-
-    Returns ``(None, None)`` when neither source carries usage (e.g. an offline
-    fake model) so callers can record a clean zero without crashing.
-    """
-    if message is None:
-        return None, None
-
-    input_tokens: int | None = None
-    output_tokens: int | None = None
-
-    usage = getattr(message, "usage_metadata", None)
-    if usage is not None:
-        input_tokens = usage.get("input_tokens")
-        output_tokens = usage.get("output_tokens")
-
-    if input_tokens is None or output_tokens is None:
-        meta = getattr(message, "response_metadata", None) or {}
-        tu = meta.get("token_usage") or meta.get("usage") or {}
-        if input_tokens is None:
-            input_tokens = tu.get("prompt_tokens") or tu.get("input_tokens")
-        if output_tokens is None:
-            output_tokens = tu.get("completion_tokens") or tu.get("output_tokens")
-
-    return input_tokens, output_tokens
-
-
-def _extract_model_name(message: Any) -> str | None:
-    """Extract the model name from an ``AIMessage``'s ``response_metadata``."""
-    resp_meta: dict = getattr(message, "response_metadata", None) or {}
-    return resp_meta.get("model_name") or resp_meta.get("model")
 
 
 def _wrap_model_node(call_model: Any, profiler: Any, iteration_getter: Any) -> Any:
@@ -1950,7 +1664,8 @@ def run_interactive_agent(
                 if prof_records:
                     # Aggregate cumulative tokens
                     model_ends = [
-                        r for r in prof_records
+                        r
+                        for r in prof_records
                         if r.get("event") == "node_end" and r.get("node") == "model"
                     ]
                     total_in = sum(int(r.get("input_tokens", 0) or 0) for r in model_ends)
@@ -2299,9 +2014,7 @@ def run_interactive_agent(
 
             save_result = save_session(engine.state, always_write=(outcome != "ok"))
             if not save_result.get("success", True):
-                logger.warning(
-                    "Session save failed: %s", save_result.get("error", "Unknown error")
-                )
+                logger.warning("Session save failed: %s", save_result.get("error", "Unknown error"))
         except Exception:
             logger.exception("Unexpected error during session save")
 
@@ -2421,6 +2134,4 @@ def _format_entity_summary(entities: list[Any]) -> str:
 __all__ = [
     "run_interactive_agent",
     "_build_langchain_tools",
-    "_detect_provider",
-    "_build_chat_model",
 ]

--- a/builder/agents/leaves.py
+++ b/builder/agents/leaves.py
@@ -30,7 +30,7 @@ from typing import Any, Callable
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from builder.agents.agent_loop import (
+from builder.agents.llm import (
     _build_chat_model,
     _extract_model_name,
     _extract_token_usage,
@@ -72,6 +72,7 @@ def _invoke_structured_with_usage(
         return raw_result.get("parsed")
     # Defensive: a model/runnable that ignored include_raw still yields a result.
     return raw_result
+
 
 # ---------------------------------------------------------------------------
 # D5: identifier-bearing scalar fields the leaf must NEVER let the model fill.
@@ -136,9 +137,7 @@ def _structured_output_schema(entity_type: str) -> dict[str, Any]:
     """
     schema = draft_hints_schema(entity_type)
     props = schema.get("properties", {})
-    schema["properties"] = {
-        key: spec for key, spec in props.items() if key not in _EXCLUDED_FIELDS
-    }
+    schema["properties"] = {key: spec for key, spec in props.items() if key not in _EXCLUDED_FIELDS}
     # The function name langchain derives for the structured-output tool. Must be
     # a valid identifier; ``entity_type`` is always a CamelCase type name.
     schema["title"] = f"{entity_type}Fields"
@@ -147,9 +146,7 @@ def _structured_output_schema(entity_type: str) -> dict[str, Any]:
 
 def _strip_identifiers(fields: dict[str, Any]) -> dict[str, Any]:
     """Defensively drop any identifier/reference field from model output (D5)."""
-    return {
-        key: value for key, value in fields.items() if key not in _EXCLUDED_FIELDS
-    }
+    return {key: value for key, value in fields.items() if key not in _EXCLUDED_FIELDS}
 
 
 # ---------------------------------------------------------------------------
@@ -508,9 +505,7 @@ def draft_entity_fields(
 # carries a clean value; ``clarify`` carries one follow-up question; ``from_file``
 # carries an optional filename hint (NEVER a value — D5); ``skip`` covers "I don't
 # know" / empty / unusable replies.
-_INTERPRET_ACTIONS: frozenset[str] = frozenset(
-    {"commit", "skip", "clarify", "from_file"}
-)
+_INTERPRET_ACTIONS: frozenset[str] = frozenset({"commit", "skip", "clarify", "from_file"})
 
 _PHRASE_SYSTEM_PROMPT = (
     "You are the conversational guidance assistant for an ISA-Tox RO-Crate "
@@ -601,9 +596,7 @@ def _interpret_schema() -> dict[str, Any]:
             },
             "filename": {
                 "type": "string",
-                "description": (
-                    "Only for action='from_file': an optional file name/path hint."
-                ),
+                "description": ("Only for action='from_file': an optional file name/path hint."),
             },
         },
         "required": ["action"],
@@ -702,9 +695,7 @@ def phrase_gap_question(
             )
         ),
     ]
-    result = _invoke_structured_with_usage(
-        llm, _phrase_schema(), messages, usage_sink
-    )
+    result = _invoke_structured_with_usage(llm, _phrase_schema(), messages, usage_sink)
     if isinstance(result, dict):
         question = result.get("question")
         if isinstance(question, str) and question.strip():
@@ -758,15 +749,11 @@ def interpret_gap_reply(
             )
         ),
     ]
-    result = _invoke_structured_with_usage(
-        llm, _interpret_schema(), messages, usage_sink
-    )
+    result = _invoke_structured_with_usage(llm, _interpret_schema(), messages, usage_sink)
     return _normalise_interpretation(result, gap_context)
 
 
-def _normalise_interpretation(
-    result: Any, gap_context: dict[str, Any]
-) -> dict[str, Any]:
+def _normalise_interpretation(result: Any, gap_context: dict[str, Any]) -> dict[str, Any]:
     """Coerce a raw interpret result into a safe, well-formed decision (D5).
 
     Guards (the model output is never trusted as-is):
@@ -902,9 +889,7 @@ def extract_field_from_file(
         the field is identifier-bearing — D5).
     """
     # D5: never extract an identifier from file text — those come from lookups.
-    target = _local_property_name(field) or _local_property_name(
-        gap_context.get("property")
-    )
+    target = _local_property_name(field) or _local_property_name(gap_context.get("property"))
     if target in _IDENTIFIER_SCALAR_FIELDS:
         return ""
     if not file_text or not file_text.strip():
@@ -924,9 +909,7 @@ def extract_field_from_file(
             )
         ),
     ]
-    result = _invoke_structured_with_usage(
-        llm, _extract_file_schema(), messages, usage_sink
-    )
+    result = _invoke_structured_with_usage(llm, _extract_file_schema(), messages, usage_sink)
     if isinstance(result, dict):
         value = result.get("value")
         if isinstance(value, str) and value.strip():

--- a/builder/agents/llm.py
+++ b/builder/agents/llm.py
@@ -1,0 +1,302 @@
+"""Shared LLM plumbing for both build modes (Issue #309).
+
+Model construction (:func:`_build_chat_model`) plus the provider-detection,
+token-usage, request-timeout and recursion-limit helpers used by BOTH the ReAct
+agent loop (:mod:`builder.agents.agent_loop`) and the deterministic pipeline's
+bounded leaves (:mod:`builder.agents.leaves`).
+
+Extracted out of ``agent_loop.py`` so the pipeline no longer imports from an
+agent-mode module just to build its drafter model -- a wrong-direction
+dependency the build-mode harmonization removes. This module depends on neither
+mode; the provider SDKs (``langchain_openai`` / ``langchain_anthropic``) are
+imported lazily inside :func:`_build_chat_model` so importing this module stays
+cheap.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+__all__ = [
+    "_build_chat_model",
+    "_detect_provider",
+    "_extract_model_name",
+    "_extract_token_usage",
+    "_get_request_timeout",
+    "_is_openai_reasoning_model",
+    "_recursion_limit",
+]
+
+
+def _recursion_limit(max_iterations: int) -> int:
+    """Map the documented tool-iteration cap to LangGraph's ``recursion_limit``.
+
+    Each tool iteration is roughly two super-steps (``model`` then ``tools``),
+    so the recursion limit is ``2 * max_iterations``. Floored at 2 so the graph
+    can always complete at least one model→tools→model cycle. Without this,
+    LangGraph applies its silent default of 25 super-steps and a runaway loop
+    raises an uncaught ``GraphRecursionError`` (#56).
+    """
+    return max(2, max_iterations * 2)
+
+
+def _detect_provider() -> str | None:
+    """Detect which LLM provider is available based on environment variables.
+
+    Checks ``VITRO_OPENAI_API_KEY`` / ``VITRO_ANTHROPIC_API_KEY`` first,
+    then falls back to the unprefixed ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``.
+
+    Returns ``"openai"``, ``"anthropic"``, or ``None`` if neither is configured.
+    """
+    if os.environ.get("VITRO_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY"):
+        return "openai"
+    if os.environ.get("VITRO_ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"):
+        return "anthropic"
+    return None
+
+
+# Per-request wall-clock timeout default (seconds) for the chat model when no
+# VITRO_REQUEST_TIMEOUT is set. A real --legacy-react run hung with a 349s+ model
+# invoke and no timeout, so the turn never ended and the #254 backstop never ran.
+_DEFAULT_REQUEST_TIMEOUT = 120.0
+
+
+def _get_request_timeout() -> float:
+    """Return the per-request wall-clock timeout (seconds) for the chat model.
+
+    Issue #263: a real ``--legacy-react`` run hung when the final model invoke
+    ran 349s+ with no response and no timeout, so the turn never ended and the
+    #254 finish-backstop never exported. A finite request timeout is the first
+    line of defence (the loop's wall-clock guard in :func:`_invoke_with_timeout`
+    is the second). Precedence:
+
+        1. Environment variable ``VITRO_REQUEST_TIMEOUT`` (seconds)
+        2. Built-in default (120s)
+
+    A non-positive or unparseable value falls back to the default so the model
+    is never built without a finite timeout.
+    """
+    env_val = os.environ.get("VITRO_REQUEST_TIMEOUT")
+    if env_val is not None:
+        try:
+            parsed = float(env_val)
+            if parsed > 0:
+                return parsed
+        except (ValueError, TypeError):
+            pass
+    return _DEFAULT_REQUEST_TIMEOUT
+
+
+_OPENAI_REASONING_PREFIXES: tuple[str, ...] = ("gpt-5", "o1", "o3", "o4")
+
+
+def _is_openai_reasoning_model(model_name: str | None) -> bool:
+    """Return True if *model_name* denotes an OpenAI reasoning model.
+
+    Reasoning models (``gpt-5.x`` and the ``o``-series) reject the ``temperature``
+    parameter and require the Responses API to bind function tools
+    (``/v1/chat/completions`` returns a 400 for tools + reasoning_effort). Custom
+    / Azure deployment names that do not match this heuristic can force
+    Responses-API routing via ``VITRO_OPENAI_USE_RESPONSES_API``.
+    """
+    m = (model_name or "").strip().lower()
+    return m.startswith(_OPENAI_REASONING_PREFIXES)
+
+
+def _build_chat_model(
+    provider: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    max_retries: int | None = None,
+    role: str = "orchestrator",
+    timeout: float | None = None,
+) -> Any:
+    """Build a LangChain chat model for the given or detected provider.
+
+    Supports custom endpoints (OpenAI-compatible only — Ollama, LiteLLM,
+    local proxies, etc.) via the ``OPENAI_BASE_URL`` environment variable
+    or the ``base_url`` parameter.
+
+    Model tiering (Issue #96): a single ``_build_chat_model`` centralises
+    construction so a different model can be bound per *role* without changing
+    the graph topology. The strong ``"orchestrator"`` keeps the primary model
+    (``VITRO_OPENAI_MODEL`` / ``VITRO_ANTHROPIC_MODEL``); the cheap
+    ``"drafter"`` uses ``VITRO_OPENAI_DRAFTER_MODEL`` /
+    ``VITRO_ANTHROPIC_DRAFTER_MODEL`` *when configured*. With no drafter model
+    set, the drafter resolves to the same primary model as the orchestrator —
+    a strict no-op (single model, identical to today's behaviour).
+
+    Args:
+        provider: One of ``"openai"``, ``"anthropic"``.  If ``None``, auto-detect.
+        model: Model name override (e.g. ``"gpt-4o-mini"``, ``"llama3.2"``).
+            An explicit value wins over role-based resolution. Falls back to
+            provider/role defaults.
+        base_url: Custom API base URL for OpenAI-compatible providers.
+            Falls back to ``OPENAI_BASE_URL`` env var, then provider default.
+        role: ``"orchestrator"`` (default) or ``"drafter"``. Selects the model
+            tier when ``model`` is not given explicitly.
+        timeout: Per-request wall-clock timeout in seconds wired onto the model
+            (Issue #263). Falls back to ``VITRO_REQUEST_TIMEOUT`` then a finite
+            built-in default so the model is never built without one — a silent
+            provider stall can never hang a turn forever.
+
+    Returns:
+        A LangChain ``BaseChatModel`` instance.
+
+    Raises:
+        RuntimeError: If no provider can be detected or the provider is unknown.
+    """
+    if max_retries is None:
+        env_val = os.environ.get("VITRO_MAX_RETRIES")
+        max_retries = int(env_val) if env_val is not None else 3
+
+    if timeout is None:
+        timeout = _get_request_timeout()
+
+    provider = provider or _detect_provider()
+    if provider is None:
+        raise RuntimeError(
+            "No LLM provider configured. Set VITRO_OPENAI_API_KEY "
+            "(or OPENAI_API_KEY) or VITRO_ANTHROPIC_API_KEY "
+            "(or ANTHROPIC_API_KEY) environment variable, or pass "
+            "--provider openai|anthropic."
+        )
+
+    # Model tiering: when the caller asks for the drafter role and no explicit
+    # model was given, prefer the configured drafter model. If none is set,
+    # ``model`` stays ``None`` and the provider branch resolves the primary
+    # model exactly as before (strict no-op default).
+    if model is None and role == "drafter":
+        if provider == "openai":
+            model = os.environ.get("VITRO_OPENAI_DRAFTER_MODEL") or None
+        elif provider == "anthropic":
+            model = os.environ.get("VITRO_ANTHROPIC_DRAFTER_MODEL") or None
+
+    if provider == "openai":
+        from langchain_openai import ChatOpenAI
+
+        # VITRO_ prefixed env vars take priority, fall back to unprefixed
+        api_key = os.environ.get("VITRO_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        resolved_base = (
+            base_url or os.environ.get("VITRO_OPENAI_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
+        )
+        resolved_model = (
+            model
+            or os.environ.get("VITRO_OPENAI_MODEL")
+            or os.environ.get("OPENAI_MODEL", "gpt-4o")
+        )
+        # Reasoning models (gpt-5.x, o-series) reject `temperature` and cannot
+        # bind function tools on /v1/chat/completions with reasoning_effort — the
+        # API requires the Responses API instead. Both the ReAct loop and the
+        # pipeline drafter leaves bind tools, so route reasoning models through
+        # the Responses API. Detect by name, with VITRO_OPENAI_USE_RESPONSES_API
+        # as an explicit override for custom/Azure deployment names the heuristic
+        # cannot recognise. An explicit reasoning_effort="none" turns reasoning
+        # OFF, so that call is treated as a standard (chat/completions,
+        # temperature-0) request.
+        #
+        # reasoning_effort is normalized once (strip + lowercase) so a
+        # capitalized/whitespaced value like "Medium" or " none " forwards as the
+        # clean lowercase enum the OpenAI API expects — and a blank value
+        # collapses to None (a no-op).
+        reasoning_effort = (
+            os.environ.get("VITRO_OPENAI_REASONING_EFFORT") or ""
+        ).strip().lower() or None
+        override = os.environ.get("VITRO_OPENAI_USE_RESPONSES_API")
+        if override is not None:
+            use_responses = override.strip().lower() in ("1", "true", "yes", "on")
+        elif reasoning_effort == "none":
+            use_responses = False
+        else:
+            use_responses = _is_openai_reasoning_model(resolved_model)
+
+        kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "max_retries": max_retries,
+            # "timeout" is the public alias of ChatOpenAI.request_timeout (#263).
+            "timeout": timeout,
+        }
+        if use_responses:
+            kwargs["use_responses_api"] = True
+        if reasoning_effort:
+            kwargs["reasoning_effort"] = reasoning_effort
+        # Keep the deterministic temperature=0 default for a standard-path model
+        # (VITRO_TEMPERATURE overrides it), but never force a temperature on a
+        # Responses-API-routed reasoning model — it only accepts the provider
+        # default (the API 400s on "temperature does not support 0").
+        if not use_responses:
+            temp_override = os.environ.get("VITRO_TEMPERATURE")
+            kwargs["temperature"] = float(temp_override) if temp_override is not None else 0
+        if api_key:
+            kwargs["api_key"] = api_key
+        if resolved_base:
+            kwargs["base_url"] = resolved_base
+
+        return ChatOpenAI(**kwargs)
+
+    if provider == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+
+        api_key = os.environ.get("VITRO_ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY")
+        resolved_model = (
+            model
+            or os.environ.get("VITRO_ANTHROPIC_MODEL")
+            or os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+        )
+        kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "temperature": 0,
+            "max_retries": max_retries,
+            # "timeout" is the public alias of ChatAnthropic
+            # .default_request_timeout (#263).
+            "timeout": timeout,
+        }
+        if api_key:
+            kwargs["api_key"] = api_key
+        return ChatAnthropic(**kwargs)
+
+    raise RuntimeError(f"Unknown provider: {provider!r}. Use openai or anthropic.")
+
+
+def _extract_token_usage(message: Any) -> tuple[int | None, int | None]:
+    """Extract ``(input_tokens, output_tokens)`` from a LangChain ``AIMessage``.
+
+    Provider-agnostic and the SINGLE source of truth for usage mining across the
+    ReAct model node (:func:`_wrap_model_node`) and the deterministic pipeline's
+    bounded leaves (:mod:`builder.agents.leaves`), so both arms of the eval
+    harness record token counts with identical semantics:
+
+    1. Prefer the standardised ``usage_metadata`` (langchain-core >=0.3).
+    2. Fall back to provider-specific ``response_metadata["token_usage"]`` /
+       ``["usage"]`` (``prompt_tokens`` / ``completion_tokens`` aliases).
+
+    Returns ``(None, None)`` when neither source carries usage (e.g. an offline
+    fake model) so callers can record a clean zero without crashing.
+    """
+    if message is None:
+        return None, None
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+
+    usage = getattr(message, "usage_metadata", None)
+    if usage is not None:
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+
+    if input_tokens is None or output_tokens is None:
+        meta = getattr(message, "response_metadata", None) or {}
+        tu = meta.get("token_usage") or meta.get("usage") or {}
+        if input_tokens is None:
+            input_tokens = tu.get("prompt_tokens") or tu.get("input_tokens")
+        if output_tokens is None:
+            output_tokens = tu.get("completion_tokens") or tu.get("output_tokens")
+
+    return input_tokens, output_tokens
+
+
+def _extract_model_name(message: Any) -> str | None:
+    """Extract the model name from an ``AIMessage``'s ``response_metadata``."""
+    resp_meta: dict = getattr(message, "response_metadata", None) or {}
+    return resp_meta.get("model_name") or resp_meta.get("model")

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -145,9 +145,9 @@ def run_main(
     if agent_factory is None:
         # LIVE path only — and BOTH arches need creds. The ReAct factory reads
         # provider/api_key/base_url/model from the environment
-        # (builder.agents.agent_loop); the deterministic pipeline now does too —
+        # (builder.agents.llm); the deterministic pipeline now does too —
         # post-#211 its drafter-leaf (builder/agents/leaves.py, via
-        # builder.agents.agent_loop._build_chat_model) reads the same env vars.
+        # builder.agents.llm._build_chat_model) reads the same env vars.
         # So bridge any creds kept solely in ~/.config/vitro-crate/config.toml
         # into os.environ first — mirroring how the interactive CLI hydrates via
         # merge_with_env(). Without this, creds-in-config.toml make a live ReAct

--- a/eval/react_factory.py
+++ b/eval/react_factory.py
@@ -59,10 +59,9 @@ def _live_graph_driver(
 
     from builder.agents.agent_loop import (
         _build_agent_graph,
-        _build_chat_model,
         _build_langchain_tools,
-        _recursion_limit,
     )
+    from builder.agents.llm import _build_chat_model, _recursion_limit
     from builder.config import get_max_iterations
 
     tools = _build_langchain_tools(engine)

--- a/tests/agents/test_llm.py
+++ b/tests/agents/test_llm.py
@@ -1,0 +1,172 @@
+"""Shared LLM plumbing lives in ``builder.agents.llm`` (Issue #309).
+
+Model construction and the provider/token/timeout/recursion helpers are used by
+BOTH build modes — the ReAct loop (``builder.agents.agent_loop``) and the
+deterministic pipeline's bounded leaves (``builder.agents.leaves``). They were
+extracted out of ``agent_loop.py`` so the pipeline no longer imports from an
+agent-mode module to build its drafter model. These tests pin the symbols to
+their new home (import parity) and smoke-test behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class TestImportParity:
+    """Every shared helper is importable from ``builder.agents.llm``."""
+
+    def test_all_shared_helpers_importable(self) -> None:
+        from builder.agents.llm import (  # noqa: F401
+            _build_chat_model,
+            _detect_provider,
+            _extract_model_name,
+            _extract_token_usage,
+            _get_request_timeout,
+            _is_openai_reasoning_model,
+            _recursion_limit,
+        )
+
+
+class TestRecursionLimit:
+    def test_doubles_iteration_cap(self) -> None:
+        from builder.agents.llm import _recursion_limit
+
+        assert _recursion_limit(50) == 100
+        assert _recursion_limit(25) == 50
+
+    def test_floored_at_two(self) -> None:
+        from builder.agents.llm import _recursion_limit
+
+        assert _recursion_limit(0) == 2
+        assert _recursion_limit(1) == 2
+        assert _recursion_limit(-5) == 2
+
+
+class TestDetectProvider:
+    def test_none_when_no_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _detect_provider
+
+        for var in (
+            "VITRO_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "VITRO_ANTHROPIC_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        assert _detect_provider() is None
+
+    def test_openai_preferred_over_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _detect_provider
+
+        monkeypatch.setenv("OPENAI_API_KEY", "x")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "y")
+        assert _detect_provider() == "openai"
+
+    def test_anthropic_when_only_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _detect_provider
+
+        for var in ("VITRO_OPENAI_API_KEY", "OPENAI_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "y")
+        assert _detect_provider() == "anthropic"
+
+
+class TestGetRequestTimeout:
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _get_request_timeout
+
+        monkeypatch.delenv("VITRO_REQUEST_TIMEOUT", raising=False)
+        assert _get_request_timeout() == 120.0
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _get_request_timeout
+
+        monkeypatch.setenv("VITRO_REQUEST_TIMEOUT", "42")
+        assert _get_request_timeout() == 42.0
+
+    def test_invalid_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _get_request_timeout
+
+        monkeypatch.setenv("VITRO_REQUEST_TIMEOUT", "not-a-number")
+        assert _get_request_timeout() == 120.0
+
+
+class TestIsOpenAIReasoningModel:
+    def test_reasoning_prefixes_true(self) -> None:
+        from builder.agents.llm import _is_openai_reasoning_model
+
+        assert _is_openai_reasoning_model("gpt-5.1")
+        assert _is_openai_reasoning_model("o3-mini")
+        assert _is_openai_reasoning_model("O4-preview")
+
+    def test_non_reasoning_false(self) -> None:
+        from builder.agents.llm import _is_openai_reasoning_model
+
+        assert not _is_openai_reasoning_model("gpt-4o")
+        assert not _is_openai_reasoning_model(None)
+        assert not _is_openai_reasoning_model("")
+
+
+class _FakeMessage:
+    def __init__(self, usage_metadata: Any = None, response_metadata: Any = None) -> None:
+        self.usage_metadata = usage_metadata
+        self.response_metadata = response_metadata
+
+
+class TestExtractTokenUsage:
+    def test_none_message(self) -> None:
+        from builder.agents.llm import _extract_token_usage
+
+        assert _extract_token_usage(None) == (None, None)
+
+    def test_usage_metadata(self) -> None:
+        from builder.agents.llm import _extract_token_usage
+
+        msg = _FakeMessage(usage_metadata={"input_tokens": 11, "output_tokens": 7})
+        assert _extract_token_usage(msg) == (11, 7)
+
+    def test_response_metadata_fallback(self) -> None:
+        from builder.agents.llm import _extract_token_usage
+
+        msg = _FakeMessage(
+            response_metadata={"token_usage": {"prompt_tokens": 3, "completion_tokens": 5}}
+        )
+        assert _extract_token_usage(msg) == (3, 5)
+
+
+class TestExtractModelName:
+    def test_none_when_absent(self) -> None:
+        from builder.agents.llm import _extract_model_name
+
+        assert _extract_model_name(_FakeMessage()) is None
+
+    def test_reads_model_name(self) -> None:
+        from builder.agents.llm import _extract_model_name
+
+        msg = _FakeMessage(response_metadata={"model_name": "gpt-4o"})
+        assert _extract_model_name(msg) == "gpt-4o"
+
+
+class TestBuildChatModel:
+    def test_raises_without_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _build_chat_model
+
+        for var in (
+            "VITRO_OPENAI_API_KEY",
+            "OPENAI_API_KEY",
+            "VITRO_ANTHROPIC_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        with pytest.raises(RuntimeError):
+            _build_chat_model()
+
+    def test_builds_openai_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from builder.agents.llm import _build_chat_model
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        model = _build_chat_model(provider="openai")
+        assert model.model_name is not None

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -18,7 +18,7 @@ class TestDetectProvider:
 
     def test_no_key_returns_none(self):
         """_detect_provider returns None when no API key is set."""
-        from builder.agents.agent_loop import _detect_provider
+        from builder.agents.llm import _detect_provider
 
         old_openai = os.environ.pop("OPENAI_API_KEY", None)
         old_anthropic = os.environ.pop("ANTHROPIC_API_KEY", None)
@@ -33,7 +33,7 @@ class TestDetectProvider:
 
     def test_openai_key_detected(self):
         """_detect_provider returns 'openai' when OPENAI_API_KEY is set."""
-        from builder.agents.agent_loop import _detect_provider
+        from builder.agents.llm import _detect_provider
 
         old = os.environ.pop("OPENAI_API_KEY", None)
         os.environ["OPENAI_API_KEY"] = "sk-test123"
@@ -48,7 +48,7 @@ class TestDetectProvider:
 
     def test_anthropic_key_detected(self):
         """_detect_provider returns 'anthropic' when ANTHROPIC_API_KEY is set."""
-        from builder.agents.agent_loop import _detect_provider
+        from builder.agents.llm import _detect_provider
 
         old = os.environ.pop("ANTHROPIC_API_KEY", None)
         os.environ["ANTHROPIC_API_KEY"] = "sk-ant-test123"
@@ -63,7 +63,7 @@ class TestDetectProvider:
 
     def test_both_keys_prefers_openai(self):
         """_detect_provider prefers OpenAI when both are set."""
-        from builder.agents.agent_loop import _detect_provider
+        from builder.agents.llm import _detect_provider
 
         old_openai = os.environ.get("OPENAI_API_KEY")
         old_anthropic = os.environ.get("ANTHROPIC_API_KEY")

--- a/tests/test_llm_reasoning_effort.py
+++ b/tests/test_llm_reasoning_effort.py
@@ -41,7 +41,7 @@ def _capture_openai_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setenv("VITRO_OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("VITRO_OPENAI_MODEL", "gpt-5.1")
 
-    from builder.agents.agent_loop import _build_chat_model
+    from builder.agents.llm import _build_chat_model
 
     _build_chat_model(provider="openai")
     return captured

--- a/tests/test_llm_reasoning_model.py
+++ b/tests/test_llm_reasoning_model.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import pytest
 
-from builder.agents.agent_loop import _build_chat_model
+from builder.agents.llm import _build_chat_model
 
 
 def _openai_env(monkeypatch: pytest.MonkeyPatch, model: str) -> None:


### PR DESCRIPTION
## #309 Step 1 — extract the shared LLM layer

First step of the [build-mode harmonization (#309)](https://github.com/johannehouweling/vitro-crate/issues/309): give both build modes **one shared toolbox + one shared LLM layer**, so an A/B comparison is genuinely apples-to-apples.

### Problem
Model construction and usage-mining helpers lived inside the **agent-mode** `agent_loop.py`, so the **deterministic pipeline** (`leaves.py`) and the eval's `react_factory.py` had to import from the ReAct loop just to build their drafter model — a wrong-direction dependency that blocks a clean mode split.

### Change
New **`builder/agents/llm.py`** — a mode-neutral home for the shared helpers, moved **byte-for-byte via AST** (identical behaviour):

- `_build_chat_model`, `_detect_provider`
- `_get_request_timeout` (+ `_DEFAULT_REQUEST_TIMEOUT`)
- `_is_openai_reasoning_model` (+ `_OPENAI_REASONING_PREFIXES`)
- `_recursion_limit`, `_extract_token_usage`, `_extract_model_name`

Repointing:
- `leaves.py` (pipeline) and `eval/react_factory.py` now import from `builder.agents.llm` — **the pipeline no longer imports from the agent-mode module.**
- `agent_loop.py` imports back only the 5 helpers its body still uses; drops the now-unused `import os`, and removes the relocated names from `__all__`.
- `eval/__main__.py` doc-comment repointed.

### Tests (TDD)
- New **`tests/agents/test_llm.py`** — written **red first**, pins every shared helper to the new import path and smoke-tests behaviour (recursion math, provider detection, timeout precedence, reasoning-model routing, token/model extraction, no-provider `RuntimeError`).
- Existing direct-import tests repointed to `builder.agents.llm`; monkeypatch-of-caller-module tests left as-is (they patch the module that *calls* the helper, which still holds the binding).

### Verification
- ✅ Full test suite: **exit 0** (all pass)
- ✅ `ty` clean · ✅ `ruff` clean
- ✅ Both modes import and share the **same** `_build_chat_model` object; `agent_loop` no longer exposes `_detect_provider`

### Notes
- **No behaviour change** — pure extraction + repoint.
- Next: Step 2 (folder split `react/` + `pipeline/`), Step 3 (`BuildMode` switch + generate `tools_spec` from the registry), Step 4 (fair-fight A/B re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)