### PR TITLE
fix(react): prune a tool result only once the model has consumed it (#376)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1365,11 +1365,22 @@ input tokens grow linearly (cumulative cost quadratically) until the context win
 `_assemble_model_messages` (`builder/agents/react/agent_loop.py`) via `_trim_history`, which runs two
 layers in order:
 
-1. **Prune consumed state-backed outputs** (`_prune_state_backed_outputs`). Tool outputs whose
-   data already lives in `CrateState` — the scan/read listings from `_STATE_BACKED_TOOLS`
-   (`scan_files`, `read_file_sample`, `read_multiple_files`) — are replaced by a short stub once
-   they exceed `_PRUNE_CONTENT_THRESHOLD` chars. The `ToolMessage` is **rewritten, not dropped**,
-   so the `AIMessage(tool_call)` → `ToolMessage` pairing is never broken.
+1. **Prune consumed verbose tool outputs** (`_prune_state_backed_outputs`). A `ToolMessage` over
+   `_PRUNE_CONTENT_THRESHOLD` chars is replaced by a short stub — but **only once the model has
+   consumed it**, i.e. a later `AIMessage` (the model responded) or `HumanMessage` (a new turn
+   began) exists. The predicate is load-bearing, not an optimization: the graph edge is
+   `tools → model`, so the node running immediately after a tool result is `call_model`, and
+   pruning on name and length alone destroyed the result *before any model saw it* (#376). Only
+   the newest tool-result block is replayed verbatim; everything older is stubbed, which is where
+   #61's savings come from. The `ToolMessage` is **rewritten, not dropped**, so the
+   `AIMessage(tool_call)` → `ToolMessage` pairing is never broken.
+
+   The stub is **truthful per tool class**, because the two classes differ in what is recoverable:
+   `_STATE_BACKED_TOOLS` (`scan_files`) genuinely persists to `CrateState.scanned_files` and its
+   stub points at `list_scanned_files`; `_REPLAYABLE_READER_TOOLS` (`read_file_sample`,
+   `read_multiple_files`) persist **nothing** — `CrateState` has no body store — so their stub
+   never claims the text is in state and never tells the model not to re-run. It points at
+   `read_file`, which returns the body in full up to its 64 KiB budget.
 2. **Token-budget trim** via `langchain_core.messages.trim_messages` with `strategy="last"` and
    `start_on="human"`. Keeping the most recent turns within the budget bounds per-turn input;
    `start_on="human"` guarantees the retained window never *begins* with a dangling `ToolMessage`

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -931,56 +931,94 @@ def _build_system_prompt_with_state(
     return brief
 
 
-# Tool names whose verbose output already lives in CrateState, so replaying it
-# verbatim in the transcript is pure waste once the model has consumed it. The
-# scan inventory is the canonical example — the full listing is stored in
-# CrateState.scanned_files, queryable via list_scanned_files (Issue #61, #172).
-_STATE_BACKED_TOOLS = frozenset({"scan_files", "read_file_sample", "read_multiple_files"})
+# Tool names whose verbose output really IS recoverable from CrateState, so
+# replaying it verbatim in the transcript is pure waste once the model has
+# consumed it: the full scan listing lives in CrateState.scanned_files and is
+# queryable via list_scanned_files (Issue #61, #172).
+_STATE_BACKED_TOOLS = frozenset({"scan_files"})
+
+# Reader tools whose output is ALSO worth pruning once consumed, but which store
+# nothing (`read_file_sample` / `read_multiple_files` return a plain string/dict
+# and persist nothing — CrateState has no body store). Their stub must therefore
+# never claim the text is retrievable from state, and must not tell the model not
+# to re-run: re-reading is the only recovery path (#376).
+_REPLAYABLE_READER_TOOLS = frozenset({"read_file_sample", "read_multiple_files"})
+
+_PRUNABLE_TOOLS = _STATE_BACKED_TOOLS | _REPLAYABLE_READER_TOOLS
 
 # Above this length (chars), a consumed state-backed tool output is pruned to a
 # stub. Kept modest so small/already-summarized outputs pass through untouched.
 _PRUNE_CONTENT_THRESHOLD = 500
 
 
-def _prune_state_backed_outputs(messages: list) -> list:
-    """Replace verbose, already-consumed state-backed tool outputs with a stub.
+def _prune_stub(name: str) -> str:
+    """The replacement text for a pruned tool output, truthful per tool class.
 
-    A ``ToolMessage`` whose ``name`` is in ``_STATE_BACKED_TOOLS`` (scan/read
-    listings) carries data that is already persisted in ``CrateState``; once the
-    model has seen it there is no value in replaying the raw blob every turn. We
-    keep the message (so the AI tool_call → ToolMessage pairing is never broken)
-    but shrink its content to a short stub. Pairing-preservation is why we
-    *rewrite* rather than *drop* — dropping a ToolMessage would orphan its
-    preceding AI tool_call.
+    ``scan_files``' inventory really is in ``CrateState`` and really is queryable
+    (``list_scanned_files``), so its stub says so — AGENTS.md §5 documents that
+    contract. A reader's body is stored **nowhere**, so its stub must not claim
+    otherwise and must not forbid re-running: re-reading is the only way back to
+    the text, and ``read_file`` returns it in full up to its 64 KiB budget (#376).
+    """
+    if name in _STATE_BACKED_TOOLS:
+        return (
+            f"[{name} output pruned from history to save tokens — the full "
+            f"result is stored in the session state (CrateState). Call "
+            f"list_scanned_files to retrieve the full file inventory "
+            f"(paginated/filterable). Do not re-run {name}.]"
+        )
+    return (
+        f"[{name} output pruned from history to save tokens. It is NOT stored in "
+        f"the session state — if you still need this file's text, read it again "
+        f"with read_file(path).]"
+    )
+
+
+def _prune_state_backed_outputs(messages: list) -> list:
+    """Replace verbose tool outputs the model has **already consumed** with a stub.
+
+    Once the model has answered a tool result there is no value in replaying the
+    raw blob on every later turn. We keep the message (so the AI tool_call →
+    ToolMessage pairing is never broken) but shrink its content to a short stub.
+    Pairing-preservation is why we *rewrite* rather than *drop* — dropping a
+    ToolMessage would orphan its preceding AI tool_call.
+
+    **"Consumed" is load-bearing and is enforced here** (#376). The graph edge is
+    ``tools → model``, so the node that runs immediately after a tool result is
+    ``call_model`` — which assembles the history through this function. Pruning on
+    name and length alone therefore destroyed a reader's body *before any model
+    had seen it*, and replaced it with a stub telling the model the text was in
+    ``CrateState`` (it never is, for a reader) and not to re-run. A message is
+    consumed only when a later ``AIMessage`` (the model responded) or
+    ``HumanMessage`` (a new turn began, which necessarily follows a final
+    ``AIMessage``) exists. Only the newest tool-result block is replayed verbatim;
+    everything older is still stubbed, so #61's savings are preserved.
 
     The list is returned with the same length and ordering; non-matching
     messages are passed through unchanged. Small outputs (below
     ``_PRUNE_CONTENT_THRESHOLD``) are left intact — they cost little and may
     already be summaries (e.g. ``summarize_scan_result``).
     """
-    from langchain_core.messages import ToolMessage
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    # The last point at which the model demonstrably moved past a tool result.
+    # Anything at or after it has not been consumed yet and must survive intact.
+    boundary = max(
+        (i for i, m in enumerate(messages) if isinstance(m, (AIMessage, HumanMessage))),
+        default=-1,
+    )
 
     pruned: list = []
-    for msg in messages:
+    for i, msg in enumerate(messages):
         if (
-            isinstance(msg, ToolMessage)
-            and getattr(msg, "name", None) in _STATE_BACKED_TOOLS
+            i < boundary
+            and isinstance(msg, ToolMessage)
+            and getattr(msg, "name", None) in _PRUNABLE_TOOLS
             and len(str(msg.content)) > _PRUNE_CONTENT_THRESHOLD
         ):
-            scan_hint = (
-                " Call list_scanned_files to retrieve the full file inventory "
-                "(paginated/filterable)."
-                if msg.name == "scan_files"
-                else ""
-            )
-            stub = (
-                f"[{msg.name} output pruned from history to save tokens — the full "
-                f"result is stored in the session state (CrateState).{scan_hint} "
-                f"Do not re-run {msg.name}.]"
-            )
             pruned.append(
                 ToolMessage(
-                    content=stub,
+                    content=_prune_stub(str(msg.name)),
                     tool_call_id=msg.tool_call_id,
                     name=msg.name,
                 )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -776,6 +776,129 @@ class TestTrimHistory:
         )
         assert self._no_orphans(trimmed)
 
+    # ---- #376: pruning must not destroy a reader result the model has not read ----
+
+    @staticmethod
+    def _fixture_body() -> str:
+        """A real reader result over a committed fixture (no synthetic blob).
+
+        Using the real `read_file_sample` over real bytes means a regression in
+        the reader, the fixture, or the assembler all redden these tests.
+        """
+        from builder.tools.scanner import read_file_sample
+
+        body = read_file_sample("tests/fixtures/svhps22_input/README.md", lines=50)
+        assert isinstance(body, str) and body.strip(), "fixture must be readable"
+        return body
+
+    def test_fresh_reader_output_survives_assembly(self):
+        """A reader result the model has NOT answered yet must reach the model.
+
+        `read_file_sample` persists nothing to CrateState, and the graph edge is
+        tools -> model, so pruning it on the very next hop destroys the body
+        before any model has seen it — then tells the model it is stored and not
+        to re-run. Both claims are false (#376).
+        """
+        from langchain_core.messages import HumanMessage, ToolMessage
+
+        from builder.agents.react.agent_loop import (
+            _PRUNE_CONTENT_THRESHOLD,
+            _assemble_model_messages,
+        )
+
+        body = self._fixture_body()
+        # Honesty control: prove this fixture actually exercises the prune branch.
+        assert len(body) > _PRUNE_CONTENT_THRESHOLD, (
+            "fixture is below the prune threshold, so this test would pass vacuously"
+        )
+        cid = "read_1"
+        history = [
+            HumanMessage(content="build the crate"),
+            self._ai_tool_call("reading", cid, name="read_file_sample"),
+            ToolMessage(content=body, tool_call_id=cid, name="read_file_sample"),
+        ]
+
+        assembled = _assemble_model_messages(
+            history, session_id="s", entity_count=0, file_count=3, iteration_count=1
+        )
+
+        # A distinctive line taken from the body at RUNTIME, never hardcoded.
+        marker = max(body.splitlines(), key=len).strip()
+        assert marker, "fixture must have a non-empty longest line"
+        blob = "\n".join(str(m.content) for m in assembled)
+        assert marker in blob, (
+            "the model must actually see the file text it just asked for; "
+            f"missing marker {marker[:60]!r}"
+        )
+
+    def test_consumed_reader_output_is_pruned(self):
+        """Anti-regression for #61: once answered, the body is still stubbed.
+
+        Without this, #376 could be 'fixed' by disabling pruning outright.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+        from builder.agents.react.agent_loop import _trim_history
+
+        body = self._fixture_body()
+        cid = "read_1"
+        history = [
+            HumanMessage(content="build the crate"),
+            self._ai_tool_call("reading", cid, name="read_file_sample"),
+            ToolMessage(content=body, tool_call_id=cid, name="read_file_sample"),
+            AIMessage(content="The protocol is a resazurin viability readout."),
+        ]
+
+        trimmed = _trim_history(history, max_tokens=100_000)
+
+        reader = [
+            m for m in trimmed if isinstance(m, ToolMessage) and m.tool_call_id == cid
+        ]
+        assert reader, "the ToolMessage must be retained so pairing is preserved"
+        assert len(str(reader[0].content)) < len(body)
+        assert self._no_orphans(trimmed)
+
+    def test_reader_prune_stub_is_truthful(self):
+        """The stub must not claim a reader body is recoverable from CrateState.
+
+        Nothing in CrateState stores a file body, and re-reading is the only
+        recovery path — so 'stored in the session state' and 'Do not re-run' are
+        both false for the readers, while they remain TRUE for `scan_files`.
+        """
+        from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+        from builder.agents.react.agent_loop import _trim_history
+
+        body = self._fixture_body()
+        big_listing = "\n".join(f"file_{i}.csv\t1234\ttext/csv" for i in range(500))
+        read_cid, scan_cid = "read_1", "scan_1"
+        history = [
+            HumanMessage(content="build the crate"),
+            self._ai_tool_call("scanning", scan_cid, name="scan_files"),
+            ToolMessage(content=big_listing, tool_call_id=scan_cid, name="scan_files"),
+            self._ai_tool_call("reading", read_cid, name="read_file_sample"),
+            ToolMessage(content=body, tool_call_id=read_cid, name="read_file_sample"),
+            AIMessage(content="done reading"),
+        ]
+
+        trimmed = _trim_history(history, max_tokens=100_000)
+        by_id = {
+            m.tool_call_id: str(m.content)
+            for m in trimmed
+            if isinstance(m, ToolMessage)
+        }
+
+        reader_stub = by_id[read_cid]
+        assert "CrateState" not in reader_stub
+        assert "Do not re-run" not in reader_stub
+        assert "read_file" in reader_stub, "the stub must point at a real recovery path"
+
+        # Honesty control: the scan stub is truthful and must keep its wording,
+        # so this asserts by tool CLASS rather than blanket-matching any string.
+        scan_stub = by_id[scan_cid]
+        assert "CrateState" in scan_stub
+        assert "list_scanned_files" in scan_stub
+
     def test_no_orphan_tool_message_when_history_ends_mid_pair(self):
         """A history ending mid tool-call pair (AI tool_call with no ToolMessage
         yet) must NOT produce an orphaned ToolMessage at the head, nor strand a


### PR DESCRIPTION
Closes #376. ReAct arm only — the deterministic pipeline never touches this assembler.

## What was wrong

The two file readers the system prompt advertises **first** returned nothing usable to the model whenever the body exceeded 500 chars — which is every substantive README, protocol or descriptor in the repo's own fixtures. The tool ran, the body came back, and on the **immediately following** model hop it was overwritten with:

> `[read_file_sample output pruned from history to save tokens — the full result is stored in the session state (CrateState). Do not re-run read_file_sample.]`

Both clauses are false for the readers. Nothing about their output is in `CrateState` — `FileClassification` stores `path / filename / size / mime_type / first_rows`, there is no body store — and re-reading is the only way back to the text. So the model got an empty result, was told the data was retrievable when it wasn't, and was told not to ask again.

`_prune_state_backed_outputs` matched on **name and length alone**, never on position, despite its docstring promising "already-consumed". The graph edge is `tools → model`, so the node running immediately after a tool result is `call_model` → `_assemble_model_messages` → `_trim_history` → the prune. **The body was destroyed before any model had seen it.**

The threshold also fires backwards on real inputs. Measured on the committed fixtures:

| payload | chars | pruned? |
|---|---|---|
| `summarize_scan_result(scan_files(svhps22_input))` | 178 | no |
| `summarize_scan_result(scan_files(svhps26_real_input))` | 470 | no |
| `read_file_sample(svhps22_input/README.md)` | 1234 | **yes** |
| `read_file_sample(svhps26_real_input/S-VHPS26.json)` | 1263 | **yes** |
| `read_file_sample(.../Assay_OATP1C1/README.txt)` | 4676 | **yes** |

The one tool whose stub is honest is the one whose output is already compacted and normally sits *below* the threshold. In practice the mechanism was almost purely reader-destroying.

## The fix

**1. Implement the consumed predicate the docstring already promised.** Prune only a `ToolMessage` positioned before the last `AIMessage`/`HumanMessage`. `HumanMessage` belongs in the boundary because in the live graph one only arrives at the start of a new turn, which necessarily follows a final `AIMessage` — and it is what keeps the existing `test_consumed_scan_output_is_pruned` green (its fixture is `[Human, AI, Tool(scan), Human]`; an `AIMessage`-only predicate turns it red). Only the newest tool-result block is replayed verbatim, so **#61's savings are preserved**.

**2. Make the stub truthful per tool class.**

| set | tools | stub says |
|---|---|---|
| `_STATE_BACKED_TOOLS` | `scan_files` | unchanged — "stored in the session state (CrateState)", call `list_scanned_files`, do not re-run. All true; AGENTS.md §5 depends on it. |
| `_REPLAYABLE_READER_TOOLS` | `read_file_sample`, `read_multiple_files` | "It is NOT stored in the session state — if you still need this file's text, read it again with `read_file(path)`." |

`read_file` is the right pointer: it is in neither prune set, returns the file in full up to 64 KiB, and self-labels a truncated result.

Fixing the predicate rather than shrinking the tool list is the root-cause fix — `scan_files`' first summary is destroyed the same way today, harmless only because `list_scanned_files` happens to recover it, and shrinking the list would forfeit #61's savings on repeated reads.

**No shared-toolbox component, deliberately.** `builder/tools/` is already correct: `read_file_sample` honestly returns a string and honestly persists nothing. Making the stub's original claim true would mean caching file bodies in `CrateState` — a much larger change that grows session state and neither arm needs.

## Verification

The issue's own reproduction, run against the fix with the real fixture:

```
real fixture body: 1234 chars
FRESH  -> model sees the text?  True      # "Cell line: FRTL-5" present
CONSUMED -> pruned?             True      # savings intact
CONSUMED -> stub text:  [read_file_sample output pruned … It is NOT stored in the
                         session state — … read it again with read_file(path).]
```

- Full suite: **1723 passed, 1 xpassed**
- `uvx ruff check` and `uv run ty check` clean
- `tests/test_agent_loop.py`: 91 passed

## Tests

Three new tests in `TestTrimHistory`, all driving the **real** `read_file_sample` over a committed fixture rather than a synthetic blob, so a regression in the reader, the fixture, or the assembler all redden them:

- `test_fresh_reader_output_survives_assembly` — asserts a marker taken from the body **at runtime** (never hardcoded) reaches the assembled messages. *Honesty control in the same test:* asserts the fixture exceeds `_PRUNE_CONTENT_THRESHOLD`, so it cannot pass vacuously on a small file.
- `test_consumed_reader_output_is_pruned` — the #61 anti-regression. Without it, this issue could be "fixed" by disabling pruning outright.
- `test_reader_prune_stub_is_truthful` — reader stub contains neither `CrateState` nor `Do not re-run`, and does contain `read_file`. *Honesty control:* a consumed `scan_files` message in the **same** assembled list must still get `CrateState` + `list_scanned_files`, so the assertion discriminates by tool class instead of blanket-matching any string.

`test_consumed_scan_output_is_pruned` stays green unmodified — it is the test that forces `HumanMessage` into the boundary.

AGENTS.md D12 corrected: it documented the same false premise ("outputs whose data already lives in `CrateState` — the scan/**read** listings").

## Not in scope

`_is_non_progress_result` treats real content as progress, so repeated *successful* identical re-reads reset the #287 loop-breaker streak and are bounded only by `max_iterations`. The live traces corroborate this issue but do not isolate it, so no claim is made here that the fix ends re-read loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)