### PR TITLE
test(quality): finish the #343 weak backlog — reframe 2, strengthen 1 (#343)

### DIFF
--- a/tests/test_agent_graph.py
+++ b/tests/test_agent_graph.py
@@ -218,10 +218,39 @@ class TestBuildAgentGraph:
 class TestRunInteractiveAgentPreservesBehavior:
     """Tests that run_interactive_agent still works via the new graph."""
 
-    def test_run_interactive_agent_imports_and_calls_create_agent(self, monkeypatch):
-        """run_interactive_agent still imports successfully and calls the new _build_agent_graph."""
+    def test_run_interactive_agent_builds_the_agent_graph(self, monkeypatch):
+        """run_interactive_agent actually DRIVES the interactive path: it builds the
+        LangChain tools + chat model and calls ``_build_agent_graph(llm, tools, engine)``.
+
+        The old test only asserted ``_build_agent_graph`` *exists* — it never ran the
+        driver, so it couldn't catch the driver wiring breaking. Here we spy the graph
+        build (raising to stop right after it, before the stdin loop), fake the chat
+        model so no provider/network is needed, and assert the driver reached the build
+        with the model, tools, and engine wired.
+        """
+        from builder.engine import AgentEngine
+
         import builder.agents.react.agent_loop as loop_mod
 
-        # The _build_agent_graph function should be defined
-        assert hasattr(loop_mod, "_build_agent_graph")
-        assert callable(loop_mod._build_agent_graph)
+        calls: dict[str, object] = {}
+
+        class _GraphBuilt(Exception):
+            pass
+
+        def _spy_build_graph(llm, tools, engine=None):
+            calls.update(llm=llm, tools=tools, engine=engine)
+            raise _GraphBuilt  # stop the driver right after the graph is built
+
+        monkeypatch.setattr(loop_mod, "_build_chat_model", lambda **kw: object())
+        monkeypatch.setattr(loop_mod, "_build_agent_graph", _spy_build_graph)
+
+        engine = AgentEngine()
+        engine.initialize()
+
+        with pytest.raises(_GraphBuilt):
+            loop_mod.run_interactive_agent(engine)
+
+        # The driver executed up through _build_agent_graph(llm, tools, engine=...).
+        assert calls["engine"] is engine
+        assert calls["llm"] is not None
+        assert calls["tools"] is not None

--- a/tests/test_crate_mapping_namespace.py
+++ b/tests/test_crate_mapping_namespace.py
@@ -121,9 +121,10 @@ class TestMintedIdNamespace:
         *resolution* (the mapper's ``_resolve_many`` fallback is order-based, not
         context-aware). RO-Crate 1.2 in fact discourages the situation this guards: two
         conceptually-different entities SHOULD NOT share an identifier (§Contextual-
-        entities), and a single entity that is genuinely both a Sample and a
-        CellLineSample should be ONE node with a ``@type`` array — a case this test does
-        not cover (see the follow-up design question in #343 discussion).
+        entities). A genuine cell-line sample is ONE ``CellLineSample`` entity, which
+        already emits as a single Sample node (``@type: Sample`` + ``additionalType:
+        CellLine``); the separate-Sample-plus-CellLineSample input this guards against
+        is itself the mis-modeling (design follow-up: #366).
         """
         state = CrateState()
         state.metadata.title = "Reference Test"

--- a/tests/test_crate_mapping_namespace.py
+++ b/tests/test_crate_mapping_namespace.py
@@ -110,8 +110,16 @@ class TestMintedIdNamespace:
             root = next(e for e in graph if e.get("@id") == "./")
             assert root.get("additionalType") == "Investigation"
 
-    def test_reference_resolution_across_collision(self):
-        """References to colliding entities resolve to the correct type-qualified node."""
+    def test_colliding_ids_get_distinct_type_qualified_nodes(self):
+        """Two entities sharing a bare entity_id (``cell_01``) but of DIFFERENT types are
+        emitted as two distinct, type-qualified @id nodes (``#Sample_cell_01`` vs
+        ``#CellLineSample_cell_01``) — they never collapse into one node.
+
+        NB: this does NOT test reference *resolution*. The mapper's ``_resolve_many``
+        typed-fragment fallback is order-based, not context-aware, so there is no
+        "correct node for a given reference" to assert (#343); what IS guaranteed — and
+        what this pins — is that colliding ids stay distinct and type-qualified.
+        """
         state = CrateState()
         state.metadata.title = "Reference Test"
 

--- a/tests/test_crate_mapping_namespace.py
+++ b/tests/test_crate_mapping_namespace.py
@@ -110,15 +110,20 @@ class TestMintedIdNamespace:
             root = next(e for e in graph if e.get("@id") == "./")
             assert root.get("additionalType") == "Investigation"
 
-    def test_colliding_ids_get_distinct_type_qualified_nodes(self):
-        """Two entities sharing a bare entity_id (``cell_01``) but of DIFFERENT types are
-        emitted as two distinct, type-qualified @id nodes (``#Sample_cell_01`` vs
-        ``#CellLineSample_cell_01``) — they never collapse into one node.
+    def test_colliding_bare_ids_still_emit_unique_ids(self):
+        """DEFENSIVE regression guard for the type-qualified @id scheme (Issue #57):
+        two CrateState entities that happen to share a bare ``entity_id`` (``cell_01``)
+        across different types still emit as @id-UNIQUE nodes (``#Sample_cell_01`` vs
+        ``#CellLineSample_cell_01``), satisfying RO-Crate 1.2's "the @graph MUST NOT
+        list multiple entities with the same @id" (§Core-Metadata).
 
-        NB: this does NOT test reference *resolution*. The mapper's ``_resolve_many``
-        typed-fragment fallback is order-based, not context-aware, so there is no
-        "correct node for a given reference" to assert (#343); what IS guaranteed — and
-        what this pins — is that colliding ids stay distinct and type-qualified.
+        This is NOT a modelling recommendation, and it does not test reference
+        *resolution* (the mapper's ``_resolve_many`` fallback is order-based, not
+        context-aware). RO-Crate 1.2 in fact discourages the situation this guards: two
+        conceptually-different entities SHOULD NOT share an identifier (§Contextual-
+        entities), and a single entity that is genuinely both a Sample and a
+        CellLineSample should be ONE node with a ``@type`` array — a case this test does
+        not cover (see the follow-up design question in #343 discussion).
         """
         state = CrateState()
         state.metadata.title = "Reference Test"

--- a/tests/test_e2e_agent_eval.py
+++ b/tests/test_e2e_agent_eval.py
@@ -308,12 +308,18 @@ class TestScoreFloors:
     """A FAIR/MIT score floor on the built crate — guards against silent drops."""
 
     def test_mit_coverage_floor(self, scripted_run):
+        """MIT coverage SCORING over the known scripted crate clears a conservative
+        non-zero floor.
+
+        This guards ``assess_mit_coverage`` (its module scores + overall) over the
+        deterministic scripted state — NOT agent extraction; this file is a
+        scripted-downstream harness (see the module docstring), and the real producer
+        coverage lives in ``tests/test_pipeline_real_input.py`` (#342). A scoring
+        regression that collapses coverage to 0, or stops crediting the General
+        Information module for the backbone fields it fills, fails here.
+        """
         report = scripted_run.engine.run_tool("assess_mit_coverage")
         assert report.module_scores, "MIT report has no module scores"
-        # The scripted crate fills the ISA backbone + key domain fields. Assert a
-        # conservative non-zero floor so a regression that stops drafting key
-        # entities (dropping coverage to 0) fails here. The General Information
-        # module specifically must have completions from the drafted entities.
         assert report.overall_score > 0.0, report.overall_score
         general = report.module_scores.get("General Information", {})
         assert general.get("completed", 0) >= 2, report.module_scores


### PR DESCRIPTION
The final three "judgment call" weak tests — **completes #343** (pending merge of #363/#364).

## `test_crate_mapping_namespace` — reframe (1B)
Renamed `test_reference_resolution_across_collision` → `test_colliding_ids_get_distinct_type_qualified_nodes`. The mapper's `_resolve_many` typed-fragment fallback is **order-based, not context-aware**, so there's no "correct node for a given reference" to assert. The honest, real guarantee — which the body already verifies — is that two entities sharing a bare id but of different types stay **distinct, type-qualified** @id nodes (`#Sample_cell_01` vs `#CellLineSample_cell_01`), never collapsing. Docstring now says exactly that.

## `test_e2e_agent_eval::test_mit_coverage_floor` — reframe (2B)
Dropped the false claim that it catches "a regression that stops drafting key entities" — **nothing drafts** here (the file is a scripted-downstream harness, per its #350 docstring). It honestly guards the `assess_mit_coverage` **scoring** over the known scripted crate; real producer coverage lives in `tests/test_pipeline_real_input.py` (#342). Assertions unchanged.

## `test_agent_graph` — strengthen (3A)
The old test only asserted `_build_agent_graph` **exists**. Now it drives `run_interactive_agent`: the chat model is faked (no provider), the graph build is spied and raises to stop before the stdin loop, and the test asserts the driver reached `_build_agent_graph(llm, tools, engine=...)` with all three wired — so a break in the interactive-driver wiring fails here.

## Test
`test_crate_mapping_namespace.py` + `TestScoreFloors::test_mit_coverage_floor` + the new agent-graph driver test → 5 passed.

## 🎉 #343 complete
**24 / 24 too-easy tests addressed** — 6 tautological + 18 weak, across PRs #342, #349, #350, #351, #352, #353, #354, #362, #363, #364, and this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)