### PR TITLE
test(sessions): isolate session working dir so tests stop polluting sessions/

### DIFF
--- a/builder/config.py
+++ b/builder/config.py
@@ -31,6 +31,17 @@ from pathlib import Path
 from typing import Any
 
 
+def session_root() -> Path:
+    """Return the root directory for per-run session artifacts.
+
+    Defaults to ``Path("sessions")`` (relative to the current working
+    directory). Set the ``VITRO_SESSION_DIR`` environment variable to relocate
+    session working data — the test suite points it at a throwaway tmp dir so
+    runs never litter the repo's ``sessions/`` folder.
+    """
+    return Path(os.environ.get("VITRO_SESSION_DIR", "sessions"))
+
+
 def _config_dir() -> Path:
     """Return the platform-appropriate config directory for vitro-crate.
 

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -17,6 +17,7 @@ from typing import Any
 from rocrate.model import File
 from rocrate.rocrate import ROCrate
 
+import builder.config as _config
 from builder.state import CrateState
 from builder.tools._crate_mapping import populate_crate
 from profiles.context import ISA_TOX_CONTEXT
@@ -107,7 +108,7 @@ def _default_crate_path(state: CrateState) -> str:
     the session persistence layout described in AGENTS.md.
     """
     session_id = state.session_id or "unknown"
-    return str(Path("sessions") / session_id / "working_crate")
+    return str(_config.session_root() / session_id / "working_crate")
 
 
 def assemble_crate(

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -26,7 +26,7 @@ import builder.config as _config
 
 logger = logging.getLogger(__name__)
 
-SESSION_DIR = Path("sessions")
+SESSION_DIR = _config.session_root()
 
 # ---------------------------------------------------------------------------
 # Agent status (▶ / ⏸ / ⏹) — issue #193

--- a/builder/tools/profiler.py
+++ b/builder/tools/profiler.py
@@ -24,14 +24,13 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
 from typing import Any
 
 import builder.config as _config
 
 logger = logging.getLogger(__name__)
 
-SESSION_DIR = Path("sessions")
+SESSION_DIR = _config.session_root()
 
 
 class ProfilingLogger:

--- a/builder/tools/session.py
+++ b/builder/tools/session.py
@@ -11,14 +11,13 @@ import json
 import logging
 import os
 import tempfile
-from pathlib import Path
 
 import builder.config as _config
 from builder.state import CrateState
 
 logger = logging.getLogger(__name__)
 
-SESSION_DIR = Path("sessions")
+SESSION_DIR = _config.session_root()
 
 # ---------------------------------------------------------------------------
 # Change-detection: cached content hash of the last saved state so we can

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,45 @@
 
 from __future__ import annotations
 
+import importlib
+import os
+import tempfile
+
 import pytest
+
+# Isolate session artifacts for the WHOLE test session before any test module
+# imports builder.tools.{profiler,session,dashboard}: their module-level
+# ``SESSION_DIR`` (= builder.config.session_root()) is evaluated at import time,
+# so the override must be in place first. This backstops the per-test fixture
+# below for any session write that resolves SESSION_DIR outside a test body
+# (collection-time construction, background threads, teardown races).
+os.environ.setdefault("VITRO_SESSION_DIR", tempfile.mkdtemp(prefix="vitro-test-sessions-"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch):
+    """Redirect all session working data to a throwaway tmp dir for every test.
+
+    Production roots session artifacts at ``builder.config.session_root()``
+    (``sessions/`` by default). Without this, every test that builds an
+    engine/profiler would write a real ``sessions/<id>/`` dir into the repo
+    (historically ~1,800 stray dirs, many empty). Sets ``VITRO_SESSION_DIR``
+    and repoints each consumer's already-imported module-level ``SESSION_DIR``
+    so both the resolver and the cached constants stay isolated. Tests that
+    override ``SESSION_DIR`` themselves still win — they run after this setup.
+    """
+    root = tmp_path / "sessions"
+    monkeypatch.setenv("VITRO_SESSION_DIR", str(root))
+    from builder import config
+
+    for name in (
+        "builder.tools.profiler",
+        "builder.tools.session",
+        "builder.tools.dashboard",
+    ):
+        module = importlib.import_module(name)
+        monkeypatch.setattr(module, "SESSION_DIR", config.session_root(), raising=False)
+    return root
 
 
 @pytest.fixture

--- a/tests/test_build_output_payload.py
+++ b/tests/test_build_output_payload.py
@@ -50,6 +50,9 @@ class TestOutputLocation:
     def test_falls_back_to_session_default(self, tmp_path, monkeypatch) -> None:
         """With neither arg nor state.metadata.output_path, use the session default."""
         monkeypatch.chdir(tmp_path)
+        # Assert the *default* session root convention (relative "sessions/"),
+        # so clear the test harness's VITRO_SESSION_DIR isolation override.
+        monkeypatch.delenv("VITRO_SESSION_DIR", raising=False)
         state = CrateState()
         state.session_id = "sess-fallback"
         # no output_path set

--- a/tests/test_session_isolation.py
+++ b/tests/test_session_isolation.py
@@ -1,0 +1,63 @@
+"""Session working-dir isolation.
+
+Session artifacts are rooted at a single, configurable location
+(``builder.config.session_root()``), overridable with the ``VITRO_SESSION_DIR``
+environment variable. The three consumers that historically hard-coded
+``Path("sessions")`` (``profiler``, ``session``, ``dashboard``) derive their
+``SESSION_DIR`` from that resolver, and an autouse conftest fixture redirects it
+to a throwaway tmp dir so the test suite never litters the repo's real
+``sessions/`` folder (the cause of ~1,800 stray session dirs).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class TestSessionRootResolver:
+    def test_defaults_to_sessions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no override, the session root is the relative ``sessions/`` dir."""
+        monkeypatch.delenv("VITRO_SESSION_DIR", raising=False)
+        from builder.config import session_root
+
+        assert session_root() == Path("sessions")
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``VITRO_SESSION_DIR`` relocates the session root."""
+        target = tmp_path / "custom_sessions"
+        monkeypatch.setenv("VITRO_SESSION_DIR", str(target))
+        from builder.config import session_root
+
+        assert session_root() == target
+
+
+class TestSessionDirIsolation:
+    """The autouse fixture in conftest.py must redirect SESSION_DIR off the repo."""
+
+    def test_session_dir_redirected_away_from_repo(self) -> None:
+        from builder.tools import dashboard as dashboard_mod
+        from builder.tools import profiler as profiler_mod
+        from builder.tools import session as session_mod
+
+        for mod in (profiler_mod, session_mod, dashboard_mod):
+            assert mod.SESSION_DIR != Path("sessions"), (
+                f"{mod.__name__}.SESSION_DIR still points at the repo sessions/ dir; "
+                "the autouse isolation fixture is not active"
+            )
+
+    def test_profiler_write_stays_in_isolated_dir(self) -> None:
+        from builder.tools import profiler as profiler_mod
+
+        sid = "isolation_probe_sid"
+        logger = profiler_mod.ProfilingLogger(sid)
+        try:
+            logger.log_event("tool_call", tool="scan_files", duration_ms=1.0, iteration=1)
+        finally:
+            logger.close()
+
+        # Written under the redirected (tmp) root...
+        assert (profiler_mod.SESSION_DIR / sid / "profile.ndjson").exists()
+        # ...and NOT under the repo's real sessions/ dir (the regression we guard).
+        assert not (Path("sessions") / sid).exists()

--- a/tests/test_tools_builder.py
+++ b/tests/test_tools_builder.py
@@ -372,9 +372,12 @@ class TestBuildCrate:
         state = CrateState()
         state.session_id = "test_default_path_001"
 
-        # Call without output_path — the function should supply a default
+        # Call without output_path — the function should supply a default.
+        # Assert the default session root convention (relative "sessions/"), so
+        # clear the test harness's VITRO_SESSION_DIR isolation override.
         with tempfile.TemporaryDirectory() as tmpdir:
             monkeypatch.chdir(tmpdir)
+            monkeypatch.delenv("VITRO_SESSION_DIR", raising=False)
             result = build_crate(state)
 
             assert result["success"] is True


### PR DESCRIPTION
## Problem
`SESSION_DIR = Path("sessions")` was hardcoded in three modules (`profiler.py`, `session.py`, `dashboard.py`) and used a relative path, and no conftest redirected it. So **every test/eval run that built an engine or profiler wrote a real `sessions/<id>/` dir into the repo** — ~1,800 stray dirs had accumulated (many just an empty `profile.ndjson`), burying real run history.

## Fix
- **`builder/config.py`** — new `session_root()`: one resolver, default `Path("sessions")`, overridable via `VITRO_SESSION_DIR`.
- **`builder/tools/{profiler,session,dashboard,builder}.py`** — `SESSION_DIR` and the default crate path (`_default_crate_path`) now derive from `session_root()`. **Production behavior is unchanged** (still defaults to `sessions/`).
- **`conftest.py`** — sets `VITRO_SESSION_DIR` to a tmp dir session-wide (before imports) plus a per-test autouse isolation fixture. Existing per-test `SESSION_DIR` monkeypatches still win.
- **tests** — new `tests/test_session_isolation.py`; the two default-crate-path tests clear the override to assert the true `sessions/` default.

## Result
- Full suite green (1642 tests) locally; changed files lint + typecheck clean.
- Session pollution drops from hundreds of stray dirs per run to a handful of `profile.ndjson` stragglers under parallel `-n auto` runs (a hard xdist/threading edge case, tracked as a follow-up). `sessions/` now collects real runs, not test noise.
- You can relocate all session output with `VITRO_SESSION_DIR` without touching code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)