### PR TITLE
fix(observability): thread a usage sink through the guidance tail so interactive cost stops under-reporting (#384, fixes b+c)

### DIFF
--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -487,6 +487,10 @@ def format_guidance_summary(guidance_result: dict[str, Any] | None) -> str:
     conformance, so the user sees the build's state after guidance at a glance.
     A ``None`` result (guidance never ran, e.g. a non-interactive build) yields a
     short, non-crashing message.
+
+    The tail's own token spend (#384) is appended when it is non-zero, so the
+    figure the status bar has been climbing through is also stated once at the
+    end. An offline / no-provider tail spends nothing and gets no line.
     """
     if not guidance_result:
         return "No interactive guidance ran (headless build)."
@@ -512,6 +516,14 @@ def format_guidance_summary(guidance_result: dict[str, Any] | None) -> str:
         (f"  conformance: base={_mark('base')} isa={_mark('isa')} tox={_mark('tox')}"),
         f"  rounds: {rounds}",
     ]
+
+    usage = guidance_result.get("usage") or {}
+    tokens_in = int(usage.get("input_tokens") or 0)
+    tokens_out = int(usage.get("output_tokens") or 0)
+    if tokens_in or tokens_out:
+        total = int(usage.get("total_tokens") or (tokens_in + tokens_out))
+        lines.append(f"  tokens: {tokens_in}→{tokens_out} ({total})")
+
     return "\n".join(lines)
 
 

--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -60,6 +60,10 @@ Determinism & safety contract:
   are single bounded calls gated on ``get_provider()``; the drafter's output is
   confirmed before commit, and the interpreter's output is a *structured* decision
   — a free-text reply is never stored verbatim.
+* **Every leaf call is accounted.** Each one reports its token usage to the run's
+  :data:`UsageSink`, which logs the same profile event the spine and the ReAct
+  model node log — so the status bar re-printed before every question, the
+  ``--dashboard`` table and the eval all include the tail's spend (#384).
 * **HITL is never removed.** ask-user and draft-confirm both route through the
   injected :class:`HumanInterface`; the loop cannot silently fabricate content.
 * **D5 at the chokepoint.** Identifier-bearing fields are never committed from the
@@ -85,7 +89,16 @@ from typing import TYPE_CHECKING, Any, Callable
 # Re-exported at module scope so the spine, tests, and the eval harness have a
 # single stable monkeypatch target — and so a flaky/absent LLM drafter / guidance
 # leaf can be stubbed without importing langchain.
-from builder.agents.pipeline.pipeline import draft_entity_fields
+#
+# ``UsageSink`` / ``_make_usage_logger`` are the spine's token-accounting seam,
+# reused verbatim rather than reimplemented (#384): the logger emits the same
+# ``node_end``/``node="model"`` profile event the ReAct model node emits, which is
+# the only surface the status bar, the ``--dashboard`` table and the eval read.
+from builder.agents.pipeline.pipeline import (
+    UsageSink,
+    _make_usage_logger,
+    draft_entity_fields,
+)
 from builder.config import get_provider
 from builder.tools.field_kinds import (
     CITATION_FIELDS,
@@ -642,7 +655,7 @@ def _draft_context(engine: AgentEngine, gap: Gap) -> str:
     return "\n".join(parts).strip()
 
 
-def _drafted_value(engine: AgentEngine, gap: Gap) -> str | None:
+def _drafted_value(engine: AgentEngine, gap: Gap, *, usage_sink: UsageSink | None) -> str | None:
     """Draft a candidate value for ``gap`` via the bounded drafter leaf, or None.
 
     Calls :func:`draft_entity_fields` for the gap's ``entity_type`` and returns the
@@ -655,7 +668,9 @@ def _drafted_value(engine: AgentEngine, gap: Gap) -> str | None:
         return None
     field = _local_name(gap.property) or (gap.property or "")
     try:
-        fields = draft_entity_fields(entity_type, _draft_context(engine, gap))
+        fields = draft_entity_fields(
+            entity_type, _draft_context(engine, gap), usage_sink=usage_sink
+        )
     except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
         logger.warning("guidance: drafter leaf failed for %s: %s", entity_type, exc)
         return None
@@ -883,7 +898,7 @@ def _gap_context(engine: AgentEngine, gap: Gap) -> dict[str, Any]:
     return context
 
 
-def _phrase_question(engine: AgentEngine, gap: Gap) -> str:
+def _phrase_question(engine: AgentEngine, gap: Gap, *, usage_sink: UsageSink | None) -> str:
     """Phrase ``gap`` as one human question via the LLM leaf, with a safe fallback.
 
     Calls :func:`phrase_gap_question` (the drafter-tier leaf); on any failure or an
@@ -892,7 +907,7 @@ def _phrase_question(engine: AgentEngine, gap: Gap) -> str:
     """
     if phrase_gap_question is not None:
         try:
-            question = phrase_gap_question(_gap_context(engine, gap))
+            question = phrase_gap_question(_gap_context(engine, gap), usage_sink=usage_sink)
         except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
             logger.warning("guidance: phrase leaf failed: %s", exc)
             question = ""
@@ -924,7 +939,14 @@ def _deterministic_decision(gap: Gap, reply: str) -> dict[str, Any]:
     return {"action": "commit", "value": reply.strip()}
 
 
-def _interpret_reply(engine: AgentEngine, gap: Gap, question: str, reply: str) -> dict[str, Any]:
+def _interpret_reply(
+    engine: AgentEngine,
+    gap: Gap,
+    question: str,
+    reply: str,
+    *,
+    usage_sink: UsageSink | None,
+) -> dict[str, Any]:
     """Interpret ``reply`` into a structured decision via the LLM leaf.
 
     Calls :func:`interpret_gap_reply` (the drafter-tier leaf) and returns its
@@ -937,13 +959,21 @@ def _interpret_reply(engine: AgentEngine, gap: Gap, question: str, reply: str) -
     if interpret_gap_reply is None:  # pragma: no cover — provider gated elsewhere
         return _deterministic_decision(gap, reply)
     try:
-        return interpret_gap_reply(question, reply, _gap_context(engine, gap))
+        return interpret_gap_reply(
+            question, reply, _gap_context(engine, gap), usage_sink=usage_sink
+        )
     except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
         logger.warning("guidance: interpret leaf failed (%s); deterministic fallback", exc)
         return _deterministic_decision(gap, reply)
 
 
-def _resolve_ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> str | None:
+def _resolve_ask_user(
+    engine: AgentEngine,
+    human: HumanInterface,
+    gap: Gap,
+    *,
+    usage_sink: UsageSink | None,
+) -> str | None:
     """Run the LLM-mediated ask-user exchange for ``gap``; return a clean value.
 
     The §14.6 "small guidance agent" (#244, #257). When a provider is configured
@@ -977,7 +1007,7 @@ def _resolve_ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> s
         value = _deterministic_decision(gap, reply).get("value")
         return value.strip() if isinstance(value, str) and value.strip() else None
 
-    question = _phrase_question(engine, gap)
+    question = _phrase_question(engine, gap, usage_sink=usage_sink)
     response = human.request_input(question)
     reply = _reply_text(response)
     if reply is None:
@@ -986,7 +1016,7 @@ def _resolve_ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> s
 
     follow_ups = 0
     while True:
-        decision = _interpret_reply(engine, gap, question, reply)
+        decision = _interpret_reply(engine, gap, question, reply, usage_sink=usage_sink)
         action = decision.get("action")
 
         if action == "commit":
@@ -1011,7 +1041,9 @@ def _resolve_ask_user(engine: AgentEngine, human: HumanInterface, gap: Gap) -> s
             # of logging the hint and skipping (the #244 behavior). The reply's
             # prose is never stored; only a value the extraction leaf pulls from
             # the file's text, gated to approved scan roots.
-            return _resolve_from_file(engine, gap, reply, decision.get("filename"))
+            return _resolve_from_file(
+                engine, gap, reply, decision.get("filename"), usage_sink=usage_sink
+            )
 
         # skip, an exhausted clarify budget, or any unrecognised action -> skip.
         return None
@@ -1095,7 +1127,12 @@ def _read_pointed_file(engine: AgentEngine, candidates: list[str]) -> str | None
 
 
 def _resolve_from_file(
-    engine: AgentEngine, gap: Gap, reply: str, filename: str | None
+    engine: AgentEngine,
+    gap: Gap,
+    reply: str,
+    filename: str | None,
+    *,
+    usage_sink: UsageSink | None,
 ) -> str | None:
     """Read the file the user pointed at and extract the gap's value (#257, fix C).
 
@@ -1135,7 +1172,9 @@ def _resolve_from_file(
         return None
 
     try:
-        value = extract_field_from_file(field, file_text, _gap_context(engine, gap))
+        value = extract_field_from_file(
+            field, file_text, _gap_context(engine, gap), usage_sink=usage_sink
+        )
     except Exception as exc:  # noqa: BLE001 — a flaky leaf must not break the loop
         logger.warning("guidance: from_file extraction leaf failed: %s", exc)
         return None
@@ -1157,6 +1196,7 @@ def _resolve_gap(
     *,
     resolved: list[dict[str, Any]],
     asked: list[dict[str, Any]],
+    usage_sink: UsageSink | None,
 ) -> bool:
     """Resolve a single ``gap``; return ``True`` iff it committed a change.
 
@@ -1168,7 +1208,8 @@ def _resolve_gap(
     * **ask-user** (or any non-auto fallback) -> prompt and apply the answer.
 
     Records the action in ``resolved`` (committed) or ``asked`` (surfaced to the
-    user) for the run summary.
+    user) for the run summary. ``usage_sink`` is threaded to every leaf this gap
+    may reach so the tail's token spend is accounted (#384).
     """
     record = {
         "tier": gap.tier,
@@ -1193,7 +1234,7 @@ def _resolve_gap(
 
     # --- draftable: draft -> confirm -> commit (D5) ---------------------------
     if gap.fix_hint == "draft":
-        candidate = _drafted_value(engine, gap)
+        candidate = _drafted_value(engine, gap, usage_sink=usage_sink)
         if candidate is not None:
             decision = human.present(
                 context=(
@@ -1214,7 +1255,7 @@ def _resolve_gap(
 
     # --- ask-user: phrase -> interpret -> apply (LLM-mediated, #244) ----------
     asked.append(record)
-    value = _resolve_ask_user(engine, human, gap)
+    value = _resolve_ask_user(engine, human, gap, usage_sink=usage_sink)
     if value is None:
         return False
     if _apply_value(engine, gap, value, human):
@@ -1245,6 +1286,7 @@ def run_guidance(
     human: HumanInterface,
     *,
     max_rounds: int = _DEFAULT_MAX_ROUNDS,
+    usage_sink: UsageSink | None = None,
 ) -> dict[str, Any]:
     """Run the deterministic HITL gap-resolution loop over the gap engine.
 
@@ -1267,6 +1309,15 @@ def run_guidance(
             ask-user prompts and draft confirmations.
         max_rounds: Hard upper bound on rounds (default 20). Guarantees
             termination even if a resolved gap never clears.
+        usage_sink: Where each leaf call reports its token usage (#384). Defaults
+            to the spine's own :func:`_make_usage_logger`, so the tail is
+            accounted whether or not a caller asks for it: without one, every
+            phrase / interpret / draft / from-file call is missing from
+            ``profile.ndjson`` and the status bar re-printed before EVERY
+            question shows a frozen token count while real money is spent. A
+            caller that injects its own sink takes over the accounting entirely
+            — including the profile write and its own totals — so the returned
+            ``usage`` then reports zero.
 
     Returns:
         A summary dict::
@@ -1277,8 +1328,15 @@ def run_guidance(
                 "remaining_gaps": {must_open, should_open, may_open},
                 "conformance":    {base, isa, tox},
                 "rounds":         <int>,
+                "usage":          {input_tokens, output_tokens, total_tokens},
             }
     """
+    # Token accounting (#384), mirroring ``run_pipeline``'s contract: the default
+    # sink both accumulates ``totals`` (the in-memory figure the summary reports)
+    # and logs the ``node_end``/``node="model"`` profile event that the status bar,
+    # the ``--dashboard`` table and the eval all read.
+    totals: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+    sink = usage_sink or _make_usage_logger(engine, totals)
     resolved: list[dict[str, Any]] = []
     asked: list[dict[str, Any]] = []
     rounds = 0
@@ -1314,7 +1372,9 @@ def run_guidance(
         rounds += 1
         identity = _gap_identity(gap)
         resolved_before = len(resolved)
-        progressed = _resolve_gap(engine, human, gap, resolved=resolved, asked=asked)
+        progressed = _resolve_gap(
+            engine, human, gap, resolved=resolved, asked=asked, usage_sink=sink
+        )
 
         if progressed:
             # State changed: re-assess from scratch and forget the per-report
@@ -1349,6 +1409,11 @@ def run_guidance(
         "remaining_gaps": dict(report.counts),
         "conformance": dict(report.conformance),
         "rounds": rounds,
+        "usage": {
+            "input_tokens": totals["input_tokens"],
+            "output_tokens": totals["output_tokens"],
+            "total_tokens": totals["input_tokens"] + totals["output_tokens"],
+        },
     }
 
 

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -186,6 +186,32 @@ class TestGuidanceSummary:
         assert isinstance(text, str)
         assert text  # non-empty
 
+    def test_format_guidance_summary_reports_the_tail_token_spend(self) -> None:
+        """#384: the tail's own token spend is surfaced, not just the spine's.
+
+        ``run_guidance`` reports what its leaves consumed under ``usage``; without
+        a line here that number would be a second dead dict (``run_pipeline``'s
+        ``usage`` already has no consumer anywhere).
+        """
+        from builder.agents.build import format_guidance_summary
+
+        result = {
+            **_GUIDANCE_RESULT,
+            "usage": {"input_tokens": 240, "output_tokens": 70, "total_tokens": 310},
+        }
+        text = format_guidance_summary(result)
+        assert "240" in text and "70" in text and "310" in text
+
+    def test_format_guidance_summary_omits_tokens_when_none_were_used(self) -> None:
+        """An offline / no-provider tail spends nothing — no misleading zero line."""
+        from builder.agents.build import format_guidance_summary
+
+        result = {
+            **_GUIDANCE_RESULT,
+            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        }
+        assert "token" not in format_guidance_summary(result).lower()
+
     def test_run_interactive_build_surfaces_summary_via_output(self) -> None:
         """The interactive build prints the guidance summary to the output channel."""
         from builder.agents.build import run_interactive_build

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -349,7 +349,7 @@ class TestDraftable:
         # Stub the drafter leaf — NO real LLM.
         called: dict[str, object] = {}
 
-        def _fake_draft(entity_type, context, *, model=None):
+        def _fake_draft(entity_type, context, *, model=None, usage_sink=None):
             called["entity_type"] = entity_type
             return {"description": "A drafted value."}
 
@@ -395,7 +395,7 @@ class TestDraftable:
         )
         monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
 
-        def _fake_draft(entity_type, context, *, model=None):
+        def _fake_draft(entity_type, context, *, model=None, usage_sink=None):
             return {"description": "A drafted value the user rejects."}
 
         monkeypatch.setattr(guidance, "draft_entity_fields", _fake_draft)
@@ -824,12 +824,12 @@ class TestLLMMediatedAskUser:
         # The phrase leaf produces a clean question; the interpret leaf reads the
         # musing as a SKIP (action="skip"), carrying no value.
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "What does this study examine?"
         )
         monkeypatch.setattr(
             guidance,
             "interpret_gap_reply",
-            lambda _q, _reply, _ctx: {"action": "skip"},
+            lambda _q, _reply, _ctx, **_kw: {"action": "skip"},
         )
 
         human = ScriptedHuman(
@@ -859,12 +859,12 @@ class TestLLMMediatedAskUser:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "What does this study examine?"
         )
 
         captured: dict[str, object] = {}
 
-        def _interpret(question, reply, ctx):
+        def _interpret(question, reply, ctx, **_kw):
             captured["reply"] = reply
             return {
                 "action": "commit",
@@ -901,13 +901,13 @@ class TestLLMMediatedAskUser:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "What does this study examine?"
         )
 
         # Every interpretation says "clarify" — without a cap this loops forever.
         interpret_calls = {"n": 0}
 
-        def _always_clarify(question, reply, ctx):
+        def _always_clarify(question, reply, ctx, **_kw):
             interpret_calls["n"] += 1
             return {"action": "clarify", "question": "Could you be more specific?"}
 
@@ -939,7 +939,7 @@ class TestLLMMediatedAskUser:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "What does this study examine?"
         )
 
         decisions = iter(
@@ -949,7 +949,7 @@ class TestLLMMediatedAskUser:
             ]
         )
         monkeypatch.setattr(
-            guidance, "interpret_gap_reply", lambda _q, _r, _c: next(decisions)
+            guidance, "interpret_gap_reply", lambda _q, _r, _c, **_kw: next(decisions)
         )
 
         human = ScriptedHuman(
@@ -977,12 +977,12 @@ class TestLLMMediatedAskUser:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "What does this study examine?"
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "What does this study examine?"
         )
         monkeypatch.setattr(
             guidance,
             "interpret_gap_reply",
-            lambda _q, _r, _c: {"action": "from_file", "filename": "README.txt"},
+            lambda _q, _r, _c, **_kw: {"action": "from_file", "filename": "README.txt"},
         )
 
         human = ScriptedHuman(
@@ -1010,9 +1010,9 @@ class TestLLMMediatedAskUser:
         )
 
         phrased = "In one sentence, what does this study set out to find?"
-        monkeypatch.setattr(guidance, "phrase_gap_question", lambda _ctx: phrased)
+        monkeypatch.setattr(guidance, "phrase_gap_question", lambda _ctx, **_kw: phrased)
         monkeypatch.setattr(
-            guidance, "interpret_gap_reply", lambda _q, _r, _c: {"action": "skip"}
+            guidance, "interpret_gap_reply", lambda _q, _r, _c, **_kw: {"action": "skip"}
         )
 
         human = ScriptedHuman(input_answers=[_value("hmm")])
@@ -1195,14 +1195,14 @@ class TestQuestionNamesEntity:
         )
 
         # A realistic phrase leaf: it echoes the entity name it is handed.
-        def _phrase(ctx):
+        def _phrase(ctx, **_kw):
             name = ctx.get("entity_name") or "this chemical substance"
             return f"What is the CAS Registry Number for {name}?"
 
         monkeypatch.setattr(guidance, "phrase_gap_question", _phrase)
         # An identifier gap: the user's prose can never become the value (D5).
         monkeypatch.setattr(
-            guidance, "interpret_gap_reply", lambda _q, _r, _c: {"action": "skip"}
+            guidance, "interpret_gap_reply", lambda _q, _r, _c, **_kw: {"action": "skip"}
         )
 
         human = ScriptedHuman(input_answers=[_value("dunno")])
@@ -1304,13 +1304,13 @@ class TestMITGapGroundedInInstanceName:
 
         # A realistic phrase leaf: it grounds on the name it is handed, else it
         # would invent the stock "HepG2" example (the bug).
-        def _phrase(ctx):
+        def _phrase(ctx, **_kw):
             name = ctx.get("entity_name") or "HepG2"
             return f"What passage number was {name} at during the assay?"
 
         monkeypatch.setattr(guidance, "phrase_gap_question", _phrase)
         monkeypatch.setattr(
-            guidance, "interpret_gap_reply", lambda _q, _r, _c: {"action": "skip"}
+            guidance, "interpret_gap_reply", lambda _q, _r, _c, **_kw: {"action": "skip"}
         )
 
         human = ScriptedHuman(input_answers=[_value("dunno")])
@@ -1396,18 +1396,18 @@ class TestFromFileReadsAndExtracts:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "Describe the study."
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "Describe the study."
         )
         monkeypatch.setattr(
             guidance,
             "interpret_gap_reply",
-            lambda _q, _r, _c: {"action": "from_file", "filename": str(meta)},
+            lambda _q, _r, _c, **_kw: {"action": "from_file", "filename": str(meta)},
         )
 
         # The extraction leaf pulls the value from the file text.
         captured: dict[str, object] = {}
 
-        def _extract(field, file_text, ctx):
+        def _extract(field, file_text, ctx, **_kw):
             captured["field"] = field
             captured["file_text"] = file_text
             return "A CHO-K1 OATP1C1 uptake assay measuring transporter activity."
@@ -1464,12 +1464,12 @@ class TestFromFileReadsAndExtracts:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "Describe the study."
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "Describe the study."
         )
         monkeypatch.setattr(
             guidance,
             "interpret_gap_reply",
-            lambda _q, _r, _c: {"action": "from_file", "filename": str(outside)},
+            lambda _q, _r, _c, **_kw: {"action": "from_file", "filename": str(outside)},
         )
 
         def _boom_extract(*_a, **_k):  # pragma: no cover - must not run
@@ -1518,12 +1518,12 @@ class TestFromFileReadsAndExtracts:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "Describe the study."
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "Describe the study."
         )
         monkeypatch.setattr(
             guidance,
             "interpret_gap_reply",
-            lambda _q, _r, _c: {"action": "from_file", "filename": str(missing)},
+            lambda _q, _r, _c, **_kw: {"action": "from_file", "filename": str(missing)},
         )
         # Extraction must not even be reached (no readable text).
         monkeypatch.setattr(
@@ -1573,12 +1573,12 @@ class TestFromFileReadsAndExtracts:
         )
 
         monkeypatch.setattr(
-            guidance, "phrase_gap_question", lambda _ctx: "What is the CAS number?"
+            guidance, "phrase_gap_question", lambda _ctx, **_kw: "What is the CAS number?"
         )
         monkeypatch.setattr(
             guidance,
             "interpret_gap_reply",
-            lambda _q, _r, _c: {"action": "from_file", "filename": str(meta)},
+            lambda _q, _r, _c, **_kw: {"action": "from_file", "filename": str(meta)},
         )
         # Even if the leaf were to return a CAS, the loop's D5 guard refuses it.
         monkeypatch.setattr(
@@ -2187,7 +2187,10 @@ class TestIdentifierNeverCommittedFromProse:
 
         human = ScriptedHuman(input_answers=[_value("CVCL_9999")])
         resolved: list[dict] = []
-        assert _resolve_gap(engine, human, gap, resolved=resolved, asked=[]) is False
+        assert (
+            _resolve_gap(engine, human, gap, resolved=resolved, asked=[], usage_sink=None)
+            is False
+        )
 
         assert engine.state.metadata.accession == _ROOT_ACCESSION, (
             "the dataset DOI must survive an answer about a cell line"
@@ -2266,4 +2269,161 @@ class TestNonClearingGapIsNotReAsked:
         assert not lying, (
             f"{len(lying)} gap(s) were reported resolved but are still open: "
             f"{[(r['source'], r['entity_type'], r['property']) for r in lying]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #384 — the guidance tail's LLM calls must reach the usage sink.
+#
+# All four guidance leaves accept a ``usage_sink`` and the deterministic spine
+# threads one, but the guidance tail never did: every phrase / interpret / draft /
+# from-file-extract call (1-5 per gap, up to ``max_rounds`` gaps) was invisible to
+# the accounting, so the status bar re-printed before EVERY gap question showed a
+# frozen token count while real money was spent.
+#
+# The assertions here deliberately read the numbers back through
+# ``ui._read_token_totals`` — the SAME function ``ui.print_status_bar`` uses — which
+# re-parses ``profile.ndjson`` off disk. Nothing hand-builds the expected total, so
+# a sink that is threaded but not wired to the displayed surface still fails.
+# (Never assert through ``ui.snapshot_from_engine``: once tokens > 0 it calls
+# ``builder.pricing.compute_cost``, which does a live urlopen on a cold cache.)
+# ---------------------------------------------------------------------------
+
+
+_PHRASED = "What does this study examine, in one or two sentences?"
+
+
+def _profiled_engine(monkeypatch, tmp_path) -> AgentEngine:
+    """A real engine whose real ``ProfilingLogger`` writes under ``tmp_path``.
+
+    ``ui._read_token_totals`` re-imports ``SESSION_DIR`` from
+    ``builder.tools.profiler`` on every call, so patching it there redirects both
+    the writer and the reader — no session data lands in the repo.
+    """
+    import builder.tools.profiler as profiler_mod
+
+    monkeypatch.setattr(profiler_mod, "SESSION_DIR", tmp_path)
+    engine = AgentEngine(state=_backbone())
+    engine.initialize()
+    return engine
+
+
+class TestGuidanceTokenAccounting:
+    """#384: the interactive tail's token spend reaches the status bar."""
+
+    @staticmethod
+    def _drive(monkeypatch, tmp_path, *, reported: tuple):
+        """One real ask-user round whose leaves each report ``reported`` usage.
+
+        Returns ``(engine, summary, human)``. The stubs stand in for the two
+        drafter-tier leaves only — the loop, the gap dispatch, the commit path and
+        the profiler are all real.
+        """
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        engine = _profiled_engine(monkeypatch, tmp_path)
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+
+        def _phrase(gap_context, *, model=None, usage_sink):
+            usage_sink(*reported)
+            return _PHRASED
+
+        def _interpret(question, reply, gap_context, *, model=None, usage_sink):
+            usage_sink(*reported)
+            return {"action": "commit", "value": reply.strip()}
+
+        monkeypatch.setattr(guidance, "phrase_gap_question", _phrase)
+        monkeypatch.setattr(guidance, "interpret_gap_reply", _interpret)
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        human = ScriptedHuman(
+            input_answers=[_value("A dose-response cytotoxicity study in HepG2 cells.")]
+        )
+        summary = run_guidance(engine, human, max_rounds=5)
+        return engine, summary, human
+
+    def test_status_bar_token_totals_include_the_guidance_leaves(self, monkeypatch, tmp_path):
+        from builder.agents import ui
+
+        engine, summary, _human = self._drive(
+            monkeypatch, tmp_path, reported=(120, 35, "gpt-4o-mini")
+        )
+
+        # The round really happened (the harness is not idling past the leaves).
+        assert _get(engine, "st1").fields.get("description") == (
+            "A dose-response cytotoxicity study in HepG2 cells."
+        )
+        assert summary["resolved"], "the ask-user round must have committed"
+
+        # Two leaf calls (phrase + interpret) x (120 in / 35 out), read back
+        # through the status bar's own reader off the real profile.ndjson.
+        assert ui._read_token_totals(engine.state.session_id) == (240, 70, "gpt-4o-mini")
+
+    def test_guidance_summary_reports_its_own_usage(self, monkeypatch, tmp_path):
+        _engine, summary, _human = self._drive(
+            monkeypatch, tmp_path, reported=(120, 35, "gpt-4o-mini")
+        )
+
+        assert summary["usage"] == {
+            "input_tokens": 240,
+            "output_tokens": 70,
+            "total_tokens": 310,
+        }
+
+    def test_token_totals_stay_zero_when_the_leaves_report_no_usage(self, monkeypatch, tmp_path):
+        """Honesty control: the ``240`` above is the leaves' REPORTED usage flowing
+        through the new plumbing — not "guidance ran", and not a pre-existing
+        logger. ``(None, None, None)`` is what ``_extract_token_usage`` returns for
+        a fake/offline model, and it must total zero while the gap still commits.
+        """
+        from builder.agents import ui
+
+        engine, summary, _human = self._drive(
+            monkeypatch, tmp_path, reported=(None, None, None)
+        )
+
+        assert ui._read_token_totals(engine.state.session_id) == (0, 0, "")
+        assert summary["usage"]["total_tokens"] == 0
+        assert summary["resolved"], "the gap must still commit when usage is unknown"
+
+    def test_threading_the_sink_does_not_silently_fall_back(self, monkeypatch, tmp_path):
+        """The trap: all four leaf calls sit inside a broad ``except Exception``
+        whose fallback is the deterministic path, so a misnamed or positionally-
+        passed ``usage_sink`` degrades SILENTLY to ``_ask_user_prompt`` instead of
+        raising. A strict-signature stub makes that fallback observable: the
+        sentinel question is what the human must have been prompted with.
+        """
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        engine = _profiled_engine(monkeypatch, tmp_path)
+        monkeypatch.setattr(guidance, "get_provider", lambda: "openai")
+
+        def _phrase(gap_context, *, usage_sink):
+            usage_sink(7, 3, "gpt-4o-mini")
+            return _PHRASED
+
+        monkeypatch.setattr(guidance, "phrase_gap_question", _phrase)
+        monkeypatch.setattr(
+            guidance,
+            "interpret_gap_reply",
+            lambda _q, _r, _c, **_kw: {"action": "skip"},
+        )
+        _single_ask_gap_report(
+            monkeypatch,
+            _study_desc_gap(),
+            counts={"must_open": 1, "should_open": 0, "may_open": 0},
+        )
+
+        human = ScriptedHuman(input_answers=[_value("dunno")])
+        run_guidance(engine, human, max_rounds=5)
+
+        assert [p for p, _ft in human.inputs] == [_PHRASED], (
+            "the phrase leaf fell back to the deterministic prompt — the sink was "
+            "not accepted by its keyword name"
         )


### PR DESCRIPTION
Partial fix for #384 — implements fixes (b) and (c). **Does not close it**; (a) and (d) are noted at the bottom.

## What was wrong

On the default `--interactive` (pipeline) arm the token/cost figure **stopped moving the moment the deterministic spine finished**. Every LLM call the HITL guidance tail makes — one to five per gap, up to 20 gaps — was invisible.

The sink existed, all four leaves accepted one, the spine threaded one, and the shared mining helper worked. The guidance tail was simply the only caller that never passed a sink: the string `usage_sink` did not occur anywhere in `guidance.py`. The four dropped call sites were `:556` (`draft_entity_fields`), `:801` (`phrase_gap_question`), `:841` (`interpret_gap_reply`), `:1032` (`extract_field_from_file`).

So the status bar reprinted before *every* guidance question showed a frozen count while real money was spent, and the final total and `--dashboard` table under-reported the run.

## The fix

`run_guidance` takes a usage sink and threads it to all four leaves by keyword. It **reuses `pipeline._make_usage_logger`** rather than writing a second logger, so guidance events are byte-identical in shape to the spine's `node_end`/`node="model"` profile events — which is what `ui._read_token_totals` (`ui.py:134`) sums.

Mechanism verified end to end: all four leaves really do route through `leaves._invoke_structured_with_usage`, which calls `usage_sink(...)` at `:70-72`; all four accept it keyword-only and guidance passes it by keyword at every site, so there is no silent positional or typo drop.

## Verification

The headline test drives **real `run_guidance` over a real `AgentEngine` with a real `ProfilingLogger`** writing an actual `profile.ndjson` under `tmp_path`, then reads the number the status bar would display. It asserts the **total the user sees actually moves** across a guidance round — so it fails if the sink is threaded but the totals are not wired to what gets displayed. Adversarially verified to go red with the production change reverted.

`uvx ruff check` clean; `uv run ty check` **9 diagnostics, identical to main**.

## Honest scope notes

1. **This changes no A/B number.** The eval harness never runs guidance — `eval/pipeline_factory.py` calls `run_pipeline` directly. This fixes interactive observability only; it does not improve the benchmark.
2. **Fix (a) not done.** `UsageSink` / `_as_int` / `_make_usage_logger` are *not* hoisted into `builder/agents/llm.py`; `guidance.py` imports them from `pipeline.py` instead. There is exactly one implementation and no import cycle, so the defect is fixed — but the "shared by construction for any future non-spine caller" half is deferred. `llm.py` and `pipeline.py` are outside this lane.
3. **Fix (d) not done.** The stale `UiSnapshot` docstring at `ui.py:113-117` is untouched and still stale.
4. TDD items 5 and 6 from the issue (leaf-level capture tests, and the "one shared implementation" identity assert) live in other lanes' test files; item 6 is moot until the hoist lands.

Both remaining items are clean mechanical follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)