### PR TITLE
fix(gaps): one MIT matcher, shared with the scorer (#377, part 2 of 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2169,7 +2169,20 @@ imports and calls it. It calls (does not re-implement) the three assessors:
   sweep yields REQUIRED + RECOMMENDED + OPTIONAL SHACL issues, each already
   routed to `{entity_id, property, message, fix, severity, profile}`.
 - `assess_mit_coverage`'s underlying YAML logic — every unfilled MIT parameter is
-  a domain-enrichment gap.
+  a domain-enrichment gap. Both go through **one** matcher,
+  `mit_assessment.slot_matcher` (#377): the `crate_slot` vocabulary describes the
+  **assembled crate**, not `CrateState`, so a state-field scan cannot see a
+  `LabProcess*` subtype (they are `LabProcess` + an `additionalType`, absent from
+  the `EntityType` literal), the `char` characteristic traversal, or a field the
+  build *promotes* — a MolecularEntity's `cas` becomes the node's `identifier`,
+  a CellLineSample's `accession` likewise. A second, un-migrated copy in the gap
+  engine is what made the loop ask for identifiers the crate already carried. The
+  document assembled for the SHACL sweep is threaded into the MIT pass, so a
+  `GapReport` costs **one** assembly, not two. A value the build *synthesized* in
+  the user's absence (the placeholder root name/description, the default
+  `license`) never counts as filled — crediting it would stop the loop asking for
+  the real one; the values are imported from the build's own constants rather
+  than duplicated.
 - `assess_fair_maturity` — every *failing* indicator is a gap.
 
 **Tiering** mirrors the §6 validation layers (MUST = blocking, SHOULD =

--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -38,6 +38,11 @@ from builder.tools.field_kinds import (
     PERSON_FIELDS,
     is_identifier_field,
 )
+from builder.tools.mit_assessment import (
+    graph_nodes,
+    slot_matcher,
+    slot_type_present,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -276,7 +281,7 @@ def _shacl_auto_fixable(state: CrateState, issue: dict[str, Any]) -> bool:
     return False
 
 
-def _shacl_gaps(state: CrateState, build_and_validate) -> tuple[list[Gap], dict[str, bool]]:
+def _shacl_gaps(state: CrateState) -> tuple[list[Gap], dict[str, bool], dict[str, Any] | None]:
     """Build SHACL gaps (all severities) and the conformance dict.
 
     Runs ``build_and_validate`` at ``recommended`` severity so REQUIRED *and*
@@ -284,11 +289,32 @@ def _shacl_gaps(state: CrateState, build_and_validate) -> tuple[list[Gap], dict[
     swept so the guidance agent sees the full picture.
     """
     # "optional" gates in REQUIRED + RECOMMENDED + OPTIONAL (the widest sweep).
-    result = build_and_validate(state, severity="optional", profile="all")
-    conformance = dict(result.get("conformance", {}))
-    if "error" in result:
-        logger.warning("gap engine: SHACL validation error: %s", result["error"])
-        return [], conformance
+    # The assembled document is captured alongside the verdict so the MIT matcher
+    # can score against the SAME assembly rather than building the crate twice.
+    from builder.tools.validation import _assemble_and_validate, _synthesize_fix
+
+    try:
+        metadata_doc, results = _assemble_and_validate(
+            state, severity="optional", profile="all"
+        )
+    except Exception as exc:  # noqa: BLE001 — mirror build_and_validate's contract
+        logger.warning("gap engine: SHACL validation error: %s", exc)
+        return [], {}, None
+    conformance: dict[str, bool] = {r.profile: r.passed_required for r in results}
+    result: dict[str, Any] = {
+        "issues": [
+            {
+                "entity_id": issue.entity_id,
+                "property": issue.property,
+                "message": issue.message,
+                "fix": _synthesize_fix(issue),
+                "severity": issue.severity,
+                "profile": issue.profile,
+            }
+            for r in results
+            for issue in r.issues
+        ],
+    }
 
     gaps: list[Gap] = []
     for issue in result.get("issues", []):
@@ -330,7 +356,7 @@ def _shacl_gaps(state: CrateState, build_and_validate) -> tuple[list[Gap], dict[
                 auto_fixable=auto,
             )
         )
-    return gaps, conformance
+    return gaps, conformance, metadata_doc
 
 
 # ---------------------------------------------------------------------------
@@ -350,19 +376,6 @@ def _load_mit_yaml() -> dict[str, Any] | None:
         return None
 
 
-def _filled_fields(state: CrateState) -> set[tuple[str, str]]:
-    """The ``(entity_type, field)`` pairs that are filled/verified in state.
-
-    Mirrors ``mit_assessment._count_filled_fields`` so a parameter is considered
-    "filled" by exactly the same rule the MIT assessor uses.
-    """
-    filled: set[tuple[str, str]] = set()
-    for entity in state.list_entities():
-        for field_name in entity.fields:
-            fc = entity.get_field_status(field_name)
-            if fc is not None and fc.status in ("filled", "verified"):
-                filled.add((entity.type, field_name))
-    return filled
 
 
 def _parse_crate_slots(slot_str: str) -> list[tuple[str, str]]:
@@ -399,7 +412,7 @@ def _present_entity_types(state: CrateState) -> set[str]:
     return {entity.type for entity in state.list_entities()}
 
 
-def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
+def _mit_gaps(state: CrateState, *, graph: Any | None = None) -> tuple[list[Gap], float]:
     """Unfilled MIT parameters as gaps; also return the overall MIT score.
 
     A parameter is a gap when *none* of its ``crate_slot`` targets is filled.
@@ -415,7 +428,13 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
     if mit_data is None:
         return [], 0.0
 
-    filled = _filled_fields(state)
+    # (#377) ONE matcher for the crate_slot vocabulary, shared with the scorer.
+    # With a graph it resolves what a CrateState field scan structurally cannot:
+    # LabProcess* subtypes (not EntityType members), the `char` characteristic
+    # traversal, and fields the assembly PROMOTES (a compound's `cas` becomes the
+    # node's `identifier`). Without one it degrades to the legacy field match.
+    matcher = slot_matcher(state, graph=graph)
+    nodes = graph_nodes(graph) if graph is not None else None
     present_types = _present_entity_types(state)
     modules = mit_data.get("modules", [])
     gaps: list[Gap] = []
@@ -443,7 +462,7 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
                 continue
             slots = _parse_crate_slots(crate_slot)
             total_required += 1
-            is_filled = any(slot in filled for slot in slots)
+            is_filled = any(matcher(et, f) for et, f in slots)
             if is_filled:
                 total_completed += 1
                 continue
@@ -459,7 +478,11 @@ def _mit_gaps(state: CrateState) -> tuple[list[Gap], float]:
             # an instance? If not, the parameter is type-level only — there is no
             # concrete entity to ask about, so phrasing it as a specific entity is
             # exactly the bug (asking for "this chemical"'s CAS with zero chemicals).
-            has_instance = any(et in present_types for et, _ in slots if et)
+            has_instance = any(
+                slot_type_present(et, nodes) if nodes is not None else et in present_types
+                for et, _ in slots
+                if et
+            )
             if not has_instance:
                 # No instance of any of the parameter's entity types: surface a
                 # creation-prompt, report-only gap (never a per-field ask on a
@@ -600,10 +623,10 @@ def assess_gaps(state: CrateState) -> GapReport:
         A :class:`GapReport` whose ``gaps`` are sorted MUST -> SHOULD -> MAY with
         a stable secondary order by ``(source, entity_id, property)``.
     """
-    from builder.tools.validation import build_and_validate
-
-    shacl_gaps, conformance = _shacl_gaps(state, build_and_validate)
-    mit_gaps, mit_overall = _mit_gaps(state)
+    shacl_gaps, conformance, metadata_doc = _shacl_gaps(state)
+    # ONE assembly per call: the MIT matcher scores against the very document the
+    # SHACL pass just validated, rather than re-assembling the crate (#377).
+    mit_gaps, mit_overall = _mit_gaps(state, graph=metadata_doc)
     fair_gaps, fair_summary = _fair_gaps(state)
 
     gaps = sorted([*shacl_gaps, *mit_gaps, *fair_gaps], key=_sort_key)

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -91,6 +91,42 @@ _SLOT_TYPE_MATCH: dict[str, tuple[frozenset[str], str | None]] = {
 # crate_slot field -> the actual property key on the assembled node.
 _SLOT_FIELD_ALIAS: dict[str, str] = {"param": "parameter"}
 
+# Values the BUILD synthesizes when the user supplied nothing. Crediting one
+# would be a false pass — and, since the gap engine shares this matcher (#377),
+# would silently stop the loop asking the user for the real value. Same class as
+# the deliberate refusal to alias `conditionsOfAccess` to the default `license`.
+def _placeholder_values() -> frozenset[str]:
+    """The synthesized values, read from the constants the BUILD actually uses.
+
+    Imported rather than duplicated as string literals: a hard-coded copy would
+    drift the moment a default is reworded, and silently start crediting it
+    again. Lazy + cached because ``builder.tools.builder`` pulls in ro-crate-py.
+    """
+    global _PLACEHOLDER_CACHE
+    if _PLACEHOLDER_CACHE is None:
+        from builder.tools.builder import (
+            _DEFAULT_ROOT_NAME,
+            _PLACEHOLDER_ROOT_DESCRIPTION,
+            _PLACEHOLDER_ROOT_NAME,
+        )
+
+        _PLACEHOLDER_CACHE = frozenset(
+            v.strip().lower()
+            for v in (
+                _PLACEHOLDER_ROOT_NAME,
+                _DEFAULT_ROOT_NAME,
+                _PLACEHOLDER_ROOT_DESCRIPTION,
+                # _crate_mapping's default root license; there is no constant for
+                # it, and the module already refuses to credit `conditionsOfAccess`
+                # from it for the same reason.
+                "ALL RIGHTS RESERVED BY THE AUTHORS",
+            )
+        )
+    return _PLACEHOLDER_CACHE
+
+
+_PLACEHOLDER_CACHE: frozenset[str] | None = None
+
 
 def _local(token: str) -> str:
     """Local name of a type/IRI token (last path/hash/CURIE segment)."""
@@ -110,11 +146,16 @@ def _additional_type_of(node: dict[str, Any]) -> str | None:
 
 
 def _nonempty(value: Any) -> bool:
-    """A property counts as filled when it carries a non-empty value (a bare
-    ``{"@id": …}`` reference or a list of them counts)."""
+    """A property counts as filled when it carries a real, non-placeholder value.
+
+    A bare ``{"@id": …}`` reference or a list of them counts. A value the BUILD
+    synthesized in the user's absence does not — see :data:`_PLACEHOLDER_VALUES`.
+    """
     if value is None:
         return False
-    if isinstance(value, (str, list, dict)):
+    if isinstance(value, str):
+        return bool(value) and value.strip().lower() not in _placeholder_values()
+    if isinstance(value, (list, dict)):
         return len(value) > 0
     return True
 
@@ -279,20 +320,72 @@ def assess_mit_coverage(
     if mit_data is None:
         return MITReport(module_scores={}, overall_score=0.0)
 
+    return _score_modules(mit_data, slot_matcher(state, graph=graph))
+
+
+def graph_nodes(graph: Any) -> list[dict[str, Any]]:
+    """The addressable nodes of an assembled crate document.
+
+    Accepts either the whole ``{"@context":…, "@graph":[…]}`` document or a bare
+    node list, so callers can pass whichever they are holding.
+    """
+    nodes = graph.get("@graph", []) if isinstance(graph, dict) else (graph or [])
+    return [n for n in nodes if isinstance(n, dict) and "@id" in n]
+
+
+def slot_matcher(
+    state: CrateState, *, graph: Any | None = None
+) -> Callable[[str, str], bool]:
+    """The single ``(crate_slot EntityType, field) -> filled?`` predicate.
+
+    **This is the one matcher for the ``crate_slot`` vocabulary** (#377). That
+    vocabulary describes the *assembled* crate — schema.org properties on nodes
+    discriminated by ``@type`` + ``additionalType`` — not the intermediate
+    ``CrateState``, so the graph branch is the accurate one. It resolves three
+    things a ``CrateState`` field scan structurally cannot:
+
+    * a slot type that is not an ``EntityType`` at all (``LabProcessExposure``
+      and its three siblings are ``LabProcess`` + an ``additionalType``);
+    * the ``char`` slot, realized only as an ``additionalProperty``
+      ``CharacteristicValue`` at assembly;
+    * a field the assembly *promotes* — a ``MolecularEntity``'s ``cas`` becomes
+      the node's ``identifier`` PropertyValue, and a ``CellLineSample``'s
+      ``accession`` becomes its ``identifier``.
+
+    Exposed publicly so the gap engine consumes it instead of keeping a second,
+    un-migrated copy — the two disagreeing is what made the pipeline ask for
+    identifiers the crate already carried.
+
+    With ``graph=None`` it degrades to the legacy ``CrateState`` field match, for
+    callers that hold no assembled document (e.g. an in-loop score floor).
+    """
     if graph is not None:
-        nodes = graph.get("@graph", []) if isinstance(graph, dict) else graph
-        nodes = [n for n in nodes if isinstance(n, dict) and "@id" in n]
+        nodes = graph_nodes(graph)
         index = {n["@id"]: n for n in nodes}
 
-        def slot_filled(entity_type: str, field: str) -> bool:
+        def _graph_match(entity_type: str, field: str) -> bool:
             return _graph_slot_filled(entity_type, field, nodes, index)
-    else:
-        filled_fields = _count_filled_fields(state)
 
-        def slot_filled(entity_type: str, field: str) -> bool:
-            return (entity_type, field) in filled_fields
+        return _graph_match
 
-    return _score_modules(mit_data, slot_filled)
+    filled_fields = _count_filled_fields(state)
+
+    def _state_match(entity_type: str, field: str) -> bool:
+        return (entity_type, field) in filled_fields
+
+    return _state_match
+
+
+def slot_type_present(entity_type: str, nodes: list[dict[str, Any]]) -> bool:
+    """Whether any assembled node matches ``entity_type``'s slot-type rule.
+
+    The graph-aware counterpart of "is there an instance of this type?" — the
+    check that decides whether an MIT parameter gets a per-field question or the
+    #257 creation prompt. A ``CrateState`` type scan answers ``False`` for every
+    ``LabProcess*`` subtype (they are not ``EntityType`` members), so a fully
+    parameterised Exposure still produced "No LabProcessExposure recorded yet".
+    """
+    return any(_node_matches_slot_type(n, entity_type) for n in nodes)
 
 
 # ---------------------------------------------------------------------------
@@ -300,4 +393,21 @@ def assess_mit_coverage(
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 
-TOOL_REGISTRY.register("assess_mit_coverage", assess_mit_coverage, takes_state=True)
+
+def _assess_mit_coverage_tool(state: CrateState, *, assemble: bool = True) -> MITReport:
+    """The registered tool: score against the ASSEMBLED crate by default (#377).
+
+    The bare function was registered directly, so every ``run_tool`` call passed
+    ``graph=None`` and both arms saw the legacy ``CrateState`` score — far below
+    what the maturity report reports for the same crate, because most of the MIT
+    vocabulary only resolves after assembly.
+
+    ``assemble=False`` keeps the cheap no-graph branch reachable for an in-loop
+    score floor; it is an explicit opt-out rather than an implicit behaviour
+    change, since a full crate assembly per call is not free.
+    """
+    graph = {"@graph": _assemble_graph(state)} if assemble else None
+    return assess_mit_coverage(state, graph=graph)
+
+
+TOOL_REGISTRY.register("assess_mit_coverage", _assess_mit_coverage_tool, takes_state=True)

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -160,6 +160,41 @@ def _synthesize_fix(issue: RoutableIssue) -> str:
     return f"Fix `{entity}`: {issue.message}"
 
 
+def _assemble_and_validate(
+    state: CrateState, *, severity: str, profile: str
+) -> tuple[dict[str, Any], list[Any]]:
+    """Assemble the crate in memory and validate it, returning BOTH.
+
+    Split out so a caller that needs the assembled document itself — the gap
+    engine, whose MIT matcher scores against the assembled graph — can reuse this
+    one assembly instead of building the crate a second time (#377).
+
+    Deliberately NOT surfaced by widening ``build_and_validate``'s return:
+    that is a registered ReAct tool whose result is serialized into the model's
+    context, and a whole ``@graph`` there would be pure token cost.
+
+    ``include_all_scanned=False``: the auto-included scanned-file leaves (#175)
+    are plain File nodes that do not change the validation verdict, so they are
+    skipped on this hot path. ``export_crate`` uses the default (True) so the
+    written crate packages the whole dataset.
+    """
+    # Imported lazily (not at module top) so validate()'s ImportError handling
+    # stays intact. profiles.validator installs the roc-validator bootstrap shim
+    # + bundled-ISA-ontology patch on import; importing validate_crate_dict here
+    # runs that shim before any rocrate_validator import is triggered.
+    from builder.tools.builder import assemble_crate
+    from profiles.validator import validate_crate_dict
+
+    crate = assemble_crate(
+        state,
+        output_dir=None,
+        materialize_payload=False,
+        include_all_scanned=False,
+    )
+    metadata_doc = crate.metadata.generate()
+    return metadata_doc, validate_crate_dict(metadata_doc, severity=severity, profile=profile)
+
+
 def build_and_validate(
     state: CrateState,
     severity: str | None = "required",
@@ -194,27 +229,14 @@ def build_and_validate(
     severity = "required" if severity is None else severity
     profile = "all" if profile is None else profile
 
-    # Imported lazily (not at module top) so validate()'s ImportError handling
-    # stays intact. profiles.validator installs the roc-validator bootstrap shim
-    # + bundled-ISA-ontology patch on import; importing validate_crate_dict here
-    # runs that shim before any rocrate_validator import is triggered. assemble_crate
-    # pulls in ro-crate-py only (no rocrate_validator), so its order is immaterial.
-    from builder.tools.builder import assemble_crate
-    from profiles.validator import validate_crate_dict
-
     try:
         # include_all_scanned=False: the auto-included scanned-file leaves (#175)
         # are plain File nodes that don't change the validation verdict, so we skip
         # them on this hot in-loop path to keep build_and_validate fast. export_crate
         # uses the default (True) so the written crate packages the whole dataset.
-        crate = assemble_crate(
-            state,
-            output_dir=None,
-            materialize_payload=False,
-            include_all_scanned=False,
+        metadata_doc, results = _assemble_and_validate(
+            state, severity=severity, profile=profile
         )
-        metadata_doc = crate.metadata.generate()
-        results = validate_crate_dict(metadata_doc, severity=severity, profile=profile)
     except Exception as e:  # noqa: BLE001 — surface as a tool error, never crash the loop
         logger.error("build_and_validate failed: %s", e)
         return {"ok": False, "conformance": {}, "issues": [], "error": str(e)}

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -13,6 +13,8 @@ CI's suite-wide ``--timeout=30`` is overridden per-module.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from builder.state import CrateState, Entity, EntityProvenance, EntityType
@@ -666,3 +668,109 @@ class TestActionableGapsAreActuallyAppliable:
             _local_name(g.property) == "description" and g.entity_type == "Assay"
             for g in actionable
         ), "the Assay description gap must remain actionable"
+
+
+class TestMitGapsUseTheGraphMatcher:
+    """#377 part 2: one matcher for the `crate_slot` vocabulary.
+
+    `mit_assessment` matches slots against the assembled `@graph` — its module
+    docstring says that is the accurate path, because the domain data is only
+    synthesized at assembly. The gap engine carried a second, un-migrated copy
+    keyed on `CrateState` field names, so it asked for identifiers the crate
+    already had and reported a coverage score the maturity report contradicted.
+    """
+
+    @staticmethod
+    def _post_lookup_state() -> CrateState:
+        """The state the lookups actually leave behind — no network needed.
+
+        `resolve_compound` writes `cas`/`pubchem_cid` (never `identifier`) and
+        `resolve_cell_line` writes `accession`; the assembly promotes both to the
+        node's `identifier`. Setting them directly with the same completion
+        status is exactly what the composites do.
+        """
+        state = _backbone()
+        chem = _entity(
+            "chem1", "MolecularEntity", name="Sodium perchlorate", cas="7601-89-0"
+        )
+        chem.set_field_status("cas", "verified", "lookup")
+        state.add_entity(chem)
+        cell = _entity("cl1", "CellLineSample", name="FRTL-5", accession="CVCL_0027")
+        cell.set_field_status("accession", "verified", "lookup")
+        state.add_entity(cell)
+        state.add_entity(
+            _entity("ex1", "LabProcess", process_type="Exposure", name="Exposure", assay_id="as1")
+        )
+        return state
+
+    def test_mit_gaps_agree_with_the_graph_scorer_param_for_param(self):
+        """THE contract: one matcher for one `crate_slot` vocabulary.
+
+        For every MIT parameter, "the gap engine emits a gap" must mean exactly
+        "the scorer counts the slot unfilled". Any divergence is the two matchers
+        disagreeing — the defect. This subsumes the individual slot cases and
+        cannot pass vacuously: it is an equality between two independently
+        computed sets, so a gap engine that emitted nothing would fail just as
+        loudly as one that emitted everything.
+        """
+        from builder.tools.mit_assessment import (
+            _assemble_graph,
+            _load_mit_yaml,
+            _parse_crate_slots,
+            slot_matcher,
+        )
+
+        state = self._post_lookup_state()
+        matcher = slot_matcher(state, graph={"@graph": _assemble_graph(state)})
+
+        scorer_unfilled: set[str] = set()
+        for module in (_load_mit_yaml() or {}).get("modules", []):
+            # The YAML nests most parameters under `sections`; walk both, exactly
+            # as the gap engine and the scorer do.
+            params = [
+                *(p for sec in module.get("sections", []) for p in sec.get("parameters", [])),
+                *module.get("parameters", []),
+            ]
+            for param in params:
+                crate_slot = param.get("crate_slot", "")
+                slots = _parse_crate_slots(crate_slot)
+                if not slots:
+                    continue
+                if not any(matcher(et, f) for et, f in slots):
+                    scorer_unfilled.add(crate_slot)
+
+        # Every MIT gap message ends with "(crate_slot <value>)" in both of its
+        # forms, so the slot string identifies the parameter without needing a
+        # new field on `Gap`.
+        emitted = {
+            m.group(1)
+            for g in assess_gaps(state).gaps
+            if g.source == "mit"
+            and (m := re.search(r"\(crate_slot ([^)]+)\)", g.message))
+        }
+        assert emitted == scorer_unfilled
+
+    def test_exposure_labprocess_stops_the_creation_prompt(self):
+        """`LabProcessExposure` is not an `EntityType`, so the state matcher
+        could never see the Exposure that is right there in state."""
+        state = self._post_lookup_state()
+        messages = [g.message for g in assess_gaps(state).gaps]
+        assert not [m for m in messages if "No LabProcessExposure recorded yet" in m]
+
+    def test_creation_prompt_reappears_without_the_exposure(self):
+        """Honesty control for the creation-prompt guard."""
+        state = self._post_lookup_state()
+        state.remove_entity("ex1")
+        messages = [g.message for g in assess_gaps(state).gaps]
+        assert [m for m in messages if "No LabProcessExposure recorded yet" in m]
+
+    def test_mit_overall_matches_the_graph_scorer(self):
+        """The gap engine's headline number must agree with the scorer the
+        maturity report uses, on the same document."""
+        from builder.tools.mit_assessment import _assemble_graph, assess_mit_coverage
+
+        state = self._post_lookup_state()
+        report = assess_gaps(state)
+        scorer = assess_mit_coverage(state, graph={"@graph": _assemble_graph(state)})
+
+        assert report.mit_overall == pytest.approx(scorer.overall_score, abs=1e-6)

--- a/tests/test_tools_mit_assessment.py
+++ b/tests/test_tools_mit_assessment.py
@@ -168,3 +168,89 @@ class TestAssessMITCoverage:
             assert isinstance(scores["completed"], int)
             assert isinstance(scores["total"], int)
             assert scores["completed"] <= scores["total"]
+
+
+class TestPlaceholderValuesAreNotCredited:
+    """#377: a build-time placeholder must not count as a filled MIT slot.
+
+    The assembly synthesizes `name = "Untitled Investigation"` on the root when
+    no title is set (`_crate_mapping.py`), so a graph-based match would credit
+    `Investigation:name` on a crate that has no title at all — and, once the gap
+    engine shares this matcher, would silently stop asking the user for it.
+
+    This is the same class the module already guards against for
+    `conditionsOfAccess` vs the always-present default `license`.
+    """
+
+    @staticmethod
+    def _untitled_state():
+        from builder.state import CrateState, Entity, EntityProvenance
+
+        def ent(eid, t, **f):
+            e = Entity(
+                entity_id=eid, type=t, fields=dict(f),
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+            for k in f:
+                e.set_field_status(k, "filled", "llm")
+            return e
+
+        state = CrateState()
+        state.add_entity(ent("inv1", "Investigation", description="d", identifier="INV-1"))
+        state.add_entity(ent("st1", "Study", description="d", investigation_id="inv1"))
+        state.add_entity(ent("as1", "Assay", study_id="st1"))
+        return state
+
+    def test_placeholder_root_name_is_not_a_filled_slot(self):
+        from builder.tools.mit_assessment import _assemble_graph, slot_matcher
+
+        state = self._untitled_state()
+        matcher = slot_matcher(state, graph={"@graph": _assemble_graph(state)})
+        assert matcher("Investigation", "name") is False
+
+    def test_a_real_title_is_still_credited(self):
+        """Honesty control: the guard rejects the placeholder, not every name."""
+        from builder.tools.mit_assessment import _assemble_graph, slot_matcher
+
+        state = self._untitled_state()
+        state.metadata.title = "FRTL-5 perchlorate thyroid study"
+        matcher = slot_matcher(state, graph={"@graph": _assemble_graph(state)})
+        assert matcher("Investigation", "name") is True
+
+
+    def test_placeholder_set_is_derived_from_the_builders_own_constants(self):
+        """Drift guard: the values come from the build, not a copied literal.
+
+        Two different entry points synthesize two different root names
+        (`_PLACEHOLDER_ROOT_NAME` via `_assemble_graph`, `_DEFAULT_ROOT_NAME` via
+        `assemble_crate`), which is exactly how a hard-coded copy would go stale
+        and start crediting a placeholder again.
+        """
+        from builder.tools.builder import (
+            _DEFAULT_ROOT_NAME,
+            _PLACEHOLDER_ROOT_DESCRIPTION,
+            _PLACEHOLDER_ROOT_NAME,
+        )
+        from builder.tools.mit_assessment import _placeholder_values
+
+        values = _placeholder_values()
+        for const in (
+            _PLACEHOLDER_ROOT_NAME,
+            _DEFAULT_ROOT_NAME,
+            _PLACEHOLDER_ROOT_DESCRIPTION,
+        ):
+            assert const.strip().lower() in values, const
+
+    def test_the_assess_gaps_path_also_rejects_its_placeholder(self):
+        """The two build paths use DIFFERENT defaults, so cover both.
+
+        `assess_gaps` scores against `assemble_crate`'s document, whose root name
+        falls back to `_DEFAULT_ROOT_NAME` — a different string from the one
+        `_assemble_graph` produces.
+        """
+        from builder.tools.mit_assessment import slot_matcher
+        from builder.tools.validation import _assemble_and_validate
+
+        state = self._untitled_state()
+        doc, _results = _assemble_and_validate(state, severity="required", profile="base")
+        assert slot_matcher(state, graph=doc)("Investigation", "name") is False


### PR DESCRIPTION
Closes #377. Part 1 (the D5 spelling hole) is #390 — independent files, no conflict.

## What was wrong

`gap_analysis` carried a **second, un-migrated copy** of the `crate_slot` matcher, keyed on `CrateState` field names, while `mit_assessment` had already moved to the assembled `@graph`. Its module docstring is explicit that the graph is the accurate path — the `crate_slot` vocabulary describes the *assembled crate*, and most of the domain data only exists after assembly.

Three consequences, all reproduced:

| symptom | why the state matcher couldn't see it |
|---|---|
| asks for a CAS the crate already has | `resolve_compound` writes `cas`; the **assembly** promotes it to the node's `identifier` |
| asks for a cell-line accession it already has | same — `accession` becomes `identifier` at assembly |
| "No LabProcessExposure recorded yet" with an Exposure right there | `LabProcessExposure` is `LabProcess` + an `additionalType`; it is not an `EntityType` member at all |

Plus a coverage figure that contradicted the maturity report on the same crate.

## The fix

- **`mit_assessment`** promotes `slot_matcher` / `slot_type_present` / `graph_nodes` to its public surface. `assess_mit_coverage` keeps its signature, so `maturity_report` is untouched.
- **`validation._assemble_and_validate`** returns the assembled document alongside the verdict. `build_and_validate`'s return is **deliberately not widened** — it is a registered ReAct tool whose result is serialized into the model's context, and a whole `@graph` there is pure token cost.
- **`assess_gaps`** threads that document into `_mit_gaps`, so a report costs **one** assembly rather than two. `_filled_fields` is deleted.
- **The registered `assess_mit_coverage` tool** assembles by default, so the ReAct arm stops seeing the legacy score. `assemble=False` keeps the cheap branch reachable as an explicit opt-out.

## The bug the migration surfaced

My own #375 honesty control started failing, and the cause was real: **the graph matcher credited values the build synthesizes when the user supplied nothing.** An untitled crate gets a synthesized root `name`, so `Investigation:name` scored as *filled* — meaning adopting the matcher naively would have made the builder **stop asking you for your study's title**.

Worse, the two build entry points use **different** defaults: `_PLACEHOLDER_ROOT_NAME` (`"Untitled Investigation"`) via `_assemble_graph`, and `_DEFAULT_ROOT_NAME` (`"ISA-Tox RO-Crate"`) via `assemble_crate` — which is the path `assess_gaps` actually uses. My first fix caught only the first, which is why the gate failed twice.

`_nonempty` now refuses them, **importing the constants from `builder.tools.builder`** rather than duplicating literals that would drift the moment a default is reworded. This is the same class the module already guarded deliberately for `conditionsOfAccess` vs the always-present default `license`.

**Be aware this moves the reported MIT number DOWN in some crates.** The placeholder credit was simply wrong — the maturity report has been counting a synthesized title and the default `ALL RIGHTS RESERVED` license as real data.

## Verification

- Full suite: **1752 passed, 1 xpassed**
- `uvx ruff check` and `uv run ty check` clean

## Tests

The headline is **`test_mit_gaps_agree_with_the_graph_scorer_param_for_param`**: for every MIT parameter, "the gap engine emits a gap" must mean exactly "the scorer counts the slot unfilled". It is an equality between two independently computed sets, so it fails just as loudly for an engine that emits nothing as for one that emits everything.

That matters, because **my first version of these tests was vacuous and the honesty controls caught it** — I probed identifier gaps, which #375 had already made `report-only`, so the primary assertions passed while their controls failed. The set-equality invariant replaced them.

Also:
- `test_exposure_labprocess_stops_the_creation_prompt` + control asserting it reappears when the Exposure is removed.
- `test_mit_overall_matches_the_graph_scorer` — the headline number must agree with the scorer the maturity report uses.
- `TestPlaceholderValuesAreNotCredited` — the placeholder is refused; **honesty control** proves a real title is still credited; a **drift guard** asserts each build constant appears in the set; and a fourth test covers the `assemble_crate` path specifically, since the two paths disagree.

## Sequencing

**#338 is now unblocked.** Its `_auto_resolve_identifier` checks `identifier` while `resolve_compound` writes `cas` — only the graph matcher reconciles them, so before this it would have merged without fixing what it describes. #372 was never affected (it writes `identifier` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)