### PR TITLE
fix(dashboard): render MIT coverage via a shared formatter reused by the UI (#355)

### DIFF
--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -125,6 +125,7 @@ class UiSnapshot:
     required_issue_count: int
     entity_counts: dict[str, int] = field(default_factory=dict)
     mit_score: float | None = None
+    mit_assessed: bool = False
     tokens_in: int = 0
     tokens_out: int = 0
     cost_usd: float | None = None
@@ -172,6 +173,7 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
     val = state.validation
     mit = getattr(state, "mit_assessment", None)
     mit_score = getattr(mit, "overall_score", None) if mit is not None else None
+    mit_assessed = bool(getattr(mit, "module_scores", None))
 
     tokens_in, tokens_out, last_model = _read_token_totals(state.session_id)
     cost_usd: float | None = None
@@ -197,6 +199,7 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
         required_issue_count=len(val.required_issues),
         entity_counts=counts,
         mit_score=mit_score,
+        mit_assessed=mit_assessed,
         tokens_in=tokens_in,
         tokens_out=tokens_out,
         cost_usd=cost_usd,
@@ -273,8 +276,11 @@ def render_resume_summary(snap: UiSnapshot) -> RenderableType:
     summary.add_row("Entities:", f"[green]{snap.entity_count}[/green]")
     summary.add_row("Files:", f"[green]{snap.file_count}[/green]")
 
-    if snap.mit_score is not None:
-        summary.add_row("MIT score:", f"[yellow]{snap.mit_score:.0%}[/yellow]")
+    if snap.mit_assessed:
+        from builder.tools.dashboard import format_mit_coverage
+
+        mit_text, mit_color = format_mit_coverage(snap.mit_score, assessed=True)
+        summary.add_row("MIT score:", f"[{mit_color}]{mit_text}[/{mit_color}]")
 
     val_status = [
         "[green]base[/green]" if snap.base_passed else "[red]base[/red]",

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -224,6 +224,34 @@ def _load_cratestate(session_id: str) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
+def format_mit_coverage(
+    overall_score: float | None, *, assessed: bool
+) -> tuple[str, str]:
+    """Format an MIT coverage score for display — the single source of truth
+    shared by the profiler dashboard panel and the interactive UI
+    (:mod:`builder.agents.ui`) so both build arms render coverage identically
+    (issue #355).
+
+    ``overall_score`` is a fraction in ``[0.0, 1.0]`` (see
+    :class:`builder.state.MITReport`). Returns ``(text, rich_color)``: the text
+    is a whole-percent string (e.g. ``"85%"``) and the colour tracks the score
+    on the fraction scale — green ``>= 0.8``, yellow ``>= 0.5``, else red. When
+    the crate was never assessed (``assessed`` false, e.g. the default empty
+    report), returns ``("—", "dim")`` so an unscored crate is not shown as a
+    misleading red 0%.
+    """
+    if not assessed or overall_score is None:
+        return "—", LABEL_STYLE
+    pct = round(overall_score * 100)
+    if overall_score >= 0.8:
+        color = OK_STYLE
+    elif overall_score >= 0.5:
+        color = WARN_STYLE
+    else:
+        color = ERR_STYLE
+    return f"{pct}%", color
+
+
 def _build_cratestate_panel(
     state: dict[str, Any] | None,
     status: str = STATUS_IDLE,
@@ -298,10 +326,12 @@ def _build_cratestate_panel(
     if required_count > 0:
         val_str += f"  [{ERR_STYLE}]{required_count} REQUIRED[/{ERR_STYLE}]"
 
-    # MIT score
+    # MIT score — shared formatter keeps this identical to the interactive UI.
     mit = state.get("mit_assessment", {})
-    mit_score = mit.get("overall_score", 0)
-    mit_color = OK_STYLE if mit_score >= 80 else WARN_STYLE if mit_score >= 50 else ERR_STYLE
+    mit_text, mit_color = format_mit_coverage(
+        mit.get("overall_score"),
+        assessed=bool(mit.get("module_scores")),
+    )
 
     # Iteration
     iteration = state.get("iteration_count", 0)
@@ -316,7 +346,7 @@ def _build_cratestate_panel(
         ("  │  Validation: ", HEADER_STYLE),
         (val_str, val_color),
         ("  │  MIT: ", HEADER_STYLE),
-        (f"{mit_score}%", mit_color),
+        (mit_text, mit_color),
         ("  │  Iteration: ", HEADER_STYLE),
         (f"{iteration}{' ⚠ STUCK' if stuck else ''}", ERR_STYLE if stuck else "white"),
     )

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -50,6 +50,7 @@ _BASE_SNAPSHOT = ui.UiSnapshot(
     required_issue_count=1,
     entity_counts={"Investigation": 1, "Study": 2},
     mit_score=0.75,
+    mit_assessed=True,
     tokens_in=0,
     tokens_out=0,
     cost_usd=None,
@@ -255,6 +256,14 @@ def test_render_resume_summary_shows_session_and_breakdown() -> None:
     assert "sess-1" in text
     assert "Investigation" in text
     assert "MIT score" in text
+    # Coverage renders as a whole percent (0.75 -> "75%"), not a raw fraction.
+    assert "75%" in text
+
+
+def test_render_resume_summary_hides_mit_when_unassessed() -> None:
+    """An unassessed crate omits the MIT row rather than showing a misleading 0%."""
+    text = _render(ui.render_resume_summary(_snapshot(mit_assessed=False, mit_score=0.0)))
+    assert "MIT score" not in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -618,3 +618,98 @@ class TestLiveRefresh:
         assert len(records2) == 2
         assert mtime2 != mtime
 
+
+class TestFormatMitCoverage:
+    """format_mit_coverage() — the shared MIT-tile formatter (issue #355).
+
+    One source of truth for the dashboard panel and the interactive UI so both
+    build arms render MIT coverage identically. ``overall_score`` is a 0.0-1.0
+    fraction; the formatter returns ``(text, rich_color)``.
+    """
+
+    def test_fraction_rendered_as_whole_percent(self) -> None:
+        from builder.tools.dashboard import format_mit_coverage
+
+        assert format_mit_coverage(0.85, assessed=True) == ("85%", "green")
+
+    def test_full_coverage_is_100_not_1(self) -> None:
+        from builder.tools.dashboard import format_mit_coverage
+
+        assert format_mit_coverage(1.0, assessed=True) == ("100%", "green")
+
+    def test_middling_score_is_yellow(self) -> None:
+        from builder.tools.dashboard import format_mit_coverage
+
+        assert format_mit_coverage(0.6, assessed=True) == ("60%", "yellow")
+
+    def test_low_score_is_red(self) -> None:
+        from builder.tools.dashboard import format_mit_coverage
+
+        assert format_mit_coverage(0.3, assessed=True) == ("30%", "red")
+
+    def test_unassessed_is_neutral_placeholder_not_zero_percent(self) -> None:
+        """A never-assessed report must not read as a red 0% — it is unknown."""
+        from builder.tools.dashboard import format_mit_coverage
+
+        text, color = format_mit_coverage(0.0, assessed=False)
+        assert text == "—"
+        assert color == "dim"
+        assert "%" not in text
+
+    def test_none_score_is_neutral(self) -> None:
+        from builder.tools.dashboard import format_mit_coverage
+
+        assert format_mit_coverage(None, assessed=False) == ("—", "dim")
+
+
+class TestCrateStatePanelMit:
+    """_build_cratestate_panel() renders MIT via the shared formatter (issue #355)."""
+
+    @staticmethod
+    def _render(state: dict) -> str:
+        from rich.console import Console
+
+        from builder.tools.dashboard import _build_cratestate_panel
+
+        console = Console(width=200)
+        with console.capture() as capture:
+            console.print(_build_cratestate_panel(state))
+        return capture.get()
+
+    def test_covered_crate_shows_whole_percent(self) -> None:
+        state = {
+            "entities": {},
+            "validation": {},
+            "mit_assessment": {
+                "module_scores": {"m1": {"completed": 17, "total": 20}},
+                "overall_score": 0.85,
+            },
+        }
+        out = self._render(state)
+        assert "85%" in out
+        assert "0.85%" not in out
+
+    def test_full_coverage_not_one_percent(self) -> None:
+        state = {
+            "entities": {},
+            "validation": {},
+            "mit_assessment": {
+                "module_scores": {"m1": {"completed": 20, "total": 20}},
+                "overall_score": 1.0,
+            },
+        }
+        out = self._render(state)
+        assert "100%" in out
+        assert "1.0%" not in out
+
+    def test_unassessed_not_shown_as_zero_percent(self) -> None:
+        state = {
+            "entities": {},
+            "validation": {},
+            "mit_assessment": {"module_scores": {}, "overall_score": 0.0},
+        }
+        out = self._render(state)
+        assert "MIT" in out
+        assert "0.0%" not in out
+        assert "0%" not in out
+


### PR DESCRIPTION
Closes #355.

## Problem
The profiler dashboard (`builder/tools/dashboard.py`) rendered the MIT coverage tile from `MITReport.overall_score` — a **0.0–1.0 fraction** — but thresholded it against `80/50` and printed `f"{mit_score}%"` with no ×100. So a fully-covered crate showed a red **"1.0%"**, and because `state.mit_assessment` is never populated at runtime, the tile normally showed a red **"0.0%"**. The interactive UI (post-#344, `builder/agents/ui.py`) rendered the same score correctly (`:.0%`) but hardcoded `[yellow]` — an example of *unfinished sharing* across the two arms.

## Fix
- **New shared formatter** `format_mit_coverage(overall_score, *, assessed) -> (text, color)` in `dashboard.py` — one source of truth, so both build arms render MIT coverage identically. Whole-percent text; green ≥ 0.8 / yellow ≥ 0.5 / else red on the fraction scale; neutral `—` (dim) when the crate was never assessed.
- **Dashboard panel** now uses it (fixes the always-red fraction bug).
- **Interactive resume summary** now uses it too → real threshold coloring instead of hardcoded yellow, and **hides** the MIT row when unassessed rather than showing a misleading `0%`.
- Adds `UiSnapshot.mit_assessed` so "never assessed" is distinguishable from a genuine 0%.

Layering stays clean: the formatter lives in the lower `builder/tools` layer and is imported by `builder/agents/ui.py` (same direction as the existing `ui → dashboard` dependency); no new `tools → agents` edge.

## Tests (TDD, red-first)
- `tests/test_dashboard.py::TestFormatMitCoverage` — 6 unit tests pinning percent + color (85%→green, 100%→green, 60%→yellow, 30%→red, unassessed/None→("—","dim")).
- `tests/test_dashboard.py::TestCrateStatePanelMit` — regression on the real panel (0.85→"85%" not "0.85%"; 1.0→"100%" not "1.0%"; unassessed → no "0.0%").
- `tests/agents/test_ui.py` — resume summary shows "75%" when assessed; hides the MIT row when unassessed.
- Full suite green.

_Part of the external-sources / harmonization cleanup lane (#355–#361)._