### PR TITLE
fix(pipeline): weight the leaf's context budget by priority, not just order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1630,14 +1630,20 @@ INPUT (dir / zip / conversation)
 - **Spine = code.** The Priority 1–4 heuristic (§4) becomes control flow, not prose.
 - **Leaves = cheap model.** Drafting/disambiguation only (binds the §4.4 drafter tier).
 - **Leaf context = bounded file bodies, not just filenames (#231).** The single
-  `extract`/`draft` leaf is fed by `pipeline.py::_gather_context`, which reads a
-  bounded body excerpt of each non-tabular rich file (preferring the scanner's cheap
-  `first_rows` preview), **fail-closed to `state.approved_scan_roots`** and capped
-  per file and in total so the one call stays token-safe. Files are read
-  **metadata-first** on a fair per-file budget, so rich structured metadata is never
-  starved by an early large file; the empty-context path is a strict no-op (no
-  provider call), preserving the no-provider determinism guarantee. The read-ordering
-  and budget algorithm is documented in the `_gather_context` docstring.
+  `extract`/`draft` leaf is fed by `pipeline.py::_gather_context`, which gives every
+  scanned file **one** content slice under **one** cap — a body excerpt when the file
+  is readable, its `first_rows` preview in full otherwise — **fail-closed to
+  `state.approved_scan_roots`**. Every emitted slice is charged against the total, so
+  the ceiling is honest and the one call stays token-safe. The empty-context path is a
+  strict no-op (no provider call), preserving the no-provider determinism guarantee.
+- **Priority decides chars, not just order (#378).** Files are read **metadata-first**,
+  and each tier draws a *weighted* share (`_TIER_SHARES`) rather than an equal one;
+  an absent or under-spending tier flows its headroom down. Equal shares are not
+  enough — with them the highest-priority file in a real deposit emitted 298 chars
+  while a bulk-data export emitted 2,049. High-priority bodies are read with the
+  shared compactors (`file_readers.compact_grid_text` / `compact_attribute_json`),
+  which is what makes the whole metadata workbook fit. The algorithm is documented in
+  the `_gather_context` docstring.
 - **Fix loop = deterministic.** `build_and_validate` already returns issues pre-routed to
   `{entity_id, property, fix, severity, profile}`; a code loop dispatches each to a
   lookup / `set_fields` / `link`, calling the LLM only for "draft new content" repairs.

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -262,27 +262,40 @@ _DEFAULT_STUDY_NAME = "Study"
 _DEFAULT_ASSAY_NAME = "Assay"
 
 # Token-safety budget for the free-text context fed to the single bounded
-# extraction/drafter leaf (#231). `_gather_context` now reads non-tabular rich
-# file BODIES (`.json` / `.docx` / `.pdf` …) — not just filenames — so it must
-# cap how much disk content reaches the leaf so the one bounded call stays
-# affordable. The cap is applied BOTH per-file (each body excerpt is truncated to
-# a FAIR per-file slice, see `_per_file_cap`) AND to the total accumulated body
-# content (the running sum of body excerpts never exceeds `_MAX_CONTEXT_CHARS`),
-# so a folder of many large files cannot blow the budget and no single early file
-# can starve the rest. ~8k chars is roughly a couple thousand tokens — enough for
-# a study title / abstract / SOP heading to survive, small enough to stay cheap.
-_MAX_CONTEXT_CHARS = 8000
+# extraction/drafter leaf (#231). `_gather_context` reads file BODIES — not just
+# filenames — so it caps how much disk content reaches the leaf and the one
+# bounded call stays affordable. EVERY emitted slice is charged against this
+# total, previews included (#378); before that only body reads decremented it, so
+# preview bytes were spent outside the arithmetic and the documented ceiling was
+# silently exceeded.
+#
+# Raised 8000 -> 14000 with #378. That is roughly +1,300 tokens on one bounded
+# cheap-model call, and it is a real if small regression in the "one bounded
+# affordable call" property this block exists to protect. It buys the whole
+# metadata workbook: compaction pays most of it back (-41% on the grid, -73% on
+# the BioStudies descriptor), but chemicals 2-5 of the real S-VHPS26 deposit sit
+# past 2,600 compacted chars and cannot be reached at 8000 under any weighting.
+_MAX_CONTEXT_CHARS = 14000
 
-# Fair per-file floor for the body excerpt (Issue #179 / real S-VHPS26 run). The
-# pre-fix bug: one shared 8000-char pool + a `min(remaining, _MAX_CONTEXT_CHARS)`
-# per-file cap let the FIRST scanned file consume the WHOLE budget, so the richest
-# structured metadata (a BioStudies `<acc>.json`, an assay-metadata `.xlsx`, a SOP
-# `.docx`) — read later — got only its filename. We now read across files fairly:
-# each file gets at most `max(_MIN_PER_FILE_CHARS, _MAX_CONTEXT_CHARS // n)` chars
-# (`n` = files to read), so an early large file cannot zero the budget while still
-# leaving generous headroom when there are few files. A small floor guarantees
-# even a long inventory yields a usable slice per file.
-_MIN_PER_FILE_CHARS = 1500
+# Per-file share by `_metadata_read_priority` tier (#378). Metadata-first was
+# previously an ORDERING only: every file got an equal `_MAX_CONTEXT_CHARS // n`
+# slice, so on the real S-VHPS26 deposit the priority-0 workbook that holds the
+# cell line, RRID, author and all five chemicals emitted 298 chars while a
+# priority-3 GraphPad file emitted 2,049. Equal shares provably cannot carry that
+# workbook, so the budget is now weighted, not merely sorted.
+#
+# A tier claims its share only if it HAS files; an absent or under-spending tier
+# flows its headroom down to the next (see `_gather_context`). That flow-down is
+# what keeps a bulk-data-only deposit safe — with no metadata/doc files, the
+# first priority-3 file inherits 10,500 chars rather than being held to 500.
+_TIER_SHARES: dict[int, int] = {0: 6000, 1: 2000, 2: 2000, 3: 500}
+
+# Tiers whose body is worth a full `read_file` with compaction rather than the
+# scanner's 20-rows-per-sheet preview (#378). The preview cap loses chemicals 3-5
+# of the real workbook even with an unlimited char budget, because it truncates by
+# ROW before any of this budgeting runs. `_EXCEL_PREVIEW_ROWS` deliberately stays
+# at 20 — the binding constraint is chars, and raising it slows every scan.
+_COMPACTED_READ_TIERS = frozenset({0, 1})
 
 
 def _backbone_hints(engine: AgentEngine) -> dict[str, dict[str, str]]:
@@ -347,21 +360,13 @@ def _metadata_read_priority(filename: str) -> int:
     return 3
 
 
-def _per_file_cap(n_files_to_read: int) -> int:
-    """Fair per-file body-excerpt cap given *n_files_to_read* files (Issue #179).
-
-    Each file gets at most an equal share of the total budget, with a floor so a
-    long inventory still yields a usable slice per file. This is the per-file
-    half of the fix — combined with the metadata-first ordering it guarantees the
-    high-signal metadata files get a fair slice instead of one early file eating
-    the whole 8000-char pool.
-    """
-    if n_files_to_read <= 0:
-        return _MAX_CONTEXT_CHARS
-    return max(_MIN_PER_FILE_CHARS, _MAX_CONTEXT_CHARS // n_files_to_read)
-
-
-def _read_body_excerpt(path: str, approved_roots: set[str], remaining: int) -> str | None:
+def _read_body_excerpt(
+    path: str,
+    approved_roots: set[str],
+    remaining: int,
+    *,
+    compact: bool = False,
+) -> str | None:
     """Read a bounded BODY excerpt of *path*, fail-closed to *approved_roots* (#231).
 
     Mirrors the engine's fail-closed containment guard (``engine.py`` /
@@ -378,6 +383,10 @@ def _read_body_excerpt(path: str, approved_roots: set[str], remaining: int) -> s
     The returned excerpt is truncated to ``min(remaining, _MAX_CONTEXT_CHARS)`` so
     both the per-file cap and the caller's total budget are honoured. Returns
     ``None`` when nothing readable was produced (so the caller emits no body line).
+
+    ``compact`` opts into the shared boilerplate compactors (#378) — see
+    :func:`builder.tools.file_readers.compact_grid_text`. The spine passes True
+    for high-priority tiers, where the same signal then fits in far fewer chars.
     """
     if remaining <= 0:
         return None
@@ -393,7 +402,7 @@ def _read_body_excerpt(path: str, approved_roots: set[str], remaining: int) -> s
         return None
 
     try:
-        body = read_file(path)
+        body = read_file(path, compact=compact)
     except (OSError, ValueError, ImportError) as exc:
         logger.warning("Body read failed for %s; skipping: %s", path, exc)
         return None
@@ -411,6 +420,35 @@ def _read_body_excerpt(path: str, approved_roots: set[str], remaining: int) -> s
     return excerpt
 
 
+def _file_slice(f: Any, approved_roots: set[str], allowance: int, tier: int) -> str:
+    """The single content slice emitted for one scanned file (#378).
+
+    One path, one cap. A body read is preferred because it clears the scanner's
+    20-rows-per-sheet preview limit; the ``first_rows`` preview is the fallback
+    for a file that is unreadable or outside an approved root, and it is emitted
+    in FULL up to *allowance*.
+
+    Previously these were mutually exclusive — a previewed file could never be
+    body-read and was pinned to three rows regardless of budget, which is what
+    starved the highest-priority file in the inventory.
+    """
+    if allowance <= 0:
+        return ""
+
+    excerpt = _read_body_excerpt(
+        f.path, approved_roots, allowance, compact=tier in _COMPACTED_READ_TIERS
+    )
+    if excerpt:
+        return excerpt
+
+    if f.first_rows:
+        preview = " | ".join(str(r) for r in f.first_rows).strip()
+        if len(preview) > allowance:
+            preview = preview[:allowance].rstrip() + " […]"
+        return preview
+    return ""
+
+
 def _gather_context(engine: AgentEngine) -> str:
     """Assemble a free-text context string for the drafter/extraction leaf (#231).
 
@@ -425,15 +463,29 @@ def _gather_context(engine: AgentEngine) -> str:
     previews and ``extract_plan`` returned an empty plan, so the backbone fell back
     to the literal default names (#231).
 
-    **Metadata-first, fair per-file budget (Issue #179 / real S-VHPS26 run).** The
-    files whose bodies must be read are sorted by :func:`_metadata_read_priority`
-    so the structured METADATA files (``*metadata*``, BioStudies ``*.json``,
-    README/SOP/``.docx`` docs) are read BEFORE bulk data files, with the original
-    scan order preserved within each tier. Each file gets at most a FAIR slice
-    (:func:`_per_file_cap`) of the total :data:`_MAX_CONTEXT_CHARS` budget, so a
-    single large early file can no longer eat the whole pool and starve the rest
-    (the pre-fix bug). The running total is still capped at
-    :data:`_MAX_CONTEXT_CHARS`.
+    **Metadata-first, priority-weighted budget (#179, corrected by #378).** Files
+    are sorted by :func:`_metadata_read_priority` — ``*metadata*``, BioStudies
+    ``*.json``, README/SOP docs, then bulk data — with scan order preserved within
+    a tier. Each file then gets **one** content slice under **one** cap, sized by
+    its tier's :data:`_TIER_SHARES` entry.
+
+    Ordering alone was not enough, and that was the #378 bug: every file drew an
+    equal slice, so the priority-0 workbook holding the cell line, RRID, author
+    and five chemicals emitted 298 chars while a priority-3 GraphPad file emitted
+    2,049. Priority now decides **chars**, not merely position.
+
+    A tier that has no files, or whose files do not spend their share, flows the
+    headroom down to the next tier — so a deposit of nothing but bulk CSVs still
+    gives its first file a generous slice rather than the bare 500-char tier
+    share. Priority-0/1 bodies are read with compaction
+    (:data:`_COMPACTED_READ_TIERS`), which is what lets the whole workbook fit.
+
+    The slice source is a single path: :func:`_read_body_excerpt` when the file is
+    readable inside an approved root, otherwise the file's ``first_rows`` preview
+    in FULL. The preview is a fallback, never a 3-row ceiling — the scanner has
+    already paid to read it, and truncating it to three rows discarded 96% of
+    what was in memory. **Every** emitted slice is charged against
+    :data:`_MAX_CONTEXT_CHARS`, previews included, so the ceiling is honest.
 
     Body reads are **fail-closed to ``state.approved_scan_roots``** and never raise
     out of the spine (see :func:`_read_body_excerpt`). Output is bounded both per
@@ -458,36 +510,34 @@ def _gather_context(engine: AgentEngine) -> str:
         approved_roots = state.approved_scan_roots
 
         # Order the WHOLE inventory metadata-first (stable within ties) so the
-        # highest-signal files lead both the disk reads and the emitted digest —
-        # the pre-fix bug let a large early bulk-data file eat the body budget and
-        # the structured metadata that followed got only its filename (#179).
-        ordered = sorted(state.scanned_files, key=lambda f: _metadata_read_priority(f.filename))
+        # highest-signal files lead both the disk reads and the emitted digest.
+        by_tier: dict[int, list[Any]] = {}
+        for f in state.scanned_files:
+            by_tier.setdefault(_metadata_read_priority(f.filename), []).append(f)
 
-        # Files that need a disk body read = those without a cheap tabular preview.
-        # Each gets at most a FAIR per-file slice of the budget so an early large
-        # file cannot starve the later metadata.
-        n_to_read = sum(1 for f in ordered if not f.first_rows)
-        per_file_cap = _per_file_cap(n_to_read)
-
-        body_budget = _MAX_CONTEXT_CHARS  # total body content across all files
+        budget = _MAX_CONTEXT_CHARS  # total emitted content across all files
+        carry = 0  # headroom flowing down from absent / under-spending tiers
         file_lines: list[str] = []
-        for f in ordered:
-            line = f"- {f.filename}"
-            if f.first_rows:
-                # Prefer the cheap preview the scanner already captured — no disk read.
-                preview = " | ".join(str(r) for r in f.first_rows[:3])
-                if preview.strip():
-                    line += f": {preview}"
-            elif body_budget > 0:
-                # No tabular preview: read a bounded body excerpt (fail-closed to
-                # approved roots; never raises) under the fair per-file cap AND the
-                # running total budget, so the leaf sees the document body.
-                remaining = min(per_file_cap, body_budget)
-                excerpt = _read_body_excerpt(f.path, approved_roots, remaining)
-                if excerpt:
-                    body_budget -= len(excerpt)
-                    line += f":\n{excerpt}"
-            file_lines.append(line)
+
+        for tier in sorted(_TIER_SHARES):
+            files = by_tier.get(tier)
+            if not files:
+                # Nobody claimed this tier's share; hand it to the tiers below.
+                carry += _TIER_SHARES[tier]
+                continue
+            for f in files:
+                allowance = min(_TIER_SHARES[tier] + carry, budget)
+                slice_text = _file_slice(f, approved_roots, allowance, tier)
+                # Unused headroom flows down rather than being forfeited.
+                carry = max(0, allowance - len(slice_text))
+                budget -= len(slice_text)
+
+                line = f"- {f.filename}"
+                if slice_text:
+                    sep = "\n" if "\n" in slice_text else " "
+                    line += f":{sep}{slice_text}"
+                file_lines.append(line)
+
         if file_lines:
             parts.append("Scanned files:\n" + "\n".join(file_lines))
 

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -888,11 +888,18 @@ TOOL_SPECS = [
     },
     {
         "name": "read_excel",
-        "description": "Read an Excel .xlsx file and return its content as pipe-delimited text.",
+        "description": "Read an Excel .xlsx file and return its content as pipe-delimited text. Set compact=true on a depositor-filled metadata workbook to strip the repeated header row, the authoring-instructions Comments column and empty cells — same values, roughly 40% fewer characters, so more of the sheet fits in one read.",
         "parameters": {
             "type": "object",
             "properties": {
                 "path": {"type": "string", "description": "Path to the .xlsx file to read"},
+                "compact": {
+                    "type": "boolean",
+                    "description": (
+                        "Strip grid boilerplate (repeated header row, Comments column, "
+                        "empty cells). No value is lost. Defaults to false."
+                    ),
+                },
             },
             "required": ["path"],
         },

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -8,8 +8,10 @@ gets flooded with large files.
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +92,7 @@ def read_excel(
     *,
     max_rows: int = _MAX_ROWS,
     max_bytes: int = _MAX_BYTES,
+    compact: bool = False,
 ) -> str | None:
     """Read an Excel ``.xlsx`` file and return its content as pipe-delimited text.
 
@@ -102,6 +105,9 @@ def read_excel(
         max_rows: Maximum number of data rows to return per sheet (default 500).
         max_bytes: Maximum file size in bytes (default 1 MB).  Larger files
             are skipped.
+        compact: Run the result through :func:`compact_grid_text` (#378), which
+            strips the repeated header row, the Comments column and empty cells.
+            Defaults to **False** so existing callers see byte-identical output.
 
     Returns:
         Pipe-delimited text with sheet headers, or *None*.
@@ -149,7 +155,8 @@ def read_excel(
     finally:
         wb.close()
 
-    return "\n".join(parts).rstrip("\n")
+    text = "\n".join(parts).rstrip("\n")
+    return compact_grid_text(text) if compact else text
 
 
 # ---------------------------------------------------------------------------
@@ -306,11 +313,151 @@ def _read_text_file(
     return content + marker
 
 
+def compact_grid_text(text: str) -> str:
+    """Densify ``[Sheet: …]`` + pipe-row output, keeping every signal cell (#378).
+
+    A depositor-filled metadata workbook is mostly boilerplate: a ``Parameter |
+    Standard or ontology reference | Value | Comments`` header repeated per
+    sheet, a Comments column of authoring instructions, and empty cells. On the
+    real S-VHPS26 workbook that noise pushes the cell line, RRID, author and
+    chemicals 2-5 past any affordable context slice.
+
+    Three rules, in order: drop the repeated header row; drop the trailing
+    Comments column **only when that sheet's own header names it** ``Comments``;
+    drop empty cells, then drop rows left with fewer than two non-empty cells.
+
+    **Rows are never dropped on the emptiness of one named column.** That rule
+    looks right and destroys the General information sheet, because this
+    depositor filled column 2 rather than the ``Value`` column — so ``Dr. Fabian
+    Wagenaars``, the ORCID, the DOI and the assay name all sit on rows whose
+    ``Value`` cell is blank. Text carrying no pipe rows is returned unchanged.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    drop_last_column = False
+    seen_header = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[Sheet:"):
+            # A new sheet re-arms header detection; the Comments column is a
+            # per-sheet property, not a workbook-wide one.
+            seen_header = False
+            drop_last_column = False
+            out.append(line)
+            continue
+        if not stripped.startswith("|"):
+            out.append(line)
+            continue
+
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if not seen_header:
+            seen_header = True
+            drop_last_column = bool(cells) and cells[-1].lower() == "comments"
+            if drop_last_column or (cells and cells[0].lower() == "parameter"):
+                continue
+
+        if drop_last_column and len(cells) > 1:
+            cells = cells[:-1]
+        kept = [c for c in cells if c]
+        if len(kept) < 2:
+            continue
+        out.append("| " + " | ".join(kept) + " |")
+
+    return "\n".join(out).strip()
+
+
+def _flatten_attributes(attrs: Any, out: list[str], indent: str = "") -> None:
+    """Emit ``name=value [Qual=Val; …]`` lines for a BioStudies attribute list."""
+    for attr in attrs or []:
+        if not isinstance(attr, dict):
+            continue
+        name = str(attr.get("name") or "").strip()
+        value = str(attr.get("value") or "").strip()
+        if not name and not value:
+            continue
+        line = f"{indent}{name}={value}" if name else f"{indent}{value}"
+        quals: list[str] = []
+        for qual in attr.get("valqual") or []:
+            if not isinstance(qual, dict):
+                continue
+            qname = str(qual.get("name") or "").strip()
+            qvalue = str(qual.get("value") or "").strip()
+            if qname or qvalue:
+                quals.append(f"{qname}={qvalue}" if qname else qvalue)
+        if quals:
+            line += " [" + "; ".join(quals) + "]"
+        out.append(line)
+
+
+def _flatten_section(node: Any, out: list[str]) -> None:
+    """Walk a BioStudies section tree, emitting attributes, links and children."""
+    if isinstance(node, list):
+        for item in node:
+            _flatten_section(item, out)
+        return
+    if not isinstance(node, dict):
+        return
+
+    stype = str(node.get("type") or "").strip()
+    accno = str(node.get("accno") or "").strip()
+    if stype or accno:
+        out.append(f"[{stype or 'section'}{' ' + accno if accno else ''}]")
+
+    _flatten_attributes(node.get("attributes"), out)
+
+    for link in node.get("links") or []:
+        if not isinstance(link, dict):
+            continue
+        url = str(link.get("url") or "").strip()
+        if url:
+            out.append(f"link={url}")
+        _flatten_attributes(link.get("attributes"), out, indent="  ")
+
+    if node.get("section") is not None:
+        _flatten_section(node["section"], out)
+    for sub in node.get("subsections") or []:
+        _flatten_section(sub, out)
+
+
+def compact_attribute_json(text: str) -> str:
+    """Flatten a BioStudies ``{name, value, valqual[]}`` tree to dense lines (#378).
+
+    A pretty-printed submission descriptor spends most of its bytes on JSON
+    punctuation and indentation, so a bounded slice of the raw file stops inside
+    the first section — on the real S-VHPS26 descriptor the licence, the AOP URL
+    and every author sit past 2,900 characters and never reach the leaf.
+
+    ``valqual`` entries are preserved as a bracketed suffix. Dropping them is the
+    tempting simplification and it loses exactly the qualified values worth
+    having — the AOP wiki URL and the BAO ontology ids.
+
+    Input that is not JSON, or is JSON without a BioStudies attribute tree, is
+    returned **unchanged** so the caller can apply this blindly.
+    """
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return text
+    if not isinstance(parsed, dict) or not (
+        "attributes" in parsed or "section" in parsed
+    ):
+        return text
+
+    out: list[str] = []
+    accno = str(parsed.get("accno") or "").strip()
+    if accno:
+        out.append(f"accno={accno}")
+    _flatten_section(parsed, out)
+    return "\n".join(out).strip()
+
+
 def read_file(
     path: str,
     *,
     max_lines: int = 100,
     max_bytes: int = _MAX_BYTES,
+    compact: bool = False,
 ) -> str | None:
     """Read a file, dispatching to the right reader based on its extension.
 
@@ -337,6 +484,11 @@ def read_file(
             and JSON are governed by the byte budget, not a line cap.
         max_bytes: Hard safety cap in bytes (default 100 MB); files larger than
             this are skipped (returns *None*).
+        compact: Apply the shared boilerplate compactors (#378) —
+            :func:`compact_grid_text` for ``.xlsx`` grids and
+            :func:`compact_attribute_json` for BioStudies ``.json`` descriptors.
+            Defaults to **False** so no existing caller's output changes; the
+            deterministic pipeline opts in for its bounded context slice.
 
     Returns:
         File content as a string, a directory-guidance message, or *None*.
@@ -350,7 +502,7 @@ def read_file(
     suffix = file_path.suffix.lower()
 
     if suffix == ".xlsx":
-        return read_excel(path, max_rows=max_lines, max_bytes=max_bytes)
+        return read_excel(path, max_rows=max_lines, max_bytes=max_bytes, compact=compact)
 
     if suffix == ".docx":
         return read_docx(path, max_bytes=max_bytes)
@@ -361,7 +513,10 @@ def read_file(
         return extract_pdf_text(path)
 
     # Everything else is read as plain text (full content up to the byte budget).
-    return _read_text_file(path, max_bytes=max_bytes)
+    text = _read_text_file(path, max_bytes=max_bytes)
+    if compact and text and suffix == ".json":
+        return compact_attribute_json(text)
+    return text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -2572,3 +2572,124 @@ class TestMaterializeAttachScannedFiles:
         n2 = len(self._by_type(engine, "File"))
         # The 3 scanned files plus any synthesized chain placeholders, stable.
         assert n1 == n2
+
+
+class TestGatherContextPreviewedFilesGetABudget:
+    """A previewed file must get a real budget slice, not a hard 3 rows (#378).
+
+    `TestGatherContextMetadataFirst` sets ``first_rows=None`` on every file with
+    the comment "forces the body-read path", so the entire class is structurally
+    blind to the preview branch. These tests drive that branch specifically.
+
+    Every file here points at a path that does NOT exist, so `_read_body_excerpt`
+    fails closed and the emitted slice comes from ``first_rows`` — the fallback
+    the fix must keep, and must stop treating as a 3-row ceiling.
+    """
+
+    _SENTINEL = "ROW{:03d}-marker"
+
+    def _state(
+        self, tmp_path: Path, spec: list[tuple[str, int]], row_pad: int = 0
+    ) -> CrateState:
+        """Build a state whose files carry *n* sentinel preview rows each.
+
+        ``row_pad`` widens each row, so a test can breach the total budget with
+        only the first three rows — the bytes today's code emits outside the
+        arithmetic.
+        """
+        state = CrateState()
+        state.approved_scan_roots = {str(tmp_path)}
+        for filename, n_rows in spec:
+            state.scanned_files.append(
+                FileClassification(
+                    path=str(tmp_path / filename),  # deliberately never created
+                    filename=filename,
+                    size=1,
+                    mime_type="text/csv",
+                    first_rows=[
+                        self._SENTINEL.format(i) + "x" * row_pad for i in range(n_rows)
+                    ],
+                )
+            )
+        return state
+
+    @staticmethod
+    def _slice_for(context: str, filename: str) -> str:
+        """The CONTENT `_gather_context` emitted for one file.
+
+        The ``- <filename>`` header is stripped deliberately: leaving it in makes
+        the length comparison below pass on filename length alone, which is a
+        tautology rather than a budget assertion.
+        """
+        for block in context.split("\n- "):
+            block = block.lstrip("- ")
+            if block.startswith(filename):
+                return block[len(filename) :].lstrip(":").strip()
+        return ""
+
+    def test_previewed_metadata_file_is_not_capped_at_three_rows(self, tmp_path):
+        """The scanner already paid to read the preview; emit more than 3 rows.
+
+        Non-tautological: the sentinel comes from `FileClassification.first_rows`
+        handed to the real `_gather_context`, not from a hand-built string.
+        """
+        engine = _engine(self._state(tmp_path, [("assay_metadata.csv", 40)]))
+
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        context = pipeline_mod._gather_context(engine)
+
+        assert self._SENTINEL.format(0) in context
+        assert self._SENTINEL.format(30) in context, "preview still truncated to 3 rows"
+
+    def test_previewed_content_is_charged_against_the_total_budget(self, tmp_path):
+        """Preview bytes must count against the ceiling, not bypass it.
+
+        Today only the body path decrements `body_budget`, so previews are spent
+        outside the arithmetic and the documented total is silently exceeded.
+        """
+        # Only 8 rows, but each is 5,000 chars wide: today's `first_rows[:3]`
+        # slice alone emits ~30,000 chars per file, none of it charged.
+        engine = _engine(
+            self._state(
+                tmp_path,
+                [("assay_metadata.csv", 8), ("bulk_data.csv", 8)],
+                row_pad=5000,
+            )
+        )
+
+        import builder.agents.pipeline.pipeline as pipeline_mod
+        from builder.agents.pipeline.pipeline import _MAX_CONTEXT_CHARS
+
+        context = pipeline_mod._gather_context(engine)
+
+        assert len(context) <= _MAX_CONTEXT_CHARS + 2000
+
+    def test_priority_zero_outranks_priority_three_in_chars_not_just_order(self, tmp_path):
+        """Metadata-first must mean CHARS, not merely position.
+
+        This is the assertion today's code inverts: the priority-0 workbook gets
+        298 chars while a priority-3 bulk file gets 2,049.
+        """
+        engine = _engine(
+            self._state(tmp_path, [("assay_metadata.csv", 4000), ("bulk_data.csv", 4000)])
+        )
+
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        context = pipeline_mod._gather_context(engine)
+
+        meta = self._slice_for(context, "assay_metadata.csv")
+        bulk = self._slice_for(context, "bulk_data.csv")
+        assert len(meta) > len(bulk), f"metadata {len(meta)} chars, bulk {len(bulk)} chars"
+
+    def test_absent_metadata_file_yields_no_metadata_content(self, tmp_path):
+        """HONESTY CONTROL — the assertions above come from the file, not scaffolding."""
+        engine = _engine(self._state(tmp_path, [("bulk_data.csv", 40)]))
+
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        context = pipeline_mod._gather_context(engine)
+
+        assert "assay_metadata.csv" not in context
+        assert self._SENTINEL.format(0) in context  # the bulk file still speaks

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -10,6 +10,7 @@ bounded; the byte ceiling is unified to 100 MB.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from builder.tools import file_readers
 from builder.tools.file_readers import _MAX_BYTES, _TEXT_BUDGET_BYTES, read_file
@@ -148,3 +149,130 @@ class TestDirectoryHandling:
         assert result is not None
         assert "is a directory" in result
         assert "list_scanned_files" in result
+
+
+# ---------------------------------------------------------------------------
+# Shared text compactors (#378)
+# ---------------------------------------------------------------------------
+
+_METADATA_XLSX = (
+    "tests/fixtures/svhps26_real_input/Assay_OATP1C1/"
+    "Assay-metadata-CHO-K1_OATP1C1-v1.1.xlsx"
+)
+_DESCRIPTOR_JSON = "tests/fixtures/svhps26_real_input/S-VHPS26.json"
+
+
+class TestCompactGridText:
+    """`compact_grid_text` densifies `[Sheet: …]` + pipe-row output (#378).
+
+    The extraction leaf gets one bounded slice per file. On the real S-VHPS26
+    workbook the signal (cell line, RRID, author, chemicals 2-5) sits past any
+    affordable cap, so the fix is to remove boilerplate rather than to raise the
+    cap further.
+    """
+
+    def test_drops_comments_column_and_empty_cells(self):
+        """Compaction must shrink the workbook while keeping every signal token.
+
+        Non-tautological: the input is the committed real deposit read through
+        the real `read_excel`, and the assertion is loss-of-noise plus
+        survival-of-signal — not a byte count the implementation could satisfy
+        by truncating.
+        """
+        from builder.tools.file_readers import compact_grid_text, read_excel
+
+        raw = read_excel(_METADATA_XLSX, max_rows=100)
+        assert raw is not None
+        compacted = compact_grid_text(raw)
+
+        assert len(compacted) < len(raw)
+        # The per-sheet instruction column is pure boilerplate.
+        assert "Enter the name of your assay" not in compacted
+        for token in ("Dr. Fabian Wagenaars", "CVCL_0214", "diclofenac", "ECACC"):
+            assert token.lower() in compacted.lower(), f"compaction lost {token!r}"
+
+    def test_never_drops_a_non_empty_cell(self):
+        """HONESTY CONTROL for the trap in #378's honest notes.
+
+        The depositor filled the FIRST sheet in column 2 (`Standard or ontology
+        reference`), not column 3 (`Value`) — so a rule that drops rows whose
+        Value cell is empty looks right and silently destroys the author, the
+        ORCID, the DOI, the assay name and the description. Every non-empty cell
+        outside the Comments column must survive.
+        """
+        from builder.tools.file_readers import compact_grid_text, read_excel
+
+        raw = read_excel(_METADATA_XLSX, max_rows=100)
+        assert raw is not None
+        compacted = compact_grid_text(raw)
+
+        dropped: list[str] = []
+        for line in raw.split("\n"):
+            if not line.startswith("|"):
+                continue
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            # Scoped to rows that actually CARRY data — two or more non-empty
+            # cells outside Comments. A label-only row (`| Accession |  |  | … |`,
+            # a field the depositor left blank) is legitimately compacted away,
+            # and the repeated header row is dropped by design. Neither weakens
+            # what this control exists to catch: `| Corresponding person | Dr.
+            # Fabian Wagenaars |  | … |` has a blank *Value* cell and two
+            # non-empty ones, so the trap rule still reddens this assertion.
+            if cells and cells[0] == "Parameter":
+                continue
+            payload = [c for c in cells[:-1] if c]
+            if len(payload) < 2:
+                continue
+            for cell in payload:
+                if cell not in compacted:
+                    dropped.append(cell)
+        assert not dropped, f"compaction dropped non-empty cells: {dropped[:5]}"
+
+    def test_is_a_noop_on_text_that_is_not_a_grid(self):
+        """HONESTY CONTROL: the compactor must not mangle arbitrary prose."""
+        from builder.tools.file_readers import compact_grid_text
+
+        prose = "A cell based in vitro assay.\nNo pipes here at all.\n"
+        assert compact_grid_text(prose) == prose.strip()
+
+
+class TestCompactAttributeJson:
+    """`compact_attribute_json` flattens BioStudies `{name,value,valqual}` trees."""
+
+    def test_keeps_valqual_payloads(self):
+        """A naive flattener drops `valqual` and loses the AOP URL and BAO ids.
+
+        Non-tautological: asserts specific domain tokens survive compaction of
+        the committed real descriptor, so a flattener that keeps only
+        `name=value` fails.
+        """
+        from builder.tools.file_readers import compact_attribute_json
+
+        raw = Path(_DESCRIPTOR_JSON).read_text(encoding="utf-8")
+        compacted = compact_attribute_json(raw)
+
+        assert len(compacted) < len(raw)
+        for token in ("https://aopwiki.org/aops/610", "BAO_0010001"):
+            assert token in compacted, f"compaction lost {token!r}"
+
+    def test_moves_the_late_signal_within_an_affordable_slice(self):
+        """The point of compaction: signal must land inside a 2,000-char slice.
+
+        In the raw pretty-printed descriptor the licence, AOP URL and first
+        author all sit past 2,900 chars, so today's slice carries none of them.
+        """
+        from builder.tools.file_readers import compact_attribute_json
+
+        raw = Path(_DESCRIPTOR_JSON).read_text(encoding="utf-8")
+        compacted = compact_attribute_json(raw)
+
+        head = compacted[:2000]
+        for token in ("aopwiki", "Wagenaars"):
+            assert token.lower() in head.lower(), f"{token!r} still past a 2000-char slice"
+
+    def test_returns_input_unchanged_when_not_an_attribute_tree(self):
+        """HONESTY CONTROL: non-BioStudies JSON must survive untouched."""
+        from builder.tools.file_readers import compact_attribute_json
+
+        plain = json.dumps({"hello": "world"})
+        assert compact_attribute_json(plain) == plain

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -79,11 +79,34 @@ _PROCESSED_DATA = _RAW_DATA.with_suffix(".pzfx")
 # (scanner delivering filenames only) empties the plan. "oatp1c1"/"cho-k1"/"th"/"sop"
 # all occur in filenames and are deliberately NOT used as gates.
 _TOKEN_SUBSTRATE = "thyroxine"
-# A method token that lives in the SOP .docx BODY (the Sandell-Kolthoff readout),
-# reachable only if the scanner read the Word document body (via python-docx) — it is
-# in no filename and no tabular preview. Gates the protocol and proves the SOP body
-# reached the leaf.
+# A method token (the Sandell-Kolthoff readout) carried in document CONTENT and no
+# filename. It lives in `Assay_OATP1C1/README.txt` at offset 1796 — NOT in the SOP
+# .docx, which this was documented as proving for a long time. Verified across every
+# entry in that zip: "Sandell" appears nowhere in the Word document.
 _TOKEN_SOP_BODY = "sandell"
+# A token that really IS reachable only through the .docx body read (python-docx):
+# the gene symbol for the transporter, written out in the SOP's Definition section
+# and in no other file, filename or preview (the rest of the deposit says OATP1C1,
+# the protein). Without this the pipeline had NO test proving the Word-document
+# read works, because the token documented as covering it does not occur there.
+_TOKEN_DOCX_BODY = "slco1c1"
+# Signal the priority-0 metadata workbook holds past its first three preview rows —
+# each was absent from the leaf's context before the #378 weighted budget.
+_TOKEN_CELL_LINE_RRID = "cvcl_0214"
+_TOKEN_CHEMICAL_2 = "lesinurad"
+_TOKEN_CHEMICAL_5 = "diclofenac"
+_TOKEN_PERSON = "wagenaars"
+
+# The five test chemicals the workbook's Chemical Information sheet names, in sheet
+# order. Chemicals 2-5 sit past 2,600 compacted chars, so the leaf saw none of them
+# before #378 — the crate carried the substrate alone.
+_TEST_CHEMICALS: tuple[tuple[str, str], ...] = (
+    ("silychristin", "Silychristin"),
+    (_TOKEN_CHEMICAL_2, "Lesinurad"),
+    ("indocyanine", "Indocyanine green"),
+    ("verapamil", "Verapamil"),
+    (_TOKEN_CHEMICAL_5, "Diclofenac"),
+)
 
 
 def _scanning_engine(input_dir: Path) -> AgentEngine:
@@ -135,6 +158,15 @@ def _install_offline_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
             }
             plan["compounds"] = [{"name": "Thyroxine", "role": "substrate"}]
             plan["cell_lines"] = [{"name": "CHO-K1 OATP1C1-overexpressing cells"}]
+            # Each test chemical is proposed ONLY when its own name reached the
+            # leaf. All five sit in the metadata workbook past the three preview
+            # rows it used to emit, so before #378 this list stayed at one entry
+            # and the crate shipped one MolecularEntity instead of six.
+            plan["compounds"] += [
+                {"name": label, "role": "test chemical"}
+                for token, label in _TEST_CHEMICALS
+                if token in low
+            ]
         if _TOKEN_SOP_BODY in low:
             # The SOP body (read from the .docx) drives a LabProtocol governing the
             # exposure — proposed only because the procedure text reached the leaf.
@@ -166,10 +198,28 @@ def _install_offline_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     # resolve_compound → lookup_compound: canned but REAL identifiers for thyroxine
     # (T4: PubChem CID 5819, CAS 51-48-9). resolve_compound's own minting / D5 handling
     # runs for real over this.
+    # Name-keyed real identifiers. Before #378 only one compound ever reached the
+    # plan, so a single canned answer was harmless; now all five do, and a
+    # name-blind stub would stamp every one of them with thyroxine's CAS. An
+    # unknown name returns found=False rather than falling through to the network —
+    # a live PubChem/ChEBI call from this module is a release blocker.
+    _CANNED_COMPOUNDS = {
+        "thyroxine": ("51-48-9", "5819"),
+        "silychristin": ("33889-69-9", "441764"),
+        "lesinurad": ("878672-00-5", "44543017"),
+        "indocyanine": ("3599-32-4", "5282412"),
+        "verapamil": ("52-53-9", "2520"),
+        "diclofenac": ("15307-86-5", "3033"),
+    }
+
     def fake_lookup_compound(name: str) -> dict[str, Any]:
+        key = next((k for k in _CANNED_COMPOUNDS if k in (name or "").lower()), None)
+        if key is None:
+            return {"found": False, "data": None, "error": "no offline candidate"}
+        cas, cid = _CANNED_COMPOUNDS[key]
         return {
             "found": True,
-            "data": {"cas": "51-48-9", "pubchem_cid": "5819", "source": "pubchem"},
+            "data": {"cas": cas, "pubchem_cid": cid, "source": "pubchem"},
             "error": None,
         }
 
@@ -246,8 +296,69 @@ class TestRealInputPipeline:
 
         context = capture["context"].lower()
         assert _TOKEN_SUBSTRATE in context, capture["context"][:600]
-        # Reachable only via the SOP .docx body read (python-docx), never a filename.
+        # Document CONTENT, never a filename (README.txt body).
         assert _TOKEN_SOP_BODY in context, capture["context"][:600]
+        # The Word-document body read specifically (python-docx).
+        assert _TOKEN_DOCX_BODY in context, capture["context"][:600]
+
+        # #378 — the priority-0 workbook's signal, all of it past the three preview
+        # rows the leaf used to receive. Red before the weighted budget, and red
+        # under the naive "count previewed files in n_to_read" fix too.
+        assert _TOKEN_CELL_LINE_RRID in context, "cell-line RRID starved"
+        assert _TOKEN_CHEMICAL_2 in context, "test chemical 2 starved"
+        assert _TOKEN_CHEMICAL_5 in context, "test chemical 5 starved"
+        assert _TOKEN_PERSON in context, "corresponding person starved"
+
+    def test_every_test_chemical_becomes_a_molecular_entity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The payoff: all five test chemicals + the substrate reach the crate (#378).
+
+        `_materialize_plan` mints compounds only from `plan["compounds"]`, and the
+        plan can only name what reached the leaf. Before the weighted budget the
+        crate carried ONE `MolecularEntity`; the workbook naming the other five was
+        emitting 298 characters.
+
+        This also exercises the name-keyed offline compound seam — with the old
+        name-blind stub all six would carry thyroxine's CAS.
+        """
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _install_offline_seams(monkeypatch)
+        engine = _scanning_engine(FIXTURE_DIR)
+        run_pipeline(engine)
+
+        compounds = engine.state.list_entities("MolecularEntity")
+        names = {(e.fields.get("name") or "").lower() for e in compounds}
+        for _token, label in _TEST_CHEMICALS:
+            assert any(label.lower() in n for n in names), f"{label} never minted: {names}"
+
+        cas_values = {e.fields.get("cas") for e in compounds if e.fields.get("cas")}
+        assert len(cas_values) > 1, f"every compound got the same CAS: {cas_values}"
+
+    def test_bulk_data_does_not_consume_the_metadata_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """STARVATION CONTROL — metadata-first must hold in CHARS (#378).
+
+        Without this the fix could turn the tokens above green while regressing
+        #179's guarantee, by simply handing every file a bigger slice. The
+        priority-0 workbook must out-weigh the priority-3 GraphPad export.
+        """
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        capture = _install_offline_seams(monkeypatch)
+        run_pipeline(_scanning_engine(FIXTURE_DIR))
+
+        def _emitted_for(stem: str) -> int:
+            for block in capture["context"].split("\n- "):
+                if block.lstrip("- ").lower().startswith(stem.lower()):
+                    return len(block)
+            return 0
+
+        metadata = _emitted_for("Assay-metadata-CHO-K1_OATP1C1")
+        bulk = _emitted_for("220825_RA_CHO-K1_hOATP1C1_P1_Timecourse.pzfx")
+        assert metadata > bulk, f"metadata {metadata} chars vs bulk {bulk} chars"
 
     def test_pipeline_builds_conformant_crate_from_real_input(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #378.

## What was wrong

`_gather_context` sorted files metadata-first but handed every one an **equal** `_MAX_CONTEXT_CHARS // n` slice, and this made preview and body read mutually exclusive:

```python
if f.first_rows:
    preview = " | ".join(str(r) for r in f.first_rows[:3])
elif body_budget > 0:
    excerpt = _read_body_excerpt(...)
```

Any previewed file was barred from the body read **and** pinned to three rows regardless of budget. On the real S-VHPS26 deposit that starved precisely the *highest*-priority file — the priority-0 metadata workbook emitted **298** chars while a priority-3 GraphPad export emitted **2,049**.

So the extraction leaf never saw the cell line, the RRID, the author, or four of five chemicals. Since `_materialize_plan` mints compounds only from `plan["compounds"]`, the crate shipped **one `MolecularEntity` instead of six**. The scanner had already paid to read 8,057 chars of that workbook; 96% was discarded at emit time.

## The fix

**Shared compactors** in `file_readers.py` — `compact_grid_text` and `compact_attribute_json` — opt-in via `compact=` on `read_file`/`read_excel`, defaulting **False** so no existing caller's output changes. Both arms benefit; the ReAct `read_excel` spec advertises it. Measured **−41%** on the workbook and **−73%** on the BioStudies descriptor, losing no value.

**One path, weighted allocation.** Every file gets one slice under one cap, sized by its `_TIER_SHARES` entry. An absent or under-spending tier flows headroom down, so a bulk-data-only deposit still gets a generous first slice rather than the bare 500-char tier share. **Every** emitted slice is charged against the total — previews previously bypassed the arithmetic entirely, so the documented ceiling was silently exceeded.

**Priority-0/1 bodies go through `read_file` with compaction** instead of the scanner's 20-rows-per-sheet preview, which truncates by ROW before any budgeting runs. `_EXCEL_PREVIEW_ROWS` stays at 20.

## Measured result

| | before | after |
|---|--:|--:|
| priority-0 metadata workbook | 298 | **6,045** |
| priority-3 GraphPad export | 2,049 | **550** |
| total context | 8,788 | 13,243 |

All 15 acceptance tokens now present, where `cvcl_0214`, `ecacc`, `wagenaars`, the ORCID and chemicals 2-5 were **all absent**.

## Verification — the tests are proven honest

With the production change stashed, the new tests fail with exactly the issue's numbers:

```
test_bulk_data_does_not_consume_the_metadata_budget  → metadata 298 chars vs bulk 2049 chars
test_real_document_content_reaches_the_extraction_leaf → cell-line RRID starved
test_every_test_chemical_becomes_a_molecular_entity  → Silychristin never minted: {'thyroxine'}
```

The compactor suite carries an **honesty control** for the trap #378 documents: this depositor filled column 2, not `Value`, so a rule dropping rows on an empty `Value` cell looks right and destroys the author, ORCID, DOI and assay name. The control asserts every data-bearing cell survives.

Full suite **1785 passed, 1 skipped, 1 xpassed**. `uvx ruff check` clean; `uv run ty check` unchanged at 9 pre-existing diagnostics.

## Two false claims corrected while here

- **`_TOKEN_SOP_BODY = "sandell"`** was documented as *"reachable only via the SOP .docx body read"*. It appears **nowhere** in that 22,834-char document — it lives in `README.txt` at offset 1796. The pipeline therefore had **no test** proving the Word-document read works. Added `slco1c1`, the gene symbol, which is genuinely docx-only.
- **`fake_lookup_compound` ignored its `name` argument.** Harmless while one compound reached the plan; now that six do it would stamp all six with thyroxine's CAS. Now name-keyed with real per-chemical identifiers, returning `found=False` for anything unknown rather than falling through to the network — a live PubChem call from this module would be a release blocker.

The context-driven plan stub was extended so each chemical is proposed only when its own name reaches the leaf, matching its existing design. Without that the seam fix would be dead code and the six-compound claim untested.

## Honest notes

1. **The budget rise is a real cost**: ~+1,300 tokens on one bounded cheap-model call, on every run including ones with no metadata file to reward it. Compaction pays most of it back, but chemicals 2-5 sit past 2,600 compacted chars and cannot be reached at 8000 under any weighting.
2. **The priority-3 tier share of 500 is the least de-risked number.** The headroom flow-down is what makes it safe for a bulk-data-only deposit, and there is no such fixture in the repo to test against — worth adding one.
3. AGENTS.md's *"never starved by an early large file"* is corrected: the starvation was the `if`/`elif`, and it hit the highest-priority file.

Out of scope per the issue: crate-level `accession`/`release_date` from the descriptor (needs its own issue), #372, #338, #337, and the plan schema's missing LabProcess parameter slots (#379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)