### PR TITLE
fix(react): gate auto-export on a content fingerprint, not an entity count (#380)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2053,10 +2053,20 @@ on the quit/EOF exit path). The legacy loop now auto-exports on **every** comple
 in-loop build too: `_auto_export_after_build` in `builder/agents/react/agent_loop.py` fires
 after a `build_and_validate` that passes **base** conformance over a non-empty crate,
 calling `export_crate` with no explicit path (same destination resolution as above),
-stamping `_EXPORTED_FLAG` (so `_finish_backstop` stays a no-op — no double-export),
-and surfacing the absolute crate path. It is idempotent via an entity-count
-fingerprint: it re-exports only when the crate changed since the last auto-export, so
-the *latest* crate always lands and an unchanged repeat build is a no-op.
+stamping `_EXPORTED_FLAG` and surfacing the absolute crate path. It is idempotent via
+`CrateState.export_fingerprint()` — a **content** hash over entities + crate metadata +
+the scanned-file inventory — so it re-exports exactly when the crate changed and an
+unchanged repeat build is a no-op. The fingerprint must be content, not an entity
+count (#380): a count is invariant under every field-level tool the arm is told to
+use for the rest of the session (`set_fields`, `set_crate_metadata`,
+`fix_required_issues`, `link`), so counting kept all of that work off disk. The
+scanned-file term is required because `export_crate` packages scanned files
+(`include_all_scanned=True`) that the validation path never sees, which is why
+`export_fingerprint()` is strictly wider than `validation_fingerprint()` — the latter
+stays narrow so the #155 debounce still hits. `_finish_backstop` gates on the same
+fingerprint rather than on "something exported this session": it is the last chance to
+catch a crate that changed after its auto-export, and it stamps the fingerprint too so
+the two exit paths (quit and EOF) cannot double-export.
 
 **Progress + persistence (#241 / #242).** Before these the default `--interactive`
 (pipeline) path *felt dead*: the deterministic spine ran for ~tens of seconds with

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -158,12 +158,16 @@ _FILE_READ_TOOLS = frozenset({"read_file_sample", "read_file", "read_excel", "re
 # from the agent itself or from the backstop.
 _EXPORTED_FLAG = "_crate_exported_this_session"
 
-# Attribute holding the entity-count fingerprint of the last in-loop auto-export
-# (#287 Fix A). A completed build auto-exports the crate to disk so the user
-# always gets a crate (the new deterministic pipeline already exports on every
+# Attribute holding the CONTENT fingerprint of the last in-loop auto-export
+# (#287 Fix A; #380). A completed build auto-exports the crate to disk so the
+# user always gets a crate (the deterministic pipeline already exports on every
 # completed build, #233); this fingerprint makes the auto-export idempotent —
 # it re-exports only when the crate has changed since the last auto-export
 # (so the *latest* crate always lands), never twice for the same build.
+# It is `CrateState.export_fingerprint()`, NOT an entity count: a count is
+# invariant under every field-level tool this arm is told to use for the rest of
+# the session (`set_fields`, `set_crate_metadata`, `fix_required_issues`,
+# `link`), so counting silently kept all of that work off disk.
 _AUTO_EXPORT_FINGERPRINT_FLAG = "_crate_auto_export_fingerprint"
 
 # Attribute holding the optional single-arg console sink the loop installs so an
@@ -419,9 +423,10 @@ def _auto_export_after_build(engine: AgentEngine, build_result: Any) -> None:
       * the build passed BASE conformance (``build_result["conformance"]["base"]``
         — the same gate the pipeline uses; ISA/Tox may still have gaps but a
         base-valid crate is worth landing), AND
-      * the crate has changed since the last auto-export (entity-count
-        fingerprint) — so the *latest* crate always lands and an unchanged repeat
-        build never re-exports (idempotency).
+      * the crate has changed since the last auto-export (a CONTENT
+        fingerprint over entities + metadata + the scanned-file inventory) — so
+        the *latest* crate always lands and an unchanged repeat build never
+        re-exports (idempotency).
 
     On a successful export the ``_EXPORTED_FLAG`` is stamped (so ``_finish_backstop``
     stays a no-op and never double-exports) and the resolved ABSOLUTE crate path is
@@ -447,7 +452,7 @@ def _auto_export_after_build(engine: AgentEngine, build_result: Any) -> None:
         # Idempotency: re-export only when the crate changed since the last
         # auto-export, so the latest crate always lands and a repeat build of an
         # unchanged crate is a no-op (no double-export for the same build).
-        fingerprint = len(engine.state.list_entities())
+        fingerprint = engine.state.export_fingerprint()
         last = getattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, None)
         if last == fingerprint and getattr(engine, _EXPORTED_FLAG, False):
             return
@@ -649,7 +654,7 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                             setattr(
                                 engine,
                                 _AUTO_EXPORT_FINGERPRINT_FLAG,
-                                len(engine.state.list_entities()),
+                                engine.state.export_fingerprint(),
                             )
                         except Exception:  # noqa: BLE001 — fingerprint is best-effort.
                             logger.debug("fingerprint stamp failed", exc_info=True)
@@ -1303,8 +1308,14 @@ def _finish_backstop(
         if not engine.state.list_entities():
             # Nothing to write — a clean no-op (e.g. user quit immediately).
             return None
-        if getattr(engine, _EXPORTED_FLAG, False):
-            # Already exported this session (agent did it, or a prior backstop).
+        # (#380) Gate on the CONTENT fingerprint, not on "something exported this
+        # session". This is the last chance to catch a crate that changed after
+        # its auto-export; gating on the boolean meant that once anything had
+        # landed, `quit` neither re-exported NOR re-validated, and every
+        # field-level fix made after that point was silently lost.
+        fingerprint = engine.state.export_fingerprint()
+        if getattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, None) == fingerprint:
+            # The crate on disk is already this exact content — a strict no-op.
             return None
 
         say("Finalizing: building and exporting the crate before exit…")
@@ -1321,8 +1332,16 @@ def _finish_backstop(
         result = engine.run_tool("export_crate")
 
         if isinstance(result, dict) and result.get("success"):
-            # Stamp BEFORE surfacing so any later call is a strict no-op.
+            # Stamp BEFORE surfacing so any later call is a strict no-op. The
+            # fingerprint must be stamped too (#380): the two exit paths (quit
+            # and EOF) both reach here, and without it the second would see a
+            # "change" and double-export — the #251 idempotency `_EXPORTED_FLAG`
+            # was introduced to protect. Reusing the pre-build value is safe:
+            # `_writeback_validation` touches only `state.validation`, which
+            # `validation_fingerprint()` deliberately excludes, and `export_crate`
+            # does not mutate state.
             setattr(engine, _EXPORTED_FLAG, True)
+            setattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, fingerprint)
             crate_path = result.get("crate_path")
             try:
                 from pathlib import Path

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -6,8 +6,6 @@ It coordinates tool calls, validation, HITL checkpoints, and session persistence
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -115,25 +113,12 @@ _VALIDATION_CACHE_MAX = 64
 def _validation_input_hash(state: CrateState) -> str:
     """Hash the inputs ``build_and_validate`` consumes: entities + crate metadata.
 
-    Deliberately EXCLUDES ``state.validation`` / assessments / checkpoint. Those
-    are *outputs* the #153 write-back mutates after every validation, so
-    including them (as ``session._state_content_hash`` does) would change the
-    hash on every call and defeat the debounce. ``assemble_crate`` reads only
-    entities + metadata, so this is a safe superset of the validation inputs: a
-    change to anything the validator could observe busts the cache, while a
-    change to a pure output (a verdict, a score) does not.
+    Thin delegation to :meth:`builder.state.CrateState.validation_fingerprint`,
+    which is where the definition lives so both build arms can reach it without
+    importing the engine (#380). Kept as a module-level name because the debounce
+    key below and ``tests/test_validation_debounce.py`` both import it.
     """
-    content = {
-        "entities": state.entities.to_dict()
-        if hasattr(state.entities, "to_dict")
-        else str(state.entities),
-        "metadata": state.metadata.to_dict()
-        if hasattr(state.metadata, "to_dict")
-        else str(state.metadata),
-    }
-    return hashlib.sha256(
-        json.dumps(content, sort_keys=True, default=str).encode("utf-8")
-    ).hexdigest()
+    return state.validation_fingerprint()
 
 
 # File-reading tools that take a model-supplied path and must be sandboxed to

--- a/builder/state.py
+++ b/builder/state.py
@@ -8,6 +8,7 @@ results, assessment scores, and agent reasoning are tracked in this state.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from collections import Counter
@@ -844,6 +845,57 @@ class CrateState:
     def list_entities(self, entity_type: str | None = None) -> list[Entity]:
         """Return all entities, optionally filtered by type."""
         return self.entities.list_entities(entity_type=entity_type)
+
+    # ------------------------------------------------------------------
+    # Content fingerprints (change detection for caching / export gating)
+    # ------------------------------------------------------------------
+
+    def validation_fingerprint(self) -> str:
+        """Hash of what ``build_and_validate`` consumes: entities + metadata.
+
+        Deliberately EXCLUDES ``validation`` / assessments / checkpoint. Those
+        are *outputs* the #153 write-back mutates after every validation, so
+        including them would change the hash on every call and defeat the #155
+        debounce. ``assemble_crate`` reads only entities + metadata, so this is a
+        safe superset of the validation inputs: a change to anything the
+        validator could observe busts the cache, while a change to a pure output
+        (a verdict, a score) does not.
+        """
+        content = {
+            "entities": self.entities.to_dict()
+            if hasattr(self.entities, "to_dict")
+            else str(self.entities),
+            "metadata": self.metadata.to_dict()
+            if hasattr(self.metadata, "to_dict")
+            else str(self.metadata),
+        }
+        return hashlib.sha256(
+            json.dumps(content, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+
+    def export_fingerprint(self) -> str:
+        """Hash of what ``export_crate`` writes: the validation inputs + payload.
+
+        Strictly wider than :meth:`validation_fingerprint` because the exporter
+        packages every scanned file that has not been drafted as a ``File``
+        entity (``assemble_crate(..., include_all_scanned=True)``), which the
+        validation path never sees (it passes ``include_all_scanned=False``). A
+        second ``scan_files`` therefore changes the exported payload without
+        changing the validation hash, so the scan inventory is folded in here and
+        deliberately kept out of the narrower hash (#380).
+
+        Used to gate re-export: an entity COUNT is invariant under every
+        field-level mutation the toolbox exposes (``set_fields``,
+        ``set_crate_metadata``, ``fix_required_issues``, ``link``), so counting
+        entities silently dropped all of that work from the crate on disk.
+        """
+        content = {
+            "validation": self.validation_fingerprint(),
+            "scanned": sorted(fc.path for fc in self.scanned_files),
+        }
+        return hashlib.sha256(
+            json.dumps(content, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
 
     # ------------------------------------------------------------------
     # Completion & reasoning helpers

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1082,6 +1082,48 @@ class TestFinishBackstop:
 # ---------------------------------------------------------------------------
 
 
+    def test_backstop_exports_when_content_changed_since_last_export(self):
+        """#380: the exit backstop was gated on a one-shot boolean, so once
+        anything had exported this session `quit` neither re-exported NOR
+        re-validated — it is the last chance to catch a stale crate."""
+        from builder.agents.react.agent_loop import (
+            _AUTO_EXPORT_FINGERPRINT_FLAG,
+            _EXPORTED_FLAG,
+            _finish_backstop,
+        )
+        from builder.tools.management import set_fields
+
+        engine = self._engine("Investigation", "Study")
+        calls = self._spy(engine)
+        # Simulate an earlier successful auto-export of the crate as it was.
+        setattr(engine, _EXPORTED_FLAG, True)
+        setattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, engine.state.export_fingerprint())
+
+        set_fields(engine.state, "e0", {"description": "fixed after the export"})
+        _finish_backstop(engine, emit=lambda _m: None)
+
+        assert "build_and_validate" in calls, "the backstop must re-validate"
+        assert "export_crate" in calls, "the backstop must re-export the newer crate"
+        assert calls.index("build_and_validate") < calls.index("export_crate")
+
+    def test_backstop_is_a_noop_when_nothing_changed(self):
+        """Honesty control: the backstop must still not double-export."""
+        from builder.agents.react.agent_loop import (
+            _AUTO_EXPORT_FINGERPRINT_FLAG,
+            _EXPORTED_FLAG,
+            _finish_backstop,
+        )
+
+        engine = self._engine("Investigation")
+        calls = self._spy(engine)
+        setattr(engine, _EXPORTED_FLAG, True)
+        setattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, engine.state.export_fingerprint())
+
+        _finish_backstop(engine, emit=lambda _m: None)
+
+        assert "export_crate" not in calls, f"unchanged crate must not re-export, got {calls}"
+
+
 class TestRequestTimeout:
     """Fix A: _build_chat_model wires a request timeout onto the chat model so a
     silent provider stall can never hang the turn forever (#263)."""
@@ -1725,6 +1767,83 @@ class TestExportOnCompletedBuild:
         engine.state.add_entity(Entity(entity_id="new", type="Study"))
         tools["build_and_validate"].invoke({})
         assert calls.count("export_crate") == 2, f"grown crate → re-export, got {calls}"
+
+    # ---- #380: the export gate must notice content changes, not just counts ----
+
+    def _built_engine_and_calls(self):
+        """An engine that has already auto-exported once, plus its call log."""
+        from builder.agents.react.agent_loop import _build_langchain_tools
+
+        engine = self._engine_with_entities("Investigation", "Study")
+        calls = self._install_spy(
+            engine,
+            build_result={"ok": True, "conformance": {"base": True}, "issues": []},
+            export_result={
+                "success": True,
+                "crate_path": "/tmp/out-ro-crate",
+                "error": None,
+            },
+        )
+        tools = {t.name: t for t in _build_langchain_tools(engine)}
+        tools["build_and_validate"].invoke({})
+        assert calls.count("export_crate") == 1
+        return engine, calls, tools
+
+    def test_field_only_change_re_exports(self):
+        """`set_fields` is what the system prompt tells the model to spend the
+        rest of the session on, and it never changes the entity count — so under
+        the old count fingerprint none of it ever reached disk."""
+        from builder.tools.management import set_fields
+
+        engine, calls, tools = self._built_engine_and_calls()
+
+        set_fields(engine.state, "e0", {"description": "added after the export"})
+        tools["build_and_validate"].invoke({})
+
+        assert calls.count("export_crate") == 2, (
+            f"a field-only fix must reach disk, got {calls}"
+        )
+
+    def test_crate_metadata_change_re_exports(self):
+        """Exercises the `state.metadata` half of the hash."""
+        from builder.tools.management import set_crate_metadata
+
+        engine, calls, tools = self._built_engine_and_calls()
+
+        set_crate_metadata(engine.state, accession="S-VHPS26")
+        tools["build_and_validate"].invoke({})
+
+        assert calls.count("export_crate") == 2, (
+            f"a crate-metadata change must reach disk, got {calls}"
+        )
+
+    def test_count_preserving_swap_re_exports(self):
+        """Honesty control against a fix that special-cases `fields` rather than
+        hashing content: remove one entity and add another, netting to zero."""
+        engine, calls, tools = self._built_engine_and_calls()
+
+        engine.state.remove_entity("e1")
+        engine.state.add_entity(Entity(entity_id="e9", type="Study"))
+        assert len(engine.state.list_entities()) == 2, "the count must be unchanged"
+
+        tools["build_and_validate"].invoke({})
+
+        assert calls.count("export_crate") == 2, (
+            f"a count-preserving swap must reach disk, got {calls}"
+        )
+
+    def test_no_change_still_exports_once(self):
+        """The control that proves the tests above are not passing trivially.
+
+        A fix that simply deletes the gate passes all three and fails this one.
+        """
+        _engine, calls, tools = self._built_engine_and_calls()
+
+        tools["build_and_validate"].invoke({})
+
+        assert calls.count("export_crate") == 1, (
+            f"no change -> no re-export, got {calls}"
+        )
 
     def test_failed_export_does_not_crash_or_stamp(self):
         """When the auto-export itself fails, the build result is still returned

--- a/tests/test_validation_debounce.py
+++ b/tests/test_validation_debounce.py
@@ -126,3 +126,88 @@ class TestDebounce:
         assert engine._validation_cache == {}
         r2 = engine.run_tool("build_and_validate", severity="bogus")
         assert "error" in r2
+
+
+class TestExportFingerprint:
+    """#380: the ReAct auto-export gate needs a CONTENT fingerprint.
+
+    It used to compare `len(state.list_entities())`, which is invariant under
+    every field-level mutation the arm exposes (`set_fields`,
+    `set_crate_metadata`, `fix_required_issues`, `link`) — so once the crate had
+    been exported once, none of that work ever reached disk.
+    """
+
+    def _state_with_investigation(self) -> CrateState:
+        state = CrateState()
+        draft_investigation(state, {"name": "Inv"})
+        return state
+
+    def test_export_fingerprint_changes_on_field_only_mutation(self):
+        """The exact case the entity count missed."""
+        from builder.tools.management import set_fields
+
+        state = self._state_with_investigation()
+        entity_id = state.list_entities("Investigation")[0].entity_id
+        before = state.export_fingerprint()
+
+        set_fields(state, entity_id, {"description": "added after the export"})
+
+        assert state.export_fingerprint() != before
+        assert len(state.list_entities()) == 1, (
+            "the entity count is unchanged — which is precisely why it was the "
+            "wrong fingerprint"
+        )
+
+    def test_export_fingerprint_changes_on_new_scanned_file(self):
+        """Honesty control for the two-helper split.
+
+        `export_crate` packages scanned files (`include_all_scanned=True`) that
+        `build_and_validate` never sees (`include_all_scanned=False`), so a new
+        scan changes the exported payload without changing the validation hash.
+        If `export_fingerprint` were merely an alias, this fails.
+        """
+        from builder.state import FileClassification
+
+        state = self._state_with_investigation()
+        export_before = state.export_fingerprint()
+        validation_before = state.validation_fingerprint()
+
+        state.scanned_files.append(
+            FileClassification(
+                path="/data/raw/plate1.csv",
+                filename="plate1.csv",
+                size=1234,
+                mime_type="text/csv",
+            )
+        )
+
+        assert state.export_fingerprint() != export_before
+        assert state.validation_fingerprint() == validation_before, (
+            "a scanned file is not a validation input — including it would "
+            "defeat the #155 debounce"
+        )
+
+    def test_export_fingerprint_stable_across_validation_writeback(self):
+        """Guards the double-export regression.
+
+        The backstop runs `build_and_validate` before exporting, and the #153
+        write-back mutates `state.validation`. If that fed the fingerprint, the
+        two exit paths (quit and EOF) would each see a "change" and export twice.
+        """
+        state = self._state_with_investigation()
+        before = state.export_fingerprint()
+
+        state.validation.base_passed = True
+        state.validation.required_issues = ["something the validator found"]
+
+        assert state.export_fingerprint() == before
+
+    def test_validation_input_hash_delegates_to_the_state_method(self):
+        """`_validation_input_hash` stays importable and equivalent.
+
+        `tests/test_validation_debounce.py` and the engine's debounce key both
+        use the module-level name, so the promotion must be a delegation, not a
+        move.
+        """
+        state = self._state_with_investigation()
+        assert _validation_input_hash(state) == state.validation_fingerprint()


### PR DESCRIPTION
Closes #380. ReAct arm only — the pipeline exports exactly once at the end, with no fingerprint and no flag, so it never had a staleness window.

## What was wrong

The crate on disk could be a **stale snapshot** of the crate in memory.

The loop auto-exports the first time `build_and_validate` passes base conformance and prints `Crate written to: …`. From that point on, **any change that did not alter the number of entities never reached disk**:

| tool | changes the crate | changes `len(list_entities())` |
|---|---|---|
| `set_fields` | yes | no |
| `set_crate_metadata` | yes | no |
| `fix_required_issues` | yes (wires existing entities) | no |
| `link` | yes | no |
| `remove_entity` + `draft_*` | yes | no (nets to zero) |

Those are precisely the operations the system prompt tells the model to spend the rest of the session on (*"Fix bottom-up … every issue names the entity id and property to fix"*), and both `set_crate_metadata` and `fix_required_issues` are advertised to this arm. This was the normal working set, not an exotic path.

The exit backstop that exists to catch exactly this was **disarmed**, and worse than "doesn't export": its `_EXPORTED_FLAG` return sits *before* its `build_and_validate`, so once anything had exported this session, `quit` neither re-exported **nor re-validated**.

The user saw a success line, got a base-valid crate, and never learned that the last N turns of work were not in it.

## The fix

**A shared content fingerprint on `CrateState`** — promoted from the engine's private `_validation_input_hash` onto the one object both arms already share. `builder/state.py` imports only `builder.config`, so there is no cycle; `_validation_input_hash` becomes a one-line delegation, keeping the name the #155 debounce key and `tests/test_validation_debounce.py` both import.

Two methods, because they must differ:

- `validation_fingerprint()` — entities + metadata. Stays narrow: it excludes `state.validation`, which the #153 write-back mutates after every call, or the debounce would never hit.
- `export_fingerprint()` — the above **plus** the sorted scanned-file inventory. Required because `export_crate` packages scanned files (`include_all_scanned=True`) that `build_and_validate` never sees (`include_all_scanned=False`), so a second `scan_files` changes the exported payload without changing the validation hash.

**`_auto_export_after_build`** and the explicit `export_crate`/`build_crate` branch stamp and compare `export_fingerprint()`.

**`_finish_backstop`** gates on fingerprint equality rather than the boolean, and stamps the fingerprint on a successful export. That stamp is load-bearing: the two exit paths (`quit` and EOF) both reach the backstop, and without it the second would see a "change" and double-export — the #251 idempotency `_EXPORTED_FLAG` was introduced to prevent. `_EXPORTED_FLAG` is **kept** as the "something landed this session" signal (four existing tests read it); it just stops being the gate.

Reusing the pre-build fingerprint there is safe: `_writeback_validation` writes only `state.validation`, which `validation_fingerprint()` deliberately excludes, and `export_crate` does not mutate state.

## Verification

- Full suite: **1730 passed, 1 xpassed**
- `uvx ruff check` and `uv run ty check` clean
- `tests/test_agent_loop.py` + `tests/test_validation_debounce.py`: 106 passed

## Tests

**`TestExportFingerprint`** (`tests/test_validation_debounce.py`)

- `test_export_fingerprint_changes_on_field_only_mutation` — the exact case the count missed; also asserts the entity count is *unchanged*, which is what made it the wrong fingerprint.
- `test_export_fingerprint_changes_on_new_scanned_file` — **honesty control for the two-helper split**: the export hash moves and the validation hash does not. If someone later "simplifies" these into an alias, this fails rather than silently breaking the #155 debounce.
- `test_export_fingerprint_stable_across_validation_writeback` — guards the double-export regression if the hash is ever widened.
- `test_validation_input_hash_delegates_to_the_state_method` — the promotion must be a delegation, not a move.

**`TestExportOnCompletedBuild`** (`tests/test_agent_loop.py`) — driven through the real `_build_langchain_tools` wrapper and the real gate, with only the heavy tools spied:

- `test_field_only_change_re_exports`, `test_crate_metadata_change_re_exports`
- `test_count_preserving_swap_re_exports` — **honesty control** against a fix that special-cases `fields` instead of hashing content: remove one entity, add another, net zero.
- `test_no_change_still_exports_once` — **the control that matters**: a fix that simply deletes the gate passes the three above and fails this one.

**`TestFinishBackstop`**

- `test_backstop_exports_when_content_changed_since_last_export` — asserts both `build_and_validate` and `export_crate` run, **in that order** (the old early return skipped both).
- `test_backstop_is_a_noop_when_nothing_changed` — the anti-double-export control.

`test_re_export_when_state_changes_between_builds` stays green unmodified — its docstring ("the latest crate always lands") only becomes true with this change.

AGENTS.md corrected: it documented the entity-count fingerprint as delivering "the *latest* crate always lands", which did not follow from counting entities.

## Note on overlap

Touches `tests/test_agent_loop.py`, as does #388 (fixing #376) — different classes (`TestExportOnCompletedBuild` / `TestFinishBackstop` vs `TestTrimHistory`), so they should auto-merge. Both are branched off `main`, not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)