### PR TITLE
test(csvw): drop two constant-vs-constant tautologies (#343)

### DIFF
--- a/tests/test_csvw_payload.py
+++ b/tests/test_csvw_payload.py
@@ -24,11 +24,7 @@ import pytest
 from rocrate.rocrate import ROCrate
 
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
-from builder.tools._crate_mapping import (
-    _CONDITION_TABLE_COLUMNS,
-    _RAW_MEASUREMENTS_COLUMNS,
-    populate_crate,
-)
+from builder.tools._crate_mapping import populate_crate
 from builder.tools.validation import build_and_validate
 from profiles.context import ISA_TOX_CONTEXT
 
@@ -96,20 +92,6 @@ _EXPECTED_RAW_COLUMNS = [
 # --- (a) Condition-table 10-column schema -----------------------------------
 
 
-def test_condition_table_columns_constant_matches_gold():
-    """The hardcoded column constant is the gold crate's 10-column contract."""
-    got = [
-        (
-            c["titles"],
-            c["datatype"],
-            c["propertyUrl"],
-        )
-        for c in _CONDITION_TABLE_COLUMNS
-    ]
-    want = [(t, d, p) for (t, d, p, _v) in _EXPECTED_CONDITION_COLUMNS]
-    assert got == want
-
-
 def _exposure_state() -> CrateState:
     state = CrateState()
     state.metadata.title = "Exposure crate"
@@ -167,11 +149,6 @@ def test_condition_table_value_urls_resolve_to_entities():
 
 
 # --- (b) raw_measurements typed csvw:Table ----------------------------------
-
-
-def test_raw_measurements_columns_constant_matches_gold():
-    got = [(c["titles"], c["datatype"], c["propertyUrl"]) for c in _RAW_MEASUREMENTS_COLUMNS]
-    assert got == _EXPECTED_RAW_COLUMNS
 
 
 def _endpoint_readout_state() -> CrateState:


### PR DESCRIPTION
First item of the #343 tautology backlog.

## What
Deletes two tautological tests in `tests/test_csvw_payload.py`:
- `test_condition_table_columns_constant_matches_gold`
- `test_raw_measurements_columns_constant_matches_gold`

Each only asserted that a **source** constant (`_CONDITION_TABLE_COLUMNS` / `_RAW_MEASUREMENTS_COLUMNS`) equalled a **hardcoded test-side** constant (`_EXPECTED_*`) — constant-vs-constant, never touching the CSVW emit path.

## Why coverage is preserved (not cut)
The honest siblings already run the real `populate_crate` emit path and assert the **emitted** columns against the same `_EXPECTED_*` contracts:
- `test_condition_table_emits_ten_typed_csvw_columns` — emitted titles + `datatype` + `propertyUrl`
- `test_raw_measurements_schema_has_three_typed_columns` — emitted titles + `datatype` + `propertyUrl`
- (`test_condition_table_value_urls_resolve_to_entities` covers the `valueUrl` the constant test dropped)

So the deleted tests transitively duplicated the siblings while adding a misleading green check. Removing them (and the now-unused constant imports) loses nothing and de-risks the suite.

## Test
`uv run pytest tests/test_csvw_payload.py` → 6 passed (was 8). No dangling references.

Progress on #343: 3 of 24 addressed (this PR + the removal in #342-era). 21 remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)