### PR TITLE
feat(agents): BuildMode switch — flip A/B in one place (#309 Step 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1525,7 +1525,7 @@ vitro-crate/
 │   │   ├── provenance_dag.py     Mermaid entity-graph / provenance DAG (#130)
 │   │   ├── maturity_report.py    Maturity / FAIR HTML report
 │   └── agents/                  Orchestration + LLM config
-│       ├── build.py             Interactive entrypoint (run_interactive_build) — mode dispatch
+│       ├── build.py             BuildMode switch + run_build dispatch; pipeline entrypoint (run_interactive_build)
 │       ├── llm.py               Shared model construction + usage mining, both modes (#309)
 │       ├── progress_spinner.py  CLI progress UI
 │       ├── pipeline/            Deterministic pipeline mode (--interactive DEFAULT)
@@ -1939,6 +1939,13 @@ HITL and lives **outside** the spine, in the interactive entrypoint
 `run_pipeline` alone; a real user gets `run_pipeline` *then* `run_guidance`.
 
 #### 14.6.1 The interactive entrypoint (`builder/agents/build.py`)
+
+`BuildMode` (`PIPELINE` / `REACT`) is the single switch that selects a variant, and
+`run_build(mode, engine, *, provider=None, model=None, base_url=None, output=None)`
+dispatches to it — `PIPELINE` → `run_interactive_build` (below), `REACT` →
+`run_interactive_agent` (§4). `main.py` derives the mode from `--legacy-react`
+(`BuildMode.from_cli`) and the eval harness maps its `--arch` string onto the same
+enum (`BuildMode(arch)`), so A/B is chosen in **one** place (#309).
 
 `run_interactive_build(engine, *, pipeline_runner=None, guidance_runner=None,
 exporter=None, output=None) -> dict` joins the two halves into the end-to-end

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -27,6 +27,7 @@ functions) so the wiring is unit-testable with no SHACL / no LLM / no network.
 
 from __future__ import annotations
 
+import enum
 import inspect
 import logging
 from contextlib import nullcontext
@@ -45,6 +46,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "BuildMode",
+    "run_build",
     "run_interactive_build",
     "format_guidance_summary",
     "format_gap_summary",
@@ -68,6 +71,30 @@ Exporter = Callable[..., dict[str, Any]]
 # Default no-op output channel: discard. The CLI passes ``print`` (or a console
 # writer); tests pass a list's ``append`` to capture the surfaced summary.
 OutputChannel = Callable[[str], Any]
+
+
+class BuildMode(enum.Enum):
+    """Which build variant runs — the single switch the CLI and eval both flip.
+
+    Both modes drive the same engine + toolbox via ``engine.run_tool``; only the
+    orchestration differs (Issue #309). Both are first-class, permanently
+    co-maintained variants (AGENTS.md §1, D15) — this is a selector, not a step
+    toward removing either.
+
+    The values are the eval harness's ``--arch`` strings, so it can map its CLI
+    choice straight onto the enum with ``BuildMode(arch)``.
+    """
+
+    PIPELINE = "pipeline"  # deterministic, code-orchestrated (--interactive default)
+    REACT = "react"  # LLM-orchestrated ReAct loop (--legacy-react)
+
+    @classmethod
+    def from_cli(cls, *, legacy_react: bool) -> BuildMode:
+        """Map the CLI mode flags to a :class:`BuildMode`.
+
+        ``--legacy-react`` selects :attr:`REACT`; the default is :attr:`PIPELINE`.
+        """
+        return cls.REACT if legacy_react else cls.PIPELINE
 
 
 class CrateExportError(RuntimeError):
@@ -194,6 +221,49 @@ def run_interactive_build(
     finally:
         # Restore the prior tool-event hook even if the build raised (#266).
         engine.on_tool_event = prior_tool_event
+
+
+def run_build(
+    mode: BuildMode,
+    engine: AgentEngine,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    output: OutputChannel | None = None,
+) -> dict[str, Any] | None:
+    """Dispatch a build to *mode*'s entrypoint — the single A/B switch (#309).
+
+    :attr:`BuildMode.PIPELINE` runs the deterministic spine + HITL guidance tail
+    (:func:`run_interactive_build`) and returns its result dict.
+    :attr:`BuildMode.REACT` runs the legacy LLM-orchestrated loop
+    (:func:`builder.agents.react.agent_loop.run_interactive_agent`), which mutates
+    ``engine.state`` in place and has no structured return, so this returns
+    ``None``.
+
+    Per-mode kwargs that don't apply to the chosen mode are ignored — the ReAct
+    loop takes ``provider`` / ``model`` / ``base_url``, the pipeline takes
+    ``output`` — so a single call site (``main.py``, the eval) can pass all of
+    them and let the switch route.
+
+    Args:
+        mode: Which variant to run.
+        engine: An initialized :class:`~builder.engine.AgentEngine`.
+        provider: LLM provider override (ReAct only; auto-detected when ``None``).
+        model: Model-name override (ReAct only).
+        base_url: Custom OpenAI-compatible base URL (ReAct only).
+        output: Progress/summary sink for the pipeline path (e.g. ``print``).
+
+    Returns:
+        The pipeline result dict for :attr:`BuildMode.PIPELINE`; ``None`` for
+        :attr:`BuildMode.REACT`.
+    """
+    if mode is BuildMode.REACT:
+        from builder.agents.react.agent_loop import run_interactive_agent
+
+        run_interactive_agent(engine, provider=provider, model=model, base_url=base_url)
+        return None
+    return run_interactive_build(engine, output=output)
 
 
 def _spinner_emit(base_emit: OutputChannel, spinner: ProgressSpinner | None) -> OutputChannel:

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
+from builder.agents.build import BuildMode
 from builder.config import load_config, merge_with_env
 from eval.agent_api import BuildAgent
 from eval.corpus import DEFAULT_CORPUS
@@ -84,21 +85,24 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 
 def select_agent_factory(
-    arch: str,
+    mode: BuildMode,
     *,
     provider: str | None,
     model: str | None,
     base_url: str | None,
 ) -> Callable[[], BuildAgent]:
-    """Return the live agent factory for the chosen *arch*.
+    """Return the live agent factory for the chosen build *mode*.
 
-    ``"react"`` (the default) builds the live ReAct factory (which reads
-    provider/model/base_url); ``"pipeline"`` builds the deterministic-spine factory
-    (which ignores those — it calls no model). Keeping selection here means
-    :func:`run_main` stays architecture-agnostic and the choice is unit-testable.
+    :attr:`~builder.agents.build.BuildMode.REACT` (the harness default) builds the
+    live ReAct factory (which reads provider/model/base_url);
+    :attr:`~builder.agents.build.BuildMode.PIPELINE` builds the deterministic-spine
+    factory (which ignores those — it calls no model). The CLI's ``--arch`` string
+    maps straight onto the shared enum via ``BuildMode(arch)``, so ``main.py`` and
+    this harness flip A/B through the *same* switch (#309). Keeping selection here
+    means :func:`run_main` stays mode-agnostic and the choice is unit-testable.
 
     Args:
-        arch: ``"react"`` or ``"pipeline"``.
+        mode: The :class:`~builder.agents.build.BuildMode` to build.
         provider: LLM provider override (ReAct only).
         model: Model name override (ReAct only).
         base_url: Custom OpenAI-compatible base URL (ReAct only).
@@ -107,17 +111,17 @@ def select_agent_factory(
         A zero-arg factory producing fresh :class:`~eval.agent_api.BuildAgent`s.
 
     Raises:
-        ValueError: If *arch* is unrecognised.
+        ValueError: If *mode* is unrecognised.
     """
-    if arch == "pipeline":
+    if mode is BuildMode.PIPELINE:
         from eval.pipeline_factory import make_pipeline_agent_factory
 
         return make_pipeline_agent_factory()
-    if arch == "react":
+    if mode is BuildMode.REACT:
         from eval.react_factory import make_react_agent_factory
 
         return make_react_agent_factory(provider=provider, model=model, base_url=base_url)
-    raise ValueError(f"Unknown arch: {arch!r}")
+    raise ValueError(f"Unknown build mode: {mode!r}")
 
 
 def run_main(
@@ -159,7 +163,7 @@ def run_main(
         merge_with_env(load_config())
 
         agent_factory = select_agent_factory(
-            args.arch,
+            BuildMode(args.arch),
             provider=args.provider,
             model=args.model,
             base_url=args.api_base,

--- a/eval/tests/test_main_arch.py
+++ b/eval/tests/test_main_arch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 
+from builder.agents.build import BuildMode
 from eval.__main__ import build_arg_parser, select_agent_factory
 
 
@@ -31,11 +32,11 @@ class TestSelectAgentFactory:
     def test_react_selects_react_factory(self) -> None:
         from eval.react_factory import ReActBuildAgent
 
-        factory = select_agent_factory("react", provider=None, model=None, base_url=None)
+        factory = select_agent_factory(BuildMode.REACT, provider=None, model=None, base_url=None)
         assert isinstance(factory(), ReActBuildAgent)
 
     def test_pipeline_selects_pipeline_factory(self) -> None:
         from eval.pipeline_factory import PipelineBuildAgent
 
-        factory = select_agent_factory("pipeline", provider=None, model=None, base_url=None)
+        factory = select_agent_factory(BuildMode.PIPELINE, provider=None, model=None, base_url=None)
         assert isinstance(factory(), PipelineBuildAgent)

--- a/main.py
+++ b/main.py
@@ -484,21 +484,16 @@ def main(argv: list[str] | None = None) -> int:
     # the deterministic pipeline + HITL guidance tail. The legacy ReAct loop is
     # retained behind --legacy-react (pending the task-7 prompt strip), not deleted.
     if args.interactive:
-        if args.legacy_react:
-            from builder.agents.react.agent_loop import run_interactive_agent
+        from builder.agents.build import BuildMode, run_build
 
-            run_interactive_agent(
-                engine,
-                provider=args.provider,
-                model=args.model,
-                base_url=args.api_base,
-            )
-            return 0
+        mode = BuildMode.from_cli(legacy_react=args.legacy_react)
 
-        # The default interactive build is folder-driven: with no scanned files
-        # there is genuinely nothing to build. Tell the user how to proceed
-        # instead of exiting near-silently, then return gracefully.
-        if len(engine.state.scanned_files) == 0:
+        # The default (pipeline) interactive build is folder-driven: with no
+        # scanned files there is genuinely nothing to build, so tell the user how
+        # to proceed instead of exiting near-silently. The ReAct loop is
+        # conversational and runs without pre-scanned files, so this guard is
+        # pipeline-only.
+        if mode is BuildMode.PIPELINE and len(engine.state.scanned_files) == 0:
             print(
                 "No input documents found. The interactive build is "
                 "folder-driven: pass --input <folder> to build an ISA-Tox crate "
@@ -507,12 +502,18 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 0
 
-        # Default: automated pipeline, then the guidance tail for the real user
-        # (run_interactive_build gates guidance on the interactive interface and
-        # surfaces a concise summary via the output channel).
-        from builder.agents.build import run_interactive_build
-
-        run_interactive_build(engine, output=print)
+        # One switch routes A/B (#309): PIPELINE -> deterministic spine + HITL
+        # guidance tail (surfaced via the output channel); REACT -> the legacy
+        # loop (provider/model/base_url apply). run_build ignores the kwargs that
+        # don't apply to the chosen mode.
+        run_build(
+            mode,
+            engine,
+            provider=args.provider,
+            model=args.model,
+            base_url=args.api_base,
+            output=print,
+        )
         return 0
 
     # Batch / info mode — print summary and exit

--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -1,0 +1,70 @@
+"""The ``BuildMode`` switch — the single A/B mode selector (Issue #309, Step 3).
+
+Both the CLI (``main.py``) and the eval harness flip between the deterministic
+pipeline and the legacy ReAct loop through *one* enum + dispatch in
+``builder.agents.build``, instead of each hard-wiring its own boolean/string. The
+two modes drive the same engine + toolbox; only orchestration differs (AGENTS.md
+§1, D15 — both stay first-class).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from builder.agents.build import BuildMode, run_build
+
+
+class TestBuildModeFromCli:
+    def test_legacy_react_maps_to_react(self) -> None:
+        assert BuildMode.from_cli(legacy_react=True) is BuildMode.REACT
+
+    def test_default_maps_to_pipeline(self) -> None:
+        assert BuildMode.from_cli(legacy_react=False) is BuildMode.PIPELINE
+
+    def test_values_match_eval_arch_strings(self) -> None:
+        # The eval's ``--arch`` choices are exactly these values, so the harness
+        # can map its CLI string straight to the shared enum: BuildMode(arch).
+        assert BuildMode.PIPELINE.value == "pipeline"
+        assert BuildMode.REACT.value == "react"
+        assert BuildMode("react") is BuildMode.REACT
+        assert BuildMode("pipeline") is BuildMode.PIPELINE
+
+
+class TestRunBuildDispatch:
+    def test_pipeline_dispatches_to_interactive_build(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builder.agents.build as build_mod
+
+        captured: dict[str, Any] = {}
+
+        def _fake_build(engine: Any, **kw: Any) -> dict[str, Any]:
+            captured["kw"] = kw
+            return {"pipeline": {}, "guidance": None}
+
+        monkeypatch.setattr(build_mod, "run_interactive_build", _fake_build)
+
+        result = run_build(BuildMode.PIPELINE, object(), output=print)
+
+        assert captured["kw"].get("output") is print
+        assert result == {"pipeline": {}, "guidance": None}
+
+    def test_react_dispatches_to_agent_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.react.agent_loop as agent_loop
+
+        captured: dict[str, Any] = {}
+
+        def _fake_agent(engine: Any, **kw: Any) -> str:
+            captured.update(kw)
+            return "return-value-is-ignored"
+
+        monkeypatch.setattr(agent_loop, "run_interactive_agent", _fake_agent)
+
+        result = run_build(BuildMode.REACT, object(), provider="openai", model="m", base_url="u")
+
+        # ReAct-only kwargs are forwarded; the loop mutates state in place, so
+        # run_build returns None rather than a structured pipeline result.
+        assert captured == {"provider": "openai", "model": "m", "base_url": "u"}
+        assert result is None


### PR DESCRIPTION
## #309 Step 3 — the `BuildMode` switch

Third step of the [build-mode harmonization (#309)](https://github.com/johannehouweling/vitro-crate/issues/309), on top of Steps 1 (#325) and 2 (#326). Mode selection was hard-wired in **two** places — `main.py`'s `--legacy-react` branch and the eval's `select_agent_factory` (keyed on an `--arch` string). This unifies both behind one enum + dispatch.

### What changed
- **`builder/agents/build.py`**: new `BuildMode` enum (`PIPELINE` / `REACT`, whose values are exactly the eval's `--arch` strings) + `BuildMode.from_cli(legacy_react=…)` + **`run_build(mode, engine, *, provider, model, base_url, output)`** — the single dispatch. `PIPELINE` → `run_interactive_build`; `REACT` → `run_interactive_agent`. Per-mode kwargs that don't apply are ignored, so one call site can pass them all.
- **`main.py`**: the `--interactive` / `--legacy-react` dispatch now goes through `BuildMode.from_cli` + `run_build` (the pipeline-only "no input documents" guard is preserved, gated on `PIPELINE`).
- **eval** (`__main__.py`): `select_agent_factory` now takes a `BuildMode`; the CLI maps its `--arch` string straight onto the enum (`BuildMode(args.arch)`) — so `main.py` and the harness flip A/B through the **same** switch.
- **Docs synced**: AGENTS.md §14.6.1 + the structure tree.

### Scope
Per discussion, Step 3 is **the BuildMode switch only**. The other half of the original plan — generating/verifying `tools_spec` from the shared tool registry (the registry doesn't yet carry the LLM param schemas) — is split out to **#327**.

### Design note
Both modes stay **first-class, permanently co-maintained** variants (AGENTS.md §1, D15). `BuildMode` is a *selector*, not a step toward removing either arm.

### Verification
- ✅ Full test suite: **exit 0** (all pass); new `tests/test_build_mode.py` (red→green)
- ✅ `ty` clean · ✅ `ruff` clean
- ✅ `main.py`/eval dispatch tests green; `--legacy-react` still routes to ReAct, default to pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)