### PR TITLE
fix(mit): one assembly path, and re-arm the guard #391 disarmed

### DIFF
--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -209,19 +209,26 @@ def _graph_slot_filled(
 
 
 def _assemble_graph(state: CrateState) -> list[dict[str, Any]]:
-    """Serialize *state* into an RO-Crate ``@graph`` in memory (no disk write)."""
-    import tempfile
+    """Serialize *state* into an RO-Crate ``@graph`` in memory (no disk write).
 
-    from rocrate.rocrate import ROCrate
+    Goes through :func:`builder.tools.builder.assemble_crate` — the one assembly
+    path — with the same arguments :func:`builder.tools.validation._assemble_and_validate`
+    uses. Reaching past it to ``populate_crate`` is not equivalent, and both
+    differences changed the score (#377): it skipped ``_apply_root_name`` (#272),
+    leaving the root at the literal placeholder name that :func:`_placeholder_values`
+    then refuses, and it took ``include_all_scanned``'s default of True, crediting
+    ``File:encodingFormat`` off scanned files the gap engine's document omits. One
+    matcher over two differently-assembled documents is still two answers.
+    """
+    from builder.tools.builder import assemble_crate
 
-    from builder.tools._crate_mapping import populate_crate
-    from profiles.context import ISA_TOX_CONTEXT
-
-    crate = ROCrate()
-    crate.metadata.extra_contexts = ISA_TOX_CONTEXT
-    with tempfile.TemporaryDirectory() as tmp:
-        populate_crate(state, crate, Path(tmp), materialize_payload=False)
-        graph = crate.metadata.generate().get("@graph", [])
+    crate = assemble_crate(
+        state,
+        output_dir=None,
+        materialize_payload=False,
+        include_all_scanned=False,
+    )
+    graph = crate.metadata.generate().get("@graph", [])
     return [n for n in graph if isinstance(n, dict) and "@id" in n]
 
 

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -286,24 +286,34 @@ class TestHeadlessGapSummary:
 
         Re-running ``assess_gaps`` on the headless path re-ran the heaviest
         ``severity="optional"`` SHACL sweep, blowing the CI per-test budget. The
-        summary must derive purely from the already-computed pipeline result. We
-        assert ``build_and_validate`` (which a fresh ``assess_gaps`` would call) is
-        never invoked from the build after the pipeline returns.
+        summary must derive purely from the already-computed pipeline result.
+
+        BOTH validation entry points are spied, not just the one the gap engine
+        happens to route through today. #391 rewired ``_shacl_gaps`` from
+        ``build_and_validate`` to ``_assemble_and_validate``, which left a
+        single-target version of this guard asserting something unconditionally
+        true — the regression could have come back green.
         """
         import builder.tools.validation as validation_mod
         from builder.agents.build import run_interactive_build
 
-        validate_calls: list[Any] = []
-        real_bav = validation_mod.build_and_validate
+        validate_calls: list[str] = []
 
-        def spy_bav(*a: Any, **k: Any) -> dict[str, Any]:
-            validate_calls.append((a, k))
-            return real_bav(*a, **k)
+        def _spy(name: str):
+            real = getattr(validation_mod, name)
 
-        # Spy on the canonical entry point a fresh assess_gaps would call. The
-        # injected pipeline runner does NOT call build_and_validate, so any call
-        # observed here would come from the headless summary path.
-        monkeypatch.setattr(validation_mod, "build_and_validate", spy_bav)
+            def spy(*a: Any, **k: Any) -> Any:
+                validate_calls.append(name)
+                return real(*a, **k)
+
+            return spy
+
+        # The injected pipeline runner calls neither entry point, so anything
+        # observed here came from the headless summary path. ``_shacl_gaps``
+        # imports ``_assemble_and_validate`` at call time, so patching the module
+        # attribute is enough to intercept a fresh ``assess_gaps``.
+        for _target in ("build_and_validate", "_assemble_and_validate"):
+            monkeypatch.setattr(validation_mod, _target, _spy(_target))
 
         engine = _engine(SimulatedHumanInterface())
         run_interactive_build(

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -17,7 +17,13 @@ import re
 
 import pytest
 
-from builder.state import CrateState, Entity, EntityProvenance, EntityType
+from builder.state import (
+    CrateState,
+    Entity,
+    EntityProvenance,
+    EntityType,
+    FileClassification,
+)
 from builder.tools.gap_analysis import (
     _CRATE_SETTABLE_FIELDS,
     REPORT_ONLY,
@@ -700,6 +706,16 @@ class TestMitGapsUseTheGraphMatcher:
         state.add_entity(cell)
         state.add_entity(
             _entity("ex1", "LabProcess", process_type="Exposure", name="Exposure", assay_id="as1")
+        )
+        # A scanned-but-un-drafted file, which is what `scan_files` leaves behind
+        # on every real run. Without one the parity assertions below pass for the
+        # wrong reason: `include_all_scanned` (#175) auto-includes such a file as a
+        # root `File` leaf, so the gap engine's assembly and the scorer's only
+        # agree on `File:encodingFormat` when both pass the same flag.
+        state.scanned_files.append(
+            FileClassification(
+                path="/data/raw.csv", filename="raw.csv", size=10, mime_type="text/csv"
+            )
         )
         return state
 


### PR DESCRIPTION
Post-merge review fixes on **#391** (merged as `b3e0fcf`, closing #377). An adversarial review of that diff raised twelve findings across four lanes; five were refuted and the seven survivors collapsed into the two defects below plus one fixture weakness. Filed as a PR off `main` rather than a push to the merged branch.

## 1. `_assemble_graph` was a second, divergent assembly path

#391's headline is *one matcher* — but a single matcher over two differently-assembled documents still yields two answers. `_assemble_graph` reached past `assemble_crate` to `populate_crate`, so it:

* **skipped `_apply_root_name` (#272)**, leaving the root at the literal placeholder name that #391's own new `_placeholder_values()` then refuses; and
* **took `include_all_scanned`'s default of `True`**, crediting `File:encodingFormat` off scanned files that `_assemble_and_validate` (`include_all_scanned=False`) omits.

So the registered `assess_mit_coverage` tool and `assess_gaps` reported **different MIT overalls for the same state**. Now routed through `assemble_crate` with `_assemble_and_validate`'s exact arguments. Measured on a probe state: both paths return `0.159091`, where the tool previously returned `0.170455`.

## 2. #391 silently disarmed the only #296 guard

`test_headless_summary_does_not_run_fresh_assess_gaps` spied `validation.build_and_validate` and asserted it was never called. Rewiring `_shacl_gaps` to `_assemble_and_validate` left `build_and_validate` with **zero call sites in that module**, making the assertion unconditionally true for every input — the #296 regression (the headless summary re-running the heaviest `severity="optional"` SHACL sweep) could have returned with no failing test, and grep confirms this was its only guard.

Rather than just retargeting the spy, it now watches **both** entry points, closing the class instead of the instance.

## 3. The parity tests passed for the wrong reason

`_post_lookup_state` had an empty `scanned_files`, which hides the `include_all_scanned` divergence entirely. One scanned `FileClassification` added, so the fixture covers the normal post-`scan_files` case rather than an artificially empty one.

## Verification

Each fix was proven, not assumed:

* **Red before green.** The fixture change (3) was made *first*: the two parity tests then failed at `File:encodingFormat`, `0.159` vs `0.170`, before any production code was touched. Fix 1 turns them green.
* **Mutation-tested guard.** The #296 regression was temporarily reintroduced into `format_gap_summary`; the strengthened guard fails with `assert ['_assemble_and_validate'] == []` — precisely the call the single-target spy would have missed. Probe reverted; `builder/agents/build.py` is untouched in this PR.
* **Cross-path agreement probed directly** — `assess_gaps` and `_assess_mit_coverage_tool` now return identical values on the same state.
* Affected files: **86 passed**. Full suite on the pre-rebase tree: **1752 passed, 1 xpassed** (unchanged). `uvx ruff check` clean; `uv run ty check` unchanged at 9 pre-existing diagnostics, none in these files.

## Corrections to #391's description, for the record

* **The default license was never credited.** There is no `license` slot among the 176 `crate_slot` entries in `mit/invitro_tox.yaml`, so that `_placeholder_values()` entry — and `_PLACEHOLDER_ROOT_DESCRIPTION` — are unreachable. Harmless dead defence, but #391's claim that the report "has been counting … the default `ALL RIGHTS RESERVED` license as real data" is false.
* **The net effect on MIT is upward, not downward.** On a realistic post-lookup state the old field matcher saw 3 of 176 parameters filled where the crate scorer sees 7. The downward move is real but confined to synthesized placeholders, which is correct.
* `test_mit_gaps_agree_with_the_graph_scorer_param_for_param` is a **consistency** contract, not a correctness one. Its docstring's claim of "two independently computed sets" is inaccurate — both sides call the same `slot_matcher`, so a matcher bug cancels.

## Deliberately not in this PR

* `gap_analysis.py:287` docstring still says it "Runs `build_and_validate` at `recommended` severity"; it now calls `_assemble_and_validate` at `optional` — wrong on both counts.
* Softening the overclaiming docstring in (3) above.
* Breaking the `CellLineSample` slot rule at `mit_assessment.py:82` is caught by no test; the `MolecularEntity` equivalent is covered at `test_tools_gap_analysis.py:390`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)