### PR TITLE
fix(d5): guard identifier fields whatever their spelling (#377, part 1 of 2)

### DIFF
--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -36,7 +36,7 @@ from builder.agents.llm import (
     _extract_token_usage,
 )
 from builder.tools._crate_mapping import _REF_FIELDS, draft_hints_schema
-from builder.tools.field_kinds import IDENTIFIER_FIELDS
+from builder.tools.field_kinds import IDENTIFIER_FIELDS, is_identifier_field
 
 # A usage sink is notified of one leaf call's token usage:
 # ``(input_tokens, output_tokens, model_name)``. Any element may be ``None`` when
@@ -756,8 +756,10 @@ def _normalise_interpretation(result: Any, gap_context: dict[str, Any]) -> dict[
         if not isinstance(value, str) or not value.strip():
             return {"action": "skip"}
         field = _local_property_name(gap_context.get("property"))
-        if field in _IDENTIFIER_SCALAR_FIELDS:
-            # D5: never let the user's prose become an identifier value.
+        # D5: never let the user's prose become an identifier value. Asked via
+        # the shared predicate, which normalises spelling — plain membership
+        # matched `inchikey` but missed a SHACL gap's `inChIKey` (#377).
+        if is_identifier_field(field):
             return {"action": "skip"}
         return {"action": "commit", "value": value.strip()}
 
@@ -872,7 +874,7 @@ def extract_field_from_file(
     """
     # D5: never extract an identifier from file text — those come from lookups.
     target = _local_property_name(field) or _local_property_name(gap_context.get("property"))
-    if target in _IDENTIFIER_SCALAR_FIELDS:
+    if is_identifier_field(target):
         return ""
     if not file_text or not file_text.strip():
         return ""

--- a/builder/tools/field_kinds.py
+++ b/builder/tools/field_kinds.py
@@ -102,9 +102,45 @@ IDENTIFIER_FIELDS: frozenset[str] = frozenset(
 )
 
 
+def normalise_field_name(field: str | None) -> str:
+    """Reduce a property name to a spelling-insensitive comparison key.
+
+    A field reaches these predicates from three places that spell it
+    differently: ``CrateState`` fields and the draft-hint schemas are snake_case
+    (``inchikey``, ``molecular_formula``); a SHACL gap carries a schema.org
+    property IRI whose local name is camelCase
+    (``http://schema.org/inChIKey``); and MIT ``crate_slot`` values are plain
+    field names. Without normalising, the D5 guard matched ``identifier`` and
+    ``smiles`` but silently missed ``inChIKey`` and ``molecularFormula``, and the
+    user's prose was committed onto the exported node (#377).
+
+    The key is the IRI's local part, lowercased, with separators removed —
+    **not** snake_case. A camelCase→snake_case conversion cannot reconcile these
+    vocabularies: ``inChIKey`` would become ``in_ch_ikey``, never the
+    ``inchikey`` the field set is written in, because the acronym boundaries are
+    not recoverable. Dropping separators on both sides sidesteps that entirely
+    and is why :data:`_IDENTIFIER_KEYS` is normalised the same way.
+    """
+    if not field:
+        return ""
+    local = str(field).rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+    return "".join(ch for ch in local if ch.isalnum()).lower()
+
+
+# The identifier vocabulary in comparison-key form, so membership is spelling-
+# insensitive in both directions (`inchikey` and `inChIKey` both hit).
+_IDENTIFIER_KEYS: frozenset[str] = frozenset(
+    normalise_field_name(f) for f in IDENTIFIER_FIELDS
+)
+
+
 def is_identifier_field(field: str) -> bool:
-    """Whether ``field`` (a local property name) is identifier-bearing (D5)."""
-    return field in IDENTIFIER_FIELDS
+    """Whether ``field`` is identifier-bearing (D5), however it is spelled.
+
+    Accepts a snake_case field name, a camelCase property, or a full property
+    IRI — see :func:`normalise_field_name`.
+    """
+    return normalise_field_name(field) in _IDENTIFIER_KEYS
 
 
 def is_reference_field(field: str) -> bool:

--- a/tests/test_tools_field_kinds.py
+++ b/tests/test_tools_field_kinds.py
@@ -1,0 +1,117 @@
+"""Tests for builder/tools/field_kinds.py — the shared field-kind vocabulary.
+
+#375 hoisted the D5 identifier list here so both build arms read one definition.
+#377 closes the hole that survived that hoist: every list was snake_case
+(``inchikey``), while a SHACL gap's local property name is schema.org camelCase
+(``inChIKey``), so the D5 guard silently missed and the user's prose was
+committed onto the exported node.
+"""
+
+from __future__ import annotations
+
+from builder.tools.field_kinds import (
+    is_identifier_field,
+    normalise_field_name,
+)
+
+
+class TestNormaliseFieldName:
+    """The key is separator-free and lowercased, NOT snake_case.
+
+    Snake_case cannot reconcile these vocabularies: ``inChIKey`` would become
+    ``in_ch_ikey``, never the ``inchikey`` the field set is written in, because
+    the acronym boundaries are not recoverable. Dropping separators on both
+    sides is what makes one vocabulary serve all three spellings.
+    """
+
+    def test_camelcase_and_snake_case_agree(self):
+        assert normalise_field_name("inChIKey") == normalise_field_name("inchikey")
+        assert normalise_field_name("molecularFormula") == normalise_field_name(
+            "molecular_formula"
+        )
+        assert normalise_field_name("pubChemCid") == normalise_field_name("pubchem_cid")
+
+    def test_handles_a_property_iri(self):
+        assert normalise_field_name("http://schema.org/inChIKey") == "inchikey"
+        assert normalise_field_name("https://schema.org/molecularFormula") == (
+            "molecularformula"
+        )
+
+    def test_distinct_fields_stay_distinct(self):
+        """Honesty control: normalisation must not collapse unrelated fields."""
+        keys = {
+            normalise_field_name(f)
+            for f in ("identifier", "accession", "smiles", "name", "description")
+        }
+        assert len(keys) == 5
+
+    def test_empty_and_none_are_safe(self):
+        assert normalise_field_name("") == ""
+        assert normalise_field_name(None) == ""
+
+
+class TestIsIdentifierFieldNormalises:
+    def test_camelcase_identifier_fields_are_guarded(self):
+        """The D5 hole: these are exactly the two that slipped through."""
+        assert is_identifier_field("inChIKey") is True
+        assert is_identifier_field("molecularFormula") is True
+
+    def test_property_iri_is_guarded(self):
+        assert is_identifier_field("http://schema.org/inChIKey") is True
+
+    def test_snake_case_identifiers_still_guarded(self):
+        for field in ("identifier", "accession", "smiles", "orcid", "doi", "cas"):
+            assert is_identifier_field(field) is True, field
+
+    def test_descriptive_fields_are_not_identifiers(self):
+        """Honesty control: the predicate is not a constant True."""
+        for field in ("name", "description", "keywords", "measurementMethod"):
+            assert is_identifier_field(field) is False, field
+
+
+class TestLeavesAndGuidanceInheritTheGuard:
+    """The two D5 chokepoints must refuse a camelCase identifier commit.
+
+    Both read the shared vocabulary, but membership was tested with `in` against
+    the raw snake_case set, so a SHACL gap's camelCase local name slipped past
+    and the user's prose was serialized onto the exported node (#377).
+    """
+
+    def test_interpret_leaf_skips_a_camelcase_identifier_commit(self):
+        from builder.agents.pipeline.leaves import _normalise_interpretation
+
+        decision = _normalise_interpretation(
+            {"action": "commit", "value": "BAUYGSIQEAFULO-UHFFFAOYSA-L"},
+            {"property": "http://schema.org/inChIKey"},
+        )
+        assert decision == {"action": "skip"}
+
+    def test_interpret_leaf_still_commits_a_descriptive_field(self):
+        """Honesty control: the refusal is caused by the identifier branch, not
+        by the function skipping everything."""
+        from builder.agents.pipeline.leaves import _normalise_interpretation
+
+        decision = _normalise_interpretation(
+            {"action": "commit", "value": "A resazurin viability readout."},
+            {"property": "http://schema.org/description"},
+        )
+        assert decision["action"] == "commit"
+
+    def test_offline_guidance_skips_a_camelcase_identifier_commit(self):
+        from builder.agents.pipeline.guidance import _deterministic_decision
+        from builder.tools.gap_analysis import Gap
+
+        gap = Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id="chem1",
+            entity_type="MolecularEntity",
+            property="http://schema.org/inChIKey",
+            message="MolecularEntity SHOULD have a schema:inChIKey",
+            suggestion=None,
+            fix_hint="ask-user",
+            auto_fixable=False,
+        )
+        assert _deterministic_decision(gap, "I think it starts with BAUY") == {
+            "action": "skip"
+        }


### PR DESCRIPTION
Part 1 of #377. **Does not close it** — part 2 (the MIT matcher migration) is described at the bottom.

## What was wrong — prose reached the exported crate

Every D5 identifier list in the repo is snake_case; a SHACL gap's local property name is schema.org camelCase. Membership was a bare `in`, so:

| gap property | local name | guarded? |
|---|---|---|
| `http://schema.org/identifier` | `identifier` | yes |
| `http://schema.org/smiles` | `smiles` | yes |
| `http://schema.org/inChIKey` | `inChIKey` | **no** |
| `http://schema.org/molecularFormula` | `molecularFormula` | **no** |

So when the guidance loop asked for an InChIKey and the user typed a guess, `_normalise_interpretation` let the commit through, `_apply_value` wrote it via `set_fields`, and it was serialized onto the node:

```json
{
  "@id": "https://pubchem.ncbi.nlm.nih.gov/compound/23682211",
  "@type": "MolecularEntity",
  "inChIKey": "I think it starts with BAUY",
  "identifier": [{"@id": "#param_CAS_5f5a5c1506"}]
}
```

That is a hard D5 violation — the one invariant the whole guidance design is built around.

## The fix, and a spec correction

`builder/tools/field_kinds.py` (the shared vocabulary hoisted in #375) gains `normalise_field_name`, and `is_identifier_field` compares normalised keys on both sides.

**The issue specified "camelCase → snake_case". That cannot work.** `inChIKey` converts to `in_ch_ikey`, never the `inchikey` the vocabulary is written in, because acronym boundaries are not recoverable from the casing. The key is instead the IRI's local part, lowercased, **with separators removed**, applied to both the input and the field set — so `inchikey` and `inChIKey` meet in the middle. This is documented in the function, since the naive reading is the tempting one.

`leaves._normalise_interpretation` and `extract_field_from_file` now ask the shared predicate rather than testing raw set membership.

**The offline guidance path needed no change** — `_deterministic_decision` already routes through the shared predicate after #375. Only `leaves` still had a raw membership test. That is the #375 hoist doing its job: one fix, and the second chokepoint was already covered.

## Verification

- Full suite: **1731 passed, 1 xpassed**
- `uvx ruff check` and `uv run ty check` clean

## Tests — `tests/test_tools_field_kinds.py` (new)

- `test_camelcase_and_snake_case_agree` / `test_handles_a_property_iri` — the normalisation contract, asserted as *agreement between spellings* rather than against a hardcoded snake_case string, so it cannot re-encode the spec error.
- `test_distinct_fields_stay_distinct` — **honesty control**: normalisation must not collapse unrelated fields into one key.
- `test_descriptive_fields_are_not_identifiers` — **honesty control**: the predicate is not a constant `True`.
- `test_interpret_leaf_skips_a_camelcase_identifier_commit` — drives the real `_normalise_interpretation` over a real gap-context shape. Red before this change.
- `test_interpret_leaf_still_commits_a_descriptive_field` — **honesty control**: proves the refusal comes from the identifier branch, not from the function skipping everything.
- `test_offline_guidance_skips_a_camelcase_identifier_commit` — pins that the guidance path stays covered, over a real `Gap`.

## What remains on #377

Part 2 is the MIT matcher migration, and it is genuinely separate work:

- `gap_analysis._filled_fields` keys on `CrateState` field names while `mit_assessment` keys on the assembled `@graph`. **141 of 176** MIT parameters are structurally unsatisfiable through the gap engine's copy (73 use the `char` slot, 68 use `LabProcess*` subtypes absent from the `EntityType` literal).
- Fixing it means promoting `slot_matcher` / `slot_type_present` to `mit_assessment`'s public surface, extracting `_assemble_and_validate` in `validation.py` (**without** widening `build_and_validate`'s return — it is a registered ReAct tool whose result is serialized into the model context), and threading the document through `assess_gaps` so there is one assembly per call rather than two.
- It also makes the ReAct arm's `assess_mit_coverage` honest, which today always passes `graph=None`.

Splitting here is deliberate: this half fixes active data corruption and is independently shippable, while part 2 is a refactor across three modules with its own test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)