### PR TITLE
feat(state): warn on cross-type entity_id collisions; record additionalType decision (closes #366)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1484,6 +1484,30 @@ force-stopped at the recursion cap. ReAct stays a supported variant
 profile conformance (base + isa + tox) plus an entity-count quota — **not** scientific
 accuracy.
 
+### D16: ISA-Tox Specialization via `additionalType`, Not `@type` Arrays
+
+Every ISA-Tox specialization is expressed as `@type: <bare base token>` +
+`additionalType: <discriminator string>` — **not** a JSON-LD `@type` array:
+
+- A cell-line sample is `@type: "Sample"` (`bioschemas:Sample`) + `additionalType:
+  "CellLine"` + a `sampleType` DefinedTerm (`profiles/shapes/tox/1_cell_line_sample.ttl`,
+  isa_tox.md §Biological model).
+- LabProcess steps are `@type: "LabProcess"` + `additionalType:
+  "CellCulture"|"Exposure"|"EndpointReadout"|"DataAnalysis"`; ISA backbone nodes are
+  `@type: "Dataset"` + `additionalType: "Investigation"|"Study"|"Assay"`.
+
+The specialized `tox:` class is **inferred by the validator**, not asserted in the crate:
+each tox shape carries a SHACL `TripleRule` that adds `rdf:type tox:CellLineSample` (etc.)
+when the discriminator matches (`FindCellLineSamples`). A generic RO-Crate consumer sees
+the base type; the ISA-Tox validator sees the specialization — this is why `@type` stays
+the bare token.
+
+Consequences the builder respects: `_crate_mapping` emits the bare base `@type` plus the
+discriminator (never a `@type` array), and a single conceptual entity is ONE node — a
+`CellLineSample` already IS a Sample, so modelling it as a *separate* `Sample` +
+`CellLineSample` (two entities sharing a bare `entity_id`) is discouraged by RO-Crate 1.2
+(§Contextual entities) and warns at `CrateState.add_entity` (#366).
+
 ## 12. Project Structure
 
 Where each component lives:

--- a/builder/state.py
+++ b/builder/state.py
@@ -809,7 +809,28 @@ class CrateState:
     # ------------------------------------------------------------------
 
     def add_entity(self, entity: Entity) -> None:
-        """Add an entity to the correct collection based on its type."""
+        """Add an entity to the correct collection based on its type.
+
+        Warns (#366) when a bare ``entity_id`` is shared across DIFFERENT entity types.
+        RO-Crate 1.2 discourages two conceptually-different entities sharing an
+        identifier (§Contextual entities); the mapper still de-collides via
+        type-qualified @ids (#57) so the crate stays @id-unique, but the collision
+        usually signals mis-modelling — e.g. one cell-line sample expressed as a
+        separate ``Sample`` + ``CellLineSample`` rather than a single ``CellLineSample``
+        (which already IS a ``bioschemas:Sample`` discriminated by ``additionalType
+        "CellLine"``; see AGENTS.md D16).
+        """
+        existing = self.entities.get_entity(entity.entity_id)
+        if existing is not None and existing.type != entity.type:
+            logger.warning(
+                "entity_id %r is shared across types (%s + %s). RO-Crate 1.2 discourages "
+                "two conceptually-different entities sharing an identifier; if these are "
+                "the same thing, model it as ONE entity (a CellLineSample already is a "
+                "Sample). See #366.",
+                entity.entity_id,
+                existing.type,
+                entity.type,
+            )
         self.entities.add_entity(entity)
 
     def get_entity(self, entity_id: str) -> Entity | None:

--- a/tests/test_entity_store.py
+++ b/tests/test_entity_store.py
@@ -18,6 +18,37 @@ def _entity(entity_id: str, entity_type: EntityType, **fields: Any) -> Entity:
     )
 
 
+class TestCrossTypeIdCollisionWarning:
+    """add_entity warns when a bare entity_id is shared across entity types (#366).
+
+    RO-Crate 1.2 discourages two conceptually-different entities sharing an identifier;
+    the collision usually signals mis-modelling (e.g. one cell-line sample expressed as a
+    separate Sample + CellLineSample rather than a single CellLineSample).
+    """
+
+    def test_warns_on_cross_type_id_collision(self, caplog):
+        import logging
+
+        state = CrateState()
+        state.add_entity(_entity("cell_01", "Sample", name="Plain sample"))
+        with caplog.at_level(logging.WARNING, logger="builder.state"):
+            state.add_entity(_entity("cell_01", "CellLineSample", name="HepG2"))
+
+        msgs = " ".join(r.getMessage() for r in caplog.records)
+        assert "shared across types" in msgs, msgs
+        assert "#366" in msgs, msgs
+
+    def test_no_cross_type_warning_for_same_type_reuse(self, caplog):
+        import logging
+
+        state = CrateState()
+        state.add_entity(_entity("s1", "Sample", name="A"))
+        with caplog.at_level(logging.WARNING, logger="builder.state"):
+            # Same id, same type (an update/re-add) must NOT trigger the warning.
+            state.add_entity(_entity("s1", "Sample", name="A updated"))
+        assert "shared across types" not in " ".join(r.getMessage() for r in caplog.records)
+
+
 class TestEntityStore:
     """Focused CRUD tests for EntityStore."""
 


### PR DESCRIPTION
Closes #366. Follow-up to the #343 review — implements the two actions you approved.

## Background (spot-check result)
The ISA-Tox profile is emphatic: a cell-line sample is `@type: "Sample"` (`bioschemas:Sample`) + `additionalType: "CellLine"` + a `sampleType` DefinedTerm, and the validator **infers** `tox:CellLineSample` via a SHACL `TripleRule` (`profiles/shapes/tox/1_cell_line_sample.ttl`). Same pattern for every specialization (CellCulture/Exposure/EndpointReadout/DataAnalysis; Investigation/Study/Assay). So `additionalType` **is** the model — not a `@type` array, not a smell. The mapper was already correct.

## 1. Warn on colliding bare `entity_id`s
`CrateState.add_entity` now logs a warning when a bare `entity_id` is shared across **different** entity types. The mapper still de-collides via type-qualified `@id`s (#57) so the crate stays `@id`-unique (RO-Crate MUST), but the collision usually signals mis-modelling — e.g. a single cell-line sample expressed as a *separate* `Sample` + `CellLineSample` instead of one `CellLineSample` (which already is a Sample). RO-Crate 1.2 discourages it (§Contextual entities).

TDD: `TestCrossTypeIdCollisionWarning` — red→green, plus a **no-false-positive** test proving a same-id **same-type** re-add does *not* warn.

## 2. Record the decision (AGENTS.md D16)
New **D16: ISA-Tox Specialization via `additionalType`, Not `@type` Arrays** — states the convention as a durable contract (validator-inferred `tox:` classes; mapper emits the bare base `@type` + discriminator), citing the profile shape and #366, so it isn't re-litigated.

## Test
`uv run pytest tests/test_entity_store.py tests/test_crate_mapping_namespace.py` → 11 passed. `builder/state.py`: ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)