### PR TITLE
test(drafters): exercise the real field-setter; drop a fictional protocol-link test (#343)

### DIFF
--- a/tests/test_tools_drafters.py
+++ b/tests/test_tools_drafters.py
@@ -215,21 +215,27 @@ class TestDraftPublication:
 class TestFieldOverwrite:
     """Tests for field overwrite behavior."""
 
-    def test_setting_same_field_preserves_source(self):
-        """Setting the same field twice overwrites value but preserves source tracking."""
-        state = CrateState()
-        hints = {"name": "Original Name"}
-        entity = draft_investigation(state, hints)
+    def test_second_set_fields_from_dict_overwrites_value_and_source(self):
+        """``set_fields_from_dict`` — the setter EVERY drafter uses — overwrites an
+        existing field's value AND updates its source; it does not silently keep the
+        old source.
 
-        # First set: comes from hints
+        (The old test hand-mutated ``entity.fields[...]`` + ``set_field_status``
+        directly, bypassing ``set_fields_from_dict`` entirely, so it never exercised
+        the field-set path the drafters actually run.)
+        """
+        state = CrateState()
+        entity = draft_investigation(state, {"name": "Original Name"})
+
+        # First set: draft_investigation ran set_fields_from_dict(source="llm").
         fc = entity.get_field_status("name")
         assert fc is not None
         assert fc.status == "filled"
         assert fc.source == "llm"
+        assert entity.fields["name"] == "Original Name"
 
-        # Overwrite via fields directly
-        entity.fields["name"] = "Updated Name"
-        entity.set_field_status("name", "filled", "user")
+        # A later user-sourced set through the REAL setter overwrites both value + source.
+        entity.set_fields_from_dict({"name": "Updated Name"}, source="user")
 
         fc2 = entity.get_field_status("name")
         assert fc2 is not None
@@ -388,16 +394,6 @@ class TestDraftSample:
 
         retrieved = state.get_entity(entity.entity_id)
         assert retrieved is entity
-
-    def test_can_link_to_protocol(self):
-        """draft_sample can store a protocol_id reference."""
-        state = CrateState()
-        entity = draft_sample(state, {"name": "Treated Sample", "protocol_id": "proto_mtt"})
-
-        assert entity.fields.get("protocol_id") == "proto_mtt"
-        fc = entity.get_field_status("protocol_id")
-        assert fc is not None
-        assert fc.status == "filled"
 
 
 def _node_by_id(graph: list[dict], node_id: str) -> dict | None:


### PR DESCRIPTION
Weak batch of #343 — drafters cluster (2 tests).

## `test_setting_same_field_preserves_source` — hand-mutation → real setter
The test hand-set `entity.fields["name"] = ...` + `set_field_status(...)` directly, **never calling `set_fields_from_dict`** — the setter every drafter uses. So it couldn't catch a regression in the actual overwrite path. Rewritten to draft once (`source="llm"`) then call `entity.set_fields_from_dict({"name": "Updated Name"}, source="user")` and assert the real overwrite: both value and source update.

## `test_can_link_to_protocol` — fictional capability → deleted
Claimed `draft_sample` "can link to protocol", but **nothing consumes `Sample.protocol_id`** — `_crate_mapping` has no Sample→protocol wiring, and a Sample links to a protocol indirectly through a `LabProcess`, not a Sample field (verified: zero non-test references to `protocol_id` in `builder/`/`profiles/`). The test only asserted an arbitrary key was stored. Deleted; field storage is covered by the class's other tests.

## Test
`uv run pytest tests/test_tools_drafters.py` → 39 passed.

#343 progress: 6 tautological + 8 weak = 14 / 24. 10 weak remain (all singletons across different files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)