### PR TITLE
feat(ui): harmonize the interactive UI across both build arms (#344)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1552,7 +1552,7 @@ vitro-crate/
 │   └── agents/                  Orchestration + LLM config
 │       ├── build.py             BuildMode switch + run_build dispatch; pipeline entrypoint (run_interactive_build)
 │       ├── llm.py               Shared model construction + usage mining, both modes (#309)
-│       ├── progress_spinner.py  CLI progress UI
+│       ├── progress_spinner.py  Shared live progress spinner (both arms)
 │       ├── pipeline/            Deterministic pipeline mode (--interactive DEFAULT)
 │       │   ├── pipeline.py        Pipeline spine (run_pipeline)
 │       │   ├── guidance.py        HITL guidance tail (run_guidance)
@@ -2030,8 +2030,8 @@ the *latest* crate always lands and an unchanged repeat build is a no-op.
 
 **Progress + persistence (#241 / #242).** Before these the default `--interactive`
 (pipeline) path *felt dead*: the deterministic spine ran for ~tens of seconds with
-**no output** (it looked frozen — the legacy ReAct loop has a `_ThinkingSpinner`,
-the pipeline had nothing, #241) and **never persisted CrateState** (so a concurrent
+**no output** (it looked frozen — the legacy ReAct loop had a live spinner, the
+pipeline had nothing, #241) and **never persisted CrateState** (so a concurrent
 `--dashboard`, which loads + watches `sessions/<id>/crate_state.json`, showed "No
 CrateState data available" and never live-updated even though a full crate was built
 in memory, #242). Both are fixed without an LLM and without perturbing the built

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1552,6 +1552,7 @@ vitro-crate/
 │   └── agents/                  Orchestration + LLM config
 │       ├── build.py             BuildMode switch + run_build dispatch; pipeline entrypoint (run_interactive_build)
 │       ├── llm.py               Shared model construction + usage mining, both modes (#309)
+│       ├── ui.py                Shared interactive UI: status bar, reply, banners, boxed prompt — both modes (#344)
 │       ├── progress_spinner.py  CLI progress UI
 │       ├── pipeline/            Deterministic pipeline mode (--interactive DEFAULT)
 │       │   ├── pipeline.py        Pipeline spine (run_pipeline)

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -208,8 +208,14 @@ def run_interactive_build(
 
     spinner_ctx = spinner if spinner is not None else nullcontext()
     try:
+        # Shared UI chrome (#344), interactive-only so the headless / eval path
+        # stays byte-identical: the resume summary before the spinner starts, the
+        # one-line status bar after it tears down (so neither is clobbered). Both
+        # render through the SAME builder.agents.ui renderers as the ReAct arm.
+        if interactive:
+            _render_session_banner(engine)
         with spinner_ctx:
-            return _run_build_body(
+            result = _run_build_body(
                 engine,
                 human=human,
                 interactive=interactive,
@@ -218,6 +224,9 @@ def run_interactive_build(
                 guidance_runner=guidance_runner,
                 exporter=exporter,
             )
+        if interactive:
+            _render_final_status(engine)
+        return result
     finally:
         # Restore the prior tool-event hook even if the build raised (#266).
         engine.on_tool_event = prior_tool_event
@@ -284,6 +293,36 @@ def _spinner_emit(base_emit: OutputChannel, spinner: ProgressSpinner | None) -> 
         return base_emit(msg)
 
     return emit
+
+
+def _render_session_banner(engine: AgentEngine) -> None:
+    """On resume, show the shared "Resumed Session" summary before the build (#344).
+
+    Interactive-only, and only when the session already carries entities/files (a
+    resumed build) — a fresh build has nothing to summarise and proceeds straight
+    to the progress lines, mirroring the ReAct arm's session-open. Rendered
+    through the shared ``builder.agents.ui`` so both arms are identical.
+    """
+    from builder.agents import ui
+
+    snap = ui.snapshot_from_engine(engine)
+    if snap.entity_count or snap.file_count:
+        ui.get_console().print(ui.render_resume_summary(snap))
+
+
+def _render_final_status(engine: AgentEngine) -> None:
+    """Print the shared one-line status bar after the build (#344).
+
+    The compact ``session · N entities · N files · ●base ●ISA ●Tox · tokens``
+    posture line the ReAct arm shows, rendered here through the SAME
+    ``builder.agents.ui`` renderer. ``engine.state.validation`` is already
+    authoritative at this point — the pipeline's final ``build_and_validate``
+    runs via ``engine.run_tool``, which folds conformance back into state (#153) —
+    so the dots read real values with no extra sync.
+    """
+    from builder.agents import ui
+
+    ui.get_console().print(ui.render_status_bar(ui.snapshot_from_engine(engine)))
 
 
 def _run_build_body(

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -41,7 +41,7 @@ from builder.tools.session import save_session
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
     from builder.state import CrateState
-    from builder.tools.hitl import HumanInterface
+    from builder.tools.hitl import HumanInterface, InputResponse
 
 logger = logging.getLogger(__name__)
 
@@ -209,11 +209,16 @@ def run_interactive_build(
     spinner_ctx = spinner if spinner is not None else nullcontext()
     try:
         # Shared UI chrome (#344), interactive-only so the headless / eval path
-        # stays byte-identical: the resume summary before the spinner starts, the
-        # one-line status bar after it tears down (so neither is clobbered). Both
-        # render through the SAME builder.agents.ui renderers as the ReAct arm.
+        # stays byte-identical: the resume summary before the spinner starts, then
+        # the status bar + goodbye after it tears down (so neither is clobbered).
+        # These are the SAME builder.agents.ui.print_* helpers the ReAct arm calls
+        # — one implementation, no per-arm copy. The per-prompt status bar the
+        # ReAct loop shows before every input is added to the guidance tail by
+        # wrapping the human (see _run_build_body / _StatusBarHuman).
+        from builder.agents import ui
+
         if interactive:
-            _render_session_banner(engine)
+            ui.print_resume_summary(engine)
         with spinner_ctx:
             result = _run_build_body(
                 engine,
@@ -225,8 +230,8 @@ def run_interactive_build(
                 exporter=exporter,
             )
         if interactive:
-            _render_final_status(engine)
-            _render_goodbye(engine)
+            ui.print_status_bar(engine)
+            ui.print_goodbye(engine)
         return result
     finally:
         # Restore the prior tool-event hook even if the build raised (#266).
@@ -296,54 +301,32 @@ def _spinner_emit(base_emit: OutputChannel, spinner: ProgressSpinner | None) -> 
     return emit
 
 
-def _render_session_banner(engine: AgentEngine) -> None:
-    """On resume, show the shared "Resumed Session" summary before the build (#344).
+class _StatusBarHuman:
+    """A ``HumanInterface`` proxy that prints the shared status bar before each
+    free-text prompt — the per-turn status line the ReAct loop shows before every
+    input (#344). It calls the SAME ``ui.print_status_bar`` the ReAct loop calls
+    (no per-arm copy); every other attribute delegates to the wrapped interface.
 
-    Interactive-only, and only when the session already carries entities/files (a
-    resumed build) — a fresh build has nothing to summarise and proceeds straight
-    to the progress lines, mirroring the ReAct arm's session-open. Rendered
-    through the shared ``builder.agents.ui`` so both arms are identical.
+    Wrapped around the real interface for the interactive guidance tail only, so a
+    fresh status bar (entities climbing, validation dots flipping green) heads each
+    gap question as the user answers.
     """
-    from builder.agents import ui
 
-    snap = ui.snapshot_from_engine(engine)
-    if snap.entity_count or snap.file_count:
-        ui.get_console().print(ui.render_resume_summary(snap))
+    def __init__(self, inner: HumanInterface, engine: AgentEngine) -> None:
+        self._inner = inner
+        self._engine = engine
 
+    def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
+        from builder.agents import ui
 
-def _render_final_status(engine: AgentEngine) -> None:
-    """Print the shared one-line status bar after the build (#344).
+        ui.print_status_bar(self._engine)
+        return self._inner.request_input(prompt, field_type)
 
-    The compact ``session · N entities · N files · ●base ●ISA ●Tox · tokens``
-    posture line the ReAct arm shows, rendered here through the SAME
-    ``builder.agents.ui`` renderer. ``engine.state.validation`` is already
-    authoritative at this point — the pipeline's final ``build_and_validate``
-    runs via ``engine.run_tool``, which folds conformance back into state (#153) —
-    so the dots read real values with no extra sync.
-    """
-    from builder.agents import ui
-
-    ui.get_console().print(ui.render_status_bar(ui.snapshot_from_engine(engine)))
-
-
-def _render_goodbye(engine: AgentEngine) -> None:
-    """Print the shared goodbye panel after an interactive build (#344).
-
-    The same exit panel the ReAct arm shows — session id, per-type entity
-    breakdown, and the ``--resume`` hint — rendered through the shared
-    ``builder.agents.ui`` renderer so both arms sign off identically.
-    Interactive-only.
-    """
-    from builder.agents import ui
-
-    state = engine.state
-    counts: dict[str, int] = {}
-    for entity in state.list_entities():
-        typ = getattr(entity, "type", "Unknown")
-        counts[typ] = counts.get(typ, 0) + 1
-    ui.get_console().print(
-        ui.render_goodbye(state.session_id, counts, resumable=Path("sessions").is_dir())
-    )
+    def __getattr__(self, name: str) -> Any:
+        # Everything not overridden above (present, is_interactive, is_done, …)
+        # delegates to the wrapped interface. __getattr__ only fires for attributes
+        # missing on the proxy, so _inner/_engine/request_input are unaffected.
+        return getattr(self._inner, name)
 
 
 def _run_build_body(
@@ -392,7 +375,11 @@ def _run_build_body(
 
     guidance_runner = guidance_runner or _default_guidance_runner()
     emit("Resolving gaps…")
-    guidance_result = guidance_runner(engine, human)
+    # Wrap the human so a fresh status bar heads each guidance question — the same
+    # per-prompt status line the ReAct loop shows, via the shared ui helper (#344).
+    # human is non-None on this interactive path (is_interactive(None) is False).
+    prompt_human = _StatusBarHuman(human, engine) if human is not None else human
+    guidance_result = guidance_runner(engine, prompt_human)
 
     emit(format_guidance_summary(guidance_result))
 

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -226,6 +226,7 @@ def run_interactive_build(
             )
         if interactive:
             _render_final_status(engine)
+            _render_goodbye(engine)
         return result
     finally:
         # Restore the prior tool-event hook even if the build raised (#266).
@@ -323,6 +324,26 @@ def _render_final_status(engine: AgentEngine) -> None:
     from builder.agents import ui
 
     ui.get_console().print(ui.render_status_bar(ui.snapshot_from_engine(engine)))
+
+
+def _render_goodbye(engine: AgentEngine) -> None:
+    """Print the shared goodbye panel after an interactive build (#344).
+
+    The same exit panel the ReAct arm shows — session id, per-type entity
+    breakdown, and the ``--resume`` hint — rendered through the shared
+    ``builder.agents.ui`` renderer so both arms sign off identically.
+    Interactive-only.
+    """
+    from builder.agents import ui
+
+    state = engine.state
+    counts: dict[str, int] = {}
+    for entity in state.list_entities():
+        typ = getattr(entity, "type", "Unknown")
+        counts[typ] = counts.get(typ, 0) + 1
+    ui.get_console().print(
+        ui.render_goodbye(state.session_id, counts, resumable=Path("sessions").is_dir())
+    )
 
 
 def _run_build_body(

--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -1,11 +1,16 @@
-"""A live progress spinner for the deterministic interactive build (#266).
+"""The shared live progress spinner for the interactive builds (#266, #344).
 
 The DEFAULT ``--interactive`` (pipeline) build prints static phase lines (#253),
 so the ~tens-of-seconds deterministic spine looked frozen. :class:`ProgressSpinner`
-gives it a live Rich spinner like the legacy ReAct loop's ``_ThinkingSpinner``
-(``builder/agents/agent_loop.py``): an animated dots spinner with a rotating funny
+gives it a live Rich spinner: an animated dots spinner with a rotating funny
 toxicology-themed phrase, the currently-running tool/phase, and elapsed seconds,
 all updating in place.
+
+**Both build arms share this one spinner (#344).** The deterministic pipeline drives
+it from ``engine.on_tool_event`` plus its per-phase strings; the legacy ReAct loop
+drives it from LangChain tool-event callbacks (``_ToolSpinnerCallback`` in
+``builder/agents/react/agent_loop.py``). This module is the single source of both the
+spinner class and :data:`TOX_SPINNER_PHRASES` — neither arm keeps a private copy.
 
 It is a reusable context manager driven by a daemon tick thread, rendering::
 
@@ -18,10 +23,6 @@ unregisters on exit, so a console HITL prompt — which wraps its ``input()`` in
 ``suspend_console_animation`` (#239) — calls :meth:`pause` (tear down the Live region,
 stop ticking) for the duration of the prompt and :meth:`resume` afterwards. The tick
 thread skips while paused.
-
-This module deliberately defines its OWN fresh :data:`TOX_SPINNER_PHRASES` list (same
-vibe as the legacy one) rather than importing from ``agent_loop.py``, which is owned by
-another lane.
 """
 
 from __future__ import annotations
@@ -42,8 +43,8 @@ logger = logging.getLogger(__name__)
 __all__ = ["ProgressSpinner", "TOX_SPINNER_PHRASES"]
 
 
-# A FRESH toxicology-themed phrase list (defined here, NOT imported from
-# agent_loop.py). Same playful lab/FAIR vibe as the legacy loop's list.
+# The single toxicology-themed phrase list, shared by both build arms (#344).
+# ``ProgressSpinner`` picks one at random when no explicit phrase is given.
 TOX_SPINNER_PHRASES: list[str] = [
     "intoxicating",
     "ro-crating",
@@ -87,8 +88,7 @@ class ProgressSpinner:
     tool/phase. On enter it registers with the hitl animation registry so a HITL
     prompt can :meth:`pause`/:meth:`resume` it via ``suspend_console_animation``.
 
-    Colour convention mirrors the legacy ``_ThinkingSpinner``: green = working,
-    dim = elapsed/meta, cyan = the current op.
+    Colour convention: green = working, dim = elapsed/meta, cyan = the current op.
 
     **Non-TTY safety (CI / piped).** A live animation only makes sense on a real
     terminal. When the console is NOT a terminal (``console.is_terminal`` is

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from time import monotonic, perf_counter
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 from langchain_core.callbacks import BaseCallbackHandler
@@ -30,13 +30,10 @@ from builder.agents.llm import (
     _get_request_timeout,
     _recursion_limit,
 )
+from builder.agents.progress_spinner import ProgressSpinner
 from builder.agents.react.system_prompt import SYSTEM_PROMPT
 from builder.agents.react.tools_spec import TOOL_SPECS, assert_tool_spec_parity
 from builder.engine import AgentEngine
-from builder.tools.hitl import (
-    register_console_animation,
-    unregister_console_animation,
-)
 
 if TYPE_CHECKING:
     from typing import cast
@@ -65,95 +62,21 @@ class AgentState(TypedDict):
 
 
 # ---------------------------------------------------------------------------
-# Thinking spinner — ticks elapsed seconds and shows the active tool
+# Tool-activity callback — bridges LangChain tool events to the shared spinner
 # ---------------------------------------------------------------------------
 
 
-class _ThinkingSpinner:
-    """A Rich status spinner that ticks elapsed seconds while the agent works
-    and surfaces the active tool — Claude Code style.
+class _ToolSpinnerCallback(BaseCallbackHandler):
+    """Forward LangChain tool-start/end events to the shared progress spinner.
 
-    Colour convention: green = the agent working (matches the ● reply marker),
-    dim = elapsed/meta, cyan = the active tool.
-    Used as a context manager around an ``app.invoke`` call; a daemon thread
-    refreshes the elapsed time roughly twice a second.
+    The spinner is :class:`builder.agents.progress_spinner.ProgressSpinner`, the
+    SAME live spinner the deterministic pipeline drives (#344) — here it is fed the
+    per-tool signal the ReAct loop gets from LangChain callbacks (the pipeline
+    feeds the same spinner from ``engine.on_tool_event``). Clearing on tool-end
+    returns the line to the rotating thinking phrase.
     """
 
-    def __init__(self, console: Any, phrase: str) -> None:
-        self._console = console
-        self._phrase = phrase
-        self._tool: str | None = None
-        self._start = monotonic()
-        self._stop = threading.Event()
-        # Set while a HITL prompt owns the terminal: the tick thread must not
-        # repaint the Rich Live region over the prompt (else stdin is unusable).
-        self._paused = threading.Event()
-        self._status = console.status(self._render(), spinner="dots", spinner_style="green")
-        self._thread = threading.Thread(target=self._tick, daemon=True)
-
-    def _render(self) -> str:
-        elapsed = int(monotonic() - self._start)
-        line = f"[green]{self._phrase}…[/green] [dim]({elapsed}s)[/dim]"
-        if self._tool:
-            line += f"  [dim]·[/dim] [cyan]{self._tool}[/cyan]"
-        return line
-
-    def _tick(self) -> None:
-        while not self._stop.wait(0.5):
-            if self._paused.is_set():
-                continue
-            try:
-                self._status.update(self._render())
-            except Exception:
-                break
-
-    def set_tool(self, name: str | None) -> None:
-        """Show (or clear, with ``None``) the tool currently running."""
-        self._tool = name
-        if self._paused.is_set():
-            return
-        try:
-            self._status.update(self._render())
-        except Exception:
-            pass
-
-    def pause(self) -> None:
-        """Tear down the Live region and stop ticking so a HITL prompt is clean.
-
-        Called (via :func:`builder.tools.hitl.suspend_console_animation`) when a
-        tool needs ``input()`` mid-``invoke``. Best-effort and idempotent.
-        """
-        self._paused.set()
-        try:
-            self._status.stop()
-        except Exception:
-            logger.debug("spinner pause: status.stop failed", exc_info=True)
-
-    def resume(self) -> None:
-        """Restart the Live region after a HITL prompt completes."""
-        try:
-            self._status.start()
-        except Exception:
-            logger.debug("spinner resume: status.start failed", exc_info=True)
-        self._paused.clear()
-
-    def __enter__(self) -> "_ThinkingSpinner":
-        self._status.__enter__()
-        self._thread.start()
-        register_console_animation(self)
-        return self
-
-    def __exit__(self, *exc: Any) -> None:
-        unregister_console_animation(self)
-        self._stop.set()
-        self._thread.join(timeout=1.0)
-        self._status.__exit__(*exc)
-
-
-class _ToolSpinnerCallback(BaseCallbackHandler):
-    """LangChain callback that surfaces the active tool on a _ThinkingSpinner."""
-
-    def __init__(self, spinner: _ThinkingSpinner) -> None:
+    def __init__(self, spinner: ProgressSpinner) -> None:
         self.spinner = spinner
         super().__init__()
 
@@ -163,10 +86,10 @@ class _ToolSpinnerCallback(BaseCallbackHandler):
         input_str: str,
         **kwargs: Any,
     ) -> None:
-        self.spinner.set_tool(serialized.get("name", "tool"))
+        self.spinner.set_current(serialized.get("name", "tool"))
 
     def on_tool_end(self, output: Any, **kwargs: Any) -> None:
-        self.spinner.set_tool(None)
+        self.spinner.set_current(None)
 
 
 # ---------------------------------------------------------------------------
@@ -1606,7 +1529,7 @@ def run_interactive_agent(
         root_logger = logging.getLogger()
         old_root_level = root_logger.level
         root_logger.setLevel(logging.ERROR)
-        spinner = _ThinkingSpinner(console, "intoxicating")
+        spinner = ProgressSpinner(console, "intoxicating")
         greeting_config = {
             **thread_config,
             "callbacks": [_ToolSpinnerCallback(spinner)],
@@ -1676,49 +1599,6 @@ def run_interactive_agent(
         """
         _finish_backstop(engine, emit=console.print)
 
-    import random
-
-    TOX_SPINNER_PHRASES = [
-        "intoxicating",
-        "ro-creating",
-        "culturing",
-        "FAIR-washing",
-        "re-FAIR-ifying",
-        "blaming the student",
-        "appeasing the cells",
-        "fighting reviewer 2",
-        "haggling the IC50",
-        "bribing the curve",
-        "vortexing",
-        "rehydrating",
-        "titrating",
-        "resuspending",
-        "denaturing self-doubt",
-        "autoclaving",
-        "thawing the -80",
-        "centrifuging",
-        "pipetting",
-        "decoding",
-        "finding a working pipette",
-        "side-eyeing",
-        "labelling 'compound X'",
-        "miscounting colonies",
-        "warming up, emotionally",
-        "manifesting p<0.05",
-        "praying to FAIR gods",
-        "hallucinating responsibly",
-        "FAIR-ifying",
-        "exposing",
-        "meta-dating",
-        "re-using",
-        "finding",
-        "interoperating",
-        "re-using, eventually",
-        "double-gloving",
-        "brewing coffee",
-        "replacing, reducing, refusing",
-    ]
-
     def _run_turn(message_content: str) -> tuple[str, str]:
         """Run ONE model invocation and return ``(reply, outcome)`` (#263).
 
@@ -1734,7 +1614,7 @@ def run_interactive_agent(
         old_root_level = root_logger.level
         root_logger.setLevel(logging.ERROR)
 
-        spinner = _ThinkingSpinner(console, random.choice(TOX_SPINNER_PHRASES))
+        spinner = ProgressSpinner(console)
         main_config = {
             **thread_config,
             "callbacks": [_ToolSpinnerCallback(spinner)],

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     from typing_extensions import Annotated as _Annotated
 
+from builder.agents import ui
 from builder.agents.llm import (
     _build_chat_model,
     _extract_model_name,
@@ -1428,102 +1429,6 @@ def _finish_backstop(
 # ---------------------------------------------------------------------------
 
 
-def _boxed_input(console: Any, label: str = "❯") -> str:
-    """Read one line of input inside a rounded box (Claude Code style).
-
-    Renders an ephemeral rounded box via prompt_toolkit; once submitted the
-    box is erased and the line is echoed into the transcript so it persists.
-    Falls back to ``console.input`` when stdin is not a TTY or prompt_toolkit
-    is unavailable. Raises ``KeyboardInterrupt`` (Ctrl+C) and ``EOFError``
-    (Ctrl+D on an empty line), matching ``input()``.
-    """
-    import sys
-
-    def _fallback() -> str:
-        return console.input(f"[bold cyan]{label} [/bold cyan]").strip()
-
-    if not sys.stdin.isatty():
-        return _fallback()
-    try:
-        from prompt_toolkit import Application
-        from prompt_toolkit.application.current import get_app
-        from prompt_toolkit.buffer import Buffer
-        from prompt_toolkit.key_binding import KeyBindings
-        from prompt_toolkit.layout import HSplit, Layout, VSplit, Window
-        from prompt_toolkit.layout.controls import (
-            BufferControl,
-            FormattedTextControl,
-        )
-        from prompt_toolkit.styles import Style
-    except Exception:
-        return _fallback()
-
-    buf = Buffer(multiline=False)
-    outcome: dict[str, Any] = {"exc": None}
-    kb = KeyBindings()
-
-    @kb.add("enter")
-    def _(event: Any) -> None:
-        event.app.exit(result=buf.text)
-
-    @kb.add("c-c")
-    def _(event: Any) -> None:
-        outcome["exc"] = KeyboardInterrupt
-        event.app.exit(result="")
-
-    @kb.add("c-d")
-    def _(event: Any) -> None:
-        if not buf.text:
-            outcome["exc"] = EOFError
-            event.app.exit(result="")
-
-    def _hline(left: str, right: str):
-        def _get() -> list[tuple[str, str]]:
-            w = get_app().output.get_size().columns
-            return [("class:box", left + "─" * max(0, w - 2) + right)]
-
-        return _get
-
-    buf_window = Window(BufferControl(buffer=buf))
-    middle = VSplit(
-        [
-            Window(
-                FormattedTextControl([("class:box", "│ "), ("class:prompt", f"{label} ")]),
-                width=4,
-            ),
-            buf_window,
-            Window(FormattedTextControl([("class:box", " │")]), width=2),
-        ],
-        height=1,
-    )
-    root = HSplit(
-        [
-            Window(FormattedTextControl(_hline("╭", "╮")), height=1),
-            middle,
-            Window(FormattedTextControl(_hline("╰", "╯")), height=1),
-        ]
-    )
-    style = Style.from_dict({"box": "fg:#5f5f5f", "prompt": "bold ansicyan"})
-    app: Any = Application(
-        layout=Layout(root, focused_element=buf_window),
-        key_bindings=kb,
-        style=style,
-        full_screen=False,
-    )
-    try:
-        text = app.run()
-    except Exception:
-        return _fallback()
-
-    if outcome["exc"] is not None:
-        raise outcome["exc"]
-    text = (text or "").strip()
-    if text:
-        # The box was ephemeral — echo the submitted line into the transcript.
-        console.print(f"[bold cyan]{label}[/bold cyan] {text}")
-    return text
-
-
 def run_interactive_agent(
     engine: AgentEngine,
     provider: str | None = None,
@@ -1565,12 +1470,9 @@ def run_interactive_agent(
     # Passing the engine enables node-level timing → profile.ndjson.
     app = _build_agent_graph(llm, tools, engine=engine)
 
-    from rich.console import Console
-    from rich.markdown import Markdown
-    from rich.padding import Padding
     from rich.panel import Panel
 
-    console = Console()
+    console = ui.get_console()
 
     # In-loop auto-export surfacing (#287 Fix A): a completed in-loop build writes
     # the crate to disk and reports its absolute path via this sink. The export
@@ -1599,7 +1501,11 @@ def run_interactive_agent(
     )
 
     def _extract_reply(state: dict) -> str:
-        """Pull the last AIMessage content from the agent state."""
+        """Pull the last AIMessage content from the agent state, as plain text.
+
+        Flattens structured message content through the shared formatter so
+        content-block lists never leak their repr to the terminal (#341).
+        """
         msgs = state.get("messages", [])
         # Walk backwards to find an AI message (not tool results)
         for msg in reversed(msgs):
@@ -1607,103 +1513,25 @@ def run_interactive_agent(
                 # Skip messages from "tool" role
                 role = getattr(msg, "type", "") or ""
                 if role == "ai" or (isinstance(msg, AIMessage)):
-                    return str(msg.content)
+                    return ui.flatten_message_content(msg.content)
                 # Also accept the very last message if it has content
                 if msg is msgs[-1]:
-                    return str(msg.content)
+                    return ui.flatten_message_content(msg.content)
         return ""
 
     def _print_reply(content: str) -> None:
-        """Print an agent reply: a slim marker plus left-indented markdown.
-
-        Lighter than a full-width bordered panel so short answers don't get
-        a big box; markdown is indented two spaces under a green marker.
-        """
+        """Print an agent reply through the shared renderer (empty → skip)."""
         if not content:
             return
-        from rich.table import Table
-
-        try:
-            body: Any = Markdown(content)
-        except Exception:
-            body = content
-
-        # Claude-Code style: the ● marker sits on the SAME line as the first
-        # line of the reply, and continuation lines align under it. A 2-wide
-        # gutter column holds the marker; the body column wraps beside it.
-        grid = Table.grid(padding=(0, 0))
-        grid.add_column(width=2, no_wrap=True)
-        grid.add_column(overflow="fold")
-        grid.add_row("[green]●[/green]", body)
-
-        console.print()  # breathing room above the reply
-        console.print()
-        console.print(grid)
-        console.print()  # ...and below
+        console.print(ui.render_reply(content))
 
     def _render_header() -> None:
-        """Print a compact one-line status header before each user prompt.
+        """Print the shared one-line status header before each user prompt.
 
         Re-rendered each turn (a recurring header rule rather than a pinned
         bar, which would conflict with ``console.input``/``console.status``).
-        Shows session id, entity/file counts, validation state, and token
-        usage with estimated cost.
         """
-        ec = len(engine.state.list_entities())
-        fc = len(engine.state.scanned_files)
-        val = engine.state.validation
-
-        def _dot(ok: bool) -> str:
-            return "[green]●[/green]" if ok else "[grey50]○[/grey50]"
-
-        sep = "[grey42]·[/grey42]"
-        # Token usage with estimated cost (read from profile.ndjson)
-        token_str = ""
-        try:
-            from builder.tools.dashboard import read_profile
-            from builder.tools.profiler import SESSION_DIR
-
-            profile_path = SESSION_DIR / engine.state.session_id / "profile.ndjson"
-            if profile_path.exists():
-                prof_records = read_profile(profile_path)
-                if prof_records:
-                    # Aggregate cumulative tokens
-                    model_ends = [
-                        r
-                        for r in prof_records
-                        if r.get("event") == "node_end" and r.get("node") == "model"
-                    ]
-                    total_in = sum(int(r.get("input_tokens", 0) or 0) for r in model_ends)
-                    total_out = sum(int(r.get("output_tokens", 0) or 0) for r in model_ends)
-                    last_model = (model_ends[-1].get("model_name") or "") if model_ends else ""
-                    if total_in + total_out > 0:
-                        from builder.config import get_model_provider
-                        from builder.pricing import compute_cost, format_cost
-
-                        mp = get_model_provider()
-                        cost_info = compute_cost(total_in, total_out, last_model, provider=mp)
-                        total_cost = cost_info.get("total_cost")
-                        cost_str = f"@{format_cost(total_cost)}" if total_cost is not None else ""
-                        token_str = (
-                            f"  {sep}  [dim]tok {total_in}→{total_out} ({total_in + total_out})"
-                            f"{cost_str}[/dim]"
-                        )
-        except Exception:
-            pass
-
-        status = (
-            f"[dim]{engine.state.session_id}[/dim]  {sep}  "
-            f"[dim]{ec} entities[/dim]  {sep}  "
-            f"[dim]{fc} files[/dim]  {sep}  "
-            f"{_dot(val.base_passed)} [dim]base[/dim]  "
-            f"{_dot(val.isa_passed)} [dim]ISA[/dim]  "
-            f"{_dot(val.tox_passed)} [dim]Tox[/dim]"
-            f"{token_str}"
-        )
-        # A dim, indented status line with breathing room above — lighter
-        # than a full-width rule, closer to the Claude Code aesthetic.
-        console.print()
-        console.print(Padding(status, (0, 0, 0, 1)))
+        console.print(ui.render_status_bar(ui.snapshot_from_engine(engine)))
 
     # ── Resume summary vs fresh greeting ────────────────────────────────
     entity_count = len(engine.state.list_entities())
@@ -1711,52 +1539,14 @@ def run_interactive_agent(
     is_resume = entity_count > 0 or file_count > 0
 
     if is_resume:
-        # Build a rich summary panel
-        from rich.table import Table
-
-        summary = Table.grid(padding=(0, 2))
-        summary.add_column(style="bold", width=16)
-        summary.add_column(style="white")
-
-        summary.add_row("Session:", f"[cyan]{engine.state.session_id}[/cyan]")
-        summary.add_row("Entities:", f"[green]{entity_count}[/green]")
-        summary.add_row("Files:", f"[green]{file_count}[/green]")
-
-        mit = getattr(engine.state, "mit_assessment", None)
-        if mit and getattr(mit, "overall_score", None) is not None:
-            summary.add_row("MIT score:", f"[yellow]{mit.overall_score:.0%}[/yellow]")
-
         val = engine.state.validation
-        val_status = []
-        if val.base_passed:
-            val_status.append("[green]base[/green]")
-        else:
-            val_status.append("[red]base[/red]")
-        if val.isa_passed:
-            val_status.append("[green]ISA[/green]")
-        else:
-            val_status.append("[red]ISA[/red]")
-        if val.tox_passed:
-            val_status.append("[green]ISA-Tox[/green]")
-        else:
-            val_status.append("[red]ISA-Tox[/red]")
-        summary.add_row("Validation:", "  ".join(val_status))
-
-        if val.required_issues:
-            summary.add_row("Issues:", f"[red]{len(val.required_issues)} REQUIRED[/red]")
-
-        # Per-type entity breakdown
+        # Per-type entity breakdown (also feeds the greeting prompt + fallback).
         counts: dict[str, int] = {}
         for e in engine.state.list_entities():
             typ = getattr(e, "type", "Unknown")
             counts[typ] = counts.get(typ, 0) + 1
-        if counts:
-            parts = ", ".join(f"[cyan]{k}[/cyan]={v}" for k, v in sorted(counts.items()))
-            summary.add_row("Breakdown:", parts)
 
-        console.print(
-            Panel(summary, title="[yellow]Resumed Session[/yellow]", border_style="yellow")
-        )
+        console.print(ui.render_resume_summary(ui.snapshot_from_engine(engine)))
         console.print()
 
         # Tell the LLM about the current state so it can give a contextual greeting
@@ -1859,37 +1649,20 @@ def run_interactive_agent(
     # ── Goodbye helper ──────────────────────────────────────────────────
 
     def _print_goodbye(state: Any) -> None:
-        """Print a goodbye message with resume instructions."""
-        session_id = getattr(state, "session_id", None) or engine.state.session_id
-        console.print()
-
-        from rich.table import Table
-
-        t = Table.grid(padding=(0, 1))
-        t.add_column(style="yellow bold", width=14)
-        t.add_column(style="white")
-        t.add_row("Session:", f"[cyan]{session_id}[/cyan]")
-
-        entities = state.list_entities() if hasattr(state, "list_entities") else []
-        if entities:
-            counts: dict[str, int] = {}
-            for e in entities:
-                typ = getattr(e, "type", "Unknown")
-                counts[typ] = counts.get(typ, 0) + 1
-            parts = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
-            t.add_row("Entities:", parts)
-        else:
-            t.add_row("Entities:", "0")
-
+        """Print the shared goodbye panel with resume instructions."""
         from pathlib import Path
 
-        if Path("sessions").is_dir():
-            t.add_row(
-                "Resume:",
-                f"python -m main [cyan]--resume {session_id}[/cyan] [dim]--interactive[/dim]",
-            )
+        session_id = getattr(state, "session_id", None) or engine.state.session_id
+        entities = state.list_entities() if hasattr(state, "list_entities") else []
+        counts: dict[str, int] = {}
+        for e in entities:
+            typ = getattr(e, "type", "Unknown")
+            counts[typ] = counts.get(typ, 0) + 1
 
-        console.print(Panel(t, title="[yellow]Goodbye![/yellow]", border_style="yellow"))
+        console.print()
+        console.print(
+            ui.render_goodbye(session_id, counts, resumable=Path("sessions").is_dir())
+        )
         console.print()
 
     def _finalize_on_exit() -> None:
@@ -2034,7 +1807,7 @@ def run_interactive_agent(
             console.print()
             # Rounded input box (Claude Code style); falls back to a plain
             # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
-            user_input = _boxed_input(console)
+            user_input = ui.boxed_input(console)
         except KeyboardInterrupt:
             # Ctrl+C: clear the line and re-prompt
             console.print()

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -1448,14 +1448,6 @@ def run_interactive_agent(
             return
         console.print(ui.render_reply(content))
 
-    def _render_header() -> None:
-        """Print the shared one-line status header before each user prompt.
-
-        Re-rendered each turn (a recurring header rule rather than a pinned
-        bar, which would conflict with ``console.input``/``console.status``).
-        """
-        console.print(ui.render_status_bar(ui.snapshot_from_engine(engine)))
-
     # ── Resume summary vs fresh greeting ────────────────────────────────
     entity_count = len(engine.state.list_entities())
     file_count = len(engine.state.scanned_files)
@@ -1469,8 +1461,7 @@ def run_interactive_agent(
             typ = getattr(e, "type", "Unknown")
             counts[typ] = counts.get(typ, 0) + 1
 
-        console.print(ui.render_resume_summary(ui.snapshot_from_engine(engine)))
-        console.print()
+        ui.print_resume_summary(engine)
 
         # Tell the LLM about the current state so it can give a contextual greeting
         greeting_prompt = (
@@ -1571,23 +1562,6 @@ def run_interactive_agent(
 
     # ── Goodbye helper ──────────────────────────────────────────────────
 
-    def _print_goodbye(state: Any) -> None:
-        """Print the shared goodbye panel with resume instructions."""
-        from pathlib import Path
-
-        session_id = getattr(state, "session_id", None) or engine.state.session_id
-        entities = state.list_entities() if hasattr(state, "list_entities") else []
-        counts: dict[str, int] = {}
-        for e in entities:
-            typ = getattr(e, "type", "Unknown")
-            counts[typ] = counts.get(typ, 0) + 1
-
-        console.print()
-        console.print(
-            ui.render_goodbye(session_id, counts, resumable=Path("sessions").is_dir())
-        )
-        console.print()
-
     def _finalize_on_exit() -> None:
         """Deterministically build + export the crate before the goodbye (#251).
 
@@ -1683,7 +1657,7 @@ def run_interactive_agent(
         try:
             # Compact status header above each prompt (counts live here now,
             # so the prompt line stays clean).
-            _render_header()
+            ui.print_status_bar(engine)
             console.print()
             # Rounded input box (Claude Code style); falls back to a plain
             # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
@@ -1696,12 +1670,12 @@ def run_interactive_agent(
             # Ctrl+D: exit
             console.print()
             _finalize_on_exit()
-            _print_goodbye(engine.state)
+            ui.print_goodbye(engine)
             break
 
         if user_input.lower() in ("quit", "exit", "q"):
             _finalize_on_exit()
-            _print_goodbye(engine.state)
+            ui.print_goodbye(engine)
             break
 
         if not user_input:

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -1,0 +1,425 @@
+"""Shared interactive terminal UI for both build arms (pipeline + ReAct).
+
+Single source of truth for the interactive chrome — the shared Rich
+``Console``, the one-line status bar, agent-reply rendering, the resume
+summary and goodbye panels, and the boxed ``❯`` prompt — so the
+deterministic pipeline and the legacy ReAct arm render *identically*.
+Both arms import from here; neither keeps a private copy (harmonization,
+GitHub #344).
+
+Design contract:
+
+* The ``render_*`` functions are **pure** — each takes a :class:`UiSnapshot`
+  (or plain values) and returns a Rich renderable, so they unit-test without
+  a TTY or a live engine.
+* :func:`snapshot_from_engine` is the single impure adapter: it reads engine
+  state and, best-effort, ``profile.ndjson`` for cumulative token/cost totals.
+* This module imports ``rich`` / ``prompt_toolkit`` / ``builder.pricing`` /
+  ``builder.config`` and **neither build arm** — depending on an arm here
+  would create an ``agents → agents`` import cycle. ``engine`` is duck-typed
+  through :func:`snapshot_from_engine`'s parameter, never imported.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from rich.console import Console, Group, RenderableType
+from rich.markdown import Markdown
+from rich.padding import Padding
+from rich.panel import Panel
+from rich.table import Table
+
+if TYPE_CHECKING:
+    from builder.engine import AgentEngine
+
+logger = logging.getLogger(__name__)
+
+# Marker glyphs shared across the chrome (green ● = active/pass, ○ = pending).
+_PASS_DOT = "[green]●[/green]"
+_PENDING_DOT = "[grey50]○[/grey50]"
+_SEP = "[grey42]·[/grey42]"
+
+_console: Console | None = None
+
+
+def get_console() -> Console:
+    """Return the process-wide shared Rich :class:`Console` (memoized).
+
+    Both arms render through one console so styling, width, and the
+    console-animation registry stay consistent.
+    """
+    global _console
+    if _console is None:
+        _console = Console()
+    return _console
+
+
+# ---------------------------------------------------------------------------
+# Message flattening — the #341 raw-message-leak fix
+# ---------------------------------------------------------------------------
+
+
+def flatten_message_content(content: Any) -> str:
+    """Reduce an LLM message ``content`` to human-readable text.
+
+    Model replies may arrive as a plain string or as a list of content
+    blocks — dicts like ``{"type": "text", "text": ...}`` (plus ``annotations``
+    / ``id`` / ``phase`` metadata) or block objects exposing a ``.text``
+    attribute. Printing such a list with ``str()`` leaks the Python repr to
+    the terminal (GitHub #341). This joins the ``text`` of every text block
+    and drops non-text blocks (``tool_use``, ``thinking``, …) and metadata.
+
+    Args:
+        content: A message ``content`` value (``str``, ``None``, or a list of
+            string / dict / block-object items).
+
+    Returns:
+        The concatenated human-readable text (empty string when there is none).
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+            else:
+                text = getattr(block, "text", None)
+                if isinstance(text, str) and getattr(block, "type", "text") == "text":
+                    parts.append(text)
+        return "".join(parts)
+    return str(content)
+
+
+# ---------------------------------------------------------------------------
+# UiSnapshot — the pure inputs the renderers need
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UiSnapshot:
+    """A flat, render-ready view of session state.
+
+    Decoupling the renderers from the live engine keeps them pure and
+    unit-testable, and lets each arm populate token/cost from whichever
+    source it has (the pipeline's structured ``usage`` dict, or ReAct's
+    ``profile.ndjson``).
+    """
+
+    session_id: str
+    entity_count: int
+    file_count: int
+    base_passed: bool
+    isa_passed: bool
+    tox_passed: bool
+    required_issue_count: int
+    entity_counts: dict[str, int] = field(default_factory=dict)
+    mit_score: float | None = None
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float | None = None
+
+
+def _read_token_totals(session_id: str) -> tuple[int, int, str]:
+    """Best-effort cumulative ``(input, output, last_model)`` from the profile.
+
+    Reads ``profile.ndjson`` for the session and sums ``model`` ``node_end``
+    token counts. Returns zeros on any failure — token display is advisory.
+    """
+    try:
+        from builder.tools.dashboard import read_profile
+        from builder.tools.profiler import SESSION_DIR
+
+        profile_path = SESSION_DIR / session_id / "profile.ndjson"
+        if not profile_path.exists():
+            return 0, 0, ""
+        records = read_profile(profile_path)
+        model_ends = [
+            r for r in records if r.get("event") == "node_end" and r.get("node") == "model"
+        ]
+        total_in = sum(int(r.get("input_tokens", 0) or 0) for r in model_ends)
+        total_out = sum(int(r.get("output_tokens", 0) or 0) for r in model_ends)
+        last_model = (model_ends[-1].get("model_name") or "") if model_ends else ""
+        return total_in, total_out, last_model
+    except Exception:
+        logger.debug("token totals unavailable for %s", session_id, exc_info=True)
+        return 0, 0, ""
+
+
+def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
+    """Build a :class:`UiSnapshot` from a live engine (the one impure adapter).
+
+    Reads entity/file counts and validation flags from ``engine.state`` and,
+    best-effort, cumulative token/cost totals from the session profile.
+    """
+    state = engine.state
+    entities = state.list_entities()
+    counts: dict[str, int] = {}
+    for e in entities:
+        typ = getattr(e, "type", "Unknown")
+        counts[typ] = counts.get(typ, 0) + 1
+
+    val = state.validation
+    mit = getattr(state, "mit_assessment", None)
+    mit_score = getattr(mit, "overall_score", None) if mit is not None else None
+
+    tokens_in, tokens_out, last_model = _read_token_totals(state.session_id)
+    cost_usd: float | None = None
+    if tokens_in + tokens_out > 0:
+        try:
+            from builder.config import get_model_provider
+            from builder.pricing import compute_cost
+
+            info = compute_cost(
+                tokens_in, tokens_out, last_model, provider=get_model_provider()
+            )
+            cost_usd = info.get("total_cost")
+        except Exception:
+            logger.debug("cost unavailable for %s", state.session_id, exc_info=True)
+
+    return UiSnapshot(
+        session_id=state.session_id,
+        entity_count=len(entities),
+        file_count=len(state.scanned_files),
+        base_passed=val.base_passed,
+        isa_passed=val.isa_passed,
+        tox_passed=val.tox_passed,
+        required_issue_count=len(val.required_issues),
+        entity_counts=counts,
+        mit_score=mit_score,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=cost_usd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure renderers
+# ---------------------------------------------------------------------------
+
+
+def _dot(ok: bool) -> str:
+    return _PASS_DOT if ok else _PENDING_DOT
+
+
+def render_status_bar(snap: UiSnapshot) -> RenderableType:
+    """A compact one-line status header (session · counts · validation · tokens).
+
+    Rendered as a re-printed dim line (not a pinned bar, which would conflict
+    with ``console.input``/``console.status``); includes one blank line above
+    for breathing room.
+    """
+    token_str = ""
+    if snap.tokens_in + snap.tokens_out > 0:
+        from builder.pricing import format_cost
+
+        cost_str = f"@{format_cost(snap.cost_usd)}" if snap.cost_usd is not None else ""
+        total = snap.tokens_in + snap.tokens_out
+        token_str = (
+            f"  {_SEP}  [dim]tok {snap.tokens_in}→{snap.tokens_out} ({total})"
+            f"{cost_str}[/dim]"
+        )
+
+    status = (
+        f"[dim]{snap.session_id}[/dim]  {_SEP}  "
+        f"[dim]{snap.entity_count} entities[/dim]  {_SEP}  "
+        f"[dim]{snap.file_count} files[/dim]  {_SEP}  "
+        f"{_dot(snap.base_passed)} [dim]base[/dim]  "
+        f"{_dot(snap.isa_passed)} [dim]ISA[/dim]  "
+        f"{_dot(snap.tox_passed)} [dim]Tox[/dim]"
+        f"{token_str}"
+    )
+    return Group("", Padding(status, (0, 0, 0, 1)))
+
+
+def render_reply(content: Any) -> RenderableType:
+    """Render an agent reply: a green ``●`` marker beside left-indented Markdown.
+
+    Accepts raw message ``content`` (str or content-block list) and flattens
+    it first, so structured replies never leak (#341). Lighter than a
+    full-width panel; continuation lines align under the marker. Includes the
+    surrounding blank lines so both arms space replies identically.
+    """
+    text = flatten_message_content(content)
+    try:
+        body: RenderableType = Markdown(text)
+    except Exception:
+        body = text
+
+    grid = Table.grid(padding=(0, 0))
+    grid.add_column(width=2, no_wrap=True)
+    grid.add_column(overflow="fold")
+    grid.add_row("[green]●[/green]", body)
+    return Group("", "", grid, "")
+
+
+def render_resume_summary(snap: UiSnapshot) -> RenderableType:
+    """The "Resumed Session" panel — session id, counts, MIT, validation, breakdown."""
+    summary = Table.grid(padding=(0, 2))
+    summary.add_column(style="bold", width=16)
+    summary.add_column(style="white")
+
+    summary.add_row("Session:", f"[cyan]{snap.session_id}[/cyan]")
+    summary.add_row("Entities:", f"[green]{snap.entity_count}[/green]")
+    summary.add_row("Files:", f"[green]{snap.file_count}[/green]")
+
+    if snap.mit_score is not None:
+        summary.add_row("MIT score:", f"[yellow]{snap.mit_score:.0%}[/yellow]")
+
+    val_status = [
+        "[green]base[/green]" if snap.base_passed else "[red]base[/red]",
+        "[green]ISA[/green]" if snap.isa_passed else "[red]ISA[/red]",
+        "[green]ISA-Tox[/green]" if snap.tox_passed else "[red]ISA-Tox[/red]",
+    ]
+    summary.add_row("Validation:", "  ".join(val_status))
+
+    if snap.required_issue_count:
+        summary.add_row("Issues:", f"[red]{snap.required_issue_count} REQUIRED[/red]")
+
+    if snap.entity_counts:
+        parts = ", ".join(
+            f"[cyan]{k}[/cyan]={v}" for k, v in sorted(snap.entity_counts.items())
+        )
+        summary.add_row("Breakdown:", parts)
+
+    return Panel(summary, title="[yellow]Resumed Session[/yellow]", border_style="yellow")
+
+
+def render_goodbye(
+    session_id: str, entity_counts: dict[str, int], *, resumable: bool
+) -> RenderableType:
+    """The goodbye panel — session id, entity breakdown, and a resume hint.
+
+    Args:
+        session_id: The session identifier to echo.
+        entity_counts: Per-type entity counts (``{}`` renders "0").
+        resumable: When true, include the ``--resume`` command line (the
+            caller decides this, e.g. only when a ``sessions/`` dir exists).
+    """
+    t = Table.grid(padding=(0, 1))
+    t.add_column(style="yellow bold", width=14)
+    t.add_column(style="white")
+    t.add_row("Session:", f"[cyan]{session_id}[/cyan]")
+
+    if entity_counts:
+        parts = ", ".join(f"{k}={v}" for k, v in sorted(entity_counts.items()))
+        t.add_row("Entities:", parts)
+    else:
+        t.add_row("Entities:", "0")
+
+    if resumable:
+        t.add_row(
+            "Resume:",
+            f"python -m main [cyan]--resume {session_id}[/cyan] [dim]--interactive[/dim]",
+        )
+
+    return Panel(t, title="[yellow]Goodbye![/yellow]", border_style="yellow")
+
+
+# ---------------------------------------------------------------------------
+# Boxed prompt
+# ---------------------------------------------------------------------------
+
+
+def boxed_input(console: Console, label: str = "❯") -> str:
+    """Read one line of input inside a rounded box (Claude Code style).
+
+    Renders an ephemeral rounded box via ``prompt_toolkit``; once submitted the
+    box is erased and the line is echoed into the transcript so it persists.
+    Falls back to ``console.input`` when stdin is not a TTY or ``prompt_toolkit``
+    is unavailable. Raises ``KeyboardInterrupt`` (Ctrl+C) and ``EOFError``
+    (Ctrl+D on an empty line), matching ``input()``.
+    """
+
+    def _fallback() -> str:
+        return console.input(f"[bold cyan]{label} [/bold cyan]").strip()
+
+    if not sys.stdin.isatty():
+        return _fallback()
+    try:
+        from prompt_toolkit import Application
+        from prompt_toolkit.application.current import get_app
+        from prompt_toolkit.buffer import Buffer
+        from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.layout import HSplit, Layout, VSplit, Window
+        from prompt_toolkit.layout.controls import (
+            BufferControl,
+            FormattedTextControl,
+        )
+        from prompt_toolkit.styles import Style
+    except Exception:
+        return _fallback()
+
+    buf = Buffer(multiline=False)
+    outcome: dict[str, Any] = {"exc": None}
+    kb = KeyBindings()
+
+    @kb.add("enter")
+    def _(event: Any) -> None:
+        event.app.exit(result=buf.text)
+
+    @kb.add("c-c")
+    def _(event: Any) -> None:
+        outcome["exc"] = KeyboardInterrupt
+        event.app.exit(result="")
+
+    @kb.add("c-d")
+    def _(event: Any) -> None:
+        if not buf.text:
+            outcome["exc"] = EOFError
+            event.app.exit(result="")
+
+    def _hline(left: str, right: str):
+        def _get() -> list[tuple[str, str]]:
+            w = get_app().output.get_size().columns
+            return [("class:box", left + "─" * max(0, w - 2) + right)]
+
+        return _get
+
+    buf_window = Window(BufferControl(buffer=buf))
+    middle = VSplit(
+        [
+            Window(
+                FormattedTextControl([("class:box", "│ "), ("class:prompt", f"{label} ")]),
+                width=4,
+            ),
+            buf_window,
+            Window(FormattedTextControl([("class:box", " │")]), width=2),
+        ],
+        height=1,
+    )
+    root = HSplit(
+        [
+            Window(FormattedTextControl(_hline("╭", "╮")), height=1),
+            middle,
+            Window(FormattedTextControl(_hline("╰", "╯")), height=1),
+        ]
+    )
+    style = Style.from_dict({"box": "fg:#5f5f5f", "prompt": "bold ansicyan"})
+    app: Any = Application(
+        layout=Layout(root, focused_element=buf_window),
+        key_bindings=kb,
+        style=style,
+        full_screen=False,
+    )
+    try:
+        text = app.run()
+    except Exception:
+        return _fallback()
+
+    if outcome["exc"] is not None:
+        raise outcome["exc"]
+    text = (text or "").strip()
+    if text:
+        # The box was ephemeral — echo the submitted line into the transcript.
+        console.print(f"[bold cyan]{label}[/bold cyan] {text}")
+    return text

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rich.console import Console, Group, RenderableType
@@ -323,6 +324,57 @@ def render_goodbye(
         )
 
     return Panel(t, title="[yellow]Goodbye![/yellow]", border_style="yellow")
+
+
+# ---------------------------------------------------------------------------
+# Print-for-engine helpers — the ONE place "snapshot → render → print to the
+# shared console" lives, so both build arms call the same code instead of each
+# inlining its own copy (#344). The pure render_* above stay unit-testable; these
+# thin impure wrappers are what the ReAct loop and the pipeline both invoke.
+# ---------------------------------------------------------------------------
+
+
+def print_status_bar(engine: AgentEngine) -> None:
+    """Print the one-line status bar for *engine*'s current state (both arms).
+
+    The per-prompt status line the ReAct loop shows before every input and the
+    pipeline shows before every guidance question. ``engine.state.validation`` is
+    authoritative by the time either arm calls this (the pipeline's final
+    ``build_and_validate`` runs via ``engine.run_tool``, whose #153 write-back
+    folds conformance into state), so the base/ISA/Tox dots read real values.
+    """
+    get_console().print(render_status_bar(snapshot_from_engine(engine)))
+
+
+def print_resume_summary(engine: AgentEngine) -> None:
+    """Print the resume summary panel when the session carries prior work (both arms).
+
+    A no-op on a fresh session (no entities, no scanned files) — there is nothing
+    to summarise — so callers need no guard of their own.
+    """
+    snap = snapshot_from_engine(engine)
+    if snap.entity_count or snap.file_count:
+        console = get_console()
+        console.print(render_resume_summary(snap))
+        console.print()
+
+
+def print_goodbye(engine: AgentEngine, *, resumable: bool | None = None) -> None:
+    """Print the goodbye panel for *engine*'s session, with breathing room (both arms).
+
+    Args:
+        engine: The engine whose ``state`` (session id + entity breakdown) is shown.
+        resumable: Whether to include the ``--resume`` hint. Defaults to *None* →
+            shown when a ``sessions/`` directory exists (the check both arms used);
+            pass an explicit bool to override.
+    """
+    if resumable is None:
+        resumable = Path("sessions").is_dir()
+    snap = snapshot_from_engine(engine)
+    console = get_console()
+    console.print()
+    console.print(render_goodbye(snap.session_id, snap.entity_counts, resumable=resumable))
+    console.print()
 
 
 # ---------------------------------------------------------------------------

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -199,6 +199,15 @@ def _default_console_prompt(field_type: str) -> str:
     return input(f"({field_type}) > ")
 
 
+def _default_console_show(text: str) -> None:
+    """Plain-terminal question display — the default when no styled renderer is
+    injected. The CLI injects a renderer that styles the question as a green-●
+    reply (:func:`builder.agents.ui.render_reply`); the injection keeps ``hitl``
+    free of a ``builder.agents.ui`` import (no ``agents → tools → agents`` cycle).
+    """
+    print(text)
+
+
 class ConsoleHumanInterface:
     """A REAL interactive HITL interface that prompts on the terminal (stdin).
 
@@ -209,10 +218,14 @@ class ConsoleHumanInterface:
     confirmations to the user.
 
     The free-text prompt is read through an injectable ``prompt_func`` (a
-    ``field_type -> text`` reader). It defaults to a plain ``input()`` so this
-    module never imports the UI layer (avoiding an ``agents → tools → agents``
-    cycle); the CLI injects :func:`builder.agents.ui.boxed_input` so the pipeline's
-    HITL prompt renders through the SAME rounded box the ReAct arm uses (#344).
+    ``field_type -> text`` reader) and the question is displayed through an
+    injectable ``show_func`` (a ``text -> None`` renderer). Both default to plain
+    terminal I/O so this module never imports the UI layer (avoiding an
+    ``agents → tools → agents`` cycle); the CLI injects
+    :func:`builder.agents.ui.boxed_input` for the box and
+    :func:`builder.agents.ui.render_reply` for the question, so the pipeline's HITL
+    prompt renders through the SAME rounded box and green-● styling the ReAct arm
+    uses (#344).
 
     A scan-root escalation still routes through the user — they are the only
     legitimate approver for widening filesystem access (#197); a non-affirmative
@@ -223,16 +236,25 @@ class ConsoleHumanInterface:
 
     is_interactive: bool = True
 
-    def __init__(self, prompt_func: Callable[[str], str] | None = None) -> None:
-        """Build the interface, optionally injecting the free-text prompt reader.
+    def __init__(
+        self,
+        prompt_func: Callable[[str], str] | None = None,
+        show_func: Callable[[str], None] | None = None,
+    ) -> None:
+        """Build the interface, optionally injecting the prompt reader + display.
 
         Args:
             prompt_func: A ``field_type -> entered-text`` reader used by
                 :meth:`request_input`. Defaults to :func:`_default_console_prompt`
                 (a plain ``input()``). The CLI passes a reader bound to the shared
                 rounded box (:func:`builder.agents.ui.boxed_input`).
+            show_func: A ``text -> None`` renderer that displays the question.
+                Defaults to :func:`_default_console_show` (a plain ``print``). The
+                CLI passes a renderer that styles it as a green-● reply
+                (:func:`builder.agents.ui.render_reply`).
         """
         self._read: Callable[[str], str] = prompt_func or _default_console_prompt
+        self._show: Callable[[str], None] = show_func or _default_console_show
 
     def present(
         self,
@@ -263,12 +285,13 @@ class ConsoleHumanInterface:
     def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
         """Prompt the user for a value; an empty answer (or EOF) is a skip.
 
-        Reads via the injected ``prompt_func`` (the shared rounded box in the CLI,
-        a plain ``input()`` otherwise), suspending any active terminal spinner so
-        stdin is not fighting a Rich Live repaint.
+        Displays the question via the injected ``show_func`` (a green-● reply in
+        the CLI, a plain ``print`` otherwise) and reads via the injected
+        ``prompt_func`` (the shared rounded box in the CLI), suspending any active
+        terminal spinner so stdin is not fighting a Rich Live repaint.
         """
         with suspend_console_animation():
-            print(prompt)
+            self._show(prompt)
             try:
                 value = self._read(field_type).strip()
             except EOFError:

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 
 logger = logging.getLogger(__name__)
@@ -188,6 +188,17 @@ class SimulatedHumanInterface:
         return {"value": None, "skipped": True}
 
 
+def _default_console_prompt(field_type: str) -> str:
+    """Plain-terminal input reader — the default when no UI box is injected.
+
+    Kept here (not in :mod:`builder.agents.ui`) so ``hitl`` stays independent of
+    the UI layer: importing ``builder.agents.ui`` from a ``builder.tools`` module
+    would form an ``agents → tools → agents`` import cycle. The CLI injects the
+    shared rounded ``❯`` box via ``ConsoleHumanInterface(prompt_func=...)`` instead.
+    """
+    return input(f"({field_type}) > ")
+
+
 class ConsoleHumanInterface:
     """A REAL interactive HITL interface that prompts on the terminal (stdin).
 
@@ -195,7 +206,13 @@ class ConsoleHumanInterface:
     (`main.py --interactive` → `run_interactive_build`, AGENTS.md §14.6.1). Unlike
     :class:`SimulatedHumanInterface` it is ``is_interactive = True``, so the
     guidance tail actually runs and routes its ask-user prompts / draft
-    confirmations to the user via ``input()``.
+    confirmations to the user.
+
+    The free-text prompt is read through an injectable ``prompt_func`` (a
+    ``field_type -> text`` reader). It defaults to a plain ``input()`` so this
+    module never imports the UI layer (avoiding an ``agents → tools → agents``
+    cycle); the CLI injects :func:`builder.agents.ui.boxed_input` so the pipeline's
+    HITL prompt renders through the SAME rounded box the ReAct arm uses (#344).
 
     A scan-root escalation still routes through the user — they are the only
     legitimate approver for widening filesystem access (#197); a non-affirmative
@@ -205,6 +222,17 @@ class ConsoleHumanInterface:
     """
 
     is_interactive: bool = True
+
+    def __init__(self, prompt_func: Callable[[str], str] | None = None) -> None:
+        """Build the interface, optionally injecting the free-text prompt reader.
+
+        Args:
+            prompt_func: A ``field_type -> entered-text`` reader used by
+                :meth:`request_input`. Defaults to :func:`_default_console_prompt`
+                (a plain ``input()``). The CLI passes a reader bound to the shared
+                rounded box (:func:`builder.agents.ui.boxed_input`).
+        """
+        self._read: Callable[[str], str] = prompt_func or _default_console_prompt
 
     def present(
         self,
@@ -233,11 +261,16 @@ class ConsoleHumanInterface:
         return {"action": action, "comments": None, "edits": None}
 
     def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
-        """Prompt the user for a value; an empty answer (or EOF) is a skip."""
+        """Prompt the user for a value; an empty answer (or EOF) is a skip.
+
+        Reads via the injected ``prompt_func`` (the shared rounded box in the CLI,
+        a plain ``input()`` otherwise), suspending any active terminal spinner so
+        stdin is not fighting a Rich Live repaint.
+        """
         with suspend_console_animation():
             print(prompt)
             try:
-                value = input(f"({field_type}) > ").strip()
+                value = self._read(field_type).strip()
             except EOFError:
                 value = ""
         if not value:

--- a/main.py
+++ b/main.py
@@ -441,13 +441,15 @@ def main(argv: list[str] | None = None) -> int:
         from builder.agents import ui
         from builder.tools.hitl import ConsoleHumanInterface
 
-        # Inject the shared rounded ❯ box (#344) as the HITL free-text reader so
-        # the pipeline's guidance prompts render like the ReAct arm's. Injection
+        # Inject the shared rounded ❯ box + green-● question styling (#344) so the
+        # pipeline's guidance prompts render like the ReAct arm's: the question is
+        # shown via ui.render_reply, the answer read via ui.boxed_input. Injection
         # (not an import inside hitl.py) keeps builder.tools free of a
         # builder.agents.ui dependency — no agents→tools→agents cycle.
         engine = AgentEngine(
             human_interface=ConsoleHumanInterface(
-                prompt_func=lambda _field_type: ui.boxed_input(ui.get_console())
+                prompt_func=lambda _field_type: ui.boxed_input(ui.get_console()),
+                show_func=lambda text: ui.get_console().print(ui.render_reply(text)),
             )
         )
     else:

--- a/main.py
+++ b/main.py
@@ -438,9 +438,18 @@ def main(argv: list[str] | None = None) -> int:
     # legacy scan of an un-approved folder returns no files. Non-interactive
     # (batch) runs keep the headless simulated default.
     if args.interactive:
+        from builder.agents import ui
         from builder.tools.hitl import ConsoleHumanInterface
 
-        engine = AgentEngine(human_interface=ConsoleHumanInterface())
+        # Inject the shared rounded ❯ box (#344) as the HITL free-text reader so
+        # the pipeline's guidance prompts render like the ReAct arm's. Injection
+        # (not an import inside hitl.py) keeps builder.tools free of a
+        # builder.agents.ui dependency — no agents→tools→agents cycle.
+        engine = AgentEngine(
+            human_interface=ConsoleHumanInterface(
+                prompt_func=lambda _field_type: ui.boxed_input(ui.get_console())
+            )
+        )
     else:
         engine = AgentEngine()
 

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -1,21 +1,36 @@
 """Unit tests for the shared interactive-UI layer (``builder/agents/ui.py``).
 
-These exercise the arm-neutral render functions offline — no TTY, no live
-engine — by rendering each Rich renderable into a recording console and
-asserting on the exported plain text. ``flatten_message_content`` is the
-#341 leak-fix helper and is tested directly as a pure string function.
+Two seams, tested at their real public entry points:
+
+* the ``render_*`` functions are pure formatters — their real input is a
+  :class:`~builder.agents.ui.UiSnapshot`, so the tests build snapshot literals
+  (no mock stands in for anything) and assert on the exported plain text;
+* ``snapshot_from_engine`` is the one impure adapter — it is driven over a
+  **real** ``AgentEngine``/``CrateState`` populated with real ``Entity`` /
+  ``FileClassification`` / ``ValidationReport`` objects, so a regression in how
+  state exposes entities or validation reddens the test.
+
+``flatten_message_content`` (the #341 leak fix) is tested directly as a pure
+string function and again through ``render_reply`` (its real call site).
 """
 
 from __future__ import annotations
 
+import dataclasses
 import io
 from types import SimpleNamespace
-from typing import Any
 
 from rich.console import Console, RenderableType
 
 from builder.agents import ui
-from builder.state import ValidationReport
+from builder.engine import AgentEngine
+from builder.state import (
+    CrateState,
+    Entity,
+    EntityProvenance,
+    FileClassification,
+    ValidationReport,
+)
 
 
 def _render(renderable: RenderableType, width: int = 100) -> str:
@@ -25,32 +40,67 @@ def _render(renderable: RenderableType, width: int = 100) -> str:
     return console.export_text()
 
 
-def _fake_engine(
-    *,
-    session_id: str = "sess-1",
-    files: int = 3,
-    entities: list[Any] | None = None,
-    validation: ValidationReport | None = None,
-    mit_score: float | None = 0.75,
-) -> SimpleNamespace:
-    if entities is None:
-        entities = [
-            SimpleNamespace(type="Investigation"),
-            SimpleNamespace(type="Study"),
-            SimpleNamespace(type="Study"),
-        ]
-    if validation is None:
-        validation = ValidationReport(
-            base_passed=True, isa_passed=False, tox_passed=False, required_issues=["x"]
+_BASE_SNAPSHOT = ui.UiSnapshot(
+    session_id="sess-1",
+    entity_count=3,
+    file_count=3,
+    base_passed=True,
+    isa_passed=False,
+    tox_passed=False,
+    required_issue_count=1,
+    entity_counts={"Investigation": 1, "Study": 2},
+    mit_score=0.75,
+    tokens_in=0,
+    tokens_out=0,
+    cost_usd=None,
+)
+
+
+def _snapshot(**overrides: object) -> ui.UiSnapshot:
+    """A ``UiSnapshot`` literal — the renderers' real, direct public input."""
+    return dataclasses.replace(_BASE_SNAPSHOT, **overrides)
+
+
+def _real_engine(populated: bool = True) -> AgentEngine:
+    """A real ``AgentEngine`` over a real ``CrateState`` (the adapter's real input).
+
+    ``populated=False`` returns a fresh, un-built session (the meaningful empty
+    edge). ``human_interface`` is left ``None`` so the engine wires its real
+    ``SimulatedHumanInterface`` default rather than a hand-written double.
+    """
+    state = CrateState(session_id="sess-1")
+    if populated:
+        state.add_entity(
+            Entity(
+                entity_id="inv_001",
+                type="Investigation",
+                fields={"title": "I"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
         )
-    state = SimpleNamespace(
-        session_id=session_id,
-        scanned_files=list(range(files)),
-        validation=validation,
-        mit_assessment=SimpleNamespace(overall_score=mit_score),
-        list_entities=lambda entity_type=None: list(entities),
-    )
-    return SimpleNamespace(state=state)
+        for i in (1, 2):
+            state.add_entity(
+                Entity(
+                    entity_id=f"stu_00{i}",
+                    type="Study",
+                    fields={"title": f"S{i}"},
+                    _provenance=EntityProvenance(created_by="llm"),
+                )
+            )
+        state.scanned_files = [
+            FileClassification(
+                path=f"/d/f{i}.csv", filename=f"f{i}.csv", size=10, mime_type="text/csv"
+            )
+            for i in range(3)
+        ]
+        state.validation = ValidationReport(
+            base_passed=True,
+            isa_passed=False,
+            tox_passed=False,
+            required_issues=["missing publisher"],
+        )
+        state.mit_assessment.overall_score = 0.75
+    return AgentEngine(state=state)
 
 
 # ---------------------------------------------------------------------------
@@ -104,12 +154,12 @@ def test_flatten_list_of_plain_strings() -> None:
 
 
 # ---------------------------------------------------------------------------
-# UiSnapshot / snapshot_from_engine
+# snapshot_from_engine — driven over a real engine/state
 # ---------------------------------------------------------------------------
 
 
-def test_snapshot_from_engine_reads_state() -> None:
-    snap = ui.snapshot_from_engine(_fake_engine())
+def test_snapshot_from_engine_reads_real_state() -> None:
+    snap = ui.snapshot_from_engine(_real_engine())
     assert snap.session_id == "sess-1"
     assert snap.entity_count == 3
     assert snap.file_count == 3
@@ -119,17 +169,21 @@ def test_snapshot_from_engine_reads_state() -> None:
     assert snap.required_issue_count == 1
     assert snap.entity_counts == {"Investigation": 1, "Study": 2}
     assert snap.mit_score == 0.75
-    # No profile.ndjson for this fake session → token totals default to zero.
+    # No profile.ndjson for this session → token totals default to zero.
     assert snap.tokens_in == 0
     assert snap.tokens_out == 0
     assert snap.cost_usd is None
 
 
-def test_snapshot_handles_missing_mit_assessment() -> None:
-    engine = _fake_engine()
-    del engine.state.mit_assessment
-    snap = ui.snapshot_from_engine(engine)
-    assert snap.mit_score is None
+def test_snapshot_from_fresh_engine_is_empty() -> None:
+    snap = ui.snapshot_from_engine(_real_engine(populated=False))
+    assert snap.entity_count == 0
+    assert snap.file_count == 0
+    assert snap.entity_counts == {}
+    assert snap.base_passed is False
+    assert snap.required_issue_count == 0
+    # A fresh MITReport scores 0.0 (assessed-but-empty), not None.
+    assert snap.mit_score == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -138,8 +192,7 @@ def test_snapshot_handles_missing_mit_assessment() -> None:
 
 
 def test_render_status_bar_shows_counts_and_validation() -> None:
-    snap = ui.snapshot_from_engine(_fake_engine())
-    text = _render(ui.render_status_bar(snap))
+    text = _render(ui.render_status_bar(_snapshot()))
     assert "sess-1" in text
     assert "3 entities" in text
     assert "3 files" in text
@@ -149,26 +202,22 @@ def test_render_status_bar_shows_counts_and_validation() -> None:
 
 
 def test_render_status_bar_shows_tokens_when_present() -> None:
-    snap = ui.UiSnapshot(
-        session_id="s",
-        entity_count=0,
-        file_count=0,
-        base_passed=False,
-        isa_passed=False,
-        tox_passed=False,
-        required_issue_count=0,
-        entity_counts={},
-        mit_score=None,
-        tokens_in=100,
-        tokens_out=50,
-        cost_usd=0.0012,
+    text = _render(
+        ui.render_status_bar(_snapshot(tokens_in=100, tokens_out=50, cost_usd=0.0012))
     )
-    text = _render(ui.render_status_bar(snap))
-    assert "100" in text and "50" in text
+    # tok 100→50 (150)@$…
+    assert "100" in text
+    assert "50" in text
+    assert "150" in text
+
+
+def test_render_status_bar_hides_tokens_when_zero() -> None:
+    text = _render(ui.render_status_bar(_snapshot(tokens_in=0, tokens_out=0)))
+    assert "tok" not in text
 
 
 # ---------------------------------------------------------------------------
-# render_reply
+# render_reply — flattens structured content at its real call site (#341)
 # ---------------------------------------------------------------------------
 
 
@@ -179,17 +228,33 @@ def test_render_reply_shows_text_and_marker() -> None:
     assert "●" in text
 
 
+def test_render_reply_flattens_structured_content_no_leak() -> None:
+    content = [
+        {
+            "type": "text",
+            "text": "The next step is the ISA backbone.",
+            "annotations": [],
+            "id": "msg_abc",
+            "phase": "final_answer",
+        }
+    ]
+    text = _render(ui.render_reply(content))
+    assert "ISA backbone" in text
+    assert "annotations" not in text
+    assert "msg_abc" not in text
+
+
 # ---------------------------------------------------------------------------
 # render_resume_summary
 # ---------------------------------------------------------------------------
 
 
-def test_render_resume_summary_shows_session_and_counts() -> None:
-    snap = ui.snapshot_from_engine(_fake_engine())
-    text = _render(ui.render_resume_summary(snap))
+def test_render_resume_summary_shows_session_and_breakdown() -> None:
+    text = _render(ui.render_resume_summary(_snapshot()))
     assert "Resumed Session" in text
     assert "sess-1" in text
     assert "Investigation" in text
+    assert "MIT score" in text
 
 
 # ---------------------------------------------------------------------------
@@ -198,12 +263,15 @@ def test_render_resume_summary_shows_session_and_counts() -> None:
 
 
 def test_render_goodbye_shows_session_and_entities() -> None:
-    text = _render(
-        ui.render_goodbye("sess-9", {"Study": 2}, resumable=True)
-    )
+    text = _render(ui.render_goodbye("sess-9", {"Study": 2}, resumable=True))
     assert "Goodbye" in text
     assert "sess-9" in text
     assert "Study=2" in text
+
+
+def test_render_goodbye_zero_entities_when_empty() -> None:
+    text = _render(ui.render_goodbye("sess-9", {}, resumable=False))
+    assert "0" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -275,6 +275,48 @@ def test_render_goodbye_zero_entities_when_empty() -> None:
 
 
 # ---------------------------------------------------------------------------
+# print_* helpers — the shared "snapshot → render → print" both arms call
+# ---------------------------------------------------------------------------
+
+
+def _rec() -> Console:
+    """A recording console captured in place of the shared one."""
+    return Console(width=100, file=io.StringIO(), record=True, color_system=None)
+
+
+def test_print_status_bar_prints_for_engine(monkeypatch) -> None:
+    rec = _rec()
+    monkeypatch.setattr(ui, "get_console", lambda: rec)
+    ui.print_status_bar(_real_engine())
+    out = rec.export_text()
+    assert "sess-1" in out
+    assert "entities" in out
+
+
+def test_print_resume_summary_prints_when_populated(monkeypatch) -> None:
+    rec = _rec()
+    monkeypatch.setattr(ui, "get_console", lambda: rec)
+    ui.print_resume_summary(_real_engine())
+    assert "Resumed Session" in rec.export_text()
+
+
+def test_print_resume_summary_is_noop_on_fresh_session(monkeypatch) -> None:
+    rec = _rec()
+    monkeypatch.setattr(ui, "get_console", lambda: rec)
+    ui.print_resume_summary(_real_engine(populated=False))
+    assert rec.export_text() == ""
+
+
+def test_print_goodbye_prints_for_engine(monkeypatch) -> None:
+    rec = _rec()
+    monkeypatch.setattr(ui, "get_console", lambda: rec)
+    ui.print_goodbye(_real_engine(), resumable=False)
+    out = rec.export_text()
+    assert "Goodbye" in out
+    assert "sess-1" in out
+
+
+# ---------------------------------------------------------------------------
 # get_console
 # ---------------------------------------------------------------------------
 

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -1,0 +1,216 @@
+"""Unit tests for the shared interactive-UI layer (``builder/agents/ui.py``).
+
+These exercise the arm-neutral render functions offline — no TTY, no live
+engine — by rendering each Rich renderable into a recording console and
+asserting on the exported plain text. ``flatten_message_content`` is the
+#341 leak-fix helper and is tested directly as a pure string function.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from typing import Any
+
+from rich.console import Console, RenderableType
+
+from builder.agents import ui
+from builder.state import ValidationReport
+
+
+def _render(renderable: RenderableType, width: int = 100) -> str:
+    """Render a Rich renderable to plain text for assertions."""
+    console = Console(width=width, file=io.StringIO(), record=True, color_system=None)
+    console.print(renderable)
+    return console.export_text()
+
+
+def _fake_engine(
+    *,
+    session_id: str = "sess-1",
+    files: int = 3,
+    entities: list[Any] | None = None,
+    validation: ValidationReport | None = None,
+    mit_score: float | None = 0.75,
+) -> SimpleNamespace:
+    if entities is None:
+        entities = [
+            SimpleNamespace(type="Investigation"),
+            SimpleNamespace(type="Study"),
+            SimpleNamespace(type="Study"),
+        ]
+    if validation is None:
+        validation = ValidationReport(
+            base_passed=True, isa_passed=False, tox_passed=False, required_issues=["x"]
+        )
+    state = SimpleNamespace(
+        session_id=session_id,
+        scanned_files=list(range(files)),
+        validation=validation,
+        mit_assessment=SimpleNamespace(overall_score=mit_score),
+        list_entities=lambda entity_type=None: list(entities),
+    )
+    return SimpleNamespace(state=state)
+
+
+# ---------------------------------------------------------------------------
+# flatten_message_content — the #341 raw-message-leak fix
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_plain_string_passthrough() -> None:
+    assert ui.flatten_message_content("hello world") == "hello world"
+
+
+def test_flatten_none_is_empty() -> None:
+    assert ui.flatten_message_content(None) == ""
+
+
+def test_flatten_list_of_text_blocks_joins_text_only() -> None:
+    # The exact #341 shape: a list of content-block dicts. Only the `text`
+    # survives; annotations/id/phase must NOT leak.
+    content = [
+        {
+            "type": "text",
+            "text": "Welcome back. The session has 3 scanned files.",
+            "annotations": [],
+            "id": "msg_0e84aa37",
+            "phase": "final_answer",
+        }
+    ]
+    out = ui.flatten_message_content(content)
+    assert out == "Welcome back. The session has 3 scanned files."
+    assert "annotations" not in out
+    assert "msg_0e84aa37" not in out
+    assert "phase" not in out
+
+
+def test_flatten_drops_non_text_blocks() -> None:
+    content = [
+        {"type": "text", "text": "before "},
+        {"type": "tool_use", "name": "scan", "id": "toolu_1"},
+        {"type": "text", "text": "after"},
+    ]
+    assert ui.flatten_message_content(content) == "before after"
+
+
+def test_flatten_langchain_block_objects_with_text_attr() -> None:
+    content = [SimpleNamespace(type="text", text="obj-text")]
+    assert ui.flatten_message_content(content) == "obj-text"
+
+
+def test_flatten_list_of_plain_strings() -> None:
+    assert ui.flatten_message_content(["a", "b"]) == "ab"
+
+
+# ---------------------------------------------------------------------------
+# UiSnapshot / snapshot_from_engine
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_from_engine_reads_state() -> None:
+    snap = ui.snapshot_from_engine(_fake_engine())
+    assert snap.session_id == "sess-1"
+    assert snap.entity_count == 3
+    assert snap.file_count == 3
+    assert snap.base_passed is True
+    assert snap.isa_passed is False
+    assert snap.tox_passed is False
+    assert snap.required_issue_count == 1
+    assert snap.entity_counts == {"Investigation": 1, "Study": 2}
+    assert snap.mit_score == 0.75
+    # No profile.ndjson for this fake session → token totals default to zero.
+    assert snap.tokens_in == 0
+    assert snap.tokens_out == 0
+    assert snap.cost_usd is None
+
+
+def test_snapshot_handles_missing_mit_assessment() -> None:
+    engine = _fake_engine()
+    del engine.state.mit_assessment
+    snap = ui.snapshot_from_engine(engine)
+    assert snap.mit_score is None
+
+
+# ---------------------------------------------------------------------------
+# render_status_bar
+# ---------------------------------------------------------------------------
+
+
+def test_render_status_bar_shows_counts_and_validation() -> None:
+    snap = ui.snapshot_from_engine(_fake_engine())
+    text = _render(ui.render_status_bar(snap))
+    assert "sess-1" in text
+    assert "3 entities" in text
+    assert "3 files" in text
+    assert "base" in text
+    assert "ISA" in text
+    assert "Tox" in text
+
+
+def test_render_status_bar_shows_tokens_when_present() -> None:
+    snap = ui.UiSnapshot(
+        session_id="s",
+        entity_count=0,
+        file_count=0,
+        base_passed=False,
+        isa_passed=False,
+        tox_passed=False,
+        required_issue_count=0,
+        entity_counts={},
+        mit_score=None,
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.0012,
+    )
+    text = _render(ui.render_status_bar(snap))
+    assert "100" in text and "50" in text
+
+
+# ---------------------------------------------------------------------------
+# render_reply
+# ---------------------------------------------------------------------------
+
+
+def test_render_reply_shows_text_and_marker() -> None:
+    text = _render(ui.render_reply("Hello **world**"))
+    assert "Hello" in text
+    assert "world" in text
+    assert "●" in text
+
+
+# ---------------------------------------------------------------------------
+# render_resume_summary
+# ---------------------------------------------------------------------------
+
+
+def test_render_resume_summary_shows_session_and_counts() -> None:
+    snap = ui.snapshot_from_engine(_fake_engine())
+    text = _render(ui.render_resume_summary(snap))
+    assert "Resumed Session" in text
+    assert "sess-1" in text
+    assert "Investigation" in text
+
+
+# ---------------------------------------------------------------------------
+# render_goodbye
+# ---------------------------------------------------------------------------
+
+
+def test_render_goodbye_shows_session_and_entities() -> None:
+    text = _render(
+        ui.render_goodbye("sess-9", {"Study": 2}, resumable=True)
+    )
+    assert "Goodbye" in text
+    assert "sess-9" in text
+    assert "Study=2" in text
+
+
+# ---------------------------------------------------------------------------
+# get_console
+# ---------------------------------------------------------------------------
+
+
+def test_get_console_is_memoized() -> None:
+    assert ui.get_console() is ui.get_console()
+    assert isinstance(ui.get_console(), Console)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -519,12 +519,12 @@ class TestBuildLangchainTools:
 
 
 class _FakeSpinner:
-    """Records set_tool calls for callback tests."""
+    """Records set_current calls for callback tests (the shared ProgressSpinner API)."""
 
     def __init__(self):
         self.tools: list = []
 
-    def set_tool(self, name) -> None:
+    def set_current(self, name) -> None:
         self.tools.append(name)
 
 
@@ -567,29 +567,6 @@ class TestToolSpinnerCallback:
         cb.on_tool_end("result")
 
         assert spinner.tools == ["lookup_compound", None]
-
-
-class TestThinkingSpinner:
-    """The spinner renders the phrase, elapsed seconds, and active tool."""
-
-    def test_render_includes_phrase_and_elapsed(self):
-        from rich.console import Console
-
-        from builder.agents.react.agent_loop import _ThinkingSpinner
-
-        sp = _ThinkingSpinner(Console(), "intoxicating")
-        text = sp._render()
-        assert "intoxicating" in text
-        assert "s)" in text  # elapsed seconds, e.g. "(0s)"
-
-    def test_render_includes_tool_when_set(self):
-        from rich.console import Console
-
-        from builder.agents.react.agent_loop import _ThinkingSpinner
-
-        sp = _ThinkingSpinner(Console(), "intoxicating")
-        sp._tool = "scan_files"
-        assert "scan_files" in sp._render()
 
 
 class TestMainInteractiveFlag:
@@ -860,77 +837,6 @@ class TestTrimHistory:
         inner = msgs[1:-1]
         assert len(inner) < len(history)
         assert TestTrimHistory._no_orphans(inner)
-
-
-class TestThinkingSpinnerPause:
-    """The thinking spinner must yield the terminal to a HITL prompt.
-
-    A scan-root approval (or any ask-user) calls ``input()`` mid-``invoke`` while
-    the spinner's Rich Live region is repainting; without a pause the prompt is
-    clobbered and stdin is unusable. The spinner registers itself as the active
-    console animation so ``suspend_console_animation`` can pause/resume it.
-    """
-
-    class _FakeStatus:
-        def __init__(self) -> None:
-            self.events: list[str] = []
-
-        def start(self) -> None:
-            self.events.append("start")
-
-        def stop(self) -> None:
-            self.events.append("stop")
-
-        def update(self, *_a, **_k) -> None:
-            pass
-
-        def __enter__(self):
-            self.start()
-            return self
-
-        def __exit__(self, *_a) -> None:
-            self.stop()
-
-    class _FakeConsole:
-        def __init__(self, status) -> None:
-            self._status = status
-
-        def status(self, *_a, **_k):
-            return self._status
-
-    def test_pause_stops_and_resume_starts_the_live_region(self) -> None:
-        from builder.agents.react.agent_loop import _ThinkingSpinner
-
-        st = self._FakeStatus()
-        sp = _ThinkingSpinner(self._FakeConsole(st), "x")
-
-        sp.pause()
-        assert sp._paused.is_set() is True
-        assert "stop" in st.events
-
-        sp.resume()
-        assert sp._paused.is_set() is False
-        assert "start" in st.events
-
-    def test_suspend_console_animation_pauses_then_resumes_spinner(self) -> None:
-        from builder.agents.react.agent_loop import _ThinkingSpinner
-        from builder.tools.hitl import (
-            register_console_animation,
-            suspend_console_animation,
-            unregister_console_animation,
-        )
-
-        st = self._FakeStatus()
-        sp = _ThinkingSpinner(self._FakeConsole(st), "x")
-        register_console_animation(sp)
-        try:
-            with suspend_console_animation():
-                paused_in_body = sp._paused.is_set()
-        finally:
-            unregister_console_animation(sp)
-
-        assert paused_in_body is True  # paused for the duration of the prompt
-        assert sp._paused.is_set() is False  # resumed after
 
 
 class TestCompletenessNudge:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1468,7 +1468,7 @@ class _LoopHarness:
             harness.stdin_reads.append(line)
             return line
 
-        self.monkeypatch.setattr(agent_loop, "_boxed_input", fake_boxed_input)
+        self.monkeypatch.setattr(agent_loop.ui, "boxed_input", fake_boxed_input)
 
         # Count backstop invocations; do not touch disk.
         def fake_backstop(engine, *, emit=None):
@@ -1623,7 +1623,7 @@ class TestTimeoutEndsTurnGracefully:
                 raise EOFError
             return stdin.pop(0)
 
-        monkeypatch.setattr(agent_loop, "_boxed_input", fake_boxed_input)
+        monkeypatch.setattr(agent_loop.ui, "boxed_input", fake_boxed_input)
 
         def fake_backstop(engine, *, emit=None):
             backstop_calls["n"] += 1

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -907,3 +907,22 @@ class TestSharedChrome:
         )
 
         assert "Resumed Session" in rec.export_text()
+
+    def test_interactive_build_renders_goodbye(self, monkeypatch) -> None:
+        from builder.agents import build, ui
+
+        rec = _rec_console()
+        monkeypatch.setattr(ui, "get_console", lambda: rec)
+        engine = _engine(_InteractiveHuman())
+
+        build.run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            exporter=_stub_export,
+        )
+
+        out = rec.export_text()
+        # The shared goodbye panel: title + session id (the --resume hint's anchor).
+        assert "Goodbye" in out
+        assert engine.state.session_id in out

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -98,7 +98,13 @@ class TestInteractiveGating:
         assert pipeline_calls[0] is engine
         assert len(guidance_calls) == 1
         assert guidance_calls[0][0] is engine
-        assert guidance_calls[0][1] is engine.human_interface
+        # Guidance receives the status-bar wrapper around the real interface (#344),
+        # so each gap question is headed by the shared status line.
+        from builder.agents.build import _StatusBarHuman
+
+        passed_human = guidance_calls[0][1]
+        assert isinstance(passed_human, _StatusBarHuman)
+        assert passed_human._inner is engine.human_interface
         assert result["guidance"] == _GUIDANCE_RESULT
 
     def test_simulated_human_skips_guidance(self) -> None:
@@ -926,3 +932,57 @@ class TestSharedChrome:
         # The shared goodbye panel: title + session id (the --resume hint's anchor).
         assert "Goodbye" in out
         assert engine.state.session_id in out
+
+    def test_status_bar_human_renders_before_prompt_and_delegates(self, monkeypatch) -> None:
+        from builder.agents import build, ui
+
+        rec = _rec_console()
+        monkeypatch.setattr(ui, "get_console", lambda: rec)
+        engine = _engine(_InteractiveHuman())
+
+        inner_calls: list[Any] = []
+
+        class _Inner:
+            is_interactive = True
+
+            def request_input(self, prompt, field_type="text"):
+                inner_calls.append((prompt, field_type))
+                return {"value": "x", "skipped": False}
+
+            def present(self, context, options=None, purpose=None):
+                return {"action": "approved", "comments": None, "edits": None}
+
+        wrapped = build._StatusBarHuman(_Inner(), engine)
+        resp = wrapped.request_input("Describe the study", "text")
+
+        # Delegates the read to the inner interface…
+        assert resp == {"value": "x", "skipped": False}
+        assert inner_calls == [("Describe the study", "text")]
+        # …after rendering a status bar (same shared line as the ReAct loop).
+        out = rec.export_text()
+        assert engine.state.session_id in out
+        assert "entities" in out
+        # Everything else passes through to the wrapped interface.
+        assert wrapped.is_interactive is True
+        assert wrapped.present("x")["action"] == "approved"
+
+    def test_interactive_build_wraps_guidance_human(self, monkeypatch) -> None:
+        from builder.agents import build, ui
+
+        monkeypatch.setattr(ui, "get_console", _rec_console)
+        engine = _engine(_InteractiveHuman())
+        seen: dict[str, Any] = {}
+
+        def fake_guidance(eng, human, **kw):
+            seen["human"] = human
+            return dict(_GUIDANCE_RESULT)
+
+        build.run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
+            guidance_runner=fake_guidance,
+            exporter=_stub_export,
+        )
+        # The guidance tail is handed the status-bar wrapper, so every gap question
+        # is headed by the shared status line.
+        assert isinstance(seen["human"], build._StatusBarHuman)

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -821,3 +821,89 @@ class TestProgressSpinner:
         # Sanity: the real pipeline produced a non-trivial crate (not the empty
         # default), so the equality above is a real signal, not two empty hashes.
         assert h1 != crate_graph_hash(CrateState())
+
+
+def _stub_export(state: CrateState) -> dict[str, Any]:
+    """An exporter double that reports success without touching disk."""
+    return {"success": True, "crate_path": "/tmp/vitro-crate-test/ro-crate-metadata.json"}
+
+
+def _rec_console() -> Any:
+    """A recording Rich console that captures printed chrome as plain text."""
+    import io
+
+    from rich.console import Console
+
+    return Console(file=io.StringIO(), record=True, color_system=None, width=100)
+
+
+class TestSharedChrome:
+    """The interactive pipeline renders the shared UI chrome; headless does not (#344).
+
+    Both arms render through ``builder.agents.ui``; here we drive the real
+    ``run_interactive_build`` (pipeline/guidance/exporter stubbed — no SHACL, LLM,
+    or disk) and capture what lands on the shared console.
+    """
+
+    def test_interactive_build_renders_final_status_bar(self, monkeypatch) -> None:
+        from builder.agents import build, ui
+
+        rec = _rec_console()
+        monkeypatch.setattr(ui, "get_console", lambda: rec)
+        engine = _engine(_InteractiveHuman())
+
+        build.run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            exporter=_stub_export,
+        )
+
+        out = rec.export_text()
+        # The shared one-line status bar: session id, counts, validation labels.
+        assert engine.state.session_id in out
+        assert "entities" in out
+        assert "base" in out and "ISA" in out and "Tox" in out
+
+    def test_headless_build_renders_no_chrome(self, monkeypatch) -> None:
+        from builder.agents import build, ui
+
+        rec = _rec_console()
+        monkeypatch.setattr(ui, "get_console", lambda: rec)
+        engine = _engine(SimulatedHumanInterface())
+
+        build.run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
+            exporter=_stub_export,
+        )
+
+        # Headless / eval path prints no banner or status bar — the A/B path is
+        # left byte-identical (the chrome is strictly interactive-only).
+        assert rec.export_text() == ""
+
+    def test_interactive_resume_renders_banner(self, monkeypatch) -> None:
+        from builder.agents import build, ui
+        from builder.state import Entity, EntityProvenance
+
+        rec = _rec_console()
+        monkeypatch.setattr(ui, "get_console", lambda: rec)
+        engine = _engine(_InteractiveHuman())
+        # A pre-existing entity marks this as a resume → the summary panel shows.
+        engine.state.add_entity(
+            Entity(
+                entity_id="inv_001",
+                type="Investigation",
+                fields={"title": "I"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+
+        build.run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            exporter=_stub_export,
+        )
+
+        assert "Resumed Session" in rec.export_text()

--- a/tests/test_progress_spinner.py
+++ b/tests/test_progress_spinner.py
@@ -1,15 +1,15 @@
-"""Tests for builder/agents/progress_spinner.py — the pipeline build spinner (#266).
+"""Tests for builder/agents/progress_spinner.py — the shared build spinner (#266, #344).
 
 The DEFAULT ``--interactive`` (deterministic pipeline) build only printed static
 phase lines (#253), so the ~tens-of-seconds spine looked frozen. :class:`ProgressSpinner`
-gives it a live Rich spinner like the legacy ReAct loop's ``_ThinkingSpinner``: an
-animated dots spinner with a rotating funny toxicology-themed phrase, the currently
-running tool/phase, and elapsed seconds, updating in place.
+gives it a live Rich spinner: an animated dots spinner with a rotating funny
+toxicology-themed phrase, the currently running tool/phase, and elapsed seconds,
+updating in place. Both build arms drive this one spinner (#344) — the pipeline from
+``engine.on_tool_event``, the ReAct loop from LangChain tool-event callbacks.
 
 The spinner registers itself as the active console animation (``register_console_animation``)
 so a guidance HITL prompt (which calls ``suspend_console_animation``) can pause it and
-own the terminal. These tests use a fake console/status (no real terminal) — the same
-pattern as ``TestThinkingSpinnerPause`` in test_agent_loop.py.
+own the terminal. These tests use a fake console/status (no real terminal).
 """
 
 from __future__ import annotations

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -106,6 +106,30 @@ class TestConsoleHumanInterface:
         resp = ConsoleHumanInterface().request_input("Name?")
         assert resp == {"value": None, "skipped": True}
 
+    def test_request_input_uses_injected_prompt_func(self):
+        """An injected prompt_func replaces the bare input() so the CLI can render
+        the shared rounded box (#344); the field_type is threaded to the reader."""
+        seen: list[str] = []
+
+        def fake_box(field_type: str) -> str:
+            seen.append(field_type)
+            return "Acme Corp"
+
+        resp = ConsoleHumanInterface(prompt_func=fake_box).request_input("Name?", "text")
+        assert resp == {"value": "Acme Corp", "skipped": False}
+        assert seen == ["text"]
+
+    def test_injected_prompt_func_empty_is_skip(self):
+        resp = ConsoleHumanInterface(prompt_func=lambda _ft: "").request_input("Name?")
+        assert resp == {"value": None, "skipped": True}
+
+    def test_injected_prompt_func_eof_is_skip(self):
+        def _raise(_ft: str) -> str:
+            raise EOFError
+
+        resp = ConsoleHumanInterface(prompt_func=_raise).request_input("Name?")
+        assert resp == {"value": None, "skipped": True}
+
 
 class TestIsInteractive:
     """The interactive signal distinguishes a real user from a headless run."""

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -130,6 +130,19 @@ class TestConsoleHumanInterface:
         resp = ConsoleHumanInterface(prompt_func=_raise).request_input("Name?")
         assert resp == {"value": None, "skipped": True}
 
+    def test_request_input_displays_question_via_show_func(self):
+        """An injected show_func renders the question so the CLI can style it as a
+        green-● reply like the ReAct arm, instead of a bare print (#344)."""
+        shown: list[str] = []
+
+        resp = ConsoleHumanInterface(
+            prompt_func=lambda _ft: "10.1234/x",
+            show_func=shown.append,
+        ).request_input("What is the DOI?", "identifier")
+
+        assert resp == {"value": "10.1234/x", "skipped": False}
+        assert shown == ["What is the DOI?"]
+
 
 class TestIsInteractive:
     """The interactive signal distinguishes a real user from a headless run."""


### PR DESCRIPTION
Harmonizes the interactive terminal UI across **both** first-class build arms — the
deterministic pipeline (`--interactive`) and the legacy ReAct loop (`--legacy-react`) —
so they render identically, with **one shared implementation and no per-arm copies**.

Closes #344. Closes #341.

## What both arms now share (`builder/agents/ui.py`)
A single arm-neutral UI layer both arms import:

- **Pure renderers** (`render_status_bar` / `render_reply` / `render_resume_summary` /
  `render_goodbye`) — take a `UiSnapshot`, return a Rich renderable, unit-tested offline.
- **`snapshot_from_engine`** — the one impure adapter (state + best-effort token/cost).
- **`print_status_bar` / `print_resume_summary` / `print_goodbye`** — the single
  "snapshot → render → print" path **both arms call**. Neither inlines its own copy.
- **`boxed_input`** — the rounded `❯` prompt.
- **`flatten_message_content`** — flattens structured message content to text
  (fixes the raw-message-repr leak, #341), used at the shared reply call site.

## Pipeline now matches ReAct end to end
resume banner → shared spinner → **green-● guidance questions** → boxed `❯` input →
**per-prompt status bar** → status bar → **goodbye panel**.

- The pipeline's HITL prompt renders through the shared box + green-● styling via two
  injectables on `ConsoleHumanInterface` (`prompt_func`, `show_func`), so `builder.tools.hitl`
  never imports the UI layer (no `agents → tools → agents` cycle).
- The per-prompt status bar wraps the guidance human (`_StatusBarHuman`) and calls the
  **same** `ui.print_status_bar` the ReAct loop calls.
- ReAct's duplicate `_ThinkingSpinner` is deleted; both arms share
  `progress_spinner.ProgressSpinner` + one `TOX_SPINNER_PHRASES`.

## Invariants preserved
- **Interactive-only** — the headless / A/B eval path is byte-identical (no banner, no
  status bar, no goodbye); the built `@graph` is unperturbed (guarded by an existing
  hash-equivalence test).
- No new dependencies; `rich` / `prompt_toolkit` already ship with the ReAct arm.

## Tests
Driven TDD-first to the #343 standard — pure renderers over `UiSnapshot` literals,
`snapshot_from_engine` over a **real** engine/state, the leak fix asserted at its real
call site. ~197 tests green across the affected modules; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
