### PR TITLE
docs(profiles): document the intentional RO-Crate 1.1 lineage vs 1.2 base pass (#361)

### DIFF
--- a/profiles/shapes/tox/profile.ttl
+++ b/profiles/shapes/tox/profile.ttl
@@ -4,6 +4,15 @@
 # RO-Crate profile (bundled in roc-validator as `isa-ro-crate`), which is itself
 # an extension of RO-Crate 1.1. Validating against the `tox-ro-crate` token
 # transitively runs the isa-ro-crate and ro-crate checks as well.
+#
+# Lineage vs. base pass (#361): the `isTransitiveProfileOf .../crate/1.1` below is
+# intentional — it mirrors the upstream `isa-ro-crate` profile, which declares
+# itself a profile of RO-Crate 1.1. This is NOT inconsistent with the validator
+# running its base pass against `ro-crate-1.2` (profiles/validator.py): RO-Crate
+# 1.2 is backward-compatible, so crates that declare `conformsTo` 1.2 (this repo,
+# #91) validate against the 1.2 base while the domain profiles keep their 1.1
+# lineage. Bump this to 1.2 only if/when the upstream isa-ro-crate profile does
+# (a guard test asserts the two stay in sync).
 
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix prof: <http://www.w3.org/ns/dx/prof/> .

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -422,6 +422,10 @@ class ValidationResult:
 # three passes in validate_crate(); the only difference is the document is fed as
 # a dict via services.validate_metadata_as_dict instead of read from disk.
 _PROFILE_PASSES: dict[str, tuple[str, dict]] = {
+    # Base pass targets ro-crate-1.2 (crates emit `conformsTo` 1.2, #91). The isa/tox
+    # domain profiles are 1.1-lineage (they extend the upstream isa-ro-crate 1.1
+    # profile); RO-Crate 1.2 is backward-compatible, so this is by design, not drift.
+    # See profiles/shapes/tox/profile.ttl and tests/test_profile_lineage.py (#361).
     "base": ("ro-crate-1.2", {}),
     "isa": ("isa-ro-crate", {"disable_inherited_profiles_issue_reporting": True}),
     "tox": (

--- a/tests/test_profile_lineage.py
+++ b/tests/test_profile_lineage.py
@@ -1,0 +1,62 @@
+"""Issue #361: the tox profile's RO-Crate base lineage mirrors the upstream
+``isa-ro-crate`` profile it extends.
+
+The tox ``profile.ttl`` declares ``isTransitiveProfileOf .../crate/1.1`` because the
+bundled ``isa-ro-crate`` profile (which it extends) is a profile of RO-Crate 1.1. This
+is intentional and NOT inconsistent with the validator running its base pass against
+``ro-crate-1.2`` — 1.2 is backward-compatible (see ``profiles/validator.py``,
+``profiles/shapes/tox/profile.ttl``). This guard fails if the two lineages diverge,
+e.g. if upstream ``isa-ro-crate`` bumps its base version and the tox profile is left
+behind.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+TOX_PROFILE = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "profiles"
+    / "shapes"
+    / "tox"
+    / "profile.ttl"
+)
+
+
+def _crate_base_versions(ttl_text: str) -> set[str]:
+    """RO-Crate base versions a profile targets (``w3id.org/ro/crate/<x.y>``)."""
+    return set(re.findall(r"w3id\.org/ro/crate/(\d+\.\d+)\b", ttl_text))
+
+
+def _isa_ro_crate_profile() -> pathlib.Path:
+    import rocrate_validator
+
+    return (
+        pathlib.Path(rocrate_validator.__file__).parent
+        / "profiles"
+        / "isa-ro-crate"
+        / "profile.ttl"
+    )
+
+
+def test_tox_profile_base_lineage_mirrors_isa_ro_crate():
+    isa_versions = _crate_base_versions(_isa_ro_crate_profile().read_text())
+    tox_versions = _crate_base_versions(TOX_PROFILE.read_text())
+
+    assert isa_versions == {"1.1"}, (
+        f"upstream isa-ro-crate profile changed its RO-Crate base to {isa_versions}; "
+        "reconcile profiles/shapes/tox/profile.ttl to match"
+    )
+    assert tox_versions == isa_versions, (
+        f"tox profile RO-Crate lineage {tox_versions} must mirror the isa-ro-crate "
+        f"profile it extends {isa_versions}"
+    )
+
+
+def test_validator_base_pass_is_1_2_by_design():
+    """The base validation pass is 1.2 (backward-compatible) even though the domain
+    profiles are 1.1-lineage — pin it so the deliberate choice is visible."""
+    from profiles.validator import _PROFILE_PASSES
+
+    assert _PROFILE_PASSES["base"][0] == "ro-crate-1.2"


### PR DESCRIPTION
Closes #361.

## Finding: not a bug
`profiles/shapes/tox/profile.ttl` declares `isTransitiveProfileOf .../crate/1.1`, while the validator's base pass is `ro-crate-1.2` (`validator.py`). That *looks* like drift left over from #91/#110, but it isn't:

- The tox profile `isProfileOf` the bundled **`isa-ro-crate`** profile, which **itself declares `isProfileOf` / `isTransitiveProfileOf <…/crate/1.1>`** (`isa-ro-crate/profile.ttl:37,40,57,79`). So the tox profile's 1.1 lineage is **accurate** — it faithfully mirrors the profile it extends.
- The `ro-crate-1.2` base pass is a **deliberate backward-compatibility choice** (crates emit `conformsTo` 1.2 per #91; RO-Crate 1.2 is a superset of 1.1's structural rules).

Bumping the profile to 1.2 would have been the *actual* error (it would misdeclare the ISA layer's lineage).

## Change (documentation + guard — no behaviour change)
- **`profile.ttl`** — comment explaining the 1.1 lineage is intentional and coexists by design with the 1.2 base pass.
- **`validator.py`** — cross-reference comment at `_PROFILE_PASSES["base"]`.
- **`tests/test_profile_lineage.py`** — guard tests:
  - the tox profile's RO-Crate lineage stays in sync with the upstream `isa-ro-crate` profile (fails if upstream bumps its base and the tox profile is left behind);
  - pins the base pass as `ro-crate-1.2` so the deliberate choice stays visible.

Full crate validation (all three profile passes) still runs clean; `ruff` clean; **full suite green**.

_Part of the external-sources / harmonization cleanup lane (#355–#361)._