### PR TITLE
refactor(profiles): single canonical source for ontology term IRIs (#358)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -37,6 +37,7 @@ from profiles.models.tox import (
     LabProcessEndpointReadout,
     LabProcessExposure,
 )
+from profiles.ontology_iris import iri
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ ROCRATE_SPEC = "https://w3id.org/ro/crate/1.2"
 # prof:isProfileOf) and that resolves — the w3id ISA permalink is not yet live.
 PROFILE_ISA = "https://github.com/nfdi4plants/isa-ro-crate-profile"
 PROFILE_ISATOX = "https://w3id.org/ro/crate/isa-tox/1.0"
-CELL_LINE_TERM_ID = "http://purl.obolibrary.org/obo/NCIT_C16403"
+CELL_LINE_TERM_ID = iri("NCIT:C16403")
 
 # Fields that hold references to other entities (resolved via the index), not literals.
 _REF_FIELDS = frozenset(
@@ -830,8 +831,8 @@ class _Characteristic:
 
 
 _CELL_LINE_CHARACTERISTICS: tuple[_Characteristic, ...] = (
-    _Characteristic(("passage",), "passage", "https://bioregistry.io/EFO:0007061"),
-    _Characteristic(("growth",), "growth", "http://www.bioassayontology.org/bao#BAO_0002648"),
+    _Characteristic(("passage",), "passage", iri("EFO:0007061")),
+    _Characteristic(("growth",), "growth", iri("BAO:0002648")),
     _Characteristic(("organ",), "Organ", f"{PROFILE_ISATOX}/param/organ"),
     _Characteristic(("tissue",), "Tissue", f"{PROFILE_ISATOX}/param/tissue"),
 )
@@ -1336,47 +1337,47 @@ _CONDITION_TABLE_COLUMNS: tuple[dict[str, str], ...] = (
     {
         "titles": "assay",
         "datatype": "string",
-        "propertyUrl": "http://purl.obolibrary.org/obo/NCIT_C60819",
+        "propertyUrl": iri("NCIT:C60819"),
     },
     {
         "titles": "cell_line",
         "datatype": "string",
-        "propertyUrl": "http://purl.obolibrary.org/obo/NCIT_C16403",
+        "propertyUrl": iri("NCIT:C16403"),
     },
     {
         "titles": "compound",
         "datatype": "string",
-        "propertyUrl": "http://purl.obolibrary.org/obo/CHEBI_23367",
+        "propertyUrl": iri("CHEBI:23367"),
     },
     {
         "titles": "concentration_value",
         "datatype": "double",
-        "propertyUrl": "http://purl.obolibrary.org/obo/PATO_0000033",
+        "propertyUrl": iri("PATO:0000033"),
     },
     {
         "titles": "concentration_unit",
         "datatype": "string",
-        "propertyUrl": "http://purl.obolibrary.org/obo/IAO_0000039",
+        "propertyUrl": iri("IAO:0000039"),
     },
     {
         "titles": "exposure_duration",
         "datatype": "string",
-        "propertyUrl": "https://bioregistry.io/NCIT:C83280",
+        "propertyUrl": iri("NCIT:C83280"),
     },
     {
         "titles": "experiment",
         "datatype": "string",
-        "propertyUrl": "https://bioregistry.io/EFO:0002091",
+        "propertyUrl": iri("EFO:0002091"),
     },
     {
         "titles": "technical_replicate",
         "datatype": "string",
-        "propertyUrl": "https://bioregistry.io/EFO:0002090",
+        "propertyUrl": iri("EFO:0002090"),
     },
     {
         "titles": "control",
         "datatype": "string",
-        "propertyUrl": "http://purl.obolibrary.org/obo/NCIT_C28143",
+        "propertyUrl": iri("NCIT:C28143"),
     },
 )
 
@@ -1398,12 +1399,12 @@ _RAW_MEASUREMENTS_COLUMNS: tuple[dict[str, str], ...] = (
     {
         "titles": "measured_value",
         "datatype": "double",
-        "propertyUrl": "http://purl.obolibrary.org/obo/IAO_0000109",
+        "propertyUrl": iri("IAO:0000109"),
     },
     {
         "titles": "measured_unit",
         "datatype": "string",
-        "propertyUrl": "http://purl.obolibrary.org/obo/IAO_0000039",
+        "propertyUrl": iri("IAO:0000039"),
     },
 )
 

--- a/builder/tools/drafters.py
+++ b/builder/tools/drafters.py
@@ -7,6 +7,7 @@ ROCrate objects — just the state representation with completion tracking.
 from __future__ import annotations
 
 from builder.state import CrateState, Entity, EntityProvenance
+from profiles.ontology_iris import iri
 
 VALID_PROCESS_TYPES = frozenset(
     {
@@ -24,8 +25,8 @@ VALID_PROCESS_TYPES = frozenset(
 # reference object so the value is machine-resolvable rather than a string literal
 # that silently fails the tox pass.
 _IDENTIFIER_PROPERTY_IDS: dict[str, str] = {
-    "DOI": "http://purl.obolibrary.org/obo/OBI_0002110",  # digital object identifier
-    "PubMedID": "http://purl.obolibrary.org/obo/OBI_0001617",  # PubMed identifier
+    "DOI": iri("OBI:0002110"),  # digital object identifier
+    "PubMedID": iri("OBI:0001617"),  # PubMed identifier
 }
 
 

--- a/profiles/context.py
+++ b/profiles/context.py
@@ -5,6 +5,8 @@ Extracted from generate_crate.py for reuse in crate_builder.py and any other
 module that creates an ROCrate with the ISA-Tox profile.
 """
 
+from profiles.ontology_iris import PREFIXES, iri
+
 ISA_TOX_CONTEXT: list[dict] = [
     {
         # Use http://schema.org/ (HTTP) to align with the RO-Crate 1.1 context and
@@ -106,8 +108,8 @@ ISA_TOX_CONTEXT: list[dict] = [
         "unitText": "http://schema.org/unitText",
         "propertyID": "http://schema.org/propertyID",
         # External ontology terms
-        "DetectionInstrument": "http://www.bioassayontology.org/bao#BAO_0000697",
-        "catalog number": "http://purl.obolibrary.org/obo/NCIT_C99286",
+        "DetectionInstrument": iri("BAO:0000697"),
+        "catalog number": iri("NCIT:C99286"),
         # --- Terms from lookup result payloads (added to context so every property key
         #     is mapped to a known IRI, as required by compacted JSON-LD) ---
         # Publication / bibliographic terms (from Crossref)
@@ -178,6 +180,6 @@ ISA_TOX_CONTEXT: list[dict] = [
         "datatype": "http://www.w3.org/ns/csvw#datatype",
         "propertyUrl": "http://www.w3.org/ns/csvw#propertyUrl",
         "valueUrl": "http://www.w3.org/ns/csvw#valueUrl",
-        "UO": "http://purl.obolibrary.org/obo/UO_",
+        "UO": PREFIXES["UO"],
     }
 ]

--- a/profiles/docs/isa_tox.md
+++ b/profiles/docs/isa_tox.md
@@ -260,9 +260,9 @@ for this step:
 
 | name | Required | propertyID |
 |------|----------|------------|
-|Exposure Duration|SHOULD|`https://bioregistry.io/NCIT:C83280`|
+|Exposure Duration|SHOULD|`http://purl.obolibrary.org/obo/NCIT_C83280`|
 |Cell Seeding Density|SHOULD|`http://purl.obolibrary.org/obo/MSIO_0000062`|
-|Microplate|SHOULD|`https://bioregistry.io/NCIT:C43377`|
+|Microplate|SHOULD|`http://purl.obolibrary.org/obo/NCIT_C43377`|
 
 ### LabProcess - Endpoint Readout
 
@@ -286,10 +286,10 @@ for this step:
 
 | name | Required | propertyID |
 |------|----------|------------|
-|Detection Instrument|SHOULD|`http://purl.obolibrary.org/obo/BAO_0000697`|
-|Instrument Manufacturer|SHOULD|`http://purl.obolibrary.org/obo/BAO_0002628`|
-|Measured Entity|SHOULD|`http://purl.obolibrary.org/obo/BAO_0002001`|
-|Technical replicate|SHOULD|`https://bioregistry.io/EFO:0002090`|
+|Detection Instrument|SHOULD|`http://www.bioassayontology.org/bao#BAO_0000697`|
+|Instrument Manufacturer|SHOULD|`http://www.bioassayontology.org/bao#BAO_0002628`|
+|Measured Entity|SHOULD|`http://www.bioassayontology.org/bao#BAO_0002001`|
+|Technical replicate|SHOULD|`http://www.ebi.ac.uk/efo/EFO_0002090`|
 |Endpoint|SHOULD|`http://www.bioassayontology.org/bao#BAO_0000179`|
 |Assay Kit|MAY|`http://www.bioassayontology.org/bao#BAO_0000248`|
 |Substrate|MAY|`http://www.bioassayontology.org/bao#BAO_0003063`|

--- a/profiles/models/tox.py
+++ b/profiles/models/tox.py
@@ -8,6 +8,7 @@ from profiles.models.isa import (
     Sample,
     param_id,
 )
+from profiles.ontology_iris import iri
 
 
 def _pv(crate, name, value, property_id=None, unit=None):
@@ -64,21 +65,21 @@ class LabProcessExposure(LabProcess):
                     crate,
                     "Exposure Duration",
                     duration,
-                    "https://bioregistry.io/NCIT:C83280",
+                    iri("NCIT:C83280"),
                     u.get("Exposure Duration"),
                 ),
                 _pv(
                     crate,
                     "Cell Seeding Density",
                     cell_seeding_density,
-                    "http://purl.obolibrary.org/obo/MSIO_0000062",
+                    iri("MSIO:0000062"),
                     u.get("Cell Seeding Density"),
                 ),
                 _pv(
                     crate,
                     "Microplate",
                     microplate,
-                    "https://bioregistry.io/NCIT:C43377",
+                    iri("NCIT:C43377"),
                     u.get("Microplate"),
                 ),
             ],
@@ -123,35 +124,35 @@ class LabProcessEndpointReadout(LabProcess):
                 crate,
                 "Detection Instrument",
                 detection_instrument,
-                "http://purl.obolibrary.org/obo/BAO_0000697",
+                iri("BAO:0000697"),
                 u.get("Detection Instrument"),
             ),
             _pv(
                 crate,
                 "Instrument Manufacturer",
                 instrument_manufacturer,
-                "http://purl.obolibrary.org/obo/BAO_0002628",
+                iri("BAO:0002628"),
                 u.get("Instrument Manufacturer"),
             ),
             _pv(
                 crate,
                 "Measured Entity",
                 measured_entity,
-                "http://purl.obolibrary.org/obo/BAO_0002001",
+                iri("BAO:0002001"),
                 u.get("Measured Entity"),
             ),
             _pv(
                 crate,
                 "Technical replicate",
                 technical_replicate,
-                "https://bioregistry.io/EFO:0002090",
+                iri("EFO:0002090"),
                 u.get("Technical replicate"),
             ),
             _pv(
                 crate,
                 "Endpoint",
                 endpoint,
-                "http://www.bioassayontology.org/bao#BAO_0000179",
+                iri("BAO:0000179"),
                 u.get("Endpoint"),
             ),
         ]
@@ -161,7 +162,7 @@ class LabProcessEndpointReadout(LabProcess):
                     crate,
                     "Assay Kit",
                     assay_kit,
-                    "http://www.bioassayontology.org/bao#BAO_0000248",
+                    iri("BAO:0000248"),
                     u.get("Assay Kit"),
                 )
             )
@@ -171,7 +172,7 @@ class LabProcessEndpointReadout(LabProcess):
                     crate,
                     "Substrate",
                     substrate,
-                    "http://www.bioassayontology.org/bao#BAO_0003063",
+                    iri("BAO:0003063"),
                     u.get("Substrate"),
                 )
             )
@@ -213,7 +214,7 @@ class LabProcessCellCulture(LabProcess):
                     crate,
                     "Culture Medium",
                     culture_medium,
-                    "http://www.bioassayontology.org/bao#BAO_0000114",
+                    iri("BAO:0000114"),
                 ),
             ],
             "input": cell_line,

--- a/profiles/ontology_iris.py
+++ b/profiles/ontology_iris.py
@@ -1,0 +1,48 @@
+"""Canonical ontology-term IRIs — the single source of truth (issue #358).
+
+Ontology term IRIs (BAO, NCIT, EFO, MSIO, CHEBI, PATO, IAO, OBI, UO, …) are built
+here by CURIE expansion so every emitter — ``profiles/models/tox.py``,
+``builder/tools/_crate_mapping.py``, ``profiles/context.py``,
+``builder/tools/drafters.py``, ``builder/agents/react/tools_spec.py`` — resolves a
+given term to exactly one IRI. Terms are referenced by CURIE, e.g.
+``iri("NCIT:C83280")``; each prefix's namespace is defined once, in :data:`PREFIXES`.
+
+Best practice: a term's identity IRI is the ontology's **own canonical, resolvable**
+IRI — never a meta-resolver URL (``bioregistry.io`` / ``identifiers.org``), which is
+for *looking things up*, not for *being* the identifier. OBO Foundry ontologies use the
+OBO PURL; BAO uses its ``bioassayontology.org`` namespace; EFO uses its EBI namespace.
+This is also what the OLS lookup path emits, so a term gets the same IRI whether it is
+hardcoded here or resolved online.
+"""
+
+from __future__ import annotations
+
+# CURIE prefix -> namespace, up to and including the ``<PREFIX>_`` (or ``#<PREFIX>_``)
+# separator, so ``PREFIXES[p] + local`` is the full term IRI.
+PREFIXES: dict[str, str] = {
+    # BioAssay Ontology — native namespace (not in the OBO PURL system)
+    "BAO": "http://www.bioassayontology.org/bao#BAO_",
+    # Experimental Factor Ontology — EBI native namespace
+    "EFO": "http://www.ebi.ac.uk/efo/EFO_",
+    # OBO Foundry ontologies — canonical OBO PURLs
+    "CHEBI": "http://purl.obolibrary.org/obo/CHEBI_",
+    "IAO": "http://purl.obolibrary.org/obo/IAO_",
+    "MSIO": "http://purl.obolibrary.org/obo/MSIO_",
+    "NCIT": "http://purl.obolibrary.org/obo/NCIT_",
+    "OBI": "http://purl.obolibrary.org/obo/OBI_",
+    "PATO": "http://purl.obolibrary.org/obo/PATO_",
+    "UO": "http://purl.obolibrary.org/obo/UO_",
+}
+
+
+def iri(curie: str) -> str:
+    """Expand a CURIE (e.g. ``"NCIT:C83280"``) to its canonical ontology term IRI.
+
+    Raises ``KeyError`` for an unregistered prefix or a malformed CURIE — a typo, or a
+    new ontology that must be added to :data:`PREFIXES` first (keeping IRIs
+    single-sourced rather than pasted inline).
+    """
+    prefix, sep, local = curie.partition(":")
+    if not sep or not local or prefix not in PREFIXES:
+        raise KeyError(f"Unknown or malformed ontology CURIE: {curie!r}")
+    return PREFIXES[prefix] + local

--- a/tests/test_csvw_payload.py
+++ b/tests/test_csvw_payload.py
@@ -76,9 +76,9 @@ _EXPECTED_CONDITION_COLUMNS = [
     ("compound", "string", "http://purl.obolibrary.org/obo/CHEBI_23367", "compound"),
     ("concentration_value", "double", "http://purl.obolibrary.org/obo/PATO_0000033", None),
     ("concentration_unit", "string", "http://purl.obolibrary.org/obo/IAO_0000039", None),
-    ("exposure_duration", "string", "https://bioregistry.io/NCIT:C83280", None),
-    ("experiment", "string", "https://bioregistry.io/EFO:0002091", None),
-    ("technical_replicate", "string", "https://bioregistry.io/EFO:0002090", None),
+    ("exposure_duration", "string", "http://purl.obolibrary.org/obo/NCIT_C83280", None),
+    ("experiment", "string", "http://www.ebi.ac.uk/efo/EFO_0002091", None),
+    ("technical_replicate", "string", "http://www.ebi.ac.uk/efo/EFO_0002090", None),
     ("control", "string", "http://purl.obolibrary.org/obo/NCIT_C28143", None),
 ]
 

--- a/tests/test_ontology_iris.py
+++ b/tests/test_ontology_iris.py
@@ -1,0 +1,91 @@
+"""Issue #358: ontology term IRIs come from one canonical source
+(``profiles.ontology_iris``), using each ontology's native IRI — never a
+``bioregistry.io`` meta-resolver URL — and no emitter file inlines raw ontology IRIs.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from profiles.ontology_iris import PREFIXES, iri
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+
+# Every file that emits ontology term IRIs must build them via ``iri()`` — no raw
+# ontology-term literals — so there is exactly one place to edit an ontology base.
+_EMITTER_FILES = [
+    "profiles/models/tox.py",
+    "builder/tools/_crate_mapping.py",
+    "profiles/context.py",
+    "builder/tools/drafters.py",
+    "builder/agents/react/tools_spec.py",
+]
+
+def _grep(rel: str, needle: str) -> list[str]:
+    return [
+        line.strip()
+        for line in (REPO / rel).read_text().splitlines()
+        if needle in line and not line.lstrip().startswith("#")
+    ]
+
+
+class TestCurieExpansion:
+    def test_obo_ontologies_expand_to_obo_purl(self):
+        assert iri("NCIT:C83280") == "http://purl.obolibrary.org/obo/NCIT_C83280"
+        assert iri("CHEBI:23367") == "http://purl.obolibrary.org/obo/CHEBI_23367"
+        assert iri("MSIO:0000062") == "http://purl.obolibrary.org/obo/MSIO_0000062"
+        assert iri("PATO:0000033") == "http://purl.obolibrary.org/obo/PATO_0000033"
+        assert iri("UO:0000064") == "http://purl.obolibrary.org/obo/UO_0000064"
+
+    def test_bao_uses_its_native_namespace(self):
+        assert iri("BAO:0000697") == "http://www.bioassayontology.org/bao#BAO_0000697"
+
+    def test_efo_uses_ebi_native_namespace(self):
+        # EFO is an EBI application ontology; its native IRI is under ebi.ac.uk/efo,
+        # not the OBO PURL and certainly not a bioregistry.io resolver URL.
+        assert iri("EFO:0002090") == "http://www.ebi.ac.uk/efo/EFO_0002090"
+
+    def test_no_prefix_is_a_meta_resolver_url(self):
+        assert all(
+            "bioregistry.io" not in ns and "identifiers.org" not in ns
+            for ns in PREFIXES.values()
+        )
+
+    def test_unknown_or_malformed_curie_raises(self):
+        with pytest.raises(KeyError):
+            iri("NOPE:123")
+        with pytest.raises(KeyError):
+            iri("NCIT_C83280")  # no ':' separator
+
+
+class TestEmittersAvoidAntiPatterns:
+    """The two IRI anti-patterns #358 fixes must not reappear in the emitter files.
+
+    (Ontology-IRI mentions inside comments, docstrings, or LLM-facing tool-description
+    examples are fine; these guards target IRIs used as data.)
+    """
+
+    def test_no_bioregistry_resolver_urls(self):
+        """A term's identity is its ontology's own IRI, never a bioregistry.io redirect."""
+        offenders = {
+            rel: hits
+            for rel in _EMITTER_FILES
+            if (hits := _grep(rel, "bioregistry.io/"))
+        }
+        assert not offenders, (
+            "bioregistry.io resolver URLs are not canonical term identities; "
+            f"build the native IRI via ontology_iris.iri(): {offenders}"
+        )
+
+    def test_bao_uses_native_namespace_not_obo_purl(self):
+        """BAO is not in the OBO PURL system; use its bioassayontology.org namespace."""
+        offenders = {
+            rel: hits
+            for rel in _EMITTER_FILES
+            if (hits := _grep(rel, "purl.obolibrary.org/obo/BAO_"))
+        }
+        assert not offenders, (
+            f"BAO must use its native bao# namespace via ontology_iris.iri(): {offenders}"
+        )


### PR DESCRIPTION
Closes #358.

## Problem
Ontology term IRIs were hardcoded independently in **four** files (`tox.py`, `_crate_mapping.py`, `context.py`, `drafters.py`) in **three inconsistent schemes**:
- NCIT/EFO as `https://bioregistry.io/…` resolver URLs,
- some BAO terms as `http://purl.obolibrary.org/obo/BAO_…`, others as `http://www.bioassayontology.org/bao#BAO_…`,

so the *same* concept could get *different* IRIs depending on which file emitted it (and the OLS lookup path emitted yet another form).

## Best practice applied
A term's **identity IRI is the ontology's own canonical, resolvable IRI — never a meta-resolver** (`bioregistry.io` / `identifiers.org`) URL, which is for *resolving*, not *being* the identifier.

- **New `profiles/ontology_iris.py`** — one CURIE prefix map + `iri("NCIT:C83280")` expander. OBO Foundry ontologies → OBO PURL; **BAO** → `bioassayontology.org/bao#`; **EFO** → `ebi.ac.uk/efo/EFO_`.
- All four emitters now build IRIs via `iri()` — one place to edit any ontology base.
- The chosen native forms **match what the OLS/lookup path already emits**, so hardcoded template terms and looked-up terms finally agree.

## Emitted-IRI changes (definitions only — no scoring/logic change)
| term(s) | before | after |
|---|---|---|
| NCIT (C83280, C43377) | `bioregistry.io/NCIT:…` | `obo/NCIT_…` |
| EFO (0002090/91, 0007061) | `bioregistry.io/EFO:…` | `ebi.ac.uk/efo/EFO_…` |
| BAO (0000697, 0002628, 0002001) | `obo/BAO_…` | `bao#BAO_…` |

`test_csvw_payload.py` (3 expected IRIs) and `profiles/docs/isa_tox.md` (6) updated to the canonical forms.

## Tests (TDD, red-first)
`tests/test_ontology_iris.py`:
- CURIE expansion unit tests (OBO PURL / BAO native / EFO EBI native; unknown prefix raises).
- **Guard invariants**: no `bioregistry.io` resolver URLs, and no `obo/BAO_`, in the emitter files — so neither anti-pattern can reappear.

`ruff` + `ty` clean; 98 directly-affected tests pass; **full suite green**.

_Part of the external-sources / harmonization cleanup lane (#355–#361)._