### PR TITLE
fix(d5): stop the cell-line drafter advertising a circular lookup and a liftable CVCL_0027 (#383, parts A/B/D)

### DIFF
--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -168,7 +168,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_publication_with_authors",
-        "description": "Create a publication (from a DOI) AND wire every author as a Person in ONE call, harmonizing each author's @id to their ORCID when it can be determined. Resolution cascade per author (first hit wins): (1) the Crossref ORCID on the author (verified before use); (2) an in-crate Person with a verified ORCID matching the author's family + given/initial (e.g. citation 'Fabian Wagenaars' -> root 'F.M.A. Wagenaars'); (3) a public ORCID search — a single strong (family + full given) match is auto-used, anything ambiguous (multiple candidates or an initial-only match) asks YOU via present_to_human/request_input; (4) fallback to a synthesized #CitationAuthor_<Given>_<Family> Person. NEVER attaches an unverified or guessed ORCID (D5). Prefer this over draft_publication when you want the authors resolved too. Example: draft_publication_with_authors(doi='10.1016/j.tox.2021.152898').",
+        "description": "Create a publication (from a DOI) AND wire every author as a Person in ONE call, harmonizing each author's @id to their ORCID when it can be determined. Resolution cascade per author (first hit wins): (1) the Crossref ORCID on the author (verified before use); (2) an in-crate Person with a verified ORCID matching the author's family + given/initial (e.g. citation 'Fabian Wagenaars' -> root 'F.M.A. Wagenaars'); (3) a public ORCID search — a single strong (family + full given) match is auto-used, anything ambiguous (multiple candidates or an initial-only match) asks YOU via present_to_human/request_input; (4) fallback to a synthesized #CitationAuthor_<Given>_<Family> Person. NEVER attaches an unverified or guessed ORCID (D5). Prefer this over draft_publication when you want the authors resolved too. Example: draft_publication_with_authors(doi='10.1234/example').",
         "parameters": {
             "type": "object",
             "properties": {
@@ -182,7 +182,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_molecular_entity",
-        "description": "Create a MolecularEntity from a compound name. Look the compound up first (lookup_compound) so you can pass a verified pubchem_cid. Example: draft_molecular_entity(name='Silychristin A', hints={'pubchem_cid': '443515', 'identifier': '33889-69-9'}).",
+        "description": "Create a MolecularEntity from a compound name. Look the compound up first (lookup_compound) so you can pass a verified pubchem_cid. Example: draft_molecular_entity(name='Silychristin A', hints={'pubchem_cid': '<CID returned by lookup_compound>', 'identifier': '<CAS RN returned by lookup_compound>'}).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -194,7 +194,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_cell_line_sample",
-        "description": "Create a CellLineSample from a cell-line name. Look it up first (lookup_cell_line) to get a verified Cellosaurus accession. Example: draft_cell_line_sample(name='HepG2', hints={'accession': 'CVCL_0027'}).",
+        "description": "Create a CellLineSample from a cell-line name. Look the cell line up first (lookup_cell_line_by_name) to get a verified Cellosaurus accession; lookup_cell_line takes an accession you already hold, so it cannot resolve a bare name. Never carry an accession over from another cell line — an accession that resolves to a different record is worse than none. Example: draft_cell_line_sample(name='HepG2', hints={'accession': '<CVCL_… returned by lookup_cell_line_by_name>'}).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -320,7 +320,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_person",
-        "description": "Create a Person entity. Look the person up first (lookup_orcid) to pass a verified orcid. Example: draft_person(name='Jane Doe', hints={'orcid': '0000-0002-1825-0097'}).",
+        "description": "Create a Person entity. Pass an orcid only when you already hold one you can confirm with lookup_orcid, which takes an ORCID iD and not a name; when the person is an author of a DOI, draft_publication_with_authors resolves their ORCID for you. Example: draft_person(name='Jane Doe', hints={'orcid': '<ORCID iD confirmed with lookup_orcid>'}).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -356,7 +356,7 @@ TOOL_SPECS = [
     },
     {
         "name": "draft_defined_term",
-        "description": "Create a schema:DefinedTerm contextual entity to PERSIST a looked-up ontology / AOP / Key-Event term so it round-trips into the crate and can be referenced (via set_fields/link) as a mentions / measurementMethod / sampleType target. Pass the looked-up IRI as the 'url' hint so the node gets a dereferenceable @id. Example: draft_defined_term(name='cell viability assay', hints={'term_code': 'BAO:0002993', 'url': 'http://www.bioassayontology.org/bao#BAO_0002993'}).",
+        "description": "Create a schema:DefinedTerm contextual entity to PERSIST a looked-up ontology / AOP / Key-Event term so it round-trips into the crate and can be referenced (via set_fields/link) as a mentions / measurementMethod / sampleType target. Pass the looked-up IRI as the 'url' hint so the node gets a dereferenceable @id. Example: draft_defined_term(name='cell viability assay', hints={'term_code': '<CURIE returned by lookup_bao_term / lookup_ontology_term>', 'url': '<IRI returned by the same lookup>'}).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -380,7 +380,7 @@ TOOL_SPECS = [
     },
     {
         "name": "set_fields",
-        "description": "Set one or more fields on an existing entity (the single mutation tool — pass one key or many). Use it to fill or correct an entity's metadata, e.g. after build_and_validate names a field to fix. Example: set_fields(entity_id='chem_silychristin_a', fields={'identifier': '33889-69-9', 'smiles': 'C[C@H]1...'}).",
+        "description": "Set one or more fields on an existing entity (the single mutation tool — pass one key or many). Use it to fill or correct an entity's metadata, e.g. after build_and_validate names a field to fix. Example: set_fields(entity_id='chem_silychristin_a', fields={'identifier': '<CAS RN from a verified lookup>', 'smiles': 'C[C@H]1...'}).",
         "parameters": {
             "type": "object",
             "properties": {
@@ -475,7 +475,7 @@ TOOL_SPECS = [
     },
     {
         "name": "lookup_cell_line",
-        "description": "Look up cell line via Cellosaurus",
+        "description": "Fetch a Cellosaurus record from an accession you already hold (CVCL_*). It does NOT accept a cell-line name — from a bare name use lookup_cell_line_by_name.",
         "parameters": {
             "type": "object",
             "properties": {"accession": {"type": "string"}},

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -185,7 +185,10 @@ ENTITY_DRAFT_SCHEMA: dict[str, EntityDraftSchema] = {
     "CellLineSample": EntityDraftSchema(
         scalar_fields={
             "name": "Cell-line name (passed as the `name` argument).",
-            "accession": "Cellosaurus accession, e.g. 'CVCL_0027'.",
+            "accession": (
+                "Cellosaurus accession (CVCL_*) as returned by a lookup for THIS "
+                "cell line — never guessed, never reused from another line."
+            ),
             "description": _DESC,
         },
     ),
@@ -264,7 +267,10 @@ ENTITY_DRAFT_SCHEMA: dict[str, EntityDraftSchema] = {
     "DefinedTerm": EntityDraftSchema(
         scalar_fields={
             "name": "Term label (passed as the `name` argument).",
-            "term_code": "Ontology code, e.g. 'BAO:0002993' or 'GO:0006915'.",
+            "term_code": (
+                "Ontology term CURIE ('PREFIX:LOCALID', e.g. 'BAO:NNNNNNN', "
+                "'GO:NNNNNNN') exactly as returned by the term lookup."
+            ),
             "in_defined_term_set": "IRI of the term set / ontology the term belongs to.",
             "url": "Dereferenceable IRI for the term (used as the entity @id).",
             "description": _DESC,

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -331,4 +331,179 @@ def test_assert_tool_spec_parity_flags_a_spec_with_no_callable_tool(monkeypatch)
         ts.assert_tool_spec_parity()
 
 
+# ---------------------------------------------------------------------------
+# Advertised-text lints (Issue #383)
+#
+# Two properties of the *shipped* model-facing text, both of which the
+# tool-existence lint above cannot see:
+#   1. no worked example hands the model a resolvable identifier it can lift
+#      onto the wrong entity;
+#   2. advice to "look it up first (tool)" names a tool the caller can actually
+#      call from the arguments it holds.
+# ---------------------------------------------------------------------------
+
+# Identifier shapes that resolve at a real authority, so a model that lifts one
+# out of an example ships a real-but-wrong id (a D5 violation on disk).
+_RESOLVABLE_IDENTIFIER_PATTERNS: dict[str, re.Pattern[str]] = {
+    "Cellosaurus accession": re.compile(r"CVCL[_:]\d+"),
+    "CAS RN": re.compile(r"\b\d{2,7}-\d{2}-\d\b"),
+    "ORCID iD": re.compile(r"0000-000\d-\d{4}-\d{3}[\dX]"),
+    "DOI": re.compile(r"10\.\d{4,9}/[^\s'\"]+"),
+    "ontology term CURIE": re.compile(r"\b(?:BAO|GO|CHEBI|EFO|OBI|UBERON|NCIT)[:_]\d+"),
+}
+
+# Literals reserved by their registries as non-resolvable documentation
+# examples, so they cannot be lifted onto a real entity.
+_NON_RESOLVABLE_PLACEHOLDERS = frozenset({"10.1234/example"})
+
+
+def _iter_descriptions(node: object, path: str) -> list[tuple[str, str]]:
+    """Return every ``description`` string in *node*, with a dotted path.
+
+    Walks the whole spec, so it reaches the nested ``hints`` parameter schemas
+    that ``draft_hints_schema`` renders from ``_crate_mapping.ENTITY_DRAFT_SCHEMA``
+    — the model sees those in the same function-call payload as the description.
+    """
+    found: list[tuple[str, str]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "description" and isinstance(value, str):
+                found.append((f"{path}.{key}", value))
+            else:
+                found.extend(_iter_descriptions(value, f"{path}.{key}"))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            found.extend(_iter_descriptions(value, f"{path}[{index}]"))
+    return found
+
+
+def _resolvable_identifier_literals(spec: dict) -> list[tuple[str, str, str]]:
+    """Return ``(path, kind, literal)`` for each resolvable id advertised by *spec*."""
+    hits: list[tuple[str, str, str]] = []
+    for path, text in _iter_descriptions(spec, str(spec.get("name", "?"))):
+        for kind, pattern in _RESOLVABLE_IDENTIFIER_PATTERNS.items():
+            for literal in pattern.findall(text):
+                if literal in _NON_RESOLVABLE_PLACEHOLDERS:
+                    continue
+                hits.append((path, kind, literal))
+    return hits
+
+
+# The repo's advisory idiom for "call this tool first": a "look … up" sentence,
+# and/or a bare tool name in parentheses.
+_LOOKUP_ADVICE_CUE = re.compile(r"\blook(?:s|ed|ing)?\s[^.]*?\bup\b", re.I)
+_PARENTHESISED_TOOL = re.compile(r"\(([a-z_]+)\)")
+
+
+def _advised_tools(description: str, tool_names: set[str]) -> set[str]:
+    """Return the tools *description* advises the caller to call."""
+    advised: set[str] = set()
+    for sentence in re.split(r"(?<=[.;])\s+", description):
+        if _LOOKUP_ADVICE_CUE.search(sentence):
+            advised |= {n for n in tool_names if re.search(rf"\b{re.escape(n)}\b", sentence)}
+        advised |= {m for m in _PARENTHESISED_TOOL.findall(sentence) if m in tool_names}
+    return advised
+
+
+def _misdirected_advice(spec: dict, specs: list) -> list[tuple[str, str, list[str]]]:
+    """Return ``(caller, advised, unsatisfiable_args)`` for misdirected advice.
+
+    A caller's *own* top-level arguments are the only ones it can pass on. Its
+    ``hints`` are excluded deliberately: hints carry the values the advised
+    lookup is supposed to *return*, so a lookup that requires one of them as
+    input is circular from where the caller stands.
+    """
+    required = {
+        str(s["name"]): set(s.get("parameters", {}).get("required", []) or []) for s in specs
+    }
+    caller = str(spec["name"])
+    own_args = set(spec.get("parameters", {}).get("properties", {}) or {}) - {"hints"}
+    findings: list[tuple[str, str, list[str]]] = []
+    for advised in sorted(_advised_tools(str(spec.get("description", "")), set(required)) - {caller}):
+        unmet = required.get(advised, set()) - own_args
+        if unmet:
+            findings.append((caller, advised, sorted(unmet)))
+    return findings
+
+
+def test_no_advertised_description_contains_a_resolvable_identifier_literal():
+    """No model-facing description hands the model a liftable real identifier.
+
+    `CVCL_0027` (HepG2) used to appear twice in one ``draft_cell_line_sample``
+    payload — in the worked example and again in the shared hint schema. A model
+    that dead-ends on a lookup reaches for the nearest concrete accession, so a
+    CHO-K1 sample could ship with HepG2's accession, verified (Issue #383).
+    """
+    offenders = [hit for spec in TOOL_SPECS for hit in _resolvable_identifier_literals(spec)]
+    assert not offenders, (
+        "Advertised text contains resolvable identifier literal(s) a model can "
+        f"lift onto the wrong entity: {offenders}. Use a shape-only placeholder."
+    )
+
+
+def test_the_identifier_literal_lint_flags_a_planted_literal():
+    """The detector fires on a planted literal, including a nested one.
+
+    Proves the green state above is 'the shipped specs are clean', not 'the
+    patterns match nothing'.
+    """
+    planted = {
+        "name": "draft_planted",
+        "description": "Example: draft_planted(doi='10.1016/j.tox.2021.152898').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "hints": {
+                    "type": "object",
+                    "properties": {
+                        "accession": {
+                            "type": "string",
+                            "description": "Cellosaurus accession, e.g. 'CVCL_0027'.",
+                        }
+                    },
+                }
+            },
+        },
+    }
+
+    hits = _resolvable_identifier_literals(planted)
+
+    assert ("draft_planted.description", "DOI", "10.1016/j.tox.2021.152898") in hits
+    nested = "draft_planted.parameters.properties.hints.properties.accession.description"
+    assert (nested, "Cellosaurus accession", "CVCL_0027") in hits
+
+
+def test_no_description_advises_a_tool_it_cannot_call_from_its_own_arguments():
+    """Advice to look something up must name a tool the caller can call.
+
+    ``draft_cell_line_sample`` used to say "Look it up first (lookup_cell_line)"
+    while ``lookup_cell_line`` requires the accession the caller is trying to
+    obtain; the tool that goes name -> accession (``lookup_cell_line_by_name``)
+    was never named. The existing existence lint passes on that, because the
+    misdirecting tool does exist (Issue #383).
+    """
+    offenders = [f for spec in TOOL_SPECS for f in _misdirected_advice(spec, TOOL_SPECS)]
+    assert not offenders, (
+        "Description(s) advise a tool whose required argument(s) the caller "
+        f"cannot supply: {offenders}. Name the tool that takes what the caller has."
+    )
+
+
+def test_the_lookup_advice_lint_flags_a_planted_misdirection():
+    """The detector fires on advice naming a lookup keyed by the wanted value."""
+    planted = {
+        "name": "draft_planted",
+        "description": "Create a thing from a name. Look it up first (lookup_cell_line).",
+        "parameters": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "hints": {"type": "object"}},
+            "required": ["name", "hints"],
+        },
+    }
+
+    findings = _misdirected_advice(planted, [*TOOL_SPECS, planted])
+
+    assert findings == [("draft_planted", "lookup_cell_line", ["accession"])]
+
+
 __all__: list[str] = []


### PR DESCRIPTION
Partial fix for #383 — **does not close it.** Parts A, B and D only. Part C is described at the bottom and is the part with teeth.

## What was wrong

Two things conspired to let a `CellLineSample` ship with a **real but wrong** Cellosaurus accession.

**A. The advertised advice was circular.** `tools_spec.py:197` told the model to call `lookup_cell_line` to go name→accession, but that tool *requires an accession as input* (`lookups.py:175`, spec at `tools_spec.py:476-484`). The tool that actually goes name→accession, `lookup_cell_line_by_name`, sits one spec entry lower and was never named by the drafter that needs it. A model holding only a name could not follow the advice.

**B. A resolvable accession was handed to the model twice in one payload.** The worked example at `tools_spec.py:197` and the shared hint schema at `_crate_mapping.py:188` both contained the literal `CVCL_0027`. When the advertised lookup dead-ends, that literal is the nearest concrete accession in context — so a CHO-K1 sample could ship carrying HepG2's accession.

**D.** `tests/test_tools_spec.py:143` lints only that a referenced tool *exists*, so a misdirection passes. That guard is strengthened here — it is the durable half of this change.

## Verification

Adversarially verified: the new tests go red with the production change reverted, no network access, lane discipline clean (`tools_spec.py`, `_crate_mapping.py`, `test_tools_spec.py` only). `uvx ruff check` clean; `uv run ty check` **9 diagnostics, identical to main**.

## ⚠️ Part C is NOT implemented — #383 must stay open

The issue says plainly: *"Part C is the only part with teeth — do not stop after A and B."* It is not in this PR, and I confirmed the hole is still reachable on disk.

`verify_identifier` (`builder/tools/verification.py:130-132`) still does:

```python
result = verifier(query)
if result.get("found"):
    entity.set_field_status(field, "verified", "lookup")
```

No comparison against the entity's own cell-line name. So an accession that merely *resolves* is stamped `status="verified", source="lookup"` even when it belongs to a different cell line. **A transposed-but-real accession is still indistinguishable from a correct one, and still exports with verified provenance.**

A+B only make the wrong accession less likely to be *produced*. Nothing here stops it being *blessed* once produced.

**Why it was skipped rather than bodged:** part C needs `verification.py` plus hoisting `_normalize_cell_line_name` out of `lookups.py:200` into a shared `cell_line_names_match`. `lookups.py` is owned by the parallel #385 lane. Writing the gate inside `verification.py` alone would mean duplicating that normalization — recreating exactly the drift the issue says to prevent by hoisting. So it is reported, not silently dropped. The three verification tests and the lookups helper test from the issue's TDD section are consequently absent.

Sequence it after #385 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)