### PR TITLE
perf(lookups): drop residual per-request sleeps; central limiter is the only throttle (#359)

### DIFF
--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import time
 from typing import Any
 
 from builder.tools._resolve_cache import compound_cache, normalize_compound_name
@@ -186,7 +185,6 @@ def lookup_cell_line(accession: str) -> dict[str, Any]:
                   alternateName, taxonomicRange, disease, etc.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_cellosaurus(accession)
         if result and result.get("name"):
@@ -278,7 +276,6 @@ def lookup_aop(aop_id: str) -> dict[str, Any]:
             data: Dict with "aop", "events", "relationships" keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_aop_wiki(str(aop_id))
         if result and result.get("aop"):
@@ -304,7 +301,6 @@ def lookup_bao_term(query: str) -> dict[str, Any]:
             data: Dict with @id, @type, name, termCode keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_bao_term_ols(query)
         if result and result.get("@id"):
@@ -336,7 +332,6 @@ def lookup_ontology_term(query: str, ontology: str) -> dict[str, Any]:
                   score keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_ontology_term_ols(query, ontology)
         if result and result.get("@id"):
@@ -363,7 +358,6 @@ def lookup_unit(unit_string: str) -> dict[str, Any]:
                   available) score keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_unit_ols(unit_string)
         if result and result.get("@id"):
@@ -391,7 +385,6 @@ def lookup_dtxsid(query: str) -> dict[str, Any]:
                   inchikey keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_dtxsid_comptox(query)
         if result and result.get("dtxsid"):
@@ -419,7 +412,6 @@ def lookup_orcid(orcid_id: str) -> dict[str, Any]:
                   familyName, affiliation_name, affiliation_ror keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_orcid_api(orcid_id)
         if result and "name" in result:
@@ -448,7 +440,6 @@ def lookup_ror(name: str) -> dict[str, Any]:
             data: Dict with @id, @type, name, url, identifier keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = search_ror(name)
         if result and result.get("@id"):
@@ -475,7 +466,6 @@ def lookup_doi(doi: str) -> dict[str, Any]:
                   datePublished, url, identifier keys.
             error: Error message or None on success.
     """
-    time.sleep(0.05)
     try:
         result = lookup_doi_crossref(doi)
         if result and result.get("name"):

--- a/lookups/cellosaurus.py
+++ b/lookups/cellosaurus.py
@@ -12,7 +12,6 @@ those resolvable IRIs rather than discarding them: the values come back as
 from __future__ import annotations
 
 import functools
-import time
 from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
@@ -46,7 +45,6 @@ def lookup_cellosaurus(accession: str) -> dict:
         Returns {} on failure so callers can spread safely.
     """
     try:
-        time.sleep(0.1)
         # Percent-encode the caller-supplied accession so a value containing a
         # "/" or ".." cannot break out of the cell-line path or inject query
         # params (Issue #170). ``safe=""`` encodes every reserved char.
@@ -193,7 +191,6 @@ def search_cellosaurus(name: str, rows: int = 10) -> tuple[dict, ...]:
     if not query:
         return ()
     try:
-        time.sleep(0.1)
         # Match the name against the cell line's identifier and synonyms. The
         # Solr field ``idsy`` covers both; quote the value so a name containing a
         # space or reserved char cannot break the query syntax.

--- a/lookups/crossref.py
+++ b/lookups/crossref.py
@@ -7,7 +7,6 @@ Returns enriched citation metadata for a given DOI.
 from __future__ import annotations
 
 import functools
-import time
 from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
@@ -39,7 +38,6 @@ def lookup_doi(doi: str) -> dict:
 
     doi_url = f"https://doi.org/{doi}"
     try:
-        time.sleep(0.1)
         # A DOI's "/" is structural (e.g. "10.1016/j.tox..."), so keep slashes
         # but percent-encode spaces, "#", "?", "&", etc. so a malformed value
         # can't inject extra query params into the Crossref request (Issue #170).
@@ -121,7 +119,6 @@ def search_works_by_title(title: str, rows: int = 5) -> tuple[dict, ...]:
     if not query:
         return ()
     try:
-        time.sleep(0.1)
         data = http_get_json(
             _BASE,
             params={

--- a/lookups/orcid.py
+++ b/lookups/orcid.py
@@ -8,7 +8,6 @@ No authentication required (uses the public ORCID API).
 from __future__ import annotations
 
 import functools
-import time
 from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
@@ -34,7 +33,6 @@ def lookup_orcid(orcid_id: str) -> dict:
     """
     orcid_url = f"https://orcid.org/{orcid_id}"
     try:
-        time.sleep(0.1)
         # Percent-encode the caller-supplied iD for the request path so a "/" or
         # ".." cannot escape the /record path or inject query params (Issue #170).
         data = http_get_json(f"{_BASE}/{quote(orcid_id, safe='')}/record", headers=_HEADERS)
@@ -109,7 +107,6 @@ def _search_orcid_by_name(
     query = " AND ".join(terms)
 
     try:
-        time.sleep(0.1)
         data = http_get_json(
             f"{_BASE}/expanded-search/",
             params={"q": query, "rows": "10"},

--- a/lookups/pubchem.py
+++ b/lookups/pubchem.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import functools
 import re
-import time
 from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
@@ -64,7 +63,6 @@ def lookup_pubchem(name: str) -> dict:
         # CAS numbers appear in the synonyms list. This is best-effort
         # enrichment: a transient/absent synonyms response must not lose the
         # compound we already resolved.
-        time.sleep(0.2)  # stay under rate limit
         cas = ""
         try:
             syn_data = http_get_json(f"{_BASE}/{quote(name)}/synonyms/JSON")

--- a/lookups/ror.py
+++ b/lookups/ror.py
@@ -7,7 +7,6 @@ Searches for an organization by name and returns enriched metadata.
 from __future__ import annotations
 
 import functools
-import time
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
@@ -29,7 +28,6 @@ def search_ror(name: str) -> dict:
     if not name:
         return {}
     try:
-        time.sleep(0.1)
         data = http_get_json(_BASE, params={"query": name})
         if data is NOT_FOUND:
             return {}

--- a/tests/test_tools_lookups.py
+++ b/tests/test_tools_lookups.py
@@ -812,3 +812,67 @@ class TestLookupCompoundChebiFallback:
         result = lookup_compound("TotallyMadeUpXYZ")
         assert result["found"] is False
         assert isinstance(result["error"], str)
+
+
+class TestNoRedundantSleeps:
+    """Issue #359: the central per-host limiter (``lookups/_http.py``
+    ``_HostRateLimiter``) is the ONLY throttle. The residual
+    ``time.sleep(0.05/0.1/0.2)`` calls in the facade and the raw clients are
+    removed so spacing is applied once, centrally, not three times over.
+    """
+
+    def test_facade_lookup_does_not_sleep(self, monkeypatch):
+        """A facade lookup must not ``time.sleep`` around its raw client."""
+        import time
+
+        from builder.tools import lookups as facade
+
+        calls: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: calls.append(s))
+        monkeypatch.setattr(
+            facade,
+            "search_ror",
+            lambda name: {"@id": "https://ror.org/02jz4aj89", "name": name},
+        )
+        facade.lookup_ror.cache_clear()
+        facade.lookup_ror("Maastricht University")
+        assert calls == []
+
+    def test_raw_client_does_not_sleep(self, monkeypatch):
+        """A raw client must not ``time.sleep`` around its HTTP call — the limiter
+        inside ``http_get_json`` handles per-host spacing."""
+        import time
+
+        from lookups import ror
+
+        calls: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: calls.append(s))
+        monkeypatch.setattr(
+            ror,
+            "http_get_json",
+            lambda url, params=None: {
+                "items": [{"id": "https://ror.org/02jz4aj89", "name": "X", "links": []}]
+            },
+        )
+        ror.search_ror.cache_clear()
+        ror.search_ror("some org")
+        assert calls == []
+
+    def test_no_direct_time_sleep_outside_the_limiter(self):
+        """No lookup module nor the facade calls ``time.sleep`` directly; it lives
+        only in the central ``_HostRateLimiter`` (``lookups/_http.py``)."""
+        import pathlib
+
+        import builder.tools.lookups as facade
+        import lookups
+
+        files = [
+            p
+            for p in pathlib.Path(lookups.__file__).parent.glob("*.py")
+            if p.name != "_http.py"
+        ]
+        files.append(pathlib.Path(facade.__file__))
+        offenders = sorted(p.name for p in files if "time.sleep" in p.read_text())
+        assert offenders == [], (
+            f"time.sleep must live only in _HostRateLimiter, found in: {offenders}"
+        )


### PR DESCRIPTION
Closes #359.

## Problem
The per-host `_HostRateLimiter` in `lookups/_http.py` (added for #62) already spaces requests per host. Layered on top of it were **redundant** `time.sleep` calls:
- **Raw clients** slept around their HTTP call: `pubchem.py` (0.2s), `cellosaurus.py` ×2, `orcid.py` ×2, `crossref.py` ×2, `ror.py` — 8 calls.
- **Facade** (`builder/tools/lookups.py`) slept `0.05s` in nearly every function — 9 calls — **before** the network even on the lru-miss path.

So requests were throttled three times over, applied inconsistently (`lookups/bao.py` was already clean — the precedent).

## Change
Removed the **16 redundant `time.sleep` calls** and the now-unused `import time` from the six modules. The central `_HostRateLimiter` is now the single source of request spacing. `lookups/_http.py` is untouched.

Behaviour is unchanged — the lookup tests mock HTTP, so no real spacing depended on these sleeps.

## Tests (TDD, red-first)
`tests/test_tools_lookups.py::TestNoRedundantSleeps`:
- `test_facade_lookup_does_not_sleep` — a facade lookup (`lookup_ror`, raw dep mocked) calls no `time.sleep`.
- `test_raw_client_does_not_sleep` — a raw client (`search_ror`, `http_get_json` mocked) calls no `time.sleep`.
- `test_no_direct_time_sleep_outside_the_limiter` — source invariant: no lookup module nor the facade contains `time.sleep`; it lives only in `_HostRateLimiter`.

All 3 red before, green after. Existing lookup suites (110 tests) unchanged; full suite green; `ruff` + `ty` clean.

_Part of the external-sources / harmonization cleanup lane (#355–#361)._