### PR TITLE
test(quality): strengthen five weak assertions to check real values (#343)

### DIFF
--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -24,12 +24,19 @@ class TestBuildModeFromCli:
         assert BuildMode.from_cli(legacy_react=False) is BuildMode.PIPELINE
 
     def test_values_match_eval_arch_strings(self) -> None:
-        # The eval's ``--arch`` choices are exactly these values, so the harness
-        # can map its CLI string straight to the shared enum: BuildMode(arch).
-        assert BuildMode.PIPELINE.value == "pipeline"
-        assert BuildMode.REACT.value == "react"
-        assert BuildMode("react") is BuildMode.REACT
-        assert BuildMode("pipeline") is BuildMode.PIPELINE
+        """The eval's ``--arch`` choices and the BuildMode enum values MUST stay in
+        lockstep so ``BuildMode(args.arch)`` always resolves. Assert against the REAL
+        parser choices — not inline literals — so a change to either side that breaks
+        the mapping (a renamed/added arch, a dropped enum value) fails here.
+        """
+        from eval.__main__ import build_arg_parser
+
+        parser = build_arg_parser()
+        arch = next(a for a in parser._actions if "--arch" in a.option_strings)
+        assert set(arch.choices) == {m.value for m in BuildMode}
+        # Every CLI choice round-trips through the shared enum.
+        for choice in arch.choices:
+            assert BuildMode(choice).value == choice
 
 
 class TestRunBuildDispatch:

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -24,13 +24,23 @@ class TestBuildMaturityHtml:
     """build_maturity_html renders the four report axes (pure, no validator)."""
 
     def test_sections_present(self) -> None:
+        """Renders the four report axes AND the COMPUTED FAIR/MIT scores.
+
+        Asserting the static labels alone (``"DSM"`` / ``"%"``) passed even if the
+        report rendered a label with no value behind it; here a real DSM level (0-5)
+        and a MIT coverage percentage NUMBER must be present, so a regression that
+        stops rendering the computed score fails.
+        """
+        import re
+
         state = vhps_fixture_state("S-VHPS21")
         page = build_maturity_html(state)
         assert "<html" in page.lower()
         for heading in ("Profile adherence", "FAIR", "OECD MIT", "Reproducibility readiness"):
             assert heading in page, f"missing section: {heading}"
-        assert "DSM" in page  # FAIR maturity level
-        assert "%" in page  # MIT coverage
+        # Computed scores, not just the static labels:
+        assert re.search(r"DSM level [0-5] of 5", page), "no computed DSM level rendered"
+        assert re.search(r"\d+(?:\.\d+)?\s*%", page), "no computed MIT percentage rendered"
 
     def test_conformance_suggestions_rendered(self) -> None:
         state = vhps_fixture_state("S-VHPS21")

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -382,7 +382,11 @@ class TestPipelineE2EConformanceAndFidelity:
         chems = state.list_entities("MolecularEntity")
         assert {c.fields.get("name") for c in chems} == {"Methimazole", "Sodium iodide"}
         # D5: the CAS is the LOOKED-UP value, never fabricated by the plan/leaf.
-        assert all(c.fields.get("cas") == "60-56-0" for c in chems if c.fields.get("cas"))
+        # No vacuous `if c.fields.get("cas")` guard — every resolved compound MUST
+        # carry the looked-up CAS, so a regression that stops populating it fails here
+        # instead of passing over an empty set.
+        assert chems
+        assert all(c.fields.get("cas") == "60-56-0" for c in chems)
 
         # A CellLine Sample.
         cells = state.list_entities("CellLineSample")

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -266,9 +266,15 @@ class TestReadExistingCrate:
         crate_dir = tmp_path / "crate"
         build_crate(state, str(crate_dir))
 
-        # Now read it back
+        # Now read it back — reconstruction must be CORRECT, not just non-empty.
         restored = read_existing_crate(str(crate_dir))
-        assert len(restored.list_entities()) >= 1
+
+        invs = restored.list_entities("Investigation")
+        assert len(invs) == 1
+        assert invs[0].type == "Investigation"
+        # The single Investigation folds onto the RO-Crate root ./, so on read-back its
+        # name is the round-tripped crate title, and the title itself round-trips.
+        assert invs[0].fields.get("name") == "Test"
         assert restored.metadata.title == "Test"
 
     def test_returns_empty_state_for_nonexistent_directory(self):

--- a/tests/test_tools_builder.py
+++ b/tests/test_tools_builder.py
@@ -348,21 +348,28 @@ class TestBuildCrate:
             # to; the exact minor version is pinned explicitly in Step 2.
             assert any("w3id.org/ro/crate" in cid for cid in conforms_ids)
 
-    def test_build_crate_returns_crate_path_for_validate(self, monkeypatch):
-        """build_crate returns a crate_path that can be passed back to validate.
+    def test_build_crate_path_round_trips_into_validate(self):
+        """build_crate's returned crate_path is a REAL on-disk crate dir that feeds
+        straight back into validate() — the build->validate round-trip the name claims.
 
-        build_crate should document this. When output_path is given, the
-        returned crate_path matches it exactly.
+        (That ``crate_path == output_path`` is already covered by the echo assertions
+        earlier in this file; this exercises the actual round-trip instead of re-asserting
+        the input argument.)
         """
+        from builder.state import ValidationReport
+        from builder.tools.validation import validate
+
         state = CrateState()
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = str(Path(tmpdir) / "my_crate")
             result = build_crate(state, output_path)
-
             assert result["success"] is True
-            # The returned crate_path must equal the output_path we passed,
-            # so it can be fed straight into validate().
-            assert result["crate_path"] == output_path
+
+            # The returned path pointed at a real crate dir, so validate ran SHACL over
+            # it (not the missing-crate guard) and produced a report.
+            report = validate(state, result["crate_path"])
+            assert isinstance(report, ValidationReport)
+            assert (Path(result["crate_path"]) / "ro-crate-metadata.json").is_file()
 
     def test_build_crate_generates_default_crate_path_to_sessions(self, monkeypatch):
         """build_crate uses a session-derived default when output_path is not given.


### PR DESCRIPTION
Weak batch of #343 — five independent strengthens (5 files, 5 tests). Each now asserts a computed/real value instead of a vacuous guard, static label, or input echo.

| Test | Before | After |
|---|---|---|
| `test_pipeline_e2e::test_fidelity_expected_entity_types_present` | `all(... for c in chems if c.fields.get("cas"))` — vacuous over an empty set | drop the guard; **every** resolved compound must carry the looked-up CAS |
| `test_build_mode::test_values_match_eval_arch_strings` | asserts inline literals `"pipeline"`/`"react"` | asserts against the **real** `build_arg_parser()` `--arch` choices == `{m.value for m in BuildMode}` |
| `test_maturity_report::test_sections_present` | `"DSM" in page`, `"%" in page` (static labels) | regex a **computed** `DSM level N of 5` + a MIT `%` number |
| `test_tools_builder` | `crate_path == output_path` (echoes the arg; already covered twice) | real **build→validate round-trip** over the returned path |
| `test_readers::test_reconstructs_entities_from_valid_crate` | `len(...) >= 1` (existence only) | reconstructed Investigation's **type + name + exact count** |

## Test
Each affected test verified passing (`test_build_mode`, `test_maturity_report`, the pipeline fidelity test, the builder round-trip, and the reader reconstruction).

#343 progress: 6 tautological + 15 weak = 21 / 24. **3 weak remain** — all the judgment calls (`test_crate_mapping_namespace`, `test_mit_coverage_floor`, `test_agent_graph`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)