### PR TITLE
test(crate): add negative type case + assert metadata-only File reference (#343)

### DIFF
--- a/tests/test_build_output_payload.py
+++ b/tests/test_build_output_payload.py
@@ -9,6 +9,7 @@ Two bugs:
 
 from __future__ import annotations
 
+import json
 import warnings
 from pathlib import Path
 
@@ -148,4 +149,14 @@ class TestPayloadCopied:
         result = build_crate(state)
 
         assert result["success"], result["error"]
-        assert (out / "ro-crate-metadata.json").is_file()
+        metadata_path = out / "ro-crate-metadata.json"
+        assert metadata_path.is_file()
+
+        # The unresolvable File degrades to a METADATA-ONLY reference (the docstring's
+        # claim, previously unverified): its node is present in the @graph, but no
+        # bytes were copied to disk.
+        graph = json.loads(metadata_path.read_text(encoding="utf-8"))["@graph"]
+        assert any(n.get("@id") == "data/ghost.csv" for n in graph), [
+            n.get("@id") for n in graph
+        ]
+        assert not (out / "data" / "ghost.csv").exists()

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -90,3 +90,29 @@ def test_populated_table_validates_with_inferred_schema(tmp_path):
     schema = csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)
     report = validate_table(result["path"], schema)
     assert report["ok"] is True, report
+
+
+def test_populated_table_rejects_non_numeric_concentration(tmp_path):
+    """The inferred CSVW schema TYPES ``concentration_value`` as a number, so a row
+    whose value is valid-as-string but not-a-number must FAIL content validation with
+    an error routed to that column.
+
+    The happy-path test above would still pass even if the column were typed as a
+    plain string — this negative case is what makes the number-typing meaningful.
+    """
+    state = _exposure_state()
+    rows = [
+        {"well_id": "A1", "cell_line": "HepG2", "compound": "Aspirin",
+         "concentration_value": "abc",  # not a number — must be rejected by the type
+         "concentration_unit": "uM", "exposure_duration": "24h"},
+    ]
+    result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
+    schema = csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)
+    report = validate_table(result["path"], schema)
+
+    assert report["ok"] is False, report
+    assert any(
+        "concentration_value" in str(issue.get("property", ""))
+        or "concentration_value" in str(issue.get("message", ""))
+        for issue in report["issues"]
+    ), report["issues"]


### PR DESCRIPTION
Weak batch of #343 — crate data-content + output assertions (2 tests).

## `test_condition_table` — happy path only → add a negative type case
`test_populated_table_validates_with_inferred_schema` only proved a well-typed row passes; it would stay green even if `concentration_value` were typed as a plain string. Added `test_populated_table_rejects_non_numeric_concentration`: a `concentration_value="abc"` must make `validate_table` return `ok=False` with an error routed to that column — so the CSVW number-typing is actually enforced, not cosmetic.

## `test_build_output_payload::test_missing_local_file_does_not_crash` — docstring claims more than it checked
The docstring says an unresolvable File "degrades gracefully (metadata-only reference)", but the test only asserted build success + `metadata.json` exists. Now loads the `@graph` and asserts the `data/ghost.csv` node **is** present as a reference **and** that no bytes were copied to disk (`data/ghost.csv` doesn't exist).

## Test
`uv run pytest tests/test_condition_table.py tests/test_build_output_payload.py` → 10 passed.

#343 progress: 6 tautological + 10 weak = 16 / 24. 8 weak remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)