### PR TITLE
Finalize Step-4 A/B numbers: per-repeat variance, offline reprice, refresh docs (#335)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1476,9 +1476,10 @@ The `--interactive` default is the deterministic pipeline (§14), not the ReAct 
 (D1): code owns the step ordering and the LLM is confined to bounded leaves. The
 rationale is **efficiency, predictability, and clean termination**, not raw
 capability — a capable model reaches SHACL conformance on either path. In the in-repo
-A/B (`eval/`, gpt-5.6-luna, 5-case corpus) the pipeline reached 5/5 conformance at
-~$0.05 and self-terminated every case, while ReAct reached 4/5 at ~50× the cost with
-3 of its 4 wins force-stopped at the recursion cap. ReAct stays a supported variant
+A/B (`eval/`, gpt-5.6-luna, 5-case corpus, repeats=3) both arms reach 5/5
+conformance, but the pipeline self-terminates every case at ~$0.05 while ReAct costs
+~39× as much (~$2.07, ~69× the tokens, ~6.7× the wall-clock) with 3 of its 5 wins
+force-stopped at the recursion cap. ReAct stays a supported variant
 (`--legacy-react`) for flexible conversational exploration. The success metric is
 profile conformance (base + isa + tox) plus an entity-count quota — **not** scientific
 accuracy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1535,7 +1535,7 @@ vitro-crate/
 │       └── react/               ReAct StateGraph mode (legacy, --legacy-react)
 │           ├── agent_loop.py      ReAct StateGraph loop
 │           ├── system_prompt.py   ReAct system prompt
-│           └── tools_spec.py      TOOL_SPECS advertised to the ReAct LLM
+│           └── tools_spec.py      TOOL_SPECS advertised to the ReAct LLM + the registry-parity contract (#327)
 ├── eval/                        A/B eval harness (--arch react|pipeline)
 ├── sessions/                    Persisted sessions
 ├── output/                      Built crates (versioned)
@@ -1698,8 +1698,15 @@ not a validity blocker, since `datePublished` is auto-set by ro-crate-py).
 
 > **Tool-registration contract:** every new LLM tool must be registered in **four**
 > lockstep places — `TOOL_REGISTRY`, `TOOL_SPECS`, the system-prompt "## Your Tools"
-> catalogue, and §5 of this doc (guarded by `tests/test_agents_doc_toolbox.py`) — plus
-> the import lists in `tests/test_tools_spec.py`, or CI fails.
+> catalogue, and §5 of this doc (guarded by `tests/test_agents_doc_toolbox.py`). The
+> `TOOL_REGISTRY` ⇄ `TOOL_SPECS` half is enforced automatically (#327): the parity
+> contract in `tools_spec.py` — `expected_tool_spec_names()`, the shared registry plus
+> a small, *documented* set of engine-routed tools (`_LLM_TOOLS_OUTSIDE_REGISTRY`) —
+> is checked at runtime by `assert_tool_spec_parity()` when the ReAct arm builds its
+> tools, and in CI by `tests/test_tools_spec.py`. A registered tool with no schema, or
+> a schema advertising a tool the engine cannot run, fails fast in either direction, so
+> the A/B always compares the *same* toolbox. A genuinely engine-routed tool (present
+> to the LLM but not in the registry) is declared once, in `_LLM_TOOLS_OUTSIDE_REGISTRY`.
 
 ### 14.5 The pipeline spine (`builder/agents/pipeline/pipeline.py`)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Both are maintained — pick the one that fits how you want to work:
 
 | Variant | Flag | What it does | When to pick it |
 | --- | --- | --- | --- |
-| **Deterministic pipeline + HITL guidance** (default) | `--interactive` | Code drives the known step ordering (scaffold the ISA backbone, draft and materialize entities, validate, auto-fix REQUIRED issues), then walks you through any remaining gaps it can't close on its own. | You want a **deterministic, cheaper, reproducible** build. It is the default and won the in-repo A/B gate (full ISA-Tox conformance on the shared corpus where the ReAct loop stalled). |
+| **Deterministic pipeline + HITL guidance** (default) | `--interactive` | Code drives the known step ordering (scaffold the ISA backbone, draft and materialize entities, validate, auto-fix REQUIRED issues), then walks you through any remaining gaps it can't close on its own. | You want a **deterministic, cheaper, reproducible** build. It is the default: on the shared-corpus A/B both arms reach full ISA-Tox conformance, but the pipeline gets there ~39× cheaper and ~6.7× faster, self-terminating every case where the ReAct loop repeatedly runs to its recursion cap. |
 | **Conversational ReAct agent** | `--interactive --legacy-react` | An LLM agent decides the order of tool calls turn by turn. | You want **flexible, conversational exploration** and to let the model drive. |
 
 Both variants are first-class and actively maintained — this is an ongoing

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -30,7 +30,7 @@ from builder.agents.llm import (
     _recursion_limit,
 )
 from builder.agents.react.system_prompt import SYSTEM_PROMPT
-from builder.agents.react.tools_spec import TOOL_SPECS
+from builder.agents.react.tools_spec import TOOL_SPECS, assert_tool_spec_parity
 from builder.engine import AgentEngine
 from builder.tools.hitl import (
     register_console_animation,
@@ -651,6 +651,11 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
         from langchain_core.tools import BaseTool, StructuredTool
     except ImportError:
         raise ImportError("langchain extra is required: pip install vitro-crate[langchain]")
+
+    # Fail fast if the advertised specs have drifted from the tools the shared
+    # engine can actually run (#327): the A/B must compare the *same* toolbox, and
+    # a silently-missing schema means the LLM can never call an available tool.
+    assert_tool_spec_parity()
 
     langchain_tools: list[BaseTool] = []
 

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -928,4 +928,113 @@ TOOL_SPECS = [
     },
 ]
 
-__all__ = ["TOOL_SPECS"]
+# ---------------------------------------------------------------------------
+# Provable tool-set parity with the shared registry (Issue #327)
+# ---------------------------------------------------------------------------
+#
+# TOOL_SPECS advertises the ReAct tool set to the LLM. For the A/B comparison to
+# be over the *same* toolbox (AGENTS.md §5, §12), it must stay in exact lockstep
+# with the tools the shared engine can actually run. The authoritative set is:
+#
+#     builder.tools.registry.TOOL_REGISTRY.list()   # registered tools
+#       | _LLM_TOOLS_OUTSIDE_REGISTRY               # engine-routed extras
+#       - _REGISTRY_TOOLS_HIDDEN_FROM_LLM           # deliberately hidden
+#
+# Both divergences are small, intentional, and enumerated here — the one place
+# they are declared — so ``expected_tool_spec_names()`` (used by the runtime
+# assert and the parity tests) can never disagree with reality.
+
+# LLM-callable tools the engine routes itself, so they are NOT in TOOL_REGISTRY:
+#   - scanner / file-sample readers gated by AgentEngine before they touch disk
+#     (Issue #167): scan_files, read_file_sample, read_multiple_files, unzip_file,
+#     preview_archive;
+#   - human-in-the-loop tools dispatched via the human interface: present_to_human,
+#     request_input.
+_LLM_TOOLS_OUTSIDE_REGISTRY: frozenset[str] = frozenset(
+    {
+        "scan_files",
+        "read_file_sample",
+        "read_multiple_files",
+        "unzip_file",
+        "preview_archive",
+        "present_to_human",
+        "request_input",
+    }
+)
+
+# Registered tools deliberately withheld from the LLM. None today; a name added
+# here (with a reason) is excluded from the advertised set without tripping parity.
+_REGISTRY_TOOLS_HIDDEN_FROM_LLM: frozenset[str] = frozenset()
+
+# Every module whose import registers tools into TOOL_REGISTRY. Enumerated so the
+# registry is fully populated before it is read (registration is an import side
+# effect), keeping this the single place that knows the tool-module set.
+_TOOL_REGISTRY_MODULES: tuple[str, ...] = (
+    "builder.tools.builder",
+    "builder.tools.composites",
+    "builder.tools.data_content",
+    "builder.tools.drafters",
+    "builder.tools.fair_assessment",
+    "builder.tools.file_readers",
+    "builder.tools.lookups",
+    "builder.tools.management",
+    "builder.tools.mit_assessment",
+    "builder.tools.provenance",
+    "builder.tools.repair",
+    "builder.tools.scanner",
+    "builder.tools.session",
+    "builder.tools.validation",
+    "builder.tools.verification",
+)
+
+
+class ToolSpecParityError(RuntimeError):
+    """TOOL_SPECS has drifted from the tools the shared engine can run (#327)."""
+
+
+def _registered_tool_names() -> set[str]:
+    """Return every tool name in the shared registry (registry fully populated)."""
+    import importlib
+
+    for module in _TOOL_REGISTRY_MODULES:
+        importlib.import_module(module)
+    from builder.tools.registry import TOOL_REGISTRY
+
+    return set(TOOL_REGISTRY.list())
+
+
+def expected_tool_spec_names() -> set[str]:
+    """The authoritative set of names TOOL_SPECS must advertise (Issue #327).
+
+    ``registry ∪ engine-routed extras − deliberately-hidden`` — the single source
+    of truth the runtime assert and the parity tests both measure against.
+    """
+    return (
+        _registered_tool_names() | _LLM_TOOLS_OUTSIDE_REGISTRY
+    ) - _REGISTRY_TOOLS_HIDDEN_FROM_LLM
+
+
+def assert_tool_spec_parity() -> None:
+    """Raise :class:`ToolSpecParityError` if TOOL_SPECS has drifted (Issue #327).
+
+    Called when the ReAct arm builds its LangChain tools, so a mismatch fails fast
+    at build time rather than silently advertising the wrong toolbox to the LLM.
+    """
+    spec_names = {spec["name"] for spec in TOOL_SPECS}
+    expected = expected_tool_spec_names()
+    missing = expected - spec_names
+    extra = spec_names - expected
+    if missing or extra:
+        raise ToolSpecParityError(
+            "TOOL_SPECS is out of sync with the shared tool registry (#327): "
+            f"callable tools with no schema: {sorted(missing)}; "
+            f"schemas advertising uncallable tools: {sorted(extra)}."
+        )
+
+
+__all__ = [
+    "TOOL_SPECS",
+    "ToolSpecParityError",
+    "assert_tool_spec_parity",
+    "expected_tool_spec_names",
+]

--- a/eval/README.md
+++ b/eval/README.md
@@ -141,10 +141,11 @@ uv run --extra langchain python -m eval --arch pipeline --label pipeline
 # -> writes eval_reports/pipeline.ndjson
 ```
 
-Then diff it against the frozen baseline with `compare_reports`. The pipeline is
-expected to beat the ReAct baseline on the D15 levers: **higher conformance**,
-**determinism rate 1.0** (identical `@graph` hash across repeats), and **much lower
-tokens** (zero — no model) **and latency**.
+Then diff it against the frozen baseline with `compare_reports`. On the shared corpus
+both arms reach full ISA-Tox conformance; the pipeline is expected to win the D15
+levers — **clean self-termination** (no recursion-cap stalls), **determinism rate
+1.0** (identical `@graph` hash across repeats), and **much lower cost, tokens, and
+latency** (its bounded drafter leaf makes far fewer model calls).
 
 `--arch react|pipeline` (DEFAULT `react`) selects the factory; ReAct stays the default
 so the existing baseline workflow is unchanged. Other options: `--repeats N` (builds per

--- a/eval/reprice.py
+++ b/eval/reprice.py
@@ -1,0 +1,152 @@
+"""Re-price an existing eval report from its recorded token counts (#335).
+
+The A/B re-run records per-case ``input_tokens`` / ``output_tokens`` / ``model_name``
+but leaves ``cost_usd`` null whenever the run's model is unpriced and no price
+override was passed — exactly the gpt-5.6-luna paper re-run, whose price is
+deliberately kept out of the public :data:`eval.metrics.MODEL_PRICES`. Re-running the
+corpus purely to add a cost column would spend real tokens for no new signal, so this
+module re-derives cost **offline** from the numbers already in the report: it reads
+the labeled ndjson, recomputes each case's ``cost_usd`` under a supplied
+``(input, output)`` price, and rewrites the summary's ``total_cost_usd`` to match.
+
+The price is passed in (never hardcoded) so no work-issued model's pricing enters the
+repo. Usage::
+
+    python -m eval.reprice eval_reports/react-luna.ndjson \\
+        --price-input 1.10 --price-output 6.60
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from eval.metrics import compute_cost
+
+logger = logging.getLogger(__name__)
+
+
+def reprice_records(
+    records: list[dict[str, Any]], *, price_input: float, price_output: float
+) -> list[dict[str, Any]]:
+    """Return *records* with cost fields recomputed under the given price.
+
+    Each ``record == "case"`` line's ``cost_usd`` is re-derived from its
+    ``input_tokens`` / ``output_tokens`` via :func:`compute_cost` with the price
+    override; the ``record == "summary"`` line's ``total_cost_usd`` becomes the sum
+    of the repriced case costs (``None`` only when there are no case lines). Every
+    other field is left untouched, and the input list is **not** mutated.
+
+    Args:
+        records: Parsed ndjson report lines (case lines followed by one summary).
+        price_input: USD price per 1M input tokens.
+        price_output: USD price per 1M output tokens.
+
+    Returns:
+        A new list of new dicts with ``cost_usd`` / ``total_cost_usd`` recomputed.
+    """
+    override = (price_input, price_output)
+    repriced: list[dict[str, Any]] = []
+    case_costs: list[float] = []
+    for rec in records:
+        new = dict(rec)
+        if new.get("record") == "case":
+            cost = compute_cost(
+                int(new.get("input_tokens", 0) or 0),
+                int(new.get("output_tokens", 0) or 0),
+                new.get("model_name"),
+                price_override=override,
+            )
+            new["cost_usd"] = cost
+            if cost is not None:
+                case_costs.append(cost)
+        repriced.append(new)
+
+    total = sum(case_costs) if case_costs else None
+    for new in repriced:
+        if new.get("record") == "summary":
+            new["total_cost_usd"] = total
+    return repriced
+
+
+def reprice_file(
+    path: str | Path,
+    *,
+    price_input: float,
+    price_output: float,
+    out: str | Path | None = None,
+) -> Path:
+    """Reprice the ndjson report at *path*, writing to *out* (or in place).
+
+    Args:
+        path: The labeled ndjson report to read.
+        price_input: USD price per 1M input tokens.
+        price_output: USD price per 1M output tokens.
+        out: Destination path; defaults to overwriting *path*.
+
+    Returns:
+        The :class:`~pathlib.Path` written.
+    """
+    src = Path(path)
+    records = [
+        json.loads(line)
+        for line in src.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    repriced = reprice_records(records, price_input=price_input, price_output=price_output)
+    dest = Path(out) if out is not None else src
+    dest.write_text(
+        "\n".join(json.dumps(r, default=str) for r in repriced) + "\n", encoding="utf-8"
+    )
+    logger.info("Repriced %d records -> %s", len(repriced), dest)
+    return dest
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser for ``python -m eval.reprice``."""
+    parser = argparse.ArgumentParser(
+        prog="python -m eval.reprice",
+        description="Recompute cost_usd in an existing eval report from its recorded tokens.",
+    )
+    parser.add_argument("report", help="Path to the labeled ndjson report to reprice.")
+    parser.add_argument(
+        "--price-input",
+        dest="price_input",
+        type=float,
+        required=True,
+        help="USD price per 1M INPUT tokens for the report's model.",
+    )
+    parser.add_argument(
+        "--price-output",
+        dest="price_output",
+        type=float,
+        required=True,
+        help="USD price per 1M OUTPUT tokens for the report's model.",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output ndjson path (default: overwrite the input report).",
+    )
+    return parser
+
+
+def reprice_main(argv: list[str] | None = None) -> int:
+    """Reprice a report from the CLI; return a process exit code."""
+    args = build_arg_parser().parse_args(argv)
+    logging.basicConfig(level=logging.INFO)
+    reprice_file(
+        args.report,
+        price_input=args.price_input,
+        price_output=args.price_output,
+        out=args.out,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    sys.exit(reprice_main())

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import statistics
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -32,6 +33,23 @@ logger = logging.getLogger(__name__)
 
 # A profile_reader maps a session_id to its parsed profile.ndjson records.
 ProfileReader = Callable[[str], list[dict[str, Any]]]
+
+
+def _spread(values: Sequence[float]) -> dict[str, float]:
+    """Return ``{mean, min, max, stdev}`` for *values* (trap 4, #335).
+
+    ``stdev`` is the sample standard deviation, and ``0.0`` for fewer than two
+    samples (a single draw has no spread). An empty sequence yields all-zeros so
+    the report always carries the block, never a missing key.
+    """
+    if not values:
+        return {"mean": 0.0, "min": 0.0, "max": 0.0, "stdev": 0.0}
+    return {
+        "mean": statistics.mean(values),
+        "min": min(values),
+        "max": max(values),
+        "stdev": statistics.stdev(values) if len(values) > 1 else 0.0,
+    }
 
 
 def _default_profile_reader(session_id: str) -> list[dict[str, Any]]:
@@ -56,6 +74,11 @@ class CaseResult:
     profile (representative of one build); latency is the first repeat's wall
     clock. ``crate_hashes`` holds one hash per repeat, and ``deterministic`` is
     ``True``/``False`` when there is more than one repeat to compare, else ``None``.
+
+    For the stochastic ReAct arm one draw is noisy, so ``total_tokens_per_repeat``
+    / ``latency_per_repeat`` / ``stop_reasons`` additionally record **every**
+    repeat (trap 4, #335); :meth:`to_dict` derives a mean ± spread block from them.
+    The headline fields above stay repeat #1's so existing consumers are unchanged.
 
     ``meets_quota`` / ``entity_counts`` are the additive content-quality signal:
     for cases that declare ``min_entities`` they say whether the build drafted the
@@ -84,6 +107,9 @@ class CaseResult:
     model_name: str | None = None
     cost_usd: float | None = None
     transient_retries: int = 0
+    total_tokens_per_repeat: list[int] = field(default_factory=list)
+    latency_per_repeat: list[float] = field(default_factory=list)
+    stop_reasons: list[str | None] = field(default_factory=list)
 
     @property
     def total_tokens(self) -> int:
@@ -114,6 +140,13 @@ class CaseResult:
             "model_name": self.model_name,
             "cost_usd": self.cost_usd,
             "transient_retries": self.transient_retries,
+            "total_tokens_per_repeat": self.total_tokens_per_repeat,
+            "latency_per_repeat": [round(x, 4) for x in self.latency_per_repeat],
+            "stop_reasons": self.stop_reasons,
+            "variance": {
+                "total_tokens": _spread(self.total_tokens_per_repeat),
+                "latency_seconds": _spread(self.latency_per_repeat),
+            },
         }
 
 
@@ -148,6 +181,16 @@ class EvalReport:
         # so an unpriced run reads as "cost unknown", not a misleading $0 (trap 5).
         known_costs = [r.cost_usd for r in self.results if r.cost_usd is not None]
         total_cost_usd = sum(known_costs) if known_costs else None
+        # Per-repeat spread (trap 4, #335): the mean coefficient of variation of
+        # total tokens across cases — one arm-level "how stochastic" number. ~0 for
+        # a deterministic arm, high for a stochastic one. A case with a zero mean (no
+        # model call) contributes CV 0 rather than dividing by zero.
+        cvs: list[float] = []
+        for r in self.results:
+            spread = _spread(r.total_tokens_per_repeat)
+            mean_tok = spread["mean"]
+            cvs.append(spread["stdev"] / mean_tok if mean_tok else 0.0)
+        mean_total_tokens_cv = statistics.mean(cvs) if cvs else 0.0
         return {
             "label": self.label,
             "repeats": self.repeats,
@@ -163,6 +206,7 @@ class EvalReport:
             "num_cap_hit": num_cap_hit,
             "num_error": num_error,
             "total_cost_usd": total_cost_usd,
+            "mean_total_tokens_cv": mean_total_tokens_cv,
         }
 
 
@@ -270,12 +314,11 @@ def _run_case(
 ) -> CaseResult:
     """Run a single case ``repeats`` times and aggregate its metrics."""
     hashes: list[str] = []
-    first_outcome: BuildOutcome | None = None
-    first_latency = 0.0
+    repeat_runs: list[tuple[BuildOutcome, float]] = []
     error: str | None = None
     transient_retries = 0
 
-    for i in range(max(1, repeats)):
+    for _ in range(max(1, repeats)):
         # A fresh agent per repeat — the determinism check must not be polluted by
         # carried-over engine/session state. Each repeat re-runs transient failures
         # (trap 1) so a network blip is not scored as an architecture failure.
@@ -283,20 +326,25 @@ def _run_case(
             agent_factory, case, max_transient_retries=max_transient_retries
         )
         transient_retries += retries
-        if i == 0:
-            first_outcome, first_latency = outcome, latency
+        repeat_runs.append((outcome, latency))
         if outcome.error and error is None:
             error = outcome.error
         hashes.append(crate_graph_hash(outcome.state))
 
-    assert first_outcome is not None  # repeats >= 1 guarantees this
+    first_outcome, first_latency = repeat_runs[0]  # repeats >= 1 guarantees one run
     state = first_outcome.state
 
     predicate = reaches_isa_tox_conformance(state)
     quota = meets_entity_quota(state, case.min_entities)
 
-    profile_records = profile_reader(first_outcome.session_id) if first_outcome.session_id else []
-    pm = mine_profile_metrics(profile_records)
+    # Mine every repeat's profile so the report carries the spread, not just one
+    # noisy draw (trap 4, #335). The representative headline fields below stay
+    # repeat #1's (cost, dashboards read those) — the per-repeat arrays are additive.
+    per_repeat_metrics = [
+        mine_profile_metrics(profile_reader(o.session_id) if o.session_id else [])
+        for o, _ in repeat_runs
+    ]
+    pm = per_repeat_metrics[0]
     cost_usd = compute_cost(
         pm.input_tokens, pm.output_tokens, pm.model_name, price_override=price_override
     )
@@ -326,6 +374,9 @@ def _run_case(
         model_name=pm.model_name,
         cost_usd=cost_usd,
         transient_retries=transient_retries,
+        total_tokens_per_repeat=[m.total_tokens for m in per_repeat_metrics],
+        latency_per_repeat=[lat for _, lat in repeat_runs],
+        stop_reasons=[o.stop_reason for o, _ in repeat_runs],
     )
 
 

--- a/eval/tests/test_reprice.py
+++ b/eval/tests/test_reprice.py
@@ -1,0 +1,115 @@
+"""Offline re-pricing of an existing eval report (#335).
+
+The gpt-5.6-luna A/B re-run records per-case ``input_tokens`` / ``output_tokens``
+but leaves ``cost_usd`` null (the model is deliberately unpriced in the public
+table and the run passed no price override). Re-running the corpus purely to add a
+cost column would spend real tokens for no new signal, so cost is re-derived here
+**offline** from the numbers already in the report. The price is passed in, never
+hardcoded, so no work-issued model's pricing enters the repo.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from eval.reprice import reprice_file, reprice_main, reprice_records
+
+
+def _case(**over):
+    rec = {
+        "record": "case",
+        "case_id": "c",
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "model_name": "gpt-5.6-luna",
+        "cost_usd": None,
+    }
+    rec.update(over)
+    return rec
+
+
+class TestRepriceRecords:
+    def test_sets_case_cost_from_recorded_tokens(self) -> None:
+        records = [_case(input_tokens=1_000_000, output_tokens=0)]
+        out = reprice_records(records, price_input=1.10, price_output=6.60)
+        assert out[0]["cost_usd"] == pytest.approx(1.10)
+
+    def test_prices_output_tokens_too(self) -> None:
+        records = [_case(input_tokens=0, output_tokens=1_000_000)]
+        out = reprice_records(records, price_input=1.10, price_output=6.60)
+        assert out[0]["cost_usd"] == pytest.approx(6.60)
+
+    def test_recomputes_summary_total_as_sum_of_case_costs(self) -> None:
+        records = [
+            _case(input_tokens=1_000_000, output_tokens=0),
+            _case(input_tokens=0, output_tokens=1_000_000),
+            {"record": "summary", "total_cost_usd": None},
+        ]
+        out = reprice_records(records, price_input=1.10, price_output=6.60)
+        summary = out[-1]
+        assert summary["total_cost_usd"] == pytest.approx(1.10 + 6.60)
+
+    def test_summary_total_is_none_when_no_cases(self) -> None:
+        out = reprice_records(
+            [{"record": "summary", "total_cost_usd": None}],
+            price_input=1.10,
+            price_output=6.60,
+        )
+        assert out[0]["total_cost_usd"] is None
+
+    def test_leaves_non_cost_fields_untouched(self) -> None:
+        records = [_case(input_tokens=10, output_tokens=5, success=True, tool_calls=3)]
+        out = reprice_records(records, price_input=1.10, price_output=6.60)
+        assert out[0]["success"] is True
+        assert out[0]["tool_calls"] == 3
+        assert out[0]["input_tokens"] == 10
+
+    def test_does_not_mutate_the_input(self) -> None:
+        records = [_case(input_tokens=1_000_000)]
+        reprice_records(records, price_input=1.10, price_output=6.60)
+        assert records[0]["cost_usd"] is None  # original untouched
+
+
+class TestRepriceFile:
+    def test_roundtrips_a_report_in_place(self, tmp_path) -> None:
+        path = tmp_path / "r.ndjson"
+        lines = [
+            _case(input_tokens=1_000_000, output_tokens=0),
+            {"record": "summary", "total_cost_usd": None},
+        ]
+        path.write_text("\n".join(json.dumps(x) for x in lines) + "\n", encoding="utf-8")
+
+        reprice_file(path, price_input=1.10, price_output=6.60)
+
+        got = [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+        assert got[0]["cost_usd"] == pytest.approx(1.10)
+        assert got[-1]["total_cost_usd"] == pytest.approx(1.10)
+
+    def test_writes_to_out_when_given(self, tmp_path) -> None:
+        src = tmp_path / "src.ndjson"
+        dest = tmp_path / "dest.ndjson"
+        src.write_text(json.dumps(_case(input_tokens=1_000_000)) + "\n", encoding="utf-8")
+
+        reprice_file(src, price_input=1.10, price_output=6.60, out=dest)
+
+        assert json.loads(src.read_text().strip())["cost_usd"] is None  # source untouched
+        assert json.loads(dest.read_text().strip())["cost_usd"] == pytest.approx(1.10)
+
+
+class TestRepriceCli:
+    def test_cli_reprices_in_place(self, tmp_path) -> None:
+        path = tmp_path / "r.ndjson"
+        path.write_text(json.dumps(_case(input_tokens=1_000_000)) + "\n", encoding="utf-8")
+
+        rc = reprice_main([str(path), "--price-input", "1.10", "--price-output", "6.60"])
+
+        assert rc == 0
+        assert json.loads(path.read_text().strip())["cost_usd"] == pytest.approx(1.10)
+
+    def test_cli_requires_both_prices(self, tmp_path) -> None:
+        path = tmp_path / "r.ndjson"
+        path.write_text(json.dumps(_case()) + "\n", encoding="utf-8")
+        with pytest.raises(SystemExit):
+            reprice_main([str(path), "--price-input", "1.10"])

--- a/eval/tests/test_variance.py
+++ b/eval/tests/test_variance.py
@@ -1,0 +1,173 @@
+"""Per-repeat variance capture (the open half of trap 4, #331 / #335).
+
+``--repeats`` defaults to 3, but the runner used to persist only repeat #1's
+tokens / latency / stop-reason for every headline metric; the other repeats fed
+only the determinism-hash boolean. For the stochastic ReAct arm one draw is
+noisy (measured CV runs as high as ~0.6–0.7), so the report has to surface the
+spread across *all* repeats, not a single sample.
+
+These tests pin the additive contract: the representative (repeat #1) fields are
+unchanged, and the runner now also records each repeat's tokens / latency /
+stop-reason plus a mean ± spread block. Offline: a stateful profile reader models
+genuine per-repeat divergence, no LLM.
+"""
+
+from __future__ import annotations
+
+import statistics
+
+import pytest
+
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS, EvalCase
+from eval.runner import run_eval
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class _ProfiledAgent:
+    """A mock agent that profiles under a fixed session id.
+
+    The runner reads the profile once per repeat, so a *stateful* reader keyed on
+    call order (below) is what injects genuine per-repeat variance even though the
+    session id is constant.
+    """
+
+    def build(self, case: EvalCase) -> BuildOutcome:
+        factory = case.build_state or CrateState
+        return BuildOutcome(state=factory(), session_id="sid")
+
+
+def _varying_reader(token_counts: list[int]):
+    """Return a profile reader that yields a different input-token count per call.
+
+    Call ``k`` reports ``token_counts[k]`` input tokens (and 0 output), modelling a
+    stochastic arm whose per-repeat token usage differs run to run.
+    """
+    calls = {"n": 0}
+
+    def reader(_sid: str) -> list[dict]:
+        i = calls["n"]
+        calls["n"] += 1
+        value = token_counts[i] if i < len(token_counts) else token_counts[-1]
+        return [
+            {
+                "event": "node_end",
+                "node": "model",
+                "input_tokens": value,
+                "output_tokens": 0,
+                "model_name": "gpt-5.6-luna",
+            }
+        ]
+
+    return reader
+
+
+class TestPerRepeatTokenCapture:
+    def test_records_total_tokens_for_every_repeat(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([100, 300, 200]),
+        )
+        res = report.results[0]
+        assert res.total_tokens_per_repeat == [100, 300, 200]
+
+    def test_records_latency_for_every_repeat(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([100, 300, 200]),
+        )
+        res = report.results[0]
+        assert len(res.latency_per_repeat) == 3
+        assert all(x >= 0.0 for x in res.latency_per_repeat)
+
+    def test_records_stop_reason_for_every_repeat(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([100, 300, 200]),
+        )
+        res = report.results[0]
+        assert len(res.stop_reasons) == 3
+
+
+class TestRepresentativeFieldsUnchanged:
+    def test_headline_metrics_still_come_from_repeat_one(self) -> None:
+        # Backwards compatible: the representative token count is repeat #1's, not
+        # the mean, so existing consumers (cost, dashboards) read the same field.
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([100, 300, 200]),
+        )
+        res = report.results[0]
+        assert res.total_tokens == 100
+        assert res.total_tokens == res.total_tokens_per_repeat[0]
+
+
+class TestVarianceBlock:
+    def test_to_dict_exposes_a_token_variance_spread(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([100, 300, 200]),
+        )
+        variance = report.results[0].to_dict()["variance"]
+        tok = variance["total_tokens"]
+        assert tok["mean"] == pytest.approx(200.0)
+        assert tok["min"] == 100
+        assert tok["max"] == 300
+        assert tok["stdev"] == pytest.approx(statistics.stdev([100, 300, 200]))
+
+    def test_to_dict_exposes_a_latency_variance_spread(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=2,
+            profile_reader=_varying_reader([100, 200]),
+        )
+        variance = report.results[0].to_dict()["variance"]
+        assert set(variance["latency_seconds"]) == {"mean", "min", "max", "stdev"}
+
+    def test_single_repeat_has_zero_spread(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=1,
+            profile_reader=_varying_reader([123]),
+        )
+        tok = report.results[0].to_dict()["variance"]["total_tokens"]
+        assert tok["mean"] == pytest.approx(123.0)
+        assert tok["stdev"] == 0.0
+
+
+class TestSummaryVariance:
+    def test_summary_reports_mean_token_cv(self) -> None:
+        # A stochastic arm has a non-zero coefficient of variation; the summary
+        # surfaces it as a single arm-level "how noisy" number.
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([100, 300, 200]),
+        )
+        summary = report.summary()
+        expected_cv = statistics.stdev([100, 300, 200]) / 200.0
+        assert summary["mean_total_tokens_cv"] == pytest.approx(expected_cv)
+
+    def test_constant_arm_has_zero_cv(self) -> None:
+        report = run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=3,
+            profile_reader=_varying_reader([500, 500, 500]),
+        )
+        assert report.summary()["mean_total_tokens_cv"] == pytest.approx(0.0)

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -25,84 +25,45 @@ _INTERNAL_TOOL_NAMES: set[str] | None = None
 def _get_registry_tool_names() -> set[str]:
     """Return tool names registered in the shared TOOL_REGISTRY.
 
-    Imports all tool modules (triggering registration calls) and returns
-    the full set of registered tool names intended for LLM use.
+    Delegates to the single-source parity contract (Issue #327) so the test and
+    the runtime assert measure the same fully-populated registry.
     """
-    import builder.tools.builder
-    import builder.tools.composites
-    import builder.tools.data_content
-    import builder.tools.drafters
-    import builder.tools.fair_assessment
-    import builder.tools.management
-    import builder.tools.mit_assessment
-    import builder.tools.provenance
-    import builder.tools.repair
-    import builder.tools.scanner
-    import builder.tools.session
-    import builder.tools.validation
-    import builder.tools.verification
-    from builder.tools.registry import TOOL_REGISTRY
+    from builder.agents.react.tools_spec import _registered_tool_names
 
-    return set(TOOL_REGISTRY.list())
+    return _registered_tool_names()
 
 
 def _get_engine_routable_llm_tools() -> set[str]:
     """Return tool names that the engine routes specially (not via registry)
     and that are intended to be callable by the LLM.
 
-    The engine has special routing for HITL tools and scanner tools.
-    Scanner tools like scan_files, read_file_sample, read_multiple_files,
-    unzip_file, and preview_archive are engine-routed and should be in
-    TOOL_SPECS (some already are). HITL tools present_to_human and
-    request_input must also be in TOOL_SPECS for the LLM to call them.
+    The engine has special routing for HITL tools and scanner tools. This set is
+    declared once, in the parity contract (Issue #327), so the test cannot drift
+    from what the runtime assert enforces.
     """
-    return {
-        "present_to_human",
-        "request_input",
-        "scan_files",
-        "read_file_sample",
-        "read_multiple_files",
-        "unzip_file",
-        "preview_archive",
-    }
+    from builder.agents.react.tools_spec import _LLM_TOOLS_OUTSIDE_REGISTRY
+
+    return set(_LLM_TOOLS_OUTSIDE_REGISTRY)
 
 
 def _get_all_registry_tool_names() -> set[str]:
-    """Return the COMPLETE set of registered tool names.
+    """Return the COMPLETE set of registered tool names (single source, #327)."""
+    from builder.agents.react.tools_spec import _registered_tool_names
 
-    Imports every tool module that registers tools (including file_readers and
-    provenance) so the registry is fully populated. Unlike
-    ``_get_registry_tool_names`` this is exhaustive — used for the bidirectional
-    source-of-truth assertion.
-    """
-    import builder.tools.builder  # noqa: F401
-    import builder.tools.composites  # noqa: F401
-    import builder.tools.data_content  # noqa: F401
-    import builder.tools.drafters  # noqa: F401
-    import builder.tools.fair_assessment  # noqa: F401
-    import builder.tools.file_readers  # noqa: F401
-    import builder.tools.lookups  # noqa: F401
-    import builder.tools.management  # noqa: F401
-    import builder.tools.mit_assessment  # noqa: F401
-    import builder.tools.provenance  # noqa: F401
-    import builder.tools.repair  # noqa: F401
-    import builder.tools.scanner  # noqa: F401
-    import builder.tools.session  # noqa: F401
-    import builder.tools.validation  # noqa: F401
-    import builder.tools.verification  # noqa: F401
-    from builder.tools.registry import TOOL_REGISTRY
-
-    return set(TOOL_REGISTRY.list())
+    return _registered_tool_names()
 
 
 def _expected_llm_tool_universe() -> set[str]:
     """The authoritative set of LLM-callable tools.
 
     A tool is LLM-callable iff it is either registered in the shared registry or
-    routed specially by the engine (HITL + scanner tools). This is the single
-    source of truth ``TOOL_SPECS`` and the system prompt must both match.
+    routed specially by the engine (HITL + scanner tools). Delegates to the parity
+    contract (Issue #327) so ``TOOL_SPECS``, the system prompt, and the runtime
+    assert all measure against one definition.
     """
-    return _get_all_registry_tool_names() | _get_engine_routable_llm_tools()
+    from builder.agents.react.tools_spec import expected_tool_spec_names
+
+    return expected_tool_spec_names()
 
 
 def _get_tool_names_from_system_prompt() -> set[str]:
@@ -324,6 +285,50 @@ def test_system_prompt_tool_list_matches_tool_specs_exactly():
     assert not extra_in_prompt, (
         f"Prompt list names not in TOOL_SPECS: {sorted(extra_in_prompt)}"
     )
+
+
+def test_expected_tool_spec_names_is_the_single_source_of_truth():
+    """``expected_tool_spec_names()`` == TOOL_SPECS names (Issue #327).
+
+    The parity contract lives in one place — the module the specs live in — so the
+    runtime assert and every test measure against the same authoritative set.
+    """
+    from builder.agents.react.tools_spec import expected_tool_spec_names
+
+    assert expected_tool_spec_names() == _tool_names()
+
+
+def test_assert_tool_spec_parity_passes_on_the_current_tree():
+    """The runtime parity guard does not raise for the shipped tool set (#327)."""
+    from builder.agents.react.tools_spec import assert_tool_spec_parity
+
+    assert_tool_spec_parity()  # must not raise
+
+
+def test_assert_tool_spec_parity_flags_a_callable_tool_with_no_spec(monkeypatch):
+    """A tool the engine can run but TOOL_SPECS omits is caught (#327)."""
+    import builder.agents.react.tools_spec as ts
+
+    monkeypatch.setattr(
+        ts,
+        "_LLM_TOOLS_OUTSIDE_REGISTRY",
+        ts._LLM_TOOLS_OUTSIDE_REGISTRY | {"phantom_registry_tool"},
+    )
+    with pytest.raises(ts.ToolSpecParityError, match="phantom_registry_tool"):
+        ts.assert_tool_spec_parity()
+
+
+def test_assert_tool_spec_parity_flags_a_spec_with_no_callable_tool(monkeypatch):
+    """A spec advertising a tool the engine cannot run is caught (#327)."""
+    import builder.agents.react.tools_spec as ts
+
+    monkeypatch.setattr(
+        ts,
+        "TOOL_SPECS",
+        [*ts.TOOL_SPECS, {"name": "phantom_spec_tool", "description": "", "parameters": {}}],
+    )
+    with pytest.raises(ts.ToolSpecParityError, match="phantom_spec_tool"):
+        ts.assert_tool_spec_parity()
 
 
 __all__: list[str] = []


### PR DESCRIPTION
Closes #335. Finalizes the Step-4 A/B numbers (follow-on to #309) so they can back the paper. Three pieces, none of which required re-running the corpus (no LLM spend).

## 1. Per-repeat variance (the open half of trap 4 / #331)

`--repeats` defaults to 3, but the runner persisted only repeat #1's tokens / latency / stop-reason for every headline metric; the other repeats fed only the determinism-hash boolean. For the stochastic ReAct arm one draw is noisy, so the report was hiding the spread.

- `_run_case` now mines **every** repeat's profile (`total_tokens_per_repeat`, `latency_per_repeat`, `stop_reasons`), and `to_dict()` derives a `variance` block (`mean / min / max / stdev`) from them.
- `EvalReport.summary()` gains `mean_total_tokens_cv` — one arm-level "how stochastic" number (~0 for the deterministic pipeline, high for ReAct).
- **Additive**: the representative headline fields stay repeat #1's, so cost / dashboards / existing tests are unchanged.

## 2. Offline reprice (trap 5)

`cost_usd` was null throughout the gpt-5.6-luna reports: the model is deliberately absent from `MODEL_PRICES` (its work-issued price stays out of the public repo) and the run passed no price override. Re-running purely to add a cost column would spend real tokens for no new signal.

- New `eval/reprice.py` (`python -m eval.reprice <report> --price-input P --price-output Q`) re-derives `cost_usd` / `total_cost_usd` **offline** from the token counts already in the report.
- Price is passed in, never hardcoded — no work-issued pricing enters the repo.
- Applied to the working-tree luna reports (gitignored): **ReAct $2.07, pipeline $0.05**.

## 3. Refresh the stale A/B figures

AGENTS.md D15, README, and eval/README cited the interim "ReAct 4/5 at ~50× cost" and (in eval/README) a wrong "pipeline uses zero tokens". Updated to the **2026-07-21 re-run**:

> both arms 5/5 conformance; pipeline self-terminates every case at ~$0.05, ReAct ~$2.07 (**~39× cost, ~69× tokens, ~6.7× wall-clock**) with 3 of its 5 wins force-stopped at the recursion cap.

The differentiator is efficiency + clean termination, not capability — as D15's rationale already states.

## Verification (TDD)

- 19 new tests (`eval/tests/test_variance.py` + `eval/tests/test_reprice.py`) written failing-first → green.
- Full `eval/tests/` suite: **145 passed**. `ruff` + `ty`: clean.

## Note

The **existing** luna reports predate the variance change, so they carry only repeat #1's per-repeat data — the spread block is a forward capability for the next run. Cost, in contrast, was recoverable offline and is now baked in.

Relates to #309, #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
