### PR TITLE
feat(eval): capture stop-reason + cost, re-run transient failures, default repeats>=3 (#331)

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -22,7 +22,7 @@ The only thing the harness knows about an architecture is the
 
 ```python
 class BuildAgent(Protocol):
-    def build(self, case: EvalCase) -> BuildOutcome: ...   # state + session_id + error
+    def build(self, case: EvalCase) -> BuildOutcome: ...   # state + session_id + error + stop_reason
 ```
 
 `run_eval(agent_factory, corpus, *, repeats=2)` takes a **zero-arg `agent_factory`**
@@ -89,12 +89,24 @@ Per case, across `repeats` runs ([`metrics.py`](metrics.py), [`runner.py`](runne
   (`node_end`/`model` events);
 - **latency** — wall-clock seconds for the build;
 - **iteration count** and **tool-call count** — also mined from `profile.ndjson`;
+- **stop-reason** (#331) — `completed` (the agent self-terminated), `cap_hit` (the
+  ReAct loop hit its recursion cap — a valid-at-the-cutoff run, **not** a clean win),
+  or `error`. The pipeline always `completed`;
+- **model + cost** (#331) — `model_name` mined from `profile.ndjson`, and `cost_usd`
+  from `eval.metrics.MODEL_PRICES` (or the `--price-input`/`--price-output` override
+  for an unlisted model). An unpriced model records `cost_usd = None` — never a
+  guessed `0`;
+- **transient retries** (#331) — how many transient network/API failures were re-run
+  before the result counted (a connection drop / timeout / rate-limit is not an
+  architecture failure);
 - **determinism** — a stable SHA-256 hash of the assembled crate `@graph` (volatile
   `datePublished`/`dateModified` stripped, nodes sorted by `@id`) compared across
   repeats; identical ⇒ deterministic. With `repeats == 1`, determinism is `None`.
 
 The aggregate `EvalReport.summary()` reports **success rate**, **mean/median tokens**,
-**mean/median latency**, and the **determinism rate**.
+**mean/median latency**, the **determinism rate**, the **stop-reason breakdown**
+(`num_completed` / `num_cap_hit` / `num_error`), and **`total_cost_usd`** (summed over
+priced cases, `None` when no case was priced).
 
 ## Report format
 
@@ -136,7 +148,11 @@ tokens** (zero — no model) **and latency**.
 
 `--arch react|pipeline` (DEFAULT `react`) selects the factory; ReAct stays the default
 so the existing baseline workflow is unchanged. Other options: `--repeats N` (builds per
-case), `--out PATH`, `--provider`, `--model`, `--api-base`. See `python -m eval --help`.
+case; **default 3** so variance is over more than one or two samples), `--out PATH`,
+`--provider`, `--model`, `--api-base`. For a fair, defensible A/B (#331):
+`--price-input`/`--price-output` (USD per 1M tokens — price a model not in the built-in
+table, e.g. for the paper re-run) and `--max-transient-retries N` (re-run transient
+network/API failures before they count; default 2). See `python -m eval --help`.
 
 ### Offline tests (CI)
 

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -12,6 +12,14 @@ a ``--label pipeline`` and diff the two reports with :func:`eval.report.compare_
 
 The ``agent_factory`` / ``profile_reader`` parameters of :func:`run_main` exist so
 the offline tests drive the whole flow with a mock — they are never used live.
+
+For a fair, defensible A/B (#331) the report also records, per case: the
+**stop-reason** (``completed`` / ``cap_hit`` / ``error`` — a ReAct "win" at the
+recursion cap is not a clean win), the **cost** in USD (from
+``eval.metrics.MODEL_PRICES`` or the ``--price-input`` / ``--price-output``
+override for an unlisted model), and how many **transient** network/API failures
+were re-run before the result counted (``--max-transient-retries``). ``--repeats``
+defaults to 3 so variance is reported over more than one or two samples.
 """
 
 from __future__ import annotations
@@ -57,8 +65,39 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--repeats",
         type=int,
+        default=3,
+        help=(
+            "Builds per case; >1 enables the determinism signal. Default 3 so "
+            "variance is reported over more than one or two samples (trap 4)."
+        ),
+    )
+    parser.add_argument(
+        "--price-input",
+        dest="price_input",
+        type=float,
+        default=None,
+        help=(
+            "USD price per 1M INPUT tokens for the run's model. With --price-output "
+            "this prices any model (e.g. one not in eval.metrics.MODEL_PRICES) so the "
+            "report carries a per-case cost_usd (trap 5)."
+        ),
+    )
+    parser.add_argument(
+        "--price-output",
+        dest="price_output",
+        type=float,
+        default=None,
+        help="USD price per 1M OUTPUT tokens for the run's model (see --price-input).",
+    )
+    parser.add_argument(
+        "--max-transient-retries",
+        dest="max_transient_retries",
+        type=int,
         default=2,
-        help="Builds per case; >1 enables the determinism signal (default: 2).",
+        help=(
+            "Re-run a case up to N times on a transient network/API failure before "
+            "it counts (trap 1). 0 disables retries (default: 2)."
+        ),
     )
     parser.add_argument(
         "--out",
@@ -177,6 +216,13 @@ def run_main(
         args.repeats,
         len(DEFAULT_CORPUS),
     )
+    price_override: tuple[float, float] | None = None
+    if args.price_input is not None and args.price_output is not None:
+        price_override = (args.price_input, args.price_output)
+    elif args.price_input is not None or args.price_output is not None:
+        # One without the other cannot price a run — warn and fall back to the table.
+        logger.warning("Ignoring --price-input/--price-output: BOTH are required to price a run.")
+
     try:
         report = run_eval(
             agent_factory,
@@ -184,6 +230,8 @@ def run_main(
             repeats=args.repeats,
             label=args.label,
             profile_reader=profile_reader,
+            price_override=price_override,
+            max_transient_retries=args.max_transient_retries,
         )
     except RuntimeError as exc:
         # e.g. no LLM provider configured for the live factory.
@@ -192,11 +240,17 @@ def run_main(
 
     write_report(report, out_path)
     summary = report.summary()
+    cost = summary["total_cost_usd"]
     logger.info(
-        "Done: success_rate=%.2f mean_tokens=%.0f determinism_rate=%.2f -> %s",
+        "Done: success_rate=%.2f mean_tokens=%.0f determinism_rate=%.2f "
+        "completed=%d cap_hit=%d error=%d total_cost=%s -> %s",
         summary["success_rate"],
         summary["mean_total_tokens"],
         summary["determinism_rate"],
+        summary["num_completed"],
+        summary["num_cap_hit"],
+        summary["num_error"],
+        f"${cost:.4f}" if cost is not None else "n/a",
         out_path,
     )
     return 0

--- a/eval/agent_api.py
+++ b/eval/agent_api.py
@@ -31,11 +31,19 @@ class BuildOutcome:
         session_id: The build's session id, used to find its ``profile.ndjson``.
             ``None`` when the agent does not profile (e.g. a mock).
         error: A short error string if the build raised / failed, else ``None``.
+        stop_reason: How the build terminated — ``"completed"`` (the agent
+            self-terminated), ``"cap_hit"`` (the ReAct loop hit its recursion cap;
+            a valid-at-the-cutoff run, **not** a clean stop — trap 2, #331), or
+            ``"error"`` (the build raised). ``None`` when the producer does not
+            classify termination (e.g. a mock). A ``"cap_hit"`` preserves the
+            partial crate and leaves ``error`` unset, so the conformance predicate
+            still measures what the run produced at the cap.
     """
 
     state: CrateState
     session_id: str | None = None
     error: str | None = None
+    stop_reason: str | None = None
 
 
 @runtime_checkable

--- a/eval/metrics.py
+++ b/eval/metrics.py
@@ -40,17 +40,82 @@ class ProfileMetrics:
         output_tokens: Sum of ``output_tokens`` across model ``node_end`` events.
         tool_calls: Number of ``tool_call`` events.
         iterations: The highest ``iteration`` counter observed (0 if none).
+        model_name: The model that produced the run (the last non-empty
+            ``model_name`` seen on a model ``node_end`` event), or ``None``. Used to
+            price the run (:func:`compute_cost`).
     """
 
     input_tokens: int = 0
     output_tokens: int = 0
     tool_calls: int = 0
     iterations: int = 0
+    model_name: str | None = None
 
     @property
     def total_tokens(self) -> int:
         """Combined input + output token count."""
         return self.input_tokens + self.output_tokens
+
+
+# USD per 1,000,000 tokens as ``(input, output)``. These are list prices at the
+# time of writing and are **not authoritative** — extend the table or pass a
+# ``price_override`` to :func:`compute_cost` for the run's actual model. A model
+# absent here yields ``cost_usd = None`` (the harness never guesses a price). The
+# gpt-5.6-luna model used for the paper re-run is deliberately NOT listed here (it
+# is priced at run time via the ``--price-input`` / ``--price-output`` override) so
+# no work-issued model's pricing lives in this public repo.
+MODEL_PRICES: dict[str, tuple[float, float]] = {
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4.1": (2.00, 8.00),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "o3": (2.00, 8.00),
+    "o4-mini": (1.10, 4.40),
+    "deepseek-chat": (0.27, 1.10),
+}
+
+
+def compute_cost(
+    input_tokens: int,
+    output_tokens: int,
+    model_name: str | None,
+    *,
+    price_override: tuple[float, float] | None = None,
+    prices: dict[str, tuple[float, float]] | None = None,
+) -> float | None:
+    """Return the USD cost of a run, or ``None`` when the model is unpriced.
+
+    Args:
+        input_tokens: Total prompt tokens for the run.
+        output_tokens: Total completion tokens for the run.
+        model_name: The run's model (e.g. mined via :func:`mine_profile_metrics`).
+        price_override: ``(input_per_mtok, output_per_mtok)`` in USD. When given it
+            prices *any* model and takes precedence over the table — the path the
+            live gpt-5.6-luna re-run uses.
+        prices: Price table to consult (defaults to :data:`MODEL_PRICES`).
+
+    Returns:
+        The cost in USD, or ``None`` when neither an override nor a table entry
+        prices *model_name* (never a guessed ``0.0``).
+
+    A dated/variant model name (e.g. ``"gpt-4o-2024-08-06"``) matches its base by
+    **longest** prefix, so ``"gpt-4o-mini-*"`` is never mispriced as ``"gpt-4o"``.
+    """
+    if price_override is not None:
+        in_price, out_price = price_override
+    else:
+        table = MODEL_PRICES if prices is None else prices
+        key = (model_name or "").strip().lower()
+        pair = table.get(key)
+        if pair is None and key:
+            for name in sorted(table, key=len, reverse=True):
+                if key.startswith(name):
+                    pair = table[name]
+                    break
+        if pair is None:
+            return None
+        in_price, out_price = pair
+    return input_tokens / 1_000_000 * in_price + output_tokens / 1_000_000 * out_price
 
 
 def _as_int(value: Any) -> int:
@@ -82,6 +147,7 @@ def mine_profile_metrics(records: list[dict[str, Any]]) -> ProfileMetrics:
     output_tokens = 0
     tool_calls = 0
     max_iteration = 0
+    model_name: str | None = None
 
     for rec in records:
         event = rec.get("event")
@@ -93,12 +159,18 @@ def mine_profile_metrics(records: list[dict[str, Any]]) -> ProfileMetrics:
         elif event == "node_end" and rec.get("node") == "model":
             input_tokens += _as_int(rec.get("input_tokens"))
             output_tokens += _as_int(rec.get("output_tokens"))
+            # Keep the last non-empty model name seen — a run is single-model, and
+            # this is robust to early events that omit it.
+            name = rec.get("model_name")
+            if name:
+                model_name = str(name)
 
     return ProfileMetrics(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         tool_calls=tool_calls,
         iterations=max_iteration,
+        model_name=model_name,
     )
 
 

--- a/eval/pipeline_factory.py
+++ b/eval/pipeline_factory.py
@@ -80,7 +80,10 @@ class PipelineBuildAgent:
 
         Returns:
             A :class:`BuildOutcome` with the final state, the run's ``session_id``,
-            and an ``error`` string if the spine raised.
+            an ``error`` string if the spine raised, and a ``stop_reason``. The
+            deterministic spine always self-terminates, so this is ``"completed"``
+            on success and ``"error"`` when it raises — it never ``"cap_hit"``
+            (there is no recursion loop to cap).
         """
         engine = self._make_engine()
         # initialize() scans the input dir (if any) — which approves it under the
@@ -89,11 +92,13 @@ class PipelineBuildAgent:
         engine.initialize(input_path=case.input_path)
 
         error: str | None = None
+        stop_reason = "completed"
         try:
             self._runner()(engine)
         except Exception as exc:  # noqa: BLE001 — a failed build is a measured result
             logger.warning("Pipeline build failed for case %s: %s", case.case_id, exc)
             error = str(exc)
+            stop_reason = "error"
         finally:
             engine.close_profiler()
 
@@ -101,6 +106,7 @@ class PipelineBuildAgent:
             state=engine.state,
             session_id=engine.state.session_id,
             error=error,
+            stop_reason=stop_reason,
         )
 
 

--- a/eval/react_factory.py
+++ b/eval/react_factory.py
@@ -39,6 +39,20 @@ logger = logging.getLogger(__name__)
 GraphDriver = Callable[[AgentEngine, str], None]
 
 
+def _is_recursion_cap_error(exc: BaseException) -> bool:
+    """True if *exc* is LangGraph's recursion-cap error (a ``cap_hit``, #331).
+
+    ``GraphRecursionError`` is imported lazily so this module stays cheap to import
+    for the offline tests — matching its existing deferral of every langchain /
+    langgraph / ``agent_loop`` import into the live driver.
+    """
+    try:
+        from langgraph.errors import GraphRecursionError
+    except ImportError:  # pragma: no cover - langgraph is a core dependency
+        return False
+    return isinstance(exc, GraphRecursionError)
+
+
 def _live_graph_driver(
     engine: AgentEngine,
     prompt: str,
@@ -142,7 +156,9 @@ class ReActBuildAgent:
 
         Returns:
             A :class:`BuildOutcome` with the final state, the run's ``session_id``,
-            and an ``error`` string if the driver raised.
+            an ``error`` string if the driver raised, and a ``stop_reason``:
+            ``"completed"`` (the loop self-terminated), ``"cap_hit"`` (it hit the
+            recursion cap — trap 2, #331), or ``"error"``.
         """
         engine = self._make_engine()
         # initialize() scans the input dir (if any) and always assigns a
@@ -150,11 +166,23 @@ class ReActBuildAgent:
         engine.initialize(input_path=case.input_path)
 
         error: str | None = None
+        stop_reason = "completed"
         try:
             self._driver()(engine, case.prompt)
         except Exception as exc:  # noqa: BLE001 — a failed build is a measured result
-            logger.warning("ReAct build failed for case %s: %s", case.case_id, exc)
-            error = str(exc)
+            if _is_recursion_cap_error(exc):
+                # The loop exhausted its recursion budget without self-terminating:
+                # a valid-at-the-cutoff run, not a clean stop. Record it as cap_hit
+                # and keep the partial crate (error stays unset) so the conformance
+                # predicate still measures what it produced at the cap (trap 2, #331).
+                logger.warning(
+                    "ReAct build hit the recursion cap for case %s: %s", case.case_id, exc
+                )
+                stop_reason = "cap_hit"
+            else:
+                logger.warning("ReAct build failed for case %s: %s", case.case_id, exc)
+                error = str(exc)
+                stop_reason = "error"
         finally:
             engine.close_profiler()
 
@@ -162,6 +190,7 @@ class ReActBuildAgent:
             state=engine.state,
             session_id=engine.state.session_id,
             error=error,
+            stop_reason=stop_reason,
         )
 
 

--- a/eval/report.py
+++ b/eval/report.py
@@ -78,6 +78,11 @@ def compare_reports(*reports: EvalReport) -> dict[str, Any]:
                 "iterations": result.iterations,
                 "tool_calls": result.tool_calls,
                 "deterministic": result.deterministic,
+                # Efficiency / termination signals (#331): a cap_hit "win" is not a
+                # clean win, and $ is the headline efficiency differentiator.
+                "stop_reason": result.stop_reason,
+                "model_name": result.model_name,
+                "cost_usd": result.cost_usd,
                 # Additive content-quality signal — ``None`` for cases that do not
                 # declare a min_entities quota.
                 "meets_quota": result.meets_quota,

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -26,7 +26,7 @@ from typing import Any, Callable
 from builder.state import CrateState
 from eval.agent_api import AgentFactory, BuildOutcome
 from eval.corpus import EvalCase, meets_entity_quota, reaches_isa_tox_conformance
-from eval.metrics import crate_graph_hash, mine_profile_metrics
+from eval.metrics import compute_cost, crate_graph_hash, mine_profile_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +80,10 @@ class CaseResult:
     error: str | None = None
     meets_quota: bool | None = None
     entity_counts: dict[str, int] = field(default_factory=dict)
+    stop_reason: str | None = None
+    model_name: str | None = None
+    cost_usd: float | None = None
+    transient_retries: int = 0
 
     @property
     def total_tokens(self) -> int:
@@ -106,6 +110,10 @@ class CaseResult:
             "error": self.error,
             "meets_quota": self.meets_quota,
             "entity_counts": self.entity_counts,
+            "stop_reason": self.stop_reason,
+            "model_name": self.model_name,
+            "cost_usd": self.cost_usd,
+            "transient_retries": self.transient_retries,
         }
 
 
@@ -130,6 +138,16 @@ class EvalReport:
         latencies = [r.latency_seconds for r in self.results]
         decided = [r for r in self.results if r.deterministic is not None]
         det_rate = sum(1 for r in decided if r.deterministic) / len(decided) if decided else None
+        # Stop-reason breakdown (trap 2): a self-terminated run is a clean win; a
+        # cap_hit is only valid-at-the-cutoff. Counting them keeps a ReAct "win" at
+        # the recursion cap from reading as an unqualified success.
+        num_cap_hit = sum(1 for r in self.results if r.stop_reason == "cap_hit")
+        num_completed = sum(1 for r in self.results if r.stop_reason == "completed")
+        num_error = sum(1 for r in self.results if r.stop_reason == "error")
+        # Total $ over cases with a KNOWN price; ``None`` when no case was priced,
+        # so an unpriced run reads as "cost unknown", not a misleading $0 (trap 5).
+        known_costs = [r.cost_usd for r in self.results if r.cost_usd is not None]
+        total_cost_usd = sum(known_costs) if known_costs else None
         return {
             "label": self.label,
             "repeats": self.repeats,
@@ -141,6 +159,10 @@ class EvalReport:
             "mean_latency_seconds": statistics.mean(latencies) if latencies else 0.0,
             "median_latency_seconds": statistics.median(latencies) if latencies else 0.0,
             "determinism_rate": det_rate if det_rate is not None else 0.0,
+            "num_completed": num_completed,
+            "num_cap_hit": num_cap_hit,
+            "num_error": num_error,
+            "total_cost_usd": total_cost_usd,
         }
 
 
@@ -155,9 +177,86 @@ def _safe_build(agent: Any, case: EvalCase) -> tuple[BuildOutcome, float]:
         outcome = agent.build(case)
     except Exception as exc:  # noqa: BLE001 — a build crash is a measured failure
         logger.warning("Build raised for case %s: %s", case.case_id, exc)
-        outcome = BuildOutcome(state=CrateState(), session_id=None, error=str(exc))
+        outcome = BuildOutcome(
+            state=CrateState(), session_id=None, error=str(exc), stop_reason="error"
+        )
     latency = time.perf_counter() - start
     return outcome, latency
+
+
+# Substrings (case-insensitive) that mark a build error as a **transient**
+# network/API failure rather than an architecture failure (trap 1). Named reason
+# phrases only — no bare numeric HTTP codes, which false-positive on unrelated text
+# (e.g. "500 entities"). A run whose error matches is re-run before it counts.
+_TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
+    "connection error",
+    "connection reset",
+    "connection aborted",
+    "connection refused",
+    "econnreset",
+    "timed out",
+    "timeout",
+    "temporarily unavailable",
+    "service unavailable",
+    "internal server error",
+    "server error",
+    "bad gateway",
+    "gateway timeout",
+    "rate limit",
+    "too many requests",
+    "overloaded",
+    "try again",
+)
+
+
+def _is_transient_error(error: str | None) -> bool:
+    """Return True if *error* looks like a transient network/API failure (trap 1).
+
+    A transient error (connection drop, timeout, rate limit, 5xx, overload) is a
+    property of the network, not of the architecture under test, so the harness
+    re-runs it rather than scoring it as a build failure. Matching is on named
+    reason phrases (see :data:`_TRANSIENT_ERROR_MARKERS`); anything else — a
+    validation failure, a ``KeyError``, a non-conformant crate — is a genuine,
+    measured result and is never retried.
+    """
+    if not error:
+        return False
+    text = error.lower()
+    return any(marker in text for marker in _TRANSIENT_ERROR_MARKERS)
+
+
+def _build_with_transient_retries(
+    agent_factory: AgentFactory,
+    case: EvalCase,
+    *,
+    max_transient_retries: int,
+) -> tuple[BuildOutcome, float, int]:
+    """Build one repeat, re-running on a transient error (trap 1).
+
+    Returns the accepted ``(outcome, latency, transient_retries)``. A fresh agent
+    is built for each attempt. Only a :func:`_is_transient_error` failure is
+    retried, and at most *max_transient_retries* times; a genuine failure (or a
+    success) is returned immediately.
+    """
+    transient_retries = 0
+    while True:
+        agent = agent_factory()
+        outcome, latency = _safe_build(agent, case)
+        if (
+            outcome.error
+            and _is_transient_error(outcome.error)
+            and transient_retries < max_transient_retries
+        ):
+            transient_retries += 1
+            logger.warning(
+                "Transient failure on case %s (retry %d/%d): %s",
+                case.case_id,
+                transient_retries,
+                max_transient_retries,
+                outcome.error,
+            )
+            continue
+        return outcome, latency, transient_retries
 
 
 def _run_case(
@@ -166,18 +265,24 @@ def _run_case(
     *,
     repeats: int,
     profile_reader: ProfileReader,
+    price_override: tuple[float, float] | None = None,
+    max_transient_retries: int = 2,
 ) -> CaseResult:
     """Run a single case ``repeats`` times and aggregate its metrics."""
     hashes: list[str] = []
     first_outcome: BuildOutcome | None = None
     first_latency = 0.0
     error: str | None = None
+    transient_retries = 0
 
     for i in range(max(1, repeats)):
         # A fresh agent per repeat — the determinism check must not be polluted by
-        # carried-over engine/session state.
-        agent = agent_factory()
-        outcome, latency = _safe_build(agent, case)
+        # carried-over engine/session state. Each repeat re-runs transient failures
+        # (trap 1) so a network blip is not scored as an architecture failure.
+        outcome, latency, retries = _build_with_transient_retries(
+            agent_factory, case, max_transient_retries=max_transient_retries
+        )
+        transient_retries += retries
         if i == 0:
             first_outcome, first_latency = outcome, latency
         if outcome.error and error is None:
@@ -192,6 +297,9 @@ def _run_case(
 
     profile_records = profile_reader(first_outcome.session_id) if first_outcome.session_id else []
     pm = mine_profile_metrics(profile_records)
+    cost_usd = compute_cost(
+        pm.input_tokens, pm.output_tokens, pm.model_name, price_override=price_override
+    )
 
     deterministic: bool | None = None
     if len(hashes) > 1:
@@ -214,6 +322,10 @@ def _run_case(
         error=error,
         meets_quota=quota["meets_quota"],
         entity_counts=quota["entity_counts"],
+        stop_reason=first_outcome.stop_reason,
+        model_name=pm.model_name,
+        cost_usd=cost_usd,
+        transient_retries=transient_retries,
     )
 
 
@@ -224,6 +336,8 @@ def run_eval(
     repeats: int = 2,
     label: str = "eval",
     profile_reader: ProfileReader | None = None,
+    price_override: tuple[float, float] | None = None,
+    max_transient_retries: int = 2,
 ) -> EvalReport:
     """Run *agent_factory* over *corpus* and return an :class:`EvalReport`.
 
@@ -238,12 +352,25 @@ def run_eval(
         profile_reader: Override for reading a session's profile records (the
             tests inject a canned reader); defaults to reading
             ``sessions/<id>/profile.ndjson`` from disk.
+        price_override: ``(input_per_mtok, output_per_mtok)`` USD prices applied to
+            every case's model (trap 5). When ``None``, cost is priced from
+            :data:`eval.metrics.MODEL_PRICES` and left ``None`` for unpriced models.
+        max_transient_retries: How many times to re-run a case on a *transient*
+            network/API failure before it counts (trap 1). ``0`` disables retries.
 
     Returns:
         An :class:`EvalReport` with one :class:`CaseResult` per case.
     """
     reader = profile_reader or _default_profile_reader
     results = [
-        _run_case(agent_factory, case, repeats=repeats, profile_reader=reader) for case in corpus
+        _run_case(
+            agent_factory,
+            case,
+            repeats=repeats,
+            profile_reader=reader,
+            price_override=price_override,
+            max_transient_retries=max_transient_retries,
+        )
+        for case in corpus
     ]
     return EvalReport(label=label, repeats=repeats, results=results)

--- a/eval/tests/test_cost.py
+++ b/eval/tests/test_cost.py
@@ -1,0 +1,141 @@
+"""Cost + model-name capture (trap 5, #331).
+
+The A/B differentiator is efficiency (tokens, wall-clock, $) and clean
+termination, not raw capability. Tokens / wall-clock / step-count are already
+recorded; this adds the model name (mined from ``profile.ndjson``) and the USD
+cost. An unpriced model records ``cost_usd = None`` (never a guessed price); a
+``price_override`` prices any model — the path the live gpt-5.6-luna re-run uses,
+since that model is deliberately not committed to the public price table.
+
+Offline: canned profile records + a mock agent, no LLM.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.metrics import compute_cost, mine_profile_metrics
+from eval.runner import run_eval
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class TestMineModelName:
+    def test_model_name_is_mined_from_model_node_ends(self) -> None:
+        records = [
+            {
+                "event": "node_end",
+                "node": "model",
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "model_name": "gpt-4o",
+            }
+        ]
+        assert mine_profile_metrics(records).model_name == "gpt-4o"
+
+    def test_model_name_none_when_absent(self) -> None:
+        assert mine_profile_metrics([{"event": "tool_call", "tool": "x"}]).model_name is None
+
+
+class TestComputeCost:
+    def test_priced_model_uses_the_table(self) -> None:
+        # gpt-4o = (2.50, 10.00) USD per 1M tokens.
+        assert compute_cost(1_000_000, 1_000_000, "gpt-4o") == pytest.approx(12.50)
+
+    def test_unknown_model_returns_none(self) -> None:
+        assert compute_cost(1000, 1000, "totally-unknown-model") is None
+
+    def test_none_model_returns_none(self) -> None:
+        assert compute_cost(1000, 1000, None) is None
+
+    def test_price_override_prices_any_model(self) -> None:
+        cost = compute_cost(1_000_000, 0, "gpt-5.6-luna", price_override=(3.0, 15.0))
+        assert cost == pytest.approx(3.0)
+
+    def test_dated_suffix_matches_longest_prefix(self) -> None:
+        # A dated variant matches its base model; the most specific name wins so
+        # "gpt-4o-mini-*" is never mispriced as "gpt-4o".
+        assert compute_cost(1_000_000, 0, "gpt-4o-2024-08-06") == compute_cost(
+            1_000_000, 0, "gpt-4o"
+        )
+        assert compute_cost(1_000_000, 0, "gpt-4o-mini-2024-07-18") == compute_cost(
+            1_000_000, 0, "gpt-4o-mini"
+        )
+
+
+class _ProfiledAgent:
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id="sid")
+
+
+def _gpt4o_reader(_sid: str) -> list[dict]:
+    return [
+        {
+            "event": "node_end",
+            "node": "model",
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "model_name": "gpt-4o",
+        }
+    ]
+
+
+class TestRunnerCapturesCost:
+    def test_case_result_carries_model_and_cost(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(), DEFAULT_CORPUS[:1], repeats=1, profile_reader=_gpt4o_reader
+        )
+        res = report.results[0]
+        assert res.model_name == "gpt-4o"
+        assert res.cost_usd == pytest.approx(2.50)
+        assert res.to_dict()["cost_usd"] == pytest.approx(2.50)
+
+    def test_summary_totals_cost(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(), DEFAULT_CORPUS[:2], repeats=1, profile_reader=_gpt4o_reader
+        )
+        assert report.summary()["total_cost_usd"] == pytest.approx(5.00)
+
+    def test_unpriced_run_totals_cost_as_none(self) -> None:
+        def reader(_sid: str) -> list[dict]:
+            return [
+                {
+                    "event": "node_end",
+                    "node": "model",
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "model_name": "mystery-model",
+                }
+            ]
+
+        report = run_eval(
+            lambda: _ProfiledAgent(), DEFAULT_CORPUS[:1], repeats=1, profile_reader=reader
+        )
+        assert report.results[0].cost_usd is None
+        # No case had a known price → total is None, not a misleading $0.
+        assert report.summary()["total_cost_usd"] is None
+
+    def test_price_override_threads_through_run_eval(self) -> None:
+        def reader(_sid: str) -> list[dict]:
+            return [
+                {
+                    "event": "node_end",
+                    "node": "model",
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 0,
+                    "model_name": "gpt-5.6-luna",
+                }
+            ]
+
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=1,
+            profile_reader=reader,
+            price_override=(4.0, 20.0),
+        )
+        assert report.results[0].cost_usd == pytest.approx(4.0)

--- a/eval/tests/test_main.py
+++ b/eval/tests/test_main.py
@@ -34,15 +34,28 @@ class TestArgParser:
     def test_defaults(self) -> None:
         args = build_arg_parser().parse_args([])
         assert args.label == "react-baseline"
-        assert args.repeats == 2
+        # repeats >= 3 so variance is reported over more than one or two samples
+        # (trap 4, #331).
+        assert args.repeats == 3
+        assert args.price_input is None
+        assert args.price_output is None
+        assert args.max_transient_retries == 2
 
     def test_overrides(self) -> None:
         args = build_arg_parser().parse_args(
-            ["--label", "pipeline", "--repeats", "3", "--out", "x.ndjson"]
+            ["--label", "pipeline", "--repeats", "5", "--out", "x.ndjson"]
         )
         assert args.label == "pipeline"
-        assert args.repeats == 3
+        assert args.repeats == 5
         assert args.out == "x.ndjson"
+
+    def test_price_and_retry_flags(self) -> None:
+        args = build_arg_parser().parse_args(
+            ["--price-input", "3.0", "--price-output", "15.0", "--max-transient-retries", "4"]
+        )
+        assert args.price_input == 3.0
+        assert args.price_output == 15.0
+        assert args.max_transient_retries == 4
 
 
 class TestRunMain:
@@ -71,3 +84,47 @@ class TestRunMain:
         produced = list(tmp_path.glob("*.ndjson"))
         assert len(produced) == 1
         assert "mock-run" in produced[0].name
+
+    def test_price_override_flows_into_the_report(self, tmp_path: Path) -> None:
+        # The --price-* flags price an otherwise-unlisted model end to end (trap 5):
+        # a profiled mock + canned reader report 1M input tokens on "mystery-model",
+        # priced at $7/Mtok input via the override.
+        out = tmp_path / "priced.ndjson"
+
+        class _ProfiledMock:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                factory = case.build_state or CrateState
+                return BuildOutcome(state=factory(), session_id="sid")
+
+        def reader(_sid: str) -> list[dict]:
+            return [
+                {
+                    "event": "node_end",
+                    "node": "model",
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 0,
+                    "model_name": "mystery-model",
+                }
+            ]
+
+        rc = run_main(
+            [
+                "--label",
+                "priced",
+                "--repeats",
+                "1",
+                "--price-input",
+                "7.0",
+                "--price-output",
+                "21.0",
+                "--out",
+                str(out),
+            ],
+            agent_factory=lambda: _ProfiledMock(),
+            profile_reader=reader,
+        )
+        assert rc == 0
+        lines = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+        case_line = next(line for line in lines if line.get("record") == "case")
+        assert case_line["model_name"] == "mystery-model"
+        assert case_line["cost_usd"] == pytest.approx(7.0)

--- a/eval/tests/test_report.py
+++ b/eval/tests/test_report.py
@@ -29,6 +29,9 @@ def _case(case_id: str, *, success: bool, tokens: int, det: bool | None) -> Case
         crate_hashes=["abc", "abc"] if det else ["abc", "xyz"],
         deterministic=det,
         repeats=2,
+        stop_reason="cap_hit" if not success else "completed",
+        model_name="gpt-4o",
+        cost_usd=0.5,
     )
 
 
@@ -94,3 +97,12 @@ class TestCompareReports:
         # A per-case table keyed by case_id, success for both labels.
         assert "cases" in diff
         assert set(diff["cases"]) == {"c1", "c2"}
+
+    def test_per_case_carries_efficiency_and_termination_signals(self) -> None:
+        # The A/B diff surfaces stop_reason / model / $ so a cap_hit "win" and the
+        # cost gap are visible per case (#331).
+        diff = compare_reports(_report("react-baseline"), _report("pipeline"))
+        c2 = diff["cases"]["c2"]["react-baseline"]
+        assert c2["stop_reason"] == "cap_hit"
+        assert c2["model_name"] == "gpt-4o"
+        assert c2["cost_usd"] == 0.5

--- a/eval/tests/test_stop_reason.py
+++ b/eval/tests/test_stop_reason.py
@@ -1,0 +1,98 @@
+"""Stop-reason capture across the A/B (trap 2, #331).
+
+A ReAct "win" at the recursion cap is not a clean win, so the harness records a
+first-class ``stop_reason`` per run: ``"completed"`` (self-terminated), ``"cap_hit"``
+(hit the LangGraph ``recursion_limit``), or ``"error"`` (the build raised). The
+deterministic pipeline always self-terminates.
+
+Offline: injected drivers/runners and a mock agent, so no LLM is contacted. A
+``cap_hit`` deliberately preserves the partial crate — the conformance predicate
+still measures what the run produced at the cutoff.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.pipeline_factory import PipelineBuildAgent
+from eval.react_factory import ReActBuildAgent
+from eval.runner import run_eval
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class TestReActStopReason:
+    def test_completed_when_driver_returns(self) -> None:
+        agent = ReActBuildAgent(graph_driver=lambda e, p: None)
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.stop_reason == "completed"
+        assert outcome.error is None
+
+    def test_cap_hit_on_graph_recursion_error(self) -> None:
+        from langgraph.errors import GraphRecursionError
+
+        def boom(engine, prompt):  # type: ignore[no-untyped-def]
+            raise GraphRecursionError("Recursion limit of 80 reached without hitting a stop")
+
+        agent = ReActBuildAgent(graph_driver=boom)
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.stop_reason == "cap_hit"
+        # cap_hit is not a hard build error: the partial crate is preserved so the
+        # conformance predicate can still measure what the run produced at the cap.
+        assert outcome.error is None
+        assert isinstance(outcome.state, CrateState)
+
+    def test_error_on_other_exception(self) -> None:
+        def boom(engine, prompt):  # type: ignore[no-untyped-def]
+            raise RuntimeError("model unreachable")
+
+        agent = ReActBuildAgent(graph_driver=boom)
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.stop_reason == "error"
+        assert outcome.error is not None
+        assert "model unreachable" in outcome.error
+
+
+class TestPipelineStopReason:
+    def test_completed_on_success(self) -> None:
+        agent = PipelineBuildAgent(pipeline_runner=lambda e: {"ok": True})
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.stop_reason == "completed"
+
+    def test_error_on_exception(self) -> None:
+        def boom(engine):  # type: ignore[no-untyped-def]
+            raise RuntimeError("pipeline exploded")
+
+        agent = PipelineBuildAgent(pipeline_runner=boom)
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.stop_reason == "error"
+
+
+class _StopReasonAgent:
+    """A mock agent returning a fixed stop_reason (offline)."""
+
+    def __init__(self, stop_reason: str) -> None:
+        self._stop_reason = stop_reason
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id=None, stop_reason=self._stop_reason)
+
+
+class TestRunnerPropagatesStopReason:
+    def test_case_result_carries_stop_reason(self) -> None:
+        report = run_eval(lambda: _StopReasonAgent("cap_hit"), DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert res.stop_reason == "cap_hit"
+        assert res.to_dict()["stop_reason"] == "cap_hit"
+
+    def test_summary_breaks_down_stop_reasons(self) -> None:
+        report = run_eval(lambda: _StopReasonAgent("cap_hit"), DEFAULT_CORPUS, repeats=1)
+        summary = report.summary()
+        # Every case self-reported cap_hit here.
+        assert summary["num_cap_hit"] == len(DEFAULT_CORPUS)
+        assert summary["num_completed"] == 0
+        assert summary["num_error"] == 0

--- a/eval/tests/test_transient_retry.py
+++ b/eval/tests/test_transient_retry.py
@@ -1,0 +1,118 @@
+"""Transient-failure re-run (trap 1, #331).
+
+A Connection / API / timeout error is a property of the network, not of the
+architecture under test — counting it as a build failure produces a wrong verdict.
+The runner re-runs a case a bounded number of times on a *transient* error before
+it counts; a genuine (non-transient) failure is never retried.
+
+Offline: mock agents whose successive instances behave as scripted, no LLM.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.runner import _is_transient_error, run_eval
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class TestTransientClassifier:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Connection error.",
+            "Request timed out.",
+            "Read timed out.",
+            "Rate limit reached for gpt-4o",
+            "Too Many Requests",
+            "overloaded_error: the model is overloaded",
+            "503 Service Unavailable",
+            "Bad gateway",
+        ],
+    )
+    def test_transient_messages(self, message: str) -> None:
+        assert _is_transient_error(message) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            None,
+            "",
+            "SHACL validation failed: missing required property",
+            "KeyError: 'name'",
+            "the crate is not conformant",
+        ],
+    )
+    def test_non_transient_messages(self, message: str | None) -> None:
+        assert _is_transient_error(message) is False
+
+
+class TestTransientRetry:
+    def test_transient_failure_is_retried_then_succeeds(self) -> None:
+        attempts = {"n": 0}
+
+        class _FlakyAgent:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    return BuildOutcome(
+                        state=CrateState(),
+                        session_id=None,
+                        error="Connection error.",
+                        stop_reason="error",
+                    )
+                factory = case.build_state or CrateState
+                return BuildOutcome(state=factory(), session_id=None, stop_reason="completed")
+
+        report = run_eval(lambda: _FlakyAgent(), DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert attempts["n"] == 2  # one initial + one retry
+        assert res.success is True
+        assert res.transient_retries == 1
+        assert res.stop_reason == "completed"
+        assert res.error is None
+
+    def test_non_transient_failure_is_not_retried(self) -> None:
+        attempts = {"n": 0}
+
+        class _HardFailAgent:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                attempts["n"] += 1
+                return BuildOutcome(
+                    state=CrateState(),
+                    session_id=None,
+                    error="SHACL validation failed",
+                    stop_reason="error",
+                )
+
+        report = run_eval(lambda: _HardFailAgent(), DEFAULT_CORPUS[:1], repeats=1)
+        res = report.results[0]
+        assert attempts["n"] == 1  # a genuine failure is measured, not retried
+        assert res.transient_retries == 0
+        assert res.error is not None
+
+    def test_persistent_transient_failure_stops_after_max_retries(self) -> None:
+        attempts = {"n": 0}
+
+        class _AlwaysFlaky:
+            def build(self, case: EvalCase) -> BuildOutcome:
+                attempts["n"] += 1
+                return BuildOutcome(
+                    state=CrateState(),
+                    session_id=None,
+                    error="Read timed out.",
+                    stop_reason="error",
+                )
+
+        report = run_eval(
+            lambda: _AlwaysFlaky(), DEFAULT_CORPUS[:1], repeats=1, max_transient_retries=2
+        )
+        res = report.results[0]
+        assert attempts["n"] == 3  # one initial + two retries, then it counts
+        assert res.transient_retries == 2
+        assert res.error is not None
+        assert res.to_dict()["transient_retries"] == 2


### PR DESCRIPTION
## What & why (Part B of the fair-fight A/B harness, #309)

Follows #329/#330 (scan-root fairness). Makes the `eval/` A/B produce **defensible, apples-to-apples numbers** by fixing four methodology traps — each had already produced a wrong verdict. TDD throughout; the A/B success metric (SHACL conformance + additive `min_entities` quota) is unchanged.

### Trap 2 — a cap-hit "win" is not a clean win
New first-class **`stop_reason`** per run: `completed` (self-terminated) / `cap_hit` (hit the LangGraph `recursion_limit`) / `error`. ReAct maps `GraphRecursionError → cap_hit` and **preserves the partial crate** (error stays unset) so conformance still measures what it produced at the cap. The pipeline always `completed`. Summary adds `num_completed`/`num_cap_hit`/`num_error`.

### Trap 5 — the differentiator is efficiency + termination, not capability
Capture **`model_name`** (mined from `profile.ndjson`) and **`cost_usd`** per case, from an overridable `MODEL_PRICES` table; an unpriced model records `cost_usd = None` (never a guessed `0`). `--price-input`/`--price-output` price any model — the path the gpt-5.6-luna re-run uses, so **no work-issued model's pricing lives in this public repo**. Summary adds `total_cost_usd` (`None` when nothing was priced). Longest-prefix match means `gpt-4o-mini-*` is never mispriced as `gpt-4o`.

### Trap 1 — transient network failures ≠ architecture failures
`_is_transient_error` classifies connection/timeout/rate-limit/5xx/overload by named reason phrase (no bare numeric codes). A transient failure is re-run up to `--max-transient-retries` (default 2) before it counts; a genuine failure (validation, `KeyError`, non-conformant) is never retried. `transient_retries` recorded per case.

### Trap 4 — repeats = 1 is one sample
`--repeats` default **2 → 3** (library `run_eval` default kept at 2 for backward-compat).

## Files
`eval/{agent_api,react_factory,pipeline_factory,metrics,runner,report,__main__}.py`; docs in `eval/README.md`. New tests: `test_stop_reason.py`, `test_cost.py`, `test_transient_retry.py`; extended `test_main.py`, `test_report.py`.

## Verification
- TDD red→green per trap. Full `eval/` suite green; `ruff check` + `ty` clean.
- **No live run** here — spending the gpt-5.6-luna key is a separate, explicitly-authorized step.

Closes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
