### PR TITLE
Score AOP-Wiki linking in the svhps22 eval case (#180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ eval_reports/
 # local maturity-report design scratch (kept locally, never committed)
 maturity_report_prototype.html
 docs/ab-and-harmonization-handoff.md
+
+# local A/B output comparison (throwaway analysis artifact, never committed)
+ab_comparison/

--- a/eval/corpus.py
+++ b/eval/corpus.py
@@ -182,8 +182,9 @@ def _drafting_state() -> CrateState:
 
     Unlike the backbone-only stand-ins above, this drafts the full domain set the
     ``structured-svhps22`` case is designed to elicit: the ISA backbone, a
-    compound, a cell line, contributors, a lab protocol, the Exposure process, and
-    the two attached data files. It is REQUIRED-clean across base/ISA/ISA-Tox *and*
+    compound, a cell line, contributors, a lab protocol, the Exposure process, the
+    two attached data files, and the Adverse Outcome Pathway it investigates
+    (AOP-Wiki 42, Issue #180). It is REQUIRED-clean across base/ISA/ISA-Tox *and*
     satisfies that case's ``min_entities`` quota, so the content-quality signal is
     exercisable offline with a mock agent.
     """
@@ -222,6 +223,9 @@ def _drafting_state() -> CrateState:
             identifier="S-VHPS22",
             investigation_id="inv",
             datePublished="2025-11-10",
+            # The Adverse Outcome Pathway this TPO screen investigates
+            # (schema:mentions), referencing the AdverseOutcomePathway entity below.
+            aop=[{"@id": "https://aopwiki.org/aops/42"}],
         )
     )
     state.add_entity(
@@ -272,6 +276,23 @@ def _drafting_state() -> CrateState:
     )
     state.add_entity(
         _ent("proc", "File", name="ic50_results.csv", path="processed_data/ic50_results.csv")
+    )
+
+    # The Adverse Outcome Pathway this TPO screen investigates (AOP-Wiki 42),
+    # keyed by its resolvable IRI exactly as materialize_aop_subgraph would
+    # (Issue #180). AOP linking is a tox SHOULD, so it does not gate REQUIRED
+    # conformance; the case's min_entities quota is what makes the A/B measure it.
+    state.add_entity(
+        _ent(
+            "https://aopwiki.org/aops/42",
+            "AdverseOutcomePathway",
+            name=(
+                "Inhibition of thyroid peroxidase and subsequent adverse "
+                "neurodevelopmental outcomes in mammals"
+            ),
+            identifier="42",
+            url="https://aopwiki.org/aops/42",
+        )
     )
     return state
 
@@ -467,8 +488,9 @@ DEFAULT_CORPUS: tuple[EvalCase, ...] = (
             "CSVs) and draft the full ISA-Tox domain set. Success is the strict "
             "{base, isa, tox} conformance gate; the additive min_entities quota "
             "measures whether the build actually drafted the domain content "
-            "(compound, cell line, the two files) — so the A/B can compare draft "
-            "QUALITY, not just that the agent acted (Issue #179)."
+            "(compound, cell line, the two files, and the AOP-Wiki pathway the "
+            "TPO screen investigates) — so the A/B can compare draft QUALITY, not "
+            "just that the agent acted (Issues #179, #180)."
         ),
         kind="structured",
         prompt=(
@@ -484,7 +506,15 @@ DEFAULT_CORPUS: tuple[EvalCase, ...] = (
         build_state=_drafting_state,
         # Content-quality quota: a real draft must carry the compound, the cell
         # line, and both attached data files — not merely a conformant backbone.
-        min_entities={"MolecularEntity": 1, "CellLineSample": 1, "File": 2},
+        min_entities={
+            "MolecularEntity": 1,
+            "CellLineSample": 1,
+            "File": 2,
+            # AOP-Wiki linking (Issue #180): TPO inhibition is AOP 42, so a good
+            # build must draft the pathway — this makes the A/B score AOP, not
+            # just backbone + compound + cell line.
+            "AdverseOutcomePathway": 1,
+        },
     ),
     EvalCase(
         case_id="unstructured-conversation",

--- a/eval/tests/test_corpus_entity_drafting.py
+++ b/eval/tests/test_corpus_entity_drafting.py
@@ -131,3 +131,55 @@ class TestEntityDraftingCaseBuildState:
 
         quota = meets_entity_quota(state, case.min_entities)
         assert quota["meets_quota"] is True, quota["missing"]
+
+
+class TestEntityDraftingCaseLinksAOP:
+    """The svhps22 case exercises AOP-Wiki linking (Issue #180) end to end.
+
+    TPO inhibition is a well-characterised Adverse Outcome Pathway (AOP-Wiki 42),
+    so a *good* svhps22 build must draft the pathway as a typed
+    ``AdverseOutcomePathway`` entity AND reference it from the Study
+    (``schema:mentions``). Before this, no corpus case exercised AOP linking, so
+    neither A/B arm was ever scored on getting it — the feature could silently
+    regress. The quota demands the AOP so the harness now measures it.
+    """
+
+    CASE_ID = "structured-svhps22"
+    AOP_IRI = "https://aopwiki.org/aops/42"
+
+    def _case(self) -> EvalCase:
+        return next(c for c in DEFAULT_CORPUS if c.case_id == self.CASE_ID)
+
+    def test_quota_demands_an_adverse_outcome_pathway(self) -> None:
+        case = self._case()
+        assert case.min_entities is not None
+        assert case.min_entities.get("AdverseOutcomePathway", 0) >= 1, (
+            "the svhps22 quota must demand an AdverseOutcomePathway so the A/B "
+            "measures AOP linking, not just backbone + compound + cell line"
+        )
+
+    def test_build_state_materializes_a_typed_aop(self) -> None:
+        case = self._case()
+        assert case.build_state is not None
+        state = case.build_state()
+        aops = state.list_entities(entity_type="AdverseOutcomePathway")
+        assert len(aops) >= 1, (
+            "the good svhps22 stand-in must draft an AdverseOutcomePathway entity"
+        )
+
+    def test_study_mentions_the_aop(self) -> None:
+        case = self._case()
+        assert case.build_state is not None
+        state = case.build_state()
+        studies = state.list_entities(entity_type="Study")
+        assert studies, "expected a Study to hang the AOP mention off"
+        ref_ids: set[str] = set()
+        for study in studies:
+            value = study.fields.get("aop")
+            if not value:
+                continue
+            for ref in value if isinstance(value, list) else [value]:
+                ref_ids.add(ref.get("@id") if isinstance(ref, dict) else ref)
+        assert self.AOP_IRI in ref_ids, (
+            f"the Study should mention the AOP via schema:mentions; got {ref_ids}"
+        )

--- a/tests/fixtures/svhps22_input/README.md
+++ b/tests/fixtures/svhps22_input/README.md
@@ -14,6 +14,7 @@ processed data so an agent must draft several distinct domain entities.
 - Cell line: FRTL-5 TPO-overexpressing rat thyroid follicular cells
 - Compound: Methimazole (reference TPO inhibitor)
 - Protocol: Amplex Red fluorometric TPO activity readout
+- AOP: AOP:42 (thyroperoxidase inhibition leading to adverse neurodevelopmental outcomes)
 
 ## Files
 


### PR DESCRIPTION
## Why

The eval's success gate is SHACL conformance at **REQUIRED** severity, but AOP-Wiki linking is a tox **SHOULD** (`sh:Warning`). So neither A/B arm was ever scored on whether it situates a study in its Adverse Outcome Pathway. The `materialize_aop_subgraph` machinery works and is unit-tested, but **no corpus case exercised it** — the example crates never showed an AOP and the A/B could not measure it, so it could silently regress.

## What

TPO inhibition is **AOP-Wiki 42**, so the `structured-svhps22` case now:

- drafts the `AdverseOutcomePathway` (AOP 42) in the good-build stand-in and references it from the Study via `schema:mentions`;
- demands it in `min_entities`, so the additive content-quality quota **measures AOP linking** (AOP stays a SHOULD — it never gates REQUIRED conformance, and flipping the gate to SHOULD was rejected: it would punish a build for correctly not fabricating a pathway, and doesn't reliably escalate the warning anyway);
- states `AOP:42` in the input README so a live build has the explicit trigger.

## Tests (TDD, failing-first)

Added three tests asserting the case demands an `AdverseOutcomePathway`, the stand-in materializes a typed one, and the Study mentions it. Confirmed red first, then green. Full `eval/` suite: **126 passed**.

Also tidies `.gitignore` (ignore the local `ab_comparison/` analysis artifact).

Relates to #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
