### PR TITLE
fix(guidance): commit answers to the entity they were about, and stop re-asking (#375)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1542,6 +1542,7 @@ vitro-crate/
 │   │   ├── lookups.py, verification.py, builder.py, validation.py
 │   │   ├── repair.py, gap_analysis.py, mit_assessment.py, fair_assessment.py
 │   │   ├── data_content.py, file_readers.py, hitl.py, session.py
+│   │   ├── field_kinds.py        Shared field-kind vocabulary (both arms)
 │   │   ├── registry.py, _crate_mapping.py, dashboard.py, provenance.py
 │   ├── readers/                 Input readers
 │   │   ├── directory.py, existing_crate.py, metadata_files.py
@@ -1911,8 +1912,36 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
     `from_file` records the filename hint and commits nothing (file extraction is
     a separate bounded reader, not this loop — never store the prose). **D5:**
     identifier-bearing fields are never committed from the user's prose — those
-    come from lookups, so an identifier `commit` is refused (the interpret leaf
-    coerces it to `skip`).
+    come from lookups, so an identifier `commit` is refused at `_apply_value`,
+    the single chokepoint every commit funnels through (#375). Guarding the
+    chokepoint rather than the interpret leaf is what closes the loop's two
+    otherwise-unguarded feeders: the no-provider ask-user path and the
+    draft-confirm dialog's `edits["value"]`.
+    - **A commit must be one the crate will actually carry** (#375). `_apply_value`
+      returns `True` only when the value truly lands, because the loop treats
+      `True` as progress and `format_guidance_summary` reports it to the user:
+      - a **typed** gap (MIT gaps carry `entity_id is None` + an `entity_type`)
+        commits to the single in-state instance of that type — the same instance
+        `_ground_entityless_gap` phrased the question about, so the prompt and the
+        write can never name different entities. Zero or several instances commit
+        nothing. Only a genuinely root-level gap (`entity_type` `None` or
+        `Investigation`, since `./` folds the Investigation) may reach
+        `set_crate_metadata`; without this a question about an Assay overwrote the
+        root's `description`, a Base MUST;
+      - a **reference-only** field (`_REF_FIELDS`) accepts only a value that
+        resolves as a reference. The build strips those keys from an entity's
+        scalar properties and `_wire_reference` emits nothing for a
+        non-resolvable literal, so storing prose there and reporting success is a
+        lie. The shared `builder/tools/field_kinds.py` answers "is this field a
+        reference / an identifier, and would this value resolve?" for both arms —
+        `set_fields` logs a warning on the same condition, so the ReAct LLM cannot
+        make the mistake silently either.
+    - **"Progress" means the gap cleared** (#375). After a commit the loop
+      re-assesses and, if the gap's identity is still present, records it in
+      `tried_identities` and drops it from `resolved` rather than counting it. A
+      commit that does not clear its gap would otherwise be re-drawn every round —
+      one un-clearable gap consuming the whole `max_rounds` budget while the rest
+      of the report is never reached.
     - **Person/agent fields are committed as ENTITY references, not strings
       (#275).** A `creator` / `author` / `publisher` / `editor` / `contributor`
       gap requires an ISA Person reference, so `_apply_value` routes its value to
@@ -2140,13 +2169,28 @@ suggestion, fix_hint, auto_fixable}`: `suggestion` is the expected propertyID
 IRI / ontology term / parameter description from the profile or MIT YAML;
 `fix_hint` is a deterministic tool name (`"fix_required_issues"`), `"draft"`,
 `"ask-user"`, or **`"report-only"`** (#230). A `report-only` gap is one the
-guidance loop can *not* commit deterministically from the gap's own fields — it
-has no settable entity field (`entity_id is None`) and its property maps to no
-Root Data Entity metadata slot (`_CRATE_SETTABLE_FIELDS` — which mirrors
-guidance's `_apply_value`). **Every FAIR gap is `report-only`** (its property is
-an indicator id like `RDA-F1-02M`, not a field), as are **crate-level MIT gaps
-whose field is not a crate slot**; they stay in the report for context but the
-guidance loop never spends an ask-user/draft turn on them. `GapReport` adds
+guidance loop can *not* commit — it stays in the report for context, but the loop
+never spends a human turn on it. `_is_committable` decides this and **must mirror
+`guidance._apply_value`'s success conditions** (#375); a test walks every
+actionable gap and asserts `_apply_value`'s preconditions hold, so the two cannot
+drift. A gap is committable when it names a field the loop can write: a
+person/citation field (their own composite routes), an entity-scoped gap whose
+`entity_id` resolves to a state entity (or the root `./` with a
+`_CRATE_SETTABLE_FIELDS` field), a **typed** gap (`entity_id is None` +
+`entity_type`) whose field is a crate slot **and** whose type has exactly one
+instance, or a crate-level gap whose field is a crate slot. Never committable: a
+gap naming **no field** (a node shape), and an **identifier-bearing field** — D5
+refuses to take an identifier from prose, so asking could only discard the answer
+(resolving it is a *lookup*, #338/#372). A **reference-only** field stays
+committable on purpose: prose is refused, but naming an entity already in the
+crate is exactly the useful answer when a repair rule declined on ambiguous
+candidates. **Every FAIR gap is `report-only`** (its property is an indicator id
+like `RDA-F1-02M`, not a field), as are **crate-level MIT gaps whose field is not
+a crate slot**. Actionability is gated on the **field**, never on the mere
+presence of an `entity_id` — MIT gaps deliberately keep `entity_id is None`, and
+populating it would flip ~167 report-only pseudo-field slots
+(`MolecularEntity:char`, `LabProcessExposure:param`, …) into ask-user turns that
+would write literal `"char"` / `"param"` keys. `GapReport` adds
 `{gaps, conformance, mit_overall, fair_summary, counts}`, with `gaps` sorted
 **all MUST, then SHOULD, then MAY**, then **committable before `report-only`**
 within a tier, stable secondary by `(source, entity_id, property)` — so the loop

--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -38,7 +38,8 @@ The loop (:func:`run_guidance`) per round:
      value applied through the existing ``set_fields`` / ``set_crate_metadata``
      tools (never hand-rolled JSON-LD). ``skip``/``from_file`` commit nothing;
      ``clarify`` asks at most one bounded follow-up. With no provider this is the
-     deterministic ask-and-set.
+     deterministic ask-and-set — still routed through
+     :func:`_deterministic_decision`, so the D5 identifier skip applies offline too.
 
 4. Re-assess after each committed change; **never loop forever** — bounded by
    ``max_rounds`` and a per-report skip-set. A gap the loop cannot progress this
@@ -61,8 +62,15 @@ Determinism & safety contract:
   — a free-text reply is never stored verbatim.
 * **HITL is never removed.** ask-user and draft-confirm both route through the
   injected :class:`HumanInterface`; the loop cannot silently fabricate content.
-* **D5 at the leaf.** Identifier-bearing fields are never committed from the user's
-  prose (those come from lookups); the interpreter refuses such a commit.
+* **D5 at the chokepoint.** Identifier-bearing fields are never committed from the
+  user's prose (those come from lookups). The refusal lives in :func:`_apply_value`,
+  which *every* commit funnels through — the interpreter refuses one too, but it is
+  not on the no-provider path, so guarding only there left the guarantee unmet
+  (#375).
+* **A ``True`` commit is one the crate will carry.** :func:`_apply_value` writes a
+  typed gap to its own instance rather than the Root Data Entity, and refuses a
+  reference-only field a value that would not resolve — the build silently drops
+  such a literal, so reporting success would be a lie (#375).
 
 This is a clean library entrypoint — the CLI / spine wiring is a later PR.
 """
@@ -79,6 +87,16 @@ from typing import TYPE_CHECKING, Any, Callable
 # leaf can be stubbed without importing langchain.
 from builder.agents.pipeline.pipeline import draft_entity_fields
 from builder.config import get_provider
+from builder.tools.field_kinds import (
+    CITATION_FIELDS,
+    IDENTIFIER_FIELDS,
+    PERSON_FIELDS,
+    is_citation_field,
+    is_identifier_field,
+    is_person_field,
+    is_reference_field,
+    is_resolvable_reference,
+)
 from builder.tools.gap_analysis import REPORT_ONLY, Gap, assess_gaps
 
 # (#275) The ORCID lookup, re-exported at module scope as the single stable
@@ -148,36 +166,13 @@ _MAX_CLARIFY_FOLLOW_UPS = 1
 # descriptive fields (identifiers come from lookups, D5).
 _DESCRIPTIVE_FIELDS: frozenset[str] = frozenset({"name", "description"})
 
-# D5: identifier-bearing field names the deterministic interpret fallback must
-# NEVER commit from the user's prose (those come from lookups). Mirrors
-# `builder.agents.pipeline.leaves._IDENTIFIER_SCALAR_FIELDS`; kept local so the no-provider
-# / offline path stays free of the (langchain-importing) leaves module.
-_IDENTIFIER_FIELDS: frozenset[str] = frozenset(
-    {
-        "identifier",
-        "accession",
-        "inchikey",
-        "smiles",
-        "molecular_formula",
-        "pubchem_cid",
-        "cas",
-        "casrn",
-        "cas_number",
-        "orcid",
-        "ror",
-        "doi",
-        "term_code",
-        "in_defined_term_set",
-        "property_id",
-        "unit_code",
-        "url",
-    }
-)
-
-
-def _is_identifier_field(field: str) -> bool:
-    """Whether ``field`` (a local property name) is identifier-bearing (D5)."""
-    return field in _IDENTIFIER_FIELDS
+# D5: identifier-bearing field names that must NEVER be committed from the user's
+# prose (those come from lookups). The definition now lives in the shared
+# :mod:`builder.tools.field_kinds` — one vocabulary for both build arms, replacing
+# the byte-identical copy that also existed in ``leaves`` (#375). These aliases
+# are kept so existing callers and monkeypatching tests are unaffected.
+_IDENTIFIER_FIELDS = IDENTIFIER_FIELDS
+_is_identifier_field = is_identifier_field
 
 
 # (#275) Person/agent-typed fields whose ISA value MUST be a Person (or
@@ -186,14 +181,11 @@ def _is_identifier_field(field: str) -> bool:
 # "creator MUST be of type Person" SHACL shape unsatisfied, so the gap re-emits
 # every round and ``isa=fail`` — the #275 re-ask loop. These are instead routed
 # to ``draft_person`` and linked as a reference (see :func:`_apply_person_value`).
-_PERSON_FIELDS: frozenset[str] = frozenset(
-    {"creator", "author", "publisher", "editor", "contributor"}
-)
-
-
-def _is_person_field(field: str) -> bool:
-    """Whether ``field`` (a local property name) is a person/agent-typed field."""
-    return field in _PERSON_FIELDS
+# Defined once in the shared :mod:`builder.tools.field_kinds` (#375) so the gap
+# engine can ask the same question without importing guidance (which would be a
+# cycle: guidance imports gap_analysis).
+_PERSON_FIELDS = PERSON_FIELDS
+_is_person_field = is_person_field
 
 
 # (Commit 1, #179) Citation-typed fields whose ISA/BASE value MUST be a
@@ -203,12 +195,8 @@ def _is_person_field(field: str) -> bool:
 # and which is not a crate-metadata slot — so committing the prose as a string did
 # nothing and the always-highest-priority gap was re-asked every round. These are
 # instead routed to the publication composites (see :func:`_apply_citation_value`).
-_CITATION_FIELDS: frozenset[str] = frozenset({"citation"})
-
-
-def _is_citation_field(field: str) -> bool:
-    """Whether ``field`` (a local property name) is a citation-typed field."""
-    return field in _CITATION_FIELDS
+_CITATION_FIELDS = CITATION_FIELDS
+_is_citation_field = is_citation_field
 
 
 def _gap_is_root(engine: AgentEngine, gap: Gap) -> bool:
@@ -464,7 +452,68 @@ def _apply_citation_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
         return False
 
 
-def _apply_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
+def _instances_for_commit(engine: AgentEngine, entity_type: str | None) -> list[Any]:
+    """In-state instances of ``entity_type`` — the commit-target selection rule.
+
+    Mirrors :func:`builder.tools.gap_analysis._instances_of`, so what the gap
+    engine advertises as actionable and what :func:`_apply_value` can actually
+    write are decided the same way.
+
+    Counts ALL instances, not only named ones: a name is needed to *phrase* the
+    question well (see :func:`_named_instances`), but the sole instance of a type
+    is an unambiguous place to *write* whether or not it has one — and an unnamed
+    sibling still makes the target ambiguous, so it must be counted.
+    """
+    if not entity_type:
+        return []
+    try:
+        return list(engine.state.list_entities(entity_type))
+    except (KeyError, ValueError) as exc:  # pragma: no cover — unknown type is rare
+        logger.debug("guidance: cannot list %s instances: %s", entity_type, exc)
+        return []
+
+
+def _named_instances(engine: AgentEngine, entity_type: str | None) -> list[tuple[Any, str]]:
+    """The NAMED in-state instances of ``entity_type`` as ``(entity, name)`` pairs.
+
+    Used to decide what a question is *about* (:func:`_ground_entityless_gap`
+    threads the real instance name into the phrase leaf). The commit target is
+    chosen by :func:`_instances_for_commit` over the same type, so the prompt and
+    the write can never point at different entities — that mismatch was the #375
+    defect.
+    """
+    return [
+        (entity, name)
+        for entity in _instances_for_commit(engine, entity_type)
+        if (name := _entity_display_name(entity))
+    ]
+
+
+def _notify(human: HumanInterface | None, message: str) -> None:
+    """Tell the user something without asking them anything.
+
+    ``HumanInterface`` has only blocking members (``present`` / ``request_input``),
+    so this uses the same **optional-attribute** pattern as ``is_interactive`` and
+    ``is_done``: a frontend that offers ``notify`` shows the message immediately;
+    one that does not simply gets the log line. Never blocks and never consumes a
+    scripted answer.
+    """
+    notify = getattr(human, "notify", None)
+    if callable(notify):
+        try:
+            notify(message)
+            return
+        except Exception:  # noqa: BLE001 — a frontend hiccup must not break the loop
+            pass
+    logger.info("guidance: %s", message)
+
+
+def _apply_value(
+    engine: AgentEngine,
+    gap: Gap,
+    value: str,
+    human: HumanInterface | None = None,
+) -> bool:
     """Commit ``value`` for ``gap`` via the existing set tools. Returns success.
 
     Uses ``set_fields`` for an entity-scoped gap and ``set_crate_metadata`` for a
@@ -497,14 +546,67 @@ def _apply_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
     if _is_citation_field(field) and _gap_is_root(engine, gap):
         return _apply_citation_value(engine, gap, value)
 
+    # (#375, D5) An identifier is never taken from prose, on ANY path. This is the
+    # single chokepoint every commit funnels through, and it has two feeders that
+    # are otherwise unguarded: the no-provider ask-user path and the draft-confirm
+    # dialog's ``edits["value"]``. Guarding here closes both at once.
+    if is_identifier_field(field):
+        _notify(
+            human,
+            f"'{field}' is an identifier, so it is looked up rather than typed in — "
+            "your answer was not stored.",
+        )
+        return False
+
+    # (#375) A reference-only property must name an entity. The build strips every
+    # `_REF_FIELDS` key out of an entity's scalar properties and `_wire_reference`
+    # emits nothing for a non-resolvable literal, so storing prose here and
+    # returning True is a lie: the value never reaches the crate.
+    if is_reference_field(field) and not is_resolvable_reference(engine.state, value):
+        _notify(
+            human,
+            f"'{field}' has to name something already in the crate, so your answer "
+            "was not stored.",
+        )
+        return False
+
     state_id = _resolve_entity_id(engine, gap)
     if state_id is not None:
         engine.run_tool("set_fields", entity_id=state_id, fields={field: value})
         return True
 
-    # Crate-level gap (no entity): route to the Root Data Entity metadata setter
-    # when the field maps to a known root slot; otherwise we cannot commit it
-    # deterministically (it was still surfaced to the user as "asked").
+    # (#375) A TYPED gap (MIT gaps carry `entity_id=None` + an `entity_type`) is
+    # about a specific instance — the question was phrased about it by
+    # `_ground_entityless_gap`. Resolve the same instance with the same rule so the
+    # answer lands where the question promised, instead of falling through to the
+    # Root Data Entity setter below and clobbering a Base MUST.
+    if gap.entity_type not in (None, "Investigation"):
+        instances = _instances_for_commit(engine, gap.entity_type)
+        if len(instances) == 1:
+            engine.run_tool(
+                "set_fields", entity_id=instances[0].entity_id, fields={field: value}
+            )
+            return True
+        # Zero or several instances: there is no unambiguous target, so commit
+        # nothing rather than guess (D5).
+        logger.debug(
+            "guidance: %d %s instance(s); no unambiguous commit target",
+            len(instances),
+            gap.entity_type,
+        )
+        if len(instances) > 1:
+            _notify(
+                human,
+                f"there are several {gap.entity_type} entries, so it is not clear which "
+                "one you meant — your answer was not stored.",
+            )
+        return False
+
+    # Crate-level gap: route to the Root Data Entity metadata setter when the field
+    # maps to a known root slot. Only a genuinely root-level gap reaches here — the
+    # root `./` node folds the Investigation, so `entity_type` is None or
+    # "Investigation"; otherwise we cannot commit it deterministically (it was
+    # still surfaced to the user as "asked").
     crate_arg = _CRATE_METADATA_FIELDS.get(field)
     if gap.entity_id is None and crate_arg is not None:
         engine.run_tool("set_crate_metadata", **{crate_arg: value})
@@ -708,15 +810,7 @@ def _ground_entityless_gap(engine: AgentEngine, gap: Gap, context: dict[str, Any
     Mutates ``context`` in place; a no-op when there is no type or no named
     instance (the prompt-side D5 guard then forbids inventing a name).
     """
-    entity_type = gap.entity_type
-    if not entity_type:
-        return
-    try:
-        instances = engine.state.list_entities(entity_type)
-    except (KeyError, ValueError) as exc:  # pragma: no cover — unknown type is rare
-        logger.debug("guidance: cannot list %s instances: %s", entity_type, exc)
-        return
-    named = [(entity, name) for entity in instances if (name := _entity_display_name(entity))]
+    named = _named_instances(engine, gap.entity_type)
     if not named:
         return
     if len(named) == 1:
@@ -810,12 +904,17 @@ def _phrase_question(engine: AgentEngine, gap: Gap) -> str:
 def _deterministic_decision(gap: Gap, reply: str) -> dict[str, Any]:
     """The deterministic interpret fallback: a non-empty reply is a commit (#244).
 
-    Used when the interpret leaf is unavailable or fails (and as the documented
-    no-provider behavior): treat a non-empty reply as a commit and an empty one as
-    a skip — *except* for an identifier-bearing field, where the user's prose must
+    Used when the interpret leaf is unavailable or fails, **and** on the
+    no-provider path: treat a non-empty reply as a commit and an empty one as a
+    skip — *except* for an identifier-bearing field, where the user's prose must
     NOT become an identifier value (D5), so it is skipped (identifiers come from
     lookups). This preserves today's ask-and-set behavior without ever storing a
     musing as an identifier.
+
+    Its docstring used to claim to be "the documented no-provider behavior" while
+    both of its call sites sat *downstream* of ``_resolve_ask_user``'s no-provider
+    early return, so offline runs never reached it and the D5 skip was dead code
+    (#375). ``_resolve_ask_user`` now routes the offline reply through here.
     """
     if not reply or not reply.strip():
         return {"action": "skip"}
@@ -868,8 +967,15 @@ def _resolve_ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> s
     (today's ask-and-set behavior), keeping offline runs deterministic.
     """
     # No provider -> deterministic ask-and-set (offline determinism, #244).
+    # The reply goes through `_deterministic_decision` rather than straight back:
+    # that is where the D5 identifier skip lives, and routing around it (#375) made
+    # the documented guard unreachable on this path — prose became an identifier.
     if get_provider() is None:
-        return _ask_user(engine, human, gap)
+        reply = _ask_user(engine, human, gap)
+        if reply is None:
+            return None
+        value = _deterministic_decision(gap, reply).get("value")
+        return value.strip() if isinstance(value, str) and value.strip() else None
 
     question = _phrase_question(engine, gap)
     response = human.request_input(question)
@@ -1068,6 +1174,11 @@ def _resolve_gap(
         "tier": gap.tier,
         "source": gap.source,
         "entity_id": gap.entity_id,
+        # A typed gap (MIT) carries no entity_id, so entity_type is the only thing
+        # identifying WHICH entity it was about — and after #375 it is also what
+        # decides where the answer is written. Recorded so a caller can tell two
+        # same-property gaps apart (e.g. Assay:description vs LabProtocol:description).
+        "entity_type": gap.entity_type,
         "property": gap.property,
         "fix_hint": gap.fix_hint,
     }
@@ -1095,7 +1206,7 @@ def _resolve_gap(
                 # An edited confirmation may carry the user's own value.
                 edits = decision.get("edits") or {}
                 value = str(edits.get("value")) if edits.get("value") else candidate
-                if _apply_value(engine, gap, value):
+                if _apply_value(engine, gap, value, human):
                     resolved.append({**record, "via": "draft-confirmed"})
                     return True
                 return False
@@ -1106,7 +1217,7 @@ def _resolve_gap(
     value = _resolve_ask_user(engine, human, gap)
     if value is None:
         return False
-    if _apply_value(engine, gap, value):
+    if _apply_value(engine, gap, value, human):
         resolved.append({**record, "via": "ask-user"})
         return True
     return False
@@ -1201,6 +1312,8 @@ def run_guidance(
             break
 
         rounds += 1
+        identity = _gap_identity(gap)
+        resolved_before = len(resolved)
         progressed = _resolve_gap(engine, human, gap, resolved=resolved, asked=asked)
 
         if progressed:
@@ -1210,6 +1323,14 @@ def run_guidance(
             # re-emits is not re-drawn.
             report = assess_gaps(engine.state)
             skipped = set()
+            # (#375) "The setter returned True" is not "the gap cleared". If the
+            # same identity is still in the fresh report, the commit did not close
+            # it — so do NOT count it resolved (`format_guidance_summary` prints
+            # that list verbatim) and never draw it again, or it is re-asked every
+            # round until `max_rounds` runs out and starves every gap behind it.
+            if any(_gap_identity(g) == identity for g in report.gaps):
+                del resolved[resolved_before:]
+                tried_identities.add(identity)
         else:
             # This one gap is not resolvable right now (e.g. skipped or its answer
             # could not be applied). Skip it BOTH by report index (so the next

--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -36,6 +36,7 @@ from builder.agents.llm import (
     _extract_token_usage,
 )
 from builder.tools._crate_mapping import _REF_FIELDS, draft_hints_schema
+from builder.tools.field_kinds import IDENTIFIER_FIELDS
 
 # A usage sink is notified of one leaf call's token usage:
 # ``(input_tokens, output_tokens, model_name)``. Any element may be ``None`` when
@@ -84,31 +85,12 @@ def _invoke_structured_with_usage(
 # extracted as free text. Both sets are pruned from the structured-output schema
 # *and* stripped from the result.
 # ---------------------------------------------------------------------------
-_IDENTIFIER_SCALAR_FIELDS: frozenset[str] = frozenset(
-    {
-        # generic identifier slot (CAS / accession / DOI, per entity type)
-        "identifier",
-        "accession",
-        # MolecularEntity structure/registry identifiers
-        "inchikey",
-        "smiles",
-        "molecular_formula",
-        "pubchem_cid",
-        "cas",
-        "casrn",
-        "cas_number",
-        # Person / Organization / Publication external ids
-        "orcid",
-        "ror",
-        "doi",
-        # DefinedTerm / PropertyValue ontology identifiers + dereferenceable IRIs
-        "term_code",
-        "in_defined_term_set",
-        "property_id",
-        "unit_code",
-        "url",
-    }
-)
+# D5: identifier-bearing fields the model is never even asked for, and which are
+# stripped from its output defensively. The set now has ONE definition, in the
+# shared :mod:`builder.tools.field_kinds` (#375) — it previously existed here and
+# byte-identically in ``guidance``, free to drift apart. Aliased rather than
+# renamed so the many references below (and any external caller) are unaffected.
+_IDENTIFIER_SCALAR_FIELDS: frozenset[str] = IDENTIFIER_FIELDS
 
 # Fields removed from the schema the model sees AND stripped from its output (D5).
 _EXCLUDED_FIELDS: frozenset[str] = _IDENTIFIER_SCALAR_FIELDS | _REF_FIELDS

--- a/builder/tools/field_kinds.py
+++ b/builder/tools/field_kinds.py
@@ -1,0 +1,144 @@
+"""What KIND of value a field takes — the single vocabulary both arms share (#375).
+
+Three questions recur across the toolbox and both build arms, and each was
+previously answered by a private copy that could drift from the build's actual
+behaviour:
+
+* **Is this field identifier-bearing?** (D5: its value comes from a lookup, never
+  from the model's or the user's prose.) Two byte-identical definitions existed —
+  ``guidance._IDENTIFIER_FIELDS`` and ``leaves._IDENTIFIER_SCALAR_FIELDS`` — the
+  first kept local only to spare the offline path an import of the
+  langchain-importing ``leaves`` module. A ``builder/tools/`` module solves that
+  properly: it is dependency-light and importable from anywhere.
+* **Is this field reference-only?** A property that must hold an entity reference,
+  never a literal. :data:`builder.tools._crate_mapping._REF_FIELDS` is the source
+  of truth; this module is its single reader.
+* **Would this value actually resolve as a reference?** Mirrors
+  :func:`builder.tools._crate_mapping._wire_reference`'s own acceptance rule, so
+  a caller cannot believe it committed a reference the build will discard.
+
+The third question is the one that made #375 a *correctness* bug rather than a
+tidiness one: the guidance loop stored free text on a reference-only property,
+reported success, and the builder then silently dropped it —
+``_scalar_props`` strips every ``_REF_FIELDS`` key, and ``_wire_reference``
+(``keep_literal=False``) emits nothing for a non-resolvable literal. Asking the
+same question here and in the build keeps the two sides from disagreeing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from builder.state import CrateState
+from builder.tools._crate_mapping import _REF_FIELDS
+
+__all__ = [
+    "CITATION_FIELDS",
+    "IDENTIFIER_FIELDS",
+    "PERSON_FIELDS",
+    "is_citation_field",
+    "is_identifier_field",
+    "is_person_field",
+    "is_reference_field",
+    "is_resolvable_reference",
+]
+
+
+# (#275) Person/agent-typed fields whose ISA value MUST be a Person (or
+# Organization) ENTITY reference, never a literal string. They have their own
+# commit route (``draft_person`` + link by ``@id``), so they are reference-shaped
+# without being members of ``_REF_FIELDS``.
+PERSON_FIELDS: frozenset[str] = frozenset(
+    {"creator", "author", "publisher", "editor", "contributor"}
+)
+
+# (#179) Citation-typed fields whose value MUST be a ``ScholarlyArticle``
+# reference with an absolute-URI ``@id``, resolved through the publication
+# composites rather than stored as prose.
+CITATION_FIELDS: frozenset[str] = frozenset({"citation"})
+
+
+def is_person_field(field: str) -> bool:
+    """Whether ``field`` (a local property name) is person/agent-typed."""
+    return field in PERSON_FIELDS
+
+
+def is_citation_field(field: str) -> bool:
+    """Whether ``field`` (a local property name) is citation-typed."""
+    return field in CITATION_FIELDS
+
+
+# D5 ("Verify, don't trust"): identifier-bearing field names whose value must come
+# from a lookup and must NEVER be taken from prose — the model's or the user's.
+#
+# NB (#377): membership is exact, so a camelCase property local name (``inChIKey``)
+# does not match the snake_case entry (``inchikey``). That mismatch is a real
+# defect, but fixing it changes which gaps are refused and is therefore #377's
+# scope, not this module's.
+IDENTIFIER_FIELDS: frozenset[str] = frozenset(
+    {
+        # generic identifier slot (CAS / accession / DOI, per entity type)
+        "identifier",
+        "accession",
+        # MolecularEntity structure/registry identifiers
+        "inchikey",
+        "smiles",
+        "molecular_formula",
+        "pubchem_cid",
+        "cas",
+        "casrn",
+        "cas_number",
+        # Person / Organization / Publication external ids
+        "orcid",
+        "ror",
+        "doi",
+        # DefinedTerm / PropertyValue ontology identifiers + dereferenceable IRIs
+        "term_code",
+        "in_defined_term_set",
+        "property_id",
+        "unit_code",
+        "url",
+    }
+)
+
+
+def is_identifier_field(field: str) -> bool:
+    """Whether ``field`` (a local property name) is identifier-bearing (D5)."""
+    return field in IDENTIFIER_FIELDS
+
+
+def is_reference_field(field: str) -> bool:
+    """Whether ``field`` must hold an entity reference rather than a literal.
+
+    The single reader of :data:`builder.tools._crate_mapping._REF_FIELDS`, which
+    the build uses to strip such keys out of an entity's scalar properties.
+    """
+    return field in _REF_FIELDS
+
+
+def is_resolvable_reference(state: CrateState, value: Any) -> bool:
+    """Whether ``value`` would actually be emitted as a reference at build time.
+
+    Mirrors :func:`builder.tools._crate_mapping._wire_reference`'s acceptance
+    rule (with its default ``keep_literal=False``) so the two cannot drift:
+
+    * an inline ``{"@id": …}`` object;
+    * a string that is already an IRI (contains ``"://"``) or a ``#``-fragment;
+    * a value naming an entity that exists in ``state`` (bare ``entity_id``, or
+      the type-qualified storage key that shared collections use — ``get_entity``
+      accepts both, per Issue #57).
+
+    Anything else — notably free text — is **not** resolvable: the build would
+    drop it, so a caller must not report it as committed.
+    """
+    if value is None or value == "":
+        return False
+    if isinstance(value, dict):
+        return bool(value.get("@id"))
+    if isinstance(value, (list, tuple)):
+        return bool(value) and all(is_resolvable_reference(state, v) for v in value)
+    if not isinstance(value, str):
+        return False
+    if "://" in value or value.startswith("#"):
+        return True
+    return state.get_entity(value) is not None

--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -32,7 +32,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from builder.state import CrateState
+from builder.state import CrateState, Entity
+from builder.tools.field_kinds import (
+    CITATION_FIELDS,
+    PERSON_FIELDS,
+    is_identifier_field,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -132,24 +137,97 @@ def _local_name(iri: str | None) -> str:
     return iri.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
 
 
-def _is_committable(entity_id: str | None, prop: str | None) -> bool:
+def _is_committable(
+    state: CrateState,
+    entity_id: str | None,
+    prop: str | None,
+    entity_type: str | None = None,
+) -> bool:
     """Whether the guidance loop could deterministically commit such a gap.
 
-    Mirrors :func:`builder.agents.pipeline.guidance._apply_value`'s success conditions
-    *from the gap's own fields alone* so the gap engine and the guidance loop can
-    never drift on what "settable" means:
+    Mirrors :func:`builder.agents.pipeline.guidance._apply_value`'s success
+    conditions so the gap engine and the guidance loop can never drift on what
+    "settable" means. A gap this returns ``False`` for stays in the report (honest
+    counting) but is marked ``report-only``, so the loop never spends a human turn
+    on a question whose answer it would then discard.
 
-    * an entity-scoped gap (``entity_id`` set) is committable — the loop resolves
-      the entity at runtime and writes the property via ``set_fields``;
-    * a crate-level gap (``entity_id is None``) is committable only when its
-      property's local name maps to a Root Data Entity metadata slot.
+    Committable when the gap names a field the loop can actually write:
 
-    Anything else (e.g. a FAIR indicator id, or a crate-level field with no slot)
-    has no deterministic target and is recorded ``report-only``.
+    * the field is a **person/agent** or **citation** field — those have composite
+      routes of their own (``draft_person`` / the publication composites);
+    * an **entity-scoped** gap whose ``entity_id`` really resolves to a state
+      entity (``repair._resolve_state_entity``), or the root ``"./"`` with a field
+      that maps to a Root Data Entity metadata slot;
+    * a **typed** gap (no ``entity_id``, an ``entity_type``) whose field is a crate
+      slot **and** whose type has exactly one instance in state — the target
+      ``_apply_value`` now resolves;
+    * a **crate-level** gap whose field maps to a Root Data Entity slot.
+
+    Never committable, whatever the target:
+
+    * a gap that names **no field** (a node shape) — there is nothing to set;
+    * an **identifier-bearing** field (D5 — the value comes from a lookup, so the
+      user's answer is refused whatever they type).
+
+    A **reference-only** field stays committable on purpose. Prose cannot be
+    committed to one, but naming an entity that already exists in the crate can —
+    and that is precisely the useful question when a repair rule declined because
+    two candidates were ambiguous ("which File is this analysis' input?"). #375
+    makes the *prose* case honest (``_apply_value`` refuses it and the loop asks
+    once) rather than removing the interaction.
     """
+    field = _local_name(prop)
+    if not field:
+        return False
+
+    if is_identifier_field(field):
+        return False
+
     if entity_id is not None:
-        return True
-    return _local_name(prop) in _CRATE_SETTABLE_FIELDS
+        # Composite routes (`_apply_person_value` / `_apply_citation_value`) commit
+        # these without needing the focus node to resolve to a state entity. Scoped
+        # to an entity-bearing gap on purpose: a crate-level MIT gap keeps the
+        # field gate below, so this cannot flip the ~167 report-only MIT gaps.
+        if field in PERSON_FIELDS or field in CITATION_FIELDS:
+            return True
+        from builder.tools.repair import _resolve_state_entity
+
+        if _resolve_state_entity(state, entity_id) is not None:
+            return True
+        # The root "./" folds the Investigation and has no separate state entity.
+        return entity_id == "./" and field in _CRATE_SETTABLE_FIELDS
+
+    # Typed gap (MIT): committable when the FIELD is settable *and* its type has
+    # exactly one named instance to write to. Gating on the field as well as the
+    # instance count is load-bearing: dropping the field test would flip the ~150
+    # pseudo-field MIT slots (``MolecularEntity:char``, ``LabProcessExposure:param``,
+    # …) from report-only to ask-user, and ``set_fields`` would then write literal
+    # ``"char"`` / ``"param"`` keys — a strictly worse regression.
+    if entity_type not in (None, "Investigation"):
+        return (
+            field in _CRATE_SETTABLE_FIELDS
+            and len(_instances_of(state, entity_type)) == 1
+        )
+
+    return field in _CRATE_SETTABLE_FIELDS
+
+
+def _instances_of(state: CrateState, entity_type: str | None) -> list[Entity]:
+    """In-state instances of ``entity_type``.
+
+    The read-only counterpart of ``guidance._instances_for_commit`` — the same
+    rule decides whether a typed gap has an unambiguous commit target. Note it
+    counts ALL instances, not only named ones: a name is needed to *phrase* the
+    question well, but the sole instance of a type is an unambiguous place to
+    *write* whether or not it has one, and an unnamed sibling still makes the
+    target ambiguous.
+    """
+    if not entity_type:
+        return []
+    try:
+        return list(state.list_entities(entity_type))
+    except (KeyError, ValueError):  # pragma: no cover — unknown type is rare
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +303,20 @@ def _shacl_gaps(state: CrateState, build_and_validate) -> tuple[list[Gap], dict[
         resolved = _resolve_state_entity(state, issue.get("entity_id"))
         if resolved is not None:
             entity_type = resolved.type
-        fix_hint = "fix_required_issues" if auto else "ask-user"
+        # (#375) A non-auto-fixable SHACL issue was previously advertised
+        # "ask-user" unconditionally, so the loop spent a human turn on gaps
+        # `_apply_value` can only refuse — a node shape naming no field, an
+        # unresolvable focus node, an identifier, a reference-only property. They
+        # stay in the report (honest counting) but no longer consume a turn.
+        fix_hint = (
+            "fix_required_issues"
+            if auto
+            else (
+                "ask-user"
+                if _is_committable(state, issue.get("entity_id"), prop, entity_type)
+                else REPORT_ONLY
+            )
+        )
         gaps.append(
             Gap(
                 tier=tier,
@@ -383,7 +474,7 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
             # committable when their field maps to a Root Data Entity slot; the
             # rest have no deterministic settable target and are report-only, so
             # the guidance loop surfaces them for context without burning a turn.
-            elif not _is_committable(None, slot_field):
+            elif not _is_committable(state, None, slot_field, slot_entity_type):
                 message = (
                     f"MIT parameter '{param_name}' is not yet captured (crate_slot {crate_slot})."
                 )

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -6,6 +6,7 @@ field-level completion tracking.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from builder.state import (
@@ -15,6 +16,9 @@ from builder.state import (
     FileClassification,
 )
 from builder.tools._crate_mapping import _REF_FIELDS
+from builder.tools.field_kinds import is_reference_field, is_resolvable_reference
+
+logger = logging.getLogger(__name__)
 
 
 def set_fields(
@@ -47,6 +51,21 @@ def set_fields(
         raise ValueError(f"Entity not found: {entity_id}")
 
     for field, value in fields.items():
+        # (#375) A reference-only property whose value is not a resolvable
+        # reference is silently DROPPED at build time (`_scalar_props` strips
+        # every `_REF_FIELDS` key, and `_wire_reference` emits nothing for a
+        # non-resolvable literal), so the caller believes it stored something the
+        # crate will never carry. Warn rather than raise: this is a hot shared
+        # tool the ReAct LLM calls directly, and refusing here would be a
+        # behaviour change to every existing caller.
+        if is_reference_field(field) and not is_resolvable_reference(state, value):
+            logger.warning(
+                "set_fields: %r on %s is a reference-only property but %r does not "
+                "resolve to an entity — the build will drop it",
+                field,
+                entity_id,
+                value,
+            )
         entity.fields[field] = value
         entity.set_field_status(field, "filled", source)
 

--- a/profiles/shapes/tox/profile.ttl
+++ b/profiles/shapes/tox/profile.ttl
@@ -4,6 +4,15 @@
 # RO-Crate profile (bundled in roc-validator as `isa-ro-crate`), which is itself
 # an extension of RO-Crate 1.1. Validating against the `tox-ro-crate` token
 # transitively runs the isa-ro-crate and ro-crate checks as well.
+#
+# Lineage vs. base pass (#361): the `isTransitiveProfileOf .../crate/1.1` below is
+# intentional — it mirrors the upstream `isa-ro-crate` profile, which declares
+# itself a profile of RO-Crate 1.1. This is NOT inconsistent with the validator
+# running its base pass against `ro-crate-1.2` (profiles/validator.py): RO-Crate
+# 1.2 is backward-compatible, so crates that declare `conformsTo` 1.2 (this repo,
+# #91) validate against the 1.2 base while the domain profiles keep their 1.1
+# lineage. Bump this to 1.2 only if/when the upstream isa-ro-crate profile does
+# (a guard test asserts the two stay in sync).
 
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix prof: <http://www.w3.org/ns/dx/prof/> .

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -422,6 +422,10 @@ class ValidationResult:
 # three passes in validate_crate(); the only difference is the document is fed as
 # a dict via services.validate_metadata_as_dict instead of read from disk.
 _PROFILE_PASSES: dict[str, tuple[str, dict]] = {
+    # Base pass targets ro-crate-1.2 (crates emit `conformsTo` 1.2, #91). The isa/tox
+    # domain profiles are 1.1-lineage (they extend the upstream isa-ro-crate 1.1
+    # profile); RO-Crate 1.2 is backward-compatible, so this is by design, not drift.
+    # See profiles/shapes/tox/profile.ttl and tests/test_profile_lineage.py (#361).
     "base": ("ro-crate-1.2", {}),
     "isa": ("isa-ro-crate", {"disable_inherited_profiles_issue_reporting": True}),
     "tox": (

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -1997,3 +1997,273 @@ class TestRootCitationGapPersistsAndIsNotReAsked:
             f"the root citation gap must be asked at most once, got "
             f"{len(citation_prompts)} prompts: {citation_prompts}"
         )
+
+
+# ---------------------------------------------------------------------------
+# #375 — guidance commits must be HONEST.
+#
+# Four defects, one lane: an entity-scoped answer landed on the Root Data
+# Entity, a reference-only field stored prose the builder then dropped, the
+# offline path bypassed the D5 identifier guard, and "the setter returned True"
+# was mistaken for "the gap cleared" (so the same question came back every
+# round until the budget ran out).
+#
+# FIXTURE REALISM (CONTRIBUTING.md, #343): every gap below comes from the REAL
+# gap engine over a REAL state. Never a hand-made ``Gap(entity_id="st1", ...)``
+# — ``_mit_gaps`` never emits a non-None ``entity_id`` (gap_analysis.py), and
+# that unrealistic double is precisely what hid these defects.
+# ---------------------------------------------------------------------------
+
+_ROOT_DESCRIPTION = "SENTINEL ROOT DESCRIPTION - about the study, not the assay"
+_ROOT_ACCESSION = "10.5281/zenodo.123456"
+
+
+def _honest_backbone(*, named_investigation: bool = True, protocols: int = 0) -> CrateState:
+    """A backbone shaped the way the pipeline actually leaves one.
+
+    ``_backbone_hints`` gives the Assay a ``name`` and nothing else, and the
+    plan's description is merged onto the Study layer only — so
+    ``Assay:description`` is an unfilled MIT slot on *every* pipeline run and is
+    the highest-priority actionable gap in the report. The root carries sentinel
+    metadata so a mis-routed commit is detectable.
+    """
+    state = CrateState()
+    state.metadata.title = "FRTL-5 perchlorate thyroid study"
+    state.metadata.description = _ROOT_DESCRIPTION
+    state.metadata.accession = _ROOT_ACCESSION
+    inv_fields = {"description": "d", "identifier": "INV-1"}
+    if named_investigation:
+        inv_fields["name"] = "Inv"
+    state.add_entity(_entity("inv1", "Investigation", **inv_fields))
+    state.add_entity(
+        _entity("st1", "Study", name="St", description="d", investigation_id="inv1")
+    )
+    # Assay: name + study_id only, exactly as the pipeline leaves it.
+    state.add_entity(_entity("as1", "Assay", name="FRTL-5 assay", study_id="st1"))
+    for i in range(protocols):
+        state.add_entity(_entity(f"lp{i}", "LabProtocol", name=f"Protocol {chr(65 + i)}"))
+    return state
+
+
+def _pick_gap(state: CrateState, predicate) -> Gap:
+    """The single live gap from the REAL gap engine matching ``predicate``.
+
+    Asserting the gap exists is itself part of each test: if the pipeline stops
+    leaving this slot open, or the engine stops emitting the gap, the test must
+    fail loudly rather than silently passing on an empty selection.
+    """
+    matches = [g for g in assess_gaps(state).gaps if predicate(g)]
+    assert matches, "expected a live gap matching the predicate over this state"
+    return matches[0]
+
+
+def _mit_gap(state: CrateState, entity_type: str, prop: str) -> Gap:
+    return _pick_gap(
+        state,
+        lambda g: g.source == "mit" and g.entity_type == entity_type and g.property == prop,
+    )
+
+
+class TestTypedGapCommitsToItsOwnEntity:
+    """#375(a): a typed MIT gap writes to its instance, not the Root Data Entity."""
+
+    def test_mit_assay_description_gap_writes_to_the_assay_not_the_root(self):
+        """The gap that starts every interactive run must land on the Assay.
+
+        Today ``_apply_value`` cannot resolve an entity (MIT gaps carry
+        ``entity_id=None``), never consults ``gap.entity_type``, and falls
+        through to ``set_crate_metadata`` — overwriting the root's
+        ``description``, a Base RO-Crate MUST, while the Assay stays empty.
+        """
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = AgentEngine(state=_honest_backbone())
+        gap = _mit_gap(engine.state, "Assay", "description")
+        answer = "A resazurin viability readout at 24 h and 48 h."
+
+        assert _apply_value(engine, gap, answer) is True
+
+        # Two independent facts, neither hand-built, both wrong today.
+        assert engine.state.metadata.description == _ROOT_DESCRIPTION, (
+            "the root's description is a Base MUST and must not be clobbered by "
+            "an answer about the Assay"
+        )
+        assay = engine.state.get_entity("as1")
+        assert assay is not None and assay.fields.get("description") == answer
+
+    def test_root_investigation_name_gap_still_reaches_set_crate_metadata(self):
+        """Honesty control: the new guard must discriminate, not blanket-refuse.
+
+        ``./`` folds the Investigation, so ``Investigation:name`` is the one MIT
+        slot that legitimately belongs on the root. Its param is
+        ``Investigation:name;Study:name;Assay:name`` and a param is a gap only
+        when *none* of its slots is filled, so the state must leave all three
+        unnamed for this gap to be live at all.
+        """
+        from builder.agents.pipeline.guidance import _apply_value
+
+        state = CrateState()
+        state.metadata.description = _ROOT_DESCRIPTION
+        state.add_entity(_entity("inv1", "Investigation", description="d", identifier="INV-1"))
+        state.add_entity(_entity("st1", "Study", description="d", investigation_id="inv1"))
+        state.add_entity(_entity("as1", "Assay", study_id="st1"))
+        engine = AgentEngine(state=state)
+        gap = _mit_gap(engine.state, "Investigation", "name")
+
+        assert _apply_value(engine, gap, "FRTL-5 perchlorate investigation") is True
+        assert engine.state.metadata.title == "FRTL-5 perchlorate investigation"
+
+    def test_typed_gap_with_two_instances_commits_nothing(self):
+        """Ambiguous target -> commit nothing (D5), rather than guessing one."""
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = AgentEngine(state=_honest_backbone(protocols=2))
+        gap = _mit_gap(engine.state, "LabProtocol", "description")
+
+        assert _apply_value(engine, gap, "Seed 20k cells/well, dose at 24 h.") is False
+        assert engine.state.metadata.description == _ROOT_DESCRIPTION
+        for eid in ("lp0", "lp1"):
+            protocol = engine.state.get_entity(eid)
+            assert protocol is not None and "description" not in protocol.fields
+
+
+class TestReferenceFieldNeverCommittedAsLiteral:
+    """#375(b): a ``_REF_FIELDS`` gap answered with prose is refused, not faked."""
+
+    @staticmethod
+    def _measurement_method_gap(state: CrateState) -> Gap:
+        return _pick_gap(
+            state,
+            lambda g: g.source == "shacl"
+            and str(g.property or "").endswith("measurementMethod"),
+        )
+
+    def test_measurement_method_prose_is_refused(self):
+        """The builder drops a non-resolvable literal on a reference property
+        (``_scalar_props`` / ``_wire_reference``), so reporting success is a lie."""
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = AgentEngine(state=_honest_backbone())
+        gap = self._measurement_method_gap(engine.state)
+
+        assert _apply_value(engine, gap, "resazurin viability assay") is False
+        assay = engine.state.get_entity("as1")
+        assert assay is not None and "measurementMethod" not in assay.fields
+
+    def test_resolvable_reference_still_commits(self):
+        """Honesty control: the guard refuses PROSE, not references."""
+        from builder.agents.pipeline.guidance import _apply_value
+
+        state = _honest_backbone()
+        state.add_entity(
+            _entity("term1", "DefinedTerm", name="viability assay", url="http://x.org/BAO_1")
+        )
+        engine = AgentEngine(state=state)
+        gap = self._measurement_method_gap(engine.state)
+
+        assert _apply_value(engine, gap, "term1") is True
+        assay = engine.state.get_entity("as1")
+        assert assay is not None and assay.fields.get("measurementMethod") == "term1"
+
+
+class TestIdentifierNeverCommittedFromProse:
+    """#375(c): D5 holds on EVERY commit path, including offline."""
+
+    @staticmethod
+    def _cell_line_state() -> CrateState:
+        state = _honest_backbone()
+        state.add_entity(_entity("cl1", "CellLineSample", name="FRTL-5"))
+        return state
+
+    def test_offline_identifier_gap_commits_nothing(self, monkeypatch):
+        """No provider -> ``_resolve_ask_user`` returned the prose verbatim,
+        bypassing ``_deterministic_decision``'s D5 skip entirely."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import _resolve_gap
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=self._cell_line_state())
+        gap = _mit_gap(engine.state, "CellLineSample", "identifier")
+
+        human = ScriptedHuman(input_answers=[_value("CVCL_9999")])
+        resolved: list[dict] = []
+        assert _resolve_gap(engine, human, gap, resolved=resolved, asked=[]) is False
+
+        assert engine.state.metadata.accession == _ROOT_ACCESSION, (
+            "the dataset DOI must survive an answer about a cell line"
+        )
+        cell = engine.state.get_entity("cl1")
+        assert cell is not None and "identifier" not in cell.fields
+        assert resolved == []
+
+    def test_draft_confirm_edit_cannot_commit_an_identifier(self):
+        """The draft-confirm dialog feeds ``edits["value"]`` straight into
+        ``_apply_value``; it is unguarded even WITH a provider configured."""
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = AgentEngine(state=self._cell_line_state())
+        gap = _mit_gap(engine.state, "CellLineSample", "identifier")
+
+        assert _apply_value(engine, gap, "CVCL_9999") is False
+        assert engine.state.metadata.accession == _ROOT_ACCESSION
+        cell = engine.state.get_entity("cl1")
+        assert cell is not None and "identifier" not in cell.fields
+
+
+class TestNonClearingGapIsNotReAsked:
+    """#375(d): "the setter returned True" is not "the gap cleared"."""
+
+    def test_no_question_is_asked_twice_in_one_run(self, monkeypatch):
+        """A gap whose answer cannot clear it must be suppressed by identity
+        after ONE ask.
+
+        Today the highest-priority gap (MIT ``Assay:description``) "progresses"
+        every round without clearing, so it is re-drawn until ``max_rounds``
+        runs out and the 18 actionable gaps behind it are never reached. The
+        assertion is over *repeats*, not over one hard-coded prompt, so it
+        cannot pass vacuously by the loop never reaching a particular gap.
+        """
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_honest_backbone())
+
+        human = ScriptedHuman(input_answers=[_value("resazurin viability assay")] * 8)
+        run_guidance(engine, human, max_rounds=5)
+
+        prompts = [p for p, _ft in human.inputs]
+        repeated = {p for p in prompts if prompts.count(p) > 1}
+        assert not repeated, f"these questions were asked more than once: {repeated}"
+        assert len(prompts) > 1, "the loop must move on to other gaps, not stall"
+
+    def test_resolved_count_only_includes_gaps_that_actually_cleared(self, monkeypatch):
+        """``format_guidance_summary`` prints ``resolved: N`` straight from this
+        list, so a commit that did not clear its gap must not be counted."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_honest_backbone())
+
+        human = ScriptedHuman(input_answers=[_value("resazurin viability assay")] * 8)
+        result = run_guidance(engine, human, max_rounds=5)
+
+        # NB the oracle is per-gap, not a count: committing an answer MINTS
+        # entities (a Person for a creator gap), and each new entity brings its
+        # own unfilled slots, so the total gap count can legitimately RISE while
+        # real progress is made. What must hold is that every gap reported
+        # resolved is genuinely gone.
+        still_open = {
+            (g.source, g.entity_id, g.entity_type, g.property)
+            for g in assess_gaps(engine.state).gaps
+        }
+        lying = [
+            r
+            for r in result["resolved"]
+            if (r["source"], r["entity_id"], r["entity_type"], r["property"]) in still_open
+        ]
+        assert not lying, (
+            f"{len(lying)} gap(s) were reported resolved but are still open: "
+            f"{[(r['source'], r['entity_type'], r['property']) for r in lying]}"
+        )

--- a/tests/test_profile_lineage.py
+++ b/tests/test_profile_lineage.py
@@ -1,0 +1,62 @@
+"""Issue #361: the tox profile's RO-Crate base lineage mirrors the upstream
+``isa-ro-crate`` profile it extends.
+
+The tox ``profile.ttl`` declares ``isTransitiveProfileOf .../crate/1.1`` because the
+bundled ``isa-ro-crate`` profile (which it extends) is a profile of RO-Crate 1.1. This
+is intentional and NOT inconsistent with the validator running its base pass against
+``ro-crate-1.2`` — 1.2 is backward-compatible (see ``profiles/validator.py``,
+``profiles/shapes/tox/profile.ttl``). This guard fails if the two lineages diverge,
+e.g. if upstream ``isa-ro-crate`` bumps its base version and the tox profile is left
+behind.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+TOX_PROFILE = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "profiles"
+    / "shapes"
+    / "tox"
+    / "profile.ttl"
+)
+
+
+def _crate_base_versions(ttl_text: str) -> set[str]:
+    """RO-Crate base versions a profile targets (``w3id.org/ro/crate/<x.y>``)."""
+    return set(re.findall(r"w3id\.org/ro/crate/(\d+\.\d+)\b", ttl_text))
+
+
+def _isa_ro_crate_profile() -> pathlib.Path:
+    import rocrate_validator
+
+    return (
+        pathlib.Path(rocrate_validator.__file__).parent
+        / "profiles"
+        / "isa-ro-crate"
+        / "profile.ttl"
+    )
+
+
+def test_tox_profile_base_lineage_mirrors_isa_ro_crate():
+    isa_versions = _crate_base_versions(_isa_ro_crate_profile().read_text())
+    tox_versions = _crate_base_versions(TOX_PROFILE.read_text())
+
+    assert isa_versions == {"1.1"}, (
+        f"upstream isa-ro-crate profile changed its RO-Crate base to {isa_versions}; "
+        "reconcile profiles/shapes/tox/profile.ttl to match"
+    )
+    assert tox_versions == isa_versions, (
+        f"tox profile RO-Crate lineage {tox_versions} must mirror the isa-ro-crate "
+        f"profile it extends {isa_versions}"
+    )
+
+
+def test_validator_base_pass_is_1_2_by_design():
+    """The base validation pass is 1.2 (backward-compatible) even though the domain
+    profiles are 1.1-lineage — pin it so the deliberate choice is visible."""
+    from profiles.validator import _PROFILE_PASSES
+
+    assert _PROFILE_PASSES["base"][0] == "ro-crate-1.2"

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -18,6 +18,7 @@ import pytest
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
 from builder.tools.gap_analysis import (
     _CRATE_SETTABLE_FIELDS,
+    REPORT_ONLY,
     Gap,
     GapReport,
     _local_name,
@@ -366,11 +367,15 @@ class TestMitGapsForAbsentEntityType:
 
     def test_present_molecular_entity_keeps_committable_field(self):
         """With a MolecularEntity in state, its crate-settable MIT slots become
-        committable again — the report-only downgrade is *only* for absent types."""
+        committable again — the report-only downgrade is *only* for absent types.
+
+        The probe is the compound's ``name`` slot, so the entity is added WITHOUT
+        one. It used to be added named, which left ``identifier`` as the only
+        crate-settable slot still open — and since #375 an identifier field is
+        report-only on D5 grounds, so that probe would now test nothing.
+        """
         state = _backbone()
-        state.add_entity(
-            _entity("chem1", "MolecularEntity", name="Acetaminophen")
-        )
+        state.add_entity(_entity("chem1", "MolecularEntity", cas="103-90-2"))
         report = assess_gaps(state)
         molecular_committable = [
             g
@@ -430,7 +435,16 @@ class TestAutoFixable:
         assert all(g.auto_fixable is False for g in result_gaps)
 
     def test_non_repairable_must_is_not_auto_fixable(self):
-        """The empty-crate identifier MUST has no repair rule -> ask-user."""
+        """The empty-crate identifier MUST has no repair rule.
+
+        It is also not *askable*: since #375 an identifier-bearing field is
+        ``report-only``, because D5 refuses to commit an identifier from the
+        user's prose — so asking could only ever discard the answer. Resolving it
+        properly means a lookup, which is #338 / #372's lane, not a prompt. This
+        assertion changed from ``ask-user`` for that reason.
+        """
+        from builder.tools.gap_analysis import REPORT_ONLY
+
         report = assess_gaps(CrateState())
         ident = [
             g
@@ -439,7 +453,7 @@ class TestAutoFixable:
         ]
         assert ident
         assert all(g.auto_fixable is False for g in ident)
-        assert all(g.fix_hint == "ask-user" for g in ident)
+        assert all(g.fix_hint == REPORT_ONLY for g in ident)
 
     def test_deterministically_repairable_input_must_is_auto_fixable(self):
         """A missing DataAnalysis object with ONE free Sample is auto-fixable."""
@@ -537,3 +551,118 @@ class TestStableSecondaryOrder:
             assert _keys(report_only) == sorted(_keys(report_only)), (
                 f"{tier} report-only gaps must have a stable secondary order"
             )
+
+
+# ---------------------------------------------------------------------------
+# #375 — `_is_committable` must genuinely mirror `guidance._apply_value`.
+#
+# Its docstring (and AGENTS.md) promise that it "mirrors _apply_value's success
+# conditions", but it was never applied to SHACL gaps at all, and it answered
+# True for shapes _apply_value can only refuse. The loop then spent a human turn
+# on each — asking a question whose answer it would silently discard.
+# ---------------------------------------------------------------------------
+
+
+class TestActionableGapsAreActuallyAppliable:
+    """Every gap advertised as actionable must be one `_apply_value` can commit."""
+
+    @staticmethod
+    def _state() -> CrateState:
+        """Backbone shaped as the pipeline leaves it (Assay: name + study_id)."""
+        state = CrateState()
+        state.metadata.title = "FRTL-5 perchlorate thyroid study"
+        state.metadata.description = "Root description"
+        state.add_entity(
+            _entity("inv1", "Investigation", name="Inv", description="d", identifier="INV-1")
+        )
+        state.add_entity(
+            _entity("st1", "Study", name="St", description="d", investigation_id="inv1")
+        )
+        state.add_entity(_entity("as1", "Assay", name="FRTL-5 assay", study_id="st1"))
+        return state
+
+    @staticmethod
+    def _actionable(report) -> list[Gap]:
+        return [g for g in report.gaps if g.fix_hint != REPORT_ONLY and not g.auto_fixable]
+
+    def test_shacl_gap_with_no_property_is_report_only(self):
+        """A node-shape gap names no field, so there is nothing to set."""
+        report = assess_gaps(self._state())
+        propless = [
+            g for g in report.gaps if g.source == "shacl" and not (g.property or "").strip()
+        ]
+        assert propless, "expected at least one real node-shape SHACL gap"
+        for gap in propless:
+            assert gap.fix_hint == REPORT_ONLY, (
+                f"a gap with no property cannot be committed, yet it is advertised "
+                f"as {gap.fix_hint!r}: {gap.message[:90]}"
+            )
+
+    def test_reference_only_gap_stays_actionable(self):
+        """A reference-only gap is deliberately NOT silenced.
+
+        Prose cannot be committed to `about` / `measurementMethod` / `object` —
+        `_apply_value` refuses it and the loop asks once (#375). But naming an
+        entity that already exists in the crate CAN be committed, and that is the
+        useful question when a repair rule declined on two ambiguous candidates.
+        Marking these report-only would remove a real interaction, so this test
+        pins the choice against a future over-correction.
+        """
+        from builder.tools.field_kinds import is_reference_field
+
+        report = assess_gaps(self._state())
+        ref_gaps = [
+            g
+            for g in report.gaps
+            if g.source == "shacl" and is_reference_field(_local_name(g.property))
+        ]
+        assert ref_gaps, "expected real reference-only SHACL gaps on this backbone"
+        assert any(g.fix_hint == "ask-user" for g in ref_gaps)
+
+    def test_every_actionable_gap_is_appliable(self):
+        """The invariant that was missing: what the loop offers, it can commit.
+
+        This is the guard that stops the gap engine and the guidance loop drifting
+        apart again — the drift four separate audit lenses found by hand.
+        """
+        from builder.agents.pipeline.guidance import (
+            _CRATE_METADATA_FIELDS,
+            _is_citation_field,
+            _is_person_field,
+        )
+        from builder.tools.field_kinds import is_identifier_field, is_reference_field
+        from builder.tools.repair import _resolve_state_entity
+
+        state = self._state()
+        for gap in self._actionable(assess_gaps(state)):
+            field = _local_name(gap.property)
+            assert field, f"actionable gap with no field: {gap.message[:90]}"
+            if _is_person_field(field) or _is_citation_field(field):
+                continue  # composite routes of their own
+            assert not is_identifier_field(field), (
+                f"identifier field {field!r} is advertised actionable, but D5 means "
+                f"the answer can only ever be discarded"
+            )
+            # NB reference-only fields ARE actionable: the user can name an
+            # existing entity even though prose is refused. See
+            # `test_reference_only_gap_stays_actionable`.
+            if is_reference_field(field):
+                continue
+            has_target = (
+                _resolve_state_entity(state, gap.entity_id) is not None
+                or (gap.entity_type not in (None, "Investigation"))
+                or field in _CRATE_METADATA_FIELDS
+            )
+            assert has_target, (
+                f"no commit target for actionable gap {gap.source}/{gap.entity_id}/{field}"
+            )
+
+    def test_actionable_gaps_do_not_collapse_to_zero(self):
+        """Honesty control: a guard that marked everything report-only would pass
+        the three tests above. The Assay's own `description` gap stays actionable."""
+        actionable = self._actionable(assess_gaps(self._state()))
+        assert actionable, "the loop must still have real work to offer the user"
+        assert any(
+            _local_name(g.property) == "description" and g.entity_type == "Assay"
+            for g in actionable
+        ), "the Assay description gap must remain actionable"


### PR DESCRIPTION
Closes #375.

## What was wrong

You answer a question in the interactive builder, the answer goes to the wrong place, and the builder tells you it worked. Then it asks you the same question again next round.

Reproduced offline against `main`, no network, no live LLM:

```
Resolving gaps…
  Describe 'description' for FRTL-5 perchlorate thyroid study (Assay)
> A resazurin viability readout at 24 h and 48 h.
  Describe 'description' for FRTL-5 perchlorate thyroid study (Assay)
> (…the same question, 5 more times…)

Guidance complete:
  resolved: 6 gap(s)
```

Zero gaps were resolved. The Assay never got a description, the crate's **Root Data Entity `description` was overwritten** (a Base RO-Crate MUST), and six of the run's rounds went to one gap while the other 18 actionable ones were never reached.

This is the default path, not a corner case: `_backbone_hints` gives the Assay a `name` and nothing else and the plan's description merges onto the Study layer, so `Assay:description` is an unfilled MIT slot and the highest-priority actionable gap on **every** pipeline run.

## The four fixes

All in `_apply_value` and the loop tail — overlapping lines, so one lane rather than four PRs.

| | Fix |
|---|---|
| **Right entity** | A typed MIT gap (`entity_id is None` + an `entity_type`) commits to the single in-state instance of that type — the same one `_ground_entityless_gap` phrased the question about, via a shared selection helper so the prompt and the write provably agree. Only a genuinely root-level gap may reach `set_crate_metadata`. |
| **No fake reference commits** | A reference-only field refuses a value that would not resolve. `_scalar_props` strips every `_REF_FIELDS` key and `_wire_reference` emits nothing for a non-resolvable literal, so returning `True` was a lie the builder then silently corrected by dropping the value. |
| **D5 everywhere** | Identifier fields are refused at `_apply_value` — the single chokepoint every commit funnels through — closing both unguarded feeders: the no-provider ask-user path and the draft-confirm `edits["value"]`. `_resolve_ask_user`'s offline branch now routes through `_deterministic_decision`, whose D5 skip both call sites sat *downstream* of, making it dead code offline. |
| **Progress means cleared** | After a commit the loop re-assesses; if the gap identity persists it is dropped from `resolved` and suppressed. `format_guidance_summary` prints that list verbatim, so it was reporting work that never happened. |

Plus the gap-engine half: `_is_committable` now genuinely mirrors `_apply_value` — the contract its own docstring and AGENTS.md already claimed — and `_shacl_gaps` finally calls it, so the loop stops spending human turns on gaps it can only refuse (a node shape naming no field, an unresolvable focus node, an identifier).

## Two deliberate departures from the issue's plan

**Reference-only gaps stay actionable.** The issue said mark them `report-only`. That broke three existing tests, and they were right: when a repair rule declines because two candidate Files are ambiguous, asking *which one* is the correct move. Prose is the problem, not the question — so prose is refused honestly and asked once. Pinned by `test_reference_only_gap_stays_actionable` against a future over-correction.

**Person/citation short-circuit is scoped to entity-bearing gaps.** Unconditional, it would flip MIT `Investigation:author` and `:citation` from report-only into ask-user turns — the exact regression the issue warns about elsewhere. Crate-level MIT gaps keep their field gate, so the ~167 report-only pseudo-field slots (`MolecularEntity:char`, `LabProcessExposure:param`, …) are untouched.

## Shared, so both arms benefit

New `builder/tools/field_kinds.py` owns the field-kind vocabulary: `is_identifier_field` (one definition replacing two byte-identical copies in `guidance` and `leaves`), `is_reference_field`, and `is_resolvable_reference`, the last mirroring `_wire_reference`'s own acceptance rule so the two cannot drift. `set_fields` logs a warning on the same condition — it is a ReAct-callable tool with no such guard, so the ReAct LLM could make the identical silent-drop mistake. Warning, not raising: refusing in a hot shared tool would be a behaviour change to every existing caller.

The routing half is inherently pipeline-only — `assess_gaps` has exactly one production consumer and the ReAct arm has no gap loop. No ReAct behaviour changes here.

## Tests

Every gap is built from the **real** gap engine over a real state — never a hand-made `Gap(entity_id="st1", …)`. `_mit_gaps` never emits a non-`None` `entity_id`, and that unrealistic double is what hid this for the module's whole life (same failure class as #343). Each new class carries an honesty control, and `test_every_actionable_gap_is_appliable` is the invariant that stops the two modules drifting again.

Two existing tests changed behaviour, each with a written rationale in the test: an identifier MUST is now `report-only` (D5 means asking can only discard the answer — resolving it is #338/#372's lookup), and the MolecularEntity probe moved from `identifier` to `name`, since `identifier` no longer tests anything.

Also fixed, not in the issue: `resolved` records carried no `entity_type`, so two same-property gaps on different entities were indistinguishable — precisely what this lane is about.

## Verification

- Full suite: **1720 passed, 1 xpassed** (`uv run pytest -n auto --maxprocesses=4`)
- `uvx ruff check` and `uv run ty check` clean
- Affected files re-verified against the final tree: **165 passed**

AGENTS.md §14.6 updated for the changed `_is_committable` and commit contracts.

## Sequencing

- **#337 overlaps this** at the loop tail — land its Part A here or rebase on top, not as a competing PR.
- **#338 should not close before #377**: `resolve_compound` writes `cas` while the MIT gap keys on `identifier`. Unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)