### PR TITLE
test(quality): fix the last two tautological tests (#343)

### DIFF
--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -226,13 +226,21 @@ class TestReadDirectory:
 
 
 class TestReadMetadataFiles:
-    """Tests for read_metadata_files (stub)."""
+    """`read_metadata_files` is an UNIMPLEMENTED stub — it parses no JSON/YAML yet.
 
-    def test_returns_state_unchanged(self):
-        """read_metadata_files returns the state unchanged (stub)."""
+    These tests only pin the current no-op contract; they are NOT metadata-reader
+    coverage (no metadata file crosses the boundary). When the reader is implemented,
+    replace this with a real test that writes a .json/.yaml metadata file into a
+    scanned dir and asserts the entities it extracts (cf. the real-input pattern in
+    tests/test_pipeline_real_input.py).
+    """
+
+    def test_stub_is_a_noop_and_mutates_nothing(self):
+        """The stub returns the SAME state object and adds no entities (no reader runs)."""
         state = CrateState()
         result = read_metadata_files(state)
         assert result is state
+        assert result.list_entities() == []  # nothing parsed, nothing added
 
 
 class TestReadExistingCrate:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -503,25 +503,27 @@ class TestReadFileSampleMode:
         assert "Format: PDF" in result or "PDF" in result
 
     def test_summary_docx(self, tmp_path):
-        """mode='summary' on DOCX returns format info when valid."""
-        import zipfile
+        """mode='summary' on a real .docx reports Word format + its real content.
+
+        Built with python-docx (as ``test_summary_xlsx`` uses openpyxl) so the
+        assertions are UNCONDITIONAL. The old version hand-crafted a minimal zip and
+        hid its assert behind ``if result is not None`` — it passed vacuously whenever
+        ``_summarize_docx`` returned None (the zip failing to parse), i.e. it never
+        actually verified the docx summary path.
+        """
+        import pytest
+
+        docx = pytest.importorskip("docx")  # python-docx
         f = tmp_path / "report.docx"
-        with zipfile.ZipFile(f, "w") as z:
-            # A more complete minimal docx with proper ContentTypes
-            z.writestr("[Content_Types].xml",
-                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-                '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
-                '<Override PartName="/word/document.xml" '
-                'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
-                '</Types>')
-            z.writestr("word/document.xml",
-                '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-                '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
-                '<w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>')
+        document = docx.Document()
+        document.add_paragraph("Hello")
+        document.save(str(f))
+
         result = read_file_sample(str(f), mode="summary")
-        if result is not None:
-            has_format = "Format: Word" in result or "docx" in result.lower()
-            assert has_format or "paragraph" in result.lower()
+        assert result is not None
+        assert "Format: Word" in result
+        assert "Paragraphs: 1" in result  # the one paragraph was counted
+        assert "Hello" in result  # its body text reached the summary
 
     def test_summary_plain_text(self, tmp_path):
         """mode='summary' on plain text returns line count and sample."""


### PR DESCRIPTION
Completes the **tautological half** of the #343 backlog.

## `test_scanner.py::test_summary_docx` — vacuous guard → real assertion
The old test hand-crafted a minimal docx zip and hid its assert behind `if result is not None:`, so whenever `_summarize_docx` returned `None` (the zip failing to parse) it passed **without checking anything**. Now mirrors the sibling `test_summary_xlsx`: builds a **real** `.docx` with python-docx (`importorskip`) and asserts **unconditionally** — `Format: Word`, `Paragraphs: 1`, and the `"Hello"` body text — so the docx-summary path is genuinely exercised.

## `test_readers.py::TestReadMetadataFiles` — honest no-op-stub pin
`read_metadata_files` is a documented no-op stub (parses no JSON/YAML yet), but the test/class were framed as metadata-reader coverage. Reframed to say plainly it only pins the no-op contract (**not** reader coverage), strengthened to assert the stub adds no entities, and pointed at the real-input pattern (#342) for when the reader is implemented.

## Test
`uv run pytest tests/test_readers.py tests/test_scanner.py::TestReadFileSampleMode` → 26 passed.

## #343 status after this
**All 6 tautological items done** (this PR + #342, #349, #350). Remaining: **18 weak** tests — a separate batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)