### PR TITLE
test(e2e): drop scripted-build entity-count tautology; honest docstring (#343)

### DIFF
--- a/tests/test_e2e_agent_eval.py
+++ b/tests/test_e2e_agent_eval.py
@@ -1,34 +1,28 @@
-"""End-to-end agent-output-quality evaluation harness (Issue #59).
+"""Deterministic build -> validate -> on-disk round-trip harness over a golden crate (Issue #59).
 
-The build/validate layer is well covered, but nothing exercises the *agent
-orchestration* path — whether a realistic file-scan input, driven through a
-sequence of tool calls, yields a complete and correct crate. This test fills
-that gap with a **deterministic, offline, no-LLM** evaluation harness.
+This does NOT exercise the agent/producer path — it hand-scripts the exact
+``engine.run_tool(...)`` sequence for the S-VHPS21 golden fixture (#97) to assemble a
+known-good ``CrateState``, then exercises the **deterministic downstream** that consumes
+it. The scripted state is legitimate *input* to that downstream (the writer, mapper and
+validator take a ``CrateState``); it is NOT a stand-in for extraction:
 
-Instead of invoking a live LLM, we hand-script the exact sequence of
-``engine.run_tool(...)`` calls that an agent *would* make for the S-VHPS21
-study (the fully-specified golden fixture from #97), reusing the same realistic
-values an agent would have inferred from the input folder:
+    scan_files          -> inventory the input directory (via the real guard)
+    draft_* (scripted)  -> assemble the golden ISA backbone + contributors + domain
+                           entities from the #97 spec (no LLM, no inference)
+    build_and_validate  -> in-memory 3-pass SHACL gate
+    build_crate         -> materialise the on-disk RO-Crate
+    validate            -> re-validate the crate read back from disk
+    assess_mit_coverage / assess_fair_maturity -> score floors
 
-    scan_files            -> inventory the input directory (via the real guard)
-    draft_investigation   \
-    draft_study            |  ISA backbone + contributors + domain entities,
-    draft_assay            >  wired by entity_id references
-    draft_person           |  (Investigation -> Study -> Assay -> LabProcess)
-    draft_organization     |
-    draft_cell_line_sample |
-    draft_molecular_entity |
-    draft_process         /
-    build_and_validate    -> in-memory 3-pass SHACL gate (no disk)
-    build_crate           -> materialise the on-disk RO-Crate
-    validate              -> re-validate the crate read back from disk
-    assess_mit_coverage   -> MIT score floor
-    assess_fair_maturity  -> FAIR/DSM score floor
+The assertions are on that downstream: crate completeness & wiring on the built
+``ro-crate-metadata.json`` (required entity types, ``hasPart``/``about`` containment,
+``conformsTo`` placement) plus FAIR/MIT floors — so a regression in the
+build/mapping/validation path fails the suite.
 
-It then asserts crate completeness & wiring on the built ``ro-crate-metadata.json``
-(required entity types, ``hasPart``/``about`` containment, ``conformsTo`` profile
-declaration) and a FAIR/MIT score floor — so an output-quality regression (agent
-stops drafting a key entity, wiring breaks, scores drop) fails the suite.
+The genuine producer coverage — does the real pipeline extract these entities from real
+scanned input? — lives in ``tests/test_pipeline_real_input.py`` (#342). This harness
+deliberately fixes the input so the downstream stays deterministic and offline; it does
+not, and must not be read as, a check that the agent drafts the right entities.
 """
 
 from __future__ import annotations
@@ -188,13 +182,6 @@ class TestScriptedAgentSequenceConformance:
         assert result["ok"] is True, result["issues"]
         assert result["conformance"] == {"base": True, "isa": True, "tox": True}
         assert result["issues"] == []
-
-    def test_required_entity_types_present_in_state(self, scripted_run):
-        state = scripted_run.engine.state
-        assert len(state.list_entities("Investigation")) == 1
-        assert len(state.list_entities("Study")) == 1
-        assert len(state.list_entities("Assay")) == 1
-        assert len(state.list_entities("LabProcess")) >= 1
 
 
 class TestBuiltCrateCompletenessAndWiring:


### PR DESCRIPTION
The scripted-e2e tautology you flagged as the big one. Part of #343.

## The tautology
`test_e2e_agent_eval.py::test_required_entity_types_present_in_state` asserted `len(list_entities("Investigation")) == 1`, etc. — but `_scripted_build` **hand-scripts** those `draft_*` calls from the #97 golden spec, so the test just re-counts what it wrote. The module docstring framed the file as exercising "the agent orchestration path" and catching "when the agent stops drafting a key entity" — a guarantee no test here meets, because no agent/producer runs.

## The fix (surgical, not a rewrite of `_scripted_build`)
- **Delete** the entity-count tautology. It's now redundant with #342's `test_pipeline_real_input.py`, which drives the real `run_pipeline` over real scanned input and asserts the backbone the producer actually emits.
- **Reframe the module docstring** to what the file honestly does: assemble a golden `CrateState` by hand, then exercise the **deterministic downstream** that consumes it (`build_and_validate` → `build_crate` → on-disk re-validate → FAIR/MIT floors), and point to #342 for the real producer coverage.
- **Keep** the legit tests untouched — `TestBuiltCrateCompletenessAndWiring` (on-disk graph types, `hasPart`/`about` wiring, `conformsTo` placement) and the validate/score-floor tests are genuine consumer coverage: the writer/mapper/validator's real input *is* a `CrateState`, so a scripted one is valid input.

## Test
`uv run pytest tests/test_e2e_agent_eval.py` → 6 passed (was 7).

Progress on #343: 4 of 24 addressed. Remaining: 2 tautological (`test_readers` no-op stub, `test_scanner` docx guard) + 18 weak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)