### PR TITLE
Enforce ReAct tools_spec ↔ registry parity at runtime (#327)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1535,7 +1535,7 @@ vitro-crate/
 │       └── react/               ReAct StateGraph mode (legacy, --legacy-react)
 │           ├── agent_loop.py      ReAct StateGraph loop
 │           ├── system_prompt.py   ReAct system prompt
-│           └── tools_spec.py      TOOL_SPECS advertised to the ReAct LLM
+│           └── tools_spec.py      TOOL_SPECS advertised to the ReAct LLM + the registry-parity contract (#327)
 ├── eval/                        A/B eval harness (--arch react|pipeline)
 ├── sessions/                    Persisted sessions
 ├── output/                      Built crates (versioned)
@@ -1698,8 +1698,15 @@ not a validity blocker, since `datePublished` is auto-set by ro-crate-py).
 
 > **Tool-registration contract:** every new LLM tool must be registered in **four**
 > lockstep places — `TOOL_REGISTRY`, `TOOL_SPECS`, the system-prompt "## Your Tools"
-> catalogue, and §5 of this doc (guarded by `tests/test_agents_doc_toolbox.py`) — plus
-> the import lists in `tests/test_tools_spec.py`, or CI fails.
+> catalogue, and §5 of this doc (guarded by `tests/test_agents_doc_toolbox.py`). The
+> `TOOL_REGISTRY` ⇄ `TOOL_SPECS` half is enforced automatically (#327): the parity
+> contract in `tools_spec.py` — `expected_tool_spec_names()`, the shared registry plus
+> a small, *documented* set of engine-routed tools (`_LLM_TOOLS_OUTSIDE_REGISTRY`) —
+> is checked at runtime by `assert_tool_spec_parity()` when the ReAct arm builds its
+> tools, and in CI by `tests/test_tools_spec.py`. A registered tool with no schema, or
+> a schema advertising a tool the engine cannot run, fails fast in either direction, so
+> the A/B always compares the *same* toolbox. A genuinely engine-routed tool (present
+> to the LLM but not in the registry) is declared once, in `_LLM_TOOLS_OUTSIDE_REGISTRY`.
 
 ### 14.5 The pipeline spine (`builder/agents/pipeline/pipeline.py`)
 

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -30,7 +30,7 @@ from builder.agents.llm import (
     _recursion_limit,
 )
 from builder.agents.react.system_prompt import SYSTEM_PROMPT
-from builder.agents.react.tools_spec import TOOL_SPECS
+from builder.agents.react.tools_spec import TOOL_SPECS, assert_tool_spec_parity
 from builder.engine import AgentEngine
 from builder.tools.hitl import (
     register_console_animation,
@@ -651,6 +651,11 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
         from langchain_core.tools import BaseTool, StructuredTool
     except ImportError:
         raise ImportError("langchain extra is required: pip install vitro-crate[langchain]")
+
+    # Fail fast if the advertised specs have drifted from the tools the shared
+    # engine can actually run (#327): the A/B must compare the *same* toolbox, and
+    # a silently-missing schema means the LLM can never call an available tool.
+    assert_tool_spec_parity()
 
     langchain_tools: list[BaseTool] = []
 

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -928,4 +928,113 @@ TOOL_SPECS = [
     },
 ]
 
-__all__ = ["TOOL_SPECS"]
+# ---------------------------------------------------------------------------
+# Provable tool-set parity with the shared registry (Issue #327)
+# ---------------------------------------------------------------------------
+#
+# TOOL_SPECS advertises the ReAct tool set to the LLM. For the A/B comparison to
+# be over the *same* toolbox (AGENTS.md §5, §12), it must stay in exact lockstep
+# with the tools the shared engine can actually run. The authoritative set is:
+#
+#     builder.tools.registry.TOOL_REGISTRY.list()   # registered tools
+#       | _LLM_TOOLS_OUTSIDE_REGISTRY               # engine-routed extras
+#       - _REGISTRY_TOOLS_HIDDEN_FROM_LLM           # deliberately hidden
+#
+# Both divergences are small, intentional, and enumerated here — the one place
+# they are declared — so ``expected_tool_spec_names()`` (used by the runtime
+# assert and the parity tests) can never disagree with reality.
+
+# LLM-callable tools the engine routes itself, so they are NOT in TOOL_REGISTRY:
+#   - scanner / file-sample readers gated by AgentEngine before they touch disk
+#     (Issue #167): scan_files, read_file_sample, read_multiple_files, unzip_file,
+#     preview_archive;
+#   - human-in-the-loop tools dispatched via the human interface: present_to_human,
+#     request_input.
+_LLM_TOOLS_OUTSIDE_REGISTRY: frozenset[str] = frozenset(
+    {
+        "scan_files",
+        "read_file_sample",
+        "read_multiple_files",
+        "unzip_file",
+        "preview_archive",
+        "present_to_human",
+        "request_input",
+    }
+)
+
+# Registered tools deliberately withheld from the LLM. None today; a name added
+# here (with a reason) is excluded from the advertised set without tripping parity.
+_REGISTRY_TOOLS_HIDDEN_FROM_LLM: frozenset[str] = frozenset()
+
+# Every module whose import registers tools into TOOL_REGISTRY. Enumerated so the
+# registry is fully populated before it is read (registration is an import side
+# effect), keeping this the single place that knows the tool-module set.
+_TOOL_REGISTRY_MODULES: tuple[str, ...] = (
+    "builder.tools.builder",
+    "builder.tools.composites",
+    "builder.tools.data_content",
+    "builder.tools.drafters",
+    "builder.tools.fair_assessment",
+    "builder.tools.file_readers",
+    "builder.tools.lookups",
+    "builder.tools.management",
+    "builder.tools.mit_assessment",
+    "builder.tools.provenance",
+    "builder.tools.repair",
+    "builder.tools.scanner",
+    "builder.tools.session",
+    "builder.tools.validation",
+    "builder.tools.verification",
+)
+
+
+class ToolSpecParityError(RuntimeError):
+    """TOOL_SPECS has drifted from the tools the shared engine can run (#327)."""
+
+
+def _registered_tool_names() -> set[str]:
+    """Return every tool name in the shared registry (registry fully populated)."""
+    import importlib
+
+    for module in _TOOL_REGISTRY_MODULES:
+        importlib.import_module(module)
+    from builder.tools.registry import TOOL_REGISTRY
+
+    return set(TOOL_REGISTRY.list())
+
+
+def expected_tool_spec_names() -> set[str]:
+    """The authoritative set of names TOOL_SPECS must advertise (Issue #327).
+
+    ``registry ∪ engine-routed extras − deliberately-hidden`` — the single source
+    of truth the runtime assert and the parity tests both measure against.
+    """
+    return (
+        _registered_tool_names() | _LLM_TOOLS_OUTSIDE_REGISTRY
+    ) - _REGISTRY_TOOLS_HIDDEN_FROM_LLM
+
+
+def assert_tool_spec_parity() -> None:
+    """Raise :class:`ToolSpecParityError` if TOOL_SPECS has drifted (Issue #327).
+
+    Called when the ReAct arm builds its LangChain tools, so a mismatch fails fast
+    at build time rather than silently advertising the wrong toolbox to the LLM.
+    """
+    spec_names = {spec["name"] for spec in TOOL_SPECS}
+    expected = expected_tool_spec_names()
+    missing = expected - spec_names
+    extra = spec_names - expected
+    if missing or extra:
+        raise ToolSpecParityError(
+            "TOOL_SPECS is out of sync with the shared tool registry (#327): "
+            f"callable tools with no schema: {sorted(missing)}; "
+            f"schemas advertising uncallable tools: {sorted(extra)}."
+        )
+
+
+__all__ = [
+    "TOOL_SPECS",
+    "ToolSpecParityError",
+    "assert_tool_spec_parity",
+    "expected_tool_spec_names",
+]

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -25,84 +25,45 @@ _INTERNAL_TOOL_NAMES: set[str] | None = None
 def _get_registry_tool_names() -> set[str]:
     """Return tool names registered in the shared TOOL_REGISTRY.
 
-    Imports all tool modules (triggering registration calls) and returns
-    the full set of registered tool names intended for LLM use.
+    Delegates to the single-source parity contract (Issue #327) so the test and
+    the runtime assert measure the same fully-populated registry.
     """
-    import builder.tools.builder
-    import builder.tools.composites
-    import builder.tools.data_content
-    import builder.tools.drafters
-    import builder.tools.fair_assessment
-    import builder.tools.management
-    import builder.tools.mit_assessment
-    import builder.tools.provenance
-    import builder.tools.repair
-    import builder.tools.scanner
-    import builder.tools.session
-    import builder.tools.validation
-    import builder.tools.verification
-    from builder.tools.registry import TOOL_REGISTRY
+    from builder.agents.react.tools_spec import _registered_tool_names
 
-    return set(TOOL_REGISTRY.list())
+    return _registered_tool_names()
 
 
 def _get_engine_routable_llm_tools() -> set[str]:
     """Return tool names that the engine routes specially (not via registry)
     and that are intended to be callable by the LLM.
 
-    The engine has special routing for HITL tools and scanner tools.
-    Scanner tools like scan_files, read_file_sample, read_multiple_files,
-    unzip_file, and preview_archive are engine-routed and should be in
-    TOOL_SPECS (some already are). HITL tools present_to_human and
-    request_input must also be in TOOL_SPECS for the LLM to call them.
+    The engine has special routing for HITL tools and scanner tools. This set is
+    declared once, in the parity contract (Issue #327), so the test cannot drift
+    from what the runtime assert enforces.
     """
-    return {
-        "present_to_human",
-        "request_input",
-        "scan_files",
-        "read_file_sample",
-        "read_multiple_files",
-        "unzip_file",
-        "preview_archive",
-    }
+    from builder.agents.react.tools_spec import _LLM_TOOLS_OUTSIDE_REGISTRY
+
+    return set(_LLM_TOOLS_OUTSIDE_REGISTRY)
 
 
 def _get_all_registry_tool_names() -> set[str]:
-    """Return the COMPLETE set of registered tool names.
+    """Return the COMPLETE set of registered tool names (single source, #327)."""
+    from builder.agents.react.tools_spec import _registered_tool_names
 
-    Imports every tool module that registers tools (including file_readers and
-    provenance) so the registry is fully populated. Unlike
-    ``_get_registry_tool_names`` this is exhaustive — used for the bidirectional
-    source-of-truth assertion.
-    """
-    import builder.tools.builder  # noqa: F401
-    import builder.tools.composites  # noqa: F401
-    import builder.tools.data_content  # noqa: F401
-    import builder.tools.drafters  # noqa: F401
-    import builder.tools.fair_assessment  # noqa: F401
-    import builder.tools.file_readers  # noqa: F401
-    import builder.tools.lookups  # noqa: F401
-    import builder.tools.management  # noqa: F401
-    import builder.tools.mit_assessment  # noqa: F401
-    import builder.tools.provenance  # noqa: F401
-    import builder.tools.repair  # noqa: F401
-    import builder.tools.scanner  # noqa: F401
-    import builder.tools.session  # noqa: F401
-    import builder.tools.validation  # noqa: F401
-    import builder.tools.verification  # noqa: F401
-    from builder.tools.registry import TOOL_REGISTRY
-
-    return set(TOOL_REGISTRY.list())
+    return _registered_tool_names()
 
 
 def _expected_llm_tool_universe() -> set[str]:
     """The authoritative set of LLM-callable tools.
 
     A tool is LLM-callable iff it is either registered in the shared registry or
-    routed specially by the engine (HITL + scanner tools). This is the single
-    source of truth ``TOOL_SPECS`` and the system prompt must both match.
+    routed specially by the engine (HITL + scanner tools). Delegates to the parity
+    contract (Issue #327) so ``TOOL_SPECS``, the system prompt, and the runtime
+    assert all measure against one definition.
     """
-    return _get_all_registry_tool_names() | _get_engine_routable_llm_tools()
+    from builder.agents.react.tools_spec import expected_tool_spec_names
+
+    return expected_tool_spec_names()
 
 
 def _get_tool_names_from_system_prompt() -> set[str]:
@@ -324,6 +285,50 @@ def test_system_prompt_tool_list_matches_tool_specs_exactly():
     assert not extra_in_prompt, (
         f"Prompt list names not in TOOL_SPECS: {sorted(extra_in_prompt)}"
     )
+
+
+def test_expected_tool_spec_names_is_the_single_source_of_truth():
+    """``expected_tool_spec_names()`` == TOOL_SPECS names (Issue #327).
+
+    The parity contract lives in one place — the module the specs live in — so the
+    runtime assert and every test measure against the same authoritative set.
+    """
+    from builder.agents.react.tools_spec import expected_tool_spec_names
+
+    assert expected_tool_spec_names() == _tool_names()
+
+
+def test_assert_tool_spec_parity_passes_on_the_current_tree():
+    """The runtime parity guard does not raise for the shipped tool set (#327)."""
+    from builder.agents.react.tools_spec import assert_tool_spec_parity
+
+    assert_tool_spec_parity()  # must not raise
+
+
+def test_assert_tool_spec_parity_flags_a_callable_tool_with_no_spec(monkeypatch):
+    """A tool the engine can run but TOOL_SPECS omits is caught (#327)."""
+    import builder.agents.react.tools_spec as ts
+
+    monkeypatch.setattr(
+        ts,
+        "_LLM_TOOLS_OUTSIDE_REGISTRY",
+        ts._LLM_TOOLS_OUTSIDE_REGISTRY | {"phantom_registry_tool"},
+    )
+    with pytest.raises(ts.ToolSpecParityError, match="phantom_registry_tool"):
+        ts.assert_tool_spec_parity()
+
+
+def test_assert_tool_spec_parity_flags_a_spec_with_no_callable_tool(monkeypatch):
+    """A spec advertising a tool the engine cannot run is caught (#327)."""
+    import builder.agents.react.tools_spec as ts
+
+    monkeypatch.setattr(
+        ts,
+        "TOOL_SPECS",
+        [*ts.TOOL_SPECS, {"name": "phantom_spec_tool", "description": "", "parameters": {}}],
+    )
+    with pytest.raises(ts.ToolSpecParityError, match="phantom_spec_tool"):
+        ts.assert_tool_spec_parity()
 
 
 __all__: list[str] = []


### PR DESCRIPTION
Closes #327. The last substantive piece of the #309 harmonization reorg.

## Why

`TOOL_SPECS` (`builder/agents/react/tools_spec.py`) advertises the ReAct tool set to the LLM. For the A/B to compare the **same** toolbox (AGENTS.md §5/§12), it must not drift from the tools the shared engine can actually run (`builder/tools/registry.py::TOOL_REGISTRY`). #90 already checked this bidirectionally — but only **in CI**, and with the divergence set (engine-routed extras) and the tool-module import list duplicated as **literals in the test file**, which can themselves silently drift.

## What (Option 1 from the issue — parity enforcement)

- **Single documented source of truth** in `tools_spec.py`: `expected_tool_spec_names()` = `TOOL_REGISTRY` ∪ `_LLM_TOOLS_OUTSIDE_REGISTRY` (a small, commented set of engine-routed scanner + HITL tools) − `_REGISTRY_TOOLS_HIDDEN_FROM_LLM` (empty today, documented). Both divergences are declared exactly once.
- **Runtime guard**: `assert_tool_spec_parity()` runs when the ReAct arm builds its LangChain tools (`_build_langchain_tools`), so a registered tool with no schema — or a schema advertising a tool the engine cannot run — **fails fast at build time**, not just in CI. Raises `ToolSpecParityError` naming the drift.
- **Tests**: `tests/test_tools_spec.py`'s registry / engine-routed helpers now **delegate** to that single source (no more duplicated import list or magic literal), plus four new tests covering the contract and drift in both directions.
- **Docs**: the tool-registration contract note + §12 file map in AGENTS.md updated.

## Verification (TDD)

- 4 tests written failing-first → implemented → green. Full `test_tools_spec.py`: **11 passed**.
- 108 agent/tool tests pass; the doc-toolbox guard passes.
- Adversarial: injected drift is caught **through the real `_build_langchain_tools` path**, not only the direct unit test.
- `ruff` + `ty`: clean.

Both build modes stay first-class (AGENTS.md §1, D15) — this is provable tool-set parity, not deprecating ReAct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
