### PR TITLE
test(file-readers): make the scanner-ceiling parity check real; drop bare budget pin (#343)

### DIFF
--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -32,6 +32,11 @@ _ZIP_EXTENSIONS = frozenset({".zip", ".tar", ".gz", ".tgz", ".tar.gz"})
 # Zip-bomb guard: refuse to extract more than this much *uncompressed* data in
 # total from a single archive.
 _MAX_UNCOMPRESSED_BYTES = 2 * 1024**3  # 2 GiB
+# Byte ceiling for reading a single file's content (read_file_sample /
+# extract_pdf_text). Unified with builder.tools.file_readers._MAX_BYTES (#148) so a
+# mid-size file is never silently dropped by one reader but accepted by the other;
+# the parity is guarded by tests/test_file_readers.py.
+_MAX_FILE_BYTES = 100 * 1024 * 1024  # 100 MB
 
 
 class _UnsafeArchiveError(Exception):
@@ -1252,7 +1257,7 @@ def read_file_sample(
     # Skip very large files
     try:
         size = precomputed_size if precomputed_size is not None else file_path.stat().st_size
-        if size > 100 * 1024 * 1024:
+        if size > _MAX_FILE_BYTES:
             logger.info("Skipping file sample (>100MB): %s", path)
             return None
     except OSError:
@@ -1314,7 +1319,7 @@ def extract_pdf_text(path: str) -> str | None:
     # Skip very large files
     try:
         size = file_path.stat().st_size
-        if size > 100 * 1024 * 1024:
+        if size > _MAX_FILE_BYTES:
             logger.info("Skipping large PDF (>100MB): %s", path)
             return None
     except OSError:

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -17,9 +17,15 @@ from builder.tools.file_readers import _MAX_BYTES, _TEXT_BUDGET_BYTES, read_file
 
 class TestSizeCeiling:
     def test_max_bytes_matches_scanner_ceiling(self):
-        # Unified ceiling: 100 MB, same as scanner.read_file_sample /
-        # extract_pdf_text — not the old 1 MB.
-        assert _MAX_BYTES == 100 * 1024 * 1024
+        """file_readers and scanner MUST use the same byte ceiling (#148 unified them).
+
+        Asserts PARITY against scanner's actual constant — not just an inline literal —
+        so a future change that bumps one reader's ceiling but not the other (the #148
+        divergence this guards) fails here.
+        """
+        from builder.tools import scanner
+
+        assert _MAX_BYTES == scanner._MAX_FILE_BYTES == 100 * 1024 * 1024
 
     def test_read_file_5mb_csv_returns_content(self, tmp_path):
         csv = tmp_path / "big.csv"
@@ -49,10 +55,6 @@ class TestTextBudget:
     not truncated at a tiny line cap, so a weak model isn't tricked into a
     'let me read the rest' loop over a small file.
     """
-
-    def test_text_budget_is_generous(self):
-        # The full-return budget for text/JSON is at least 64 KiB.
-        assert _TEXT_BUDGET_BYTES >= 64 * 1024
 
     def test_32kb_pretty_json_returned_in_full(self, tmp_path):
         # A ~32 KB pretty-printed JSON is well under the budget and must come


### PR DESCRIPTION
Weak batch of #343 — file_readers cluster (2 tests).

## `test_max_bytes_matches_scanner_ceiling` — fake parity → real parity
Named "matches scanner ceiling" but only asserted `file_readers._MAX_BYTES == 100*1024*1024` — an inline literal that **never referenced scanner**. scanner used the ceiling as a bare `100 * 1024 * 1024` literal in two spots, so the #148 divergence this test claims to guard (the two readers' ceilings drifting apart) would pass unnoticed.

Fix: named scanner's literal `scanner._MAX_FILE_BYTES` (behavior-preserving — same value, used in the same two spots) and made the test assert `file_readers._MAX_BYTES == scanner._MAX_FILE_BYTES == 100MB`. Now bumping either ceiling alone fails the test.

## `test_text_budget_is_generous` — bare constant pin → deleted
`assert _TEXT_BUDGET_BYTES >= 64*1024` never ran the reader. The budget **behaviour** is already covered by `test_32kb_pretty_json_returned_in_full` (full return under budget) and `test_over_budget_text_returns_content_plus_explicit_marker` (truncation marker over budget), so the pin added nothing.

## Test
`uv run pytest tests/test_file_readers.py` → 10 passed. scanner.py: ruff + ty clean.

#343 progress: 6 tautological + 6 weak = 12 / 24. 12 weak remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)