### PR TITLE
fix(pipeline): give the candidate plan a LabProcess parameter channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1840,7 +1840,14 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
 
 - **Extract** (`extract_plan`, leaf #213, §14.4) — the bounded whole-document
   extractor pulls a *candidate plan* (names/titles only, no identifiers — D5)
-  from the input context in a single model call.
+  from the input context in a single model call. The plan also carries each
+  process step's **descriptive experimental parameters** (exposure duration,
+  detection instrument, endpoint …), drawn from the shared LabProcess hint
+  vocabulary (`_crate_mapping.LABPROCESS_PARAMETER_FIELDS`) so both arms offer the
+  same keys; without that channel the crate publishes ontology-typed
+  ParameterValues asserting `"unknown"` that nobody stated (#379). Identifiers
+  remain excluded, and the parameter sub-object is closed so an unrecognised key
+  cannot reach LabProcess state.
 - **Materialize** (`_materialize_plan` via the idempotent composites #217, §14.5)
   — deterministically turns each plan section into linked ISA-Tox entities through
   `scaffold_isa_backbone` / `resolve_compound` / `draft_cell_line_sample` /

--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -131,6 +131,44 @@ def _strip_identifiers(fields: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in fields.items() if key not in _EXCLUDED_FIELDS}
 
 
+def _process_parameters_schema() -> dict[str, Any]:
+    """The ``parameters`` sub-object of a ``process_chain[]`` item (#379).
+
+    Properties are **derived** from the shared LabProcess hint vocabulary rather
+    than written out here, so the deterministic pipeline and the ReAct arm offer
+    the same experimental parameters and cannot drift. Without this slot the
+    extraction leaf has nowhere to put the SOP's exposure duration or detection
+    instrument, and every crate publishes ``"unknown"`` placeholders instead.
+
+    Unlike its open siblings this sub-object is **closed**. Plan array items are
+    ``additionalProperties: True`` for descriptive long-tail fields, which is
+    exactly wrong here: an unrecognised key would be overlaid onto LabProcess
+    state, and an ``entity_id`` key would hijack the process ``@id`` through
+    ``drafters._make_entity_id``. The overlay in ``_merge_plan_chain_names``
+    whitelists independently — this is defence in depth, not the only guard.
+    """
+    from builder.tools._crate_mapping import (
+        LABPROCESS_PARAMETER_FIELDS,
+        draft_hints_schema,
+    )
+
+    props = draft_hints_schema("LabProcess").get("properties", {})
+    parameters = {
+        key: spec
+        for key, spec in props.items()
+        if key in LABPROCESS_PARAMETER_FIELDS and key not in _EXCLUDED_FIELDS
+    }
+    return {
+        "type": "object",
+        "description": (
+            "Experimental parameters this step states, e.g. exposure duration or "
+            "detection instrument. Only what the documents say — omit the rest."
+        ),
+        "properties": parameters,
+        "additionalProperties": False,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Stage A: the bounded candidate-plan extractor (Issue #179).
 #
@@ -280,6 +318,7 @@ def _plan_schema() -> dict[str, Any]:
                     "name": {**str_field, "description": "Step name."},
                     "object_hint": {**str_field, "description": "Free-text hint of the input."},
                     "result_hint": {**str_field, "description": "Free-text hint of the output."},
+                    "parameters": _process_parameters_schema(),
                 },
                 required=["process_type"],
             ),

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -817,7 +817,8 @@ _STANDARD_CHAIN: tuple[dict[str, str], ...] = (
 def _merge_plan_chain_names(
     plan: dict[str, Any] | None,
 ) -> list[dict[str, Any]]:
-    """Build the chain spec: the standard 4 steps, overlaid with plan step names.
+    """Build the chain spec: the standard 4 steps, overlaid with plan step names
+    and the experimental parameters the plan states (#379).
 
     Always returns the full canonical chain (so the no-provider crate is never
     hollow), but when *plan* carries a ``process_chain`` each plan step's ``name``
@@ -825,20 +826,57 @@ def _merge_plan_chain_names(
     names drive the process ``@id``s. Plan process_types outside the standard four
     are ignored here — ``draft_process_chain`` only wires the valid subtypes and a
     bogus type would raise; the standard chain is the deterministic backbone.
+
+    Each step's ``parameters`` are overlaid alongside ``name`` and flow on through
+    ``draft_process_chain`` -> ``draft_process`` -> ``_build_process``, replacing
+    the ``"unknown"`` / ``"NA"`` / ``"Standard medium"`` placeholders that the
+    crate otherwise publishes as ontology-typed ParameterValues nobody asserted.
+
+    Three guards, each load-bearing:
+
+    * **Whitelisted** to ``LABPROCESS_PARAMETER_FIELDS``, never splatted. Plan
+      items are ``additionalProperties: True``, so a splat would turn
+      ``object_hint`` into a LabProcess state field and an ``entity_id`` key would
+      hijack the process ``@id`` through ``drafters._make_entity_id``.
+    * **Non-empty stripped strings only.** ``_build_process`` does
+      ``f.get("duration", "unknown")`` — a default that applies only when the key
+      is ABSENT, so an empty overlaid value would ship an *empty* ParameterValue.
+    * A plan with no parameters yields exactly the previous name-only hints, so
+      the #262 "no-provider crate is byte-identical" guarantee is untouched.
     """
+    from builder.tools._crate_mapping import LABPROCESS_PARAMETER_FIELDS
+
     plan_names: dict[str, str] = {}
+    plan_parameters: dict[str, dict[str, str]] = {}
     for step in (plan or {}).get("process_chain") or []:
         if not isinstance(step, dict):
             continue
         ptype = str(step.get("process_type") or "").strip()
+        if not ptype:
+            continue
         name = str(step.get("name") or "").strip()
-        if ptype and name:
+        if name:
             plan_names[ptype] = name
+
+        raw = step.get("parameters")
+        if not isinstance(raw, dict):
+            continue
+        kept = {
+            key: value.strip()
+            for key, value in raw.items()
+            if key in LABPROCESS_PARAMETER_FIELDS
+            and isinstance(value, str)
+            and value.strip()
+        }
+        if kept:
+            plan_parameters[ptype] = kept
 
     chain: list[dict[str, Any]] = []
     for std in _STANDARD_CHAIN:
         ptype = std["process_type"]
-        chain.append({"process_type": ptype, "hints": {"name": plan_names.get(ptype, std["name"])}})
+        hints: dict[str, Any] = {"name": plan_names.get(ptype, std["name"])}
+        hints.update(plan_parameters.get(ptype, {}))
+        chain.append({"process_type": ptype, "hints": hints})
     return chain
 
 

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -203,6 +203,7 @@ ENTITY_DRAFT_SCHEMA: dict[str, EntityDraftSchema] = {
             "detection_instrument": "EndpointReadout: detection instrument.",
             "instrument_manufacturer": "EndpointReadout: instrument manufacturer.",
             "measured_entity": "EndpointReadout: what is measured.",
+            "technical_replicate": "EndpointReadout: number of technical replicates.",
             "endpoint": "EndpointReadout: the measured endpoint.",
             "data_processing": "DataAnalysis: data-processing description.",
             "software": "DataAnalysis: software used.",
@@ -286,6 +287,27 @@ ENTITY_DRAFT_SCHEMA: dict[str, EntityDraftSchema] = {
         },
     ),
 }
+
+
+# The LabProcess scalars that are experimental PARAMETERS — the single source of
+# truth for "what may be overlaid onto a process step's hints" (#379). Derived, not
+# hand-written, so the deterministic pipeline's plan schema and the ReAct arm's
+# hints schema cannot drift apart.
+#
+# Three deliberate exclusions:
+#   * `name` drives the process `@id` via `drafters._make_entity_id` and is merged
+#     separately — overlaying it would let a plan hijack the entity id;
+#   * `description` is never read by `_build_process`, so it would be a dead field;
+#   * `units` is advertised as a string but the code wants a dict keyed by
+#     ParameterValue DISPLAY NAME (`profiles/models/tox.py` does `units.get("Exposure
+#     Duration")`). A model that follows the advertised type passes a bare string and
+#     the build raises `'str' object has no attribute 'get'`, which surfaces as an
+#     error with zero routable issues. Excluded until that type is corrected.
+LABPROCESS_PARAMETER_FIELDS: frozenset[str] = (
+    frozenset(ENTITY_DRAFT_SCHEMA["LabProcess"].scalar_fields)
+    - _REF_FIELDS
+    - {"name", "description", "units"}
+)
 
 
 def draft_hints_schema(entity_type: str) -> dict[str, Any]:

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -1176,3 +1176,77 @@ def _flatten_keys(schema: Any) -> set[str]:
 
     _walk(schema)
     return keys
+
+
+class TestPlanSchemaProcessParameters:
+    """The candidate plan must carry process parameters, not just step names (#379).
+
+    Without a parameter slot the extraction leaf has nowhere to put the SOP's
+    "30 minutes" or "gamma counter", so every default-arm crate publishes 11
+    ontology-typed PropertyValues asserting `"unknown"`, `"NA"` and
+    `"Standard medium"` — fabricated experimental conditions with real BAO
+    `propertyID`s attached, and the tox SHACL pass calls it conformant.
+    """
+
+    @staticmethod
+    def _parameter_properties() -> dict:
+        from builder.agents.pipeline.leaves import _plan_schema
+
+        chain = _plan_schema()["properties"]["process_chain"]
+        return chain["items"]["properties"]["parameters"]["properties"]
+
+    def test_process_chain_item_advertises_the_shared_parameter_vocabulary(self):
+        """The plan's parameter keys ARE the shared LabProcess vocabulary.
+
+        Non-tautological: the expectation is imported from `_crate_mapping`, not
+        written out as a literal list, so the two arms cannot drift.
+        """
+        from builder.tools._crate_mapping import LABPROCESS_PARAMETER_FIELDS
+
+        assert set(self._parameter_properties()) == set(LABPROCESS_PARAMETER_FIELDS)
+
+    def test_a_field_added_to_the_shared_schema_reaches_the_plan_schema(self, monkeypatch):
+        """HONESTY CONTROL — proves derivation, not a coincidentally-equal list.
+
+        A hard-coded list that happens to match today would pass the test above
+        and fail this one.
+        """
+        import dataclasses
+
+        import builder.tools._crate_mapping as cm
+
+        schema = cm.ENTITY_DRAFT_SCHEMA["LabProcess"]
+        extended = dict(schema.scalar_fields)
+        extended["sentinel_parameter"] = "Sentinel added by the honesty control."
+        # EntityDraftSchema is a frozen dataclass — replace the entry, not a field.
+        monkeypatch.setitem(
+            cm.ENTITY_DRAFT_SCHEMA,
+            "LabProcess",
+            dataclasses.replace(schema, scalar_fields=extended),
+        )
+        monkeypatch.setattr(
+            cm,
+            "LABPROCESS_PARAMETER_FIELDS",
+            cm.LABPROCESS_PARAMETER_FIELDS | {"sentinel_parameter"},
+        )
+
+        assert "sentinel_parameter" in self._parameter_properties()
+
+    def test_units_is_not_offered_to_the_plan_model(self):
+        """`units` wants a display-name-keyed dict; the schema would advertise a string."""
+        assert "units" not in self._parameter_properties()
+
+    def test_parameters_object_is_closed(self):
+        """Unlike its open siblings, this sub-object rejects unknown keys.
+
+        The plan's array items are deliberately `additionalProperties: True` for
+        descriptive long-tail fields. That is exactly wrong here: an unknown key
+        would be overlaid onto LabProcess state, and an `entity_id` key would
+        hijack the process `@id`.
+        """
+        from builder.agents.pipeline.leaves import _plan_schema
+
+        params = _plan_schema()["properties"]["process_chain"]["items"]["properties"][
+            "parameters"
+        ]
+        assert params.get("additionalProperties") is False

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -2693,3 +2693,102 @@ class TestGatherContextPreviewedFilesGetABudget:
 
         assert "assay_metadata.csv" not in context
         assert self._SENTINEL.format(0) in context  # the bulk file still speaks
+
+
+class TestPlanChainParameterOverlay:
+    """Plan-stated experimental parameters must reach the process hints (#379).
+
+    `_merge_plan_chain_names` read only `step["name"]`, so a model that volunteered
+    `{"duration": "30 minutes"}` had it silently discarded — and every default-arm
+    crate shipped 11 ontology-typed PropertyValues asserting `"unknown"`, `"NA"`
+    and `"Standard medium"` that nobody stated.
+    """
+
+    @staticmethod
+    def _hints_for(chain: list[dict], ptype: str) -> dict:
+        return next(s["hints"] for s in chain if s["process_type"] == ptype)
+
+    def test_plan_parameters_are_overlaid_onto_the_step_hints(self):
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        chain = pipeline_mod._merge_plan_chain_names(
+            {
+                "process_chain": [
+                    {
+                        "process_type": "Exposure",
+                        "name": "Dose",
+                        "parameters": {"duration": "30 minutes", "microplate": "96-well"},
+                    }
+                ]
+            }
+        )
+
+        assert self._hints_for(chain, "Exposure") == {
+            "name": "Dose",
+            "duration": "30 minutes",
+            "microplate": "96-well",
+        }
+
+    def test_non_whitelisted_step_keys_are_not_overlaid(self):
+        """HONESTY CONTROL — a whitelist, not a splat.
+
+        This is the test that fails if someone "fixes" the red above by merging
+        the step dict wholesale. Plan items are `additionalProperties: True`, so
+        `object_hint` would become a LabProcess state field and an `entity_id`
+        would hijack the process `@id` via `drafters._make_entity_id`.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        chain = pipeline_mod._merge_plan_chain_names(
+            {
+                "process_chain": [
+                    {
+                        "process_type": "Exposure",
+                        "name": "Dose",
+                        "object_hint": "cells",
+                        "entity_id": "proc_hijack",
+                        "parameters": {
+                            "duration": "30 minutes",
+                            "entity_id": "proc_hijack",
+                            "units": "min",
+                            "cas": "51-48-9",
+                            "object_hint": "cells",
+                        },
+                    }
+                ]
+            }
+        )
+
+        hints = self._hints_for(chain, "Exposure")
+        assert hints == {"name": "Dose", "duration": "30 minutes"}
+        for smuggled in ("entity_id", "units", "cas", "object_hint"):
+            assert smuggled not in hints
+
+    def test_empty_parameter_values_do_not_overlay(self):
+        """A present-but-blank value must not replace the placeholder with "".
+
+        `_build_process` does `f.get("duration", "unknown")` — a default that only
+        applies when the key is ABSENT. An empty overlaid value would ship an
+        empty ParameterValue, which is worse than the placeholder.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        chain = pipeline_mod._merge_plan_chain_names(
+            {
+                "process_chain": [
+                    {"process_type": "Exposure", "name": "Dose", "parameters": {"duration": "  "}}
+                ]
+            }
+        )
+
+        assert "duration" not in self._hints_for(chain, "Exposure")
+
+    def test_no_plan_still_yields_the_canonical_name_only_chain(self):
+        """#262 regression guard — the no-provider crate stays byte-identical."""
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        chain = pipeline_mod._merge_plan_chain_names(None)
+
+        assert len(chain) == len(pipeline_mod._STANDARD_CHAIN)
+        for step in chain:
+            assert set(step["hints"]) == {"name"}

--- a/tests/test_entity_draft_schema.py
+++ b/tests/test_entity_draft_schema.py
@@ -107,3 +107,60 @@ def test_draft_study_hints_advertise_ref_keys():
     props = spec["parameters"]["properties"]["hints"]["properties"]
     assert "name" in props
     assert "aop" in props  # a reference key from the Study schema
+
+
+# ---------------------------------------------------------------------------
+# LabProcess experimental parameters (#379)
+# ---------------------------------------------------------------------------
+
+
+def test_technical_replicate_is_advertised():
+    """`_build_process` reads it, so the vocabulary must offer it.
+
+    `_build_process` does `f.get("technical_replicate", "1")`, but the key was
+    absent from the advertised scalars — so `Technical replicate = "1"` was
+    unfillable through the advertised vocabulary on BOTH arms.
+    """
+    assert "technical_replicate" in ENTITY_DRAFT_SCHEMA["LabProcess"].scalar_fields
+
+
+def test_labprocess_parameter_fields_are_all_advertised():
+    """The parameter constant must be DERIVED from the shared vocabulary.
+
+    Non-tautological: both sides are read from the module, so this can only fail
+    if someone hand-writes the constant instead of deriving it — which is exactly
+    how the two arms would drift apart again.
+    """
+    from builder.tools._crate_mapping import LABPROCESS_PARAMETER_FIELDS
+
+    advertised = set(ENTITY_DRAFT_SCHEMA["LabProcess"].scalar_fields)
+    assert LABPROCESS_PARAMETER_FIELDS <= advertised
+    assert LABPROCESS_PARAMETER_FIELDS, "the parameter vocabulary must not be empty"
+
+
+def test_units_is_not_a_parameter_field():
+    """`units` is advertised as a string but the code requires a dict.
+
+    `profiles/models/tox.py` does `u = units or {}` then `u.get("Exposure
+    Duration")` — a display-name-keyed map. `draft_hints_schema` flattens every
+    scalar to `{"type": "string"}`, so a model following the advertised type
+    passes a bare string and the build dies with `'str' object has no attribute
+    'get'`, which `build_and_validate` reports as an error with ZERO routable
+    issues. Excluded here until the type is fixed; see #379 Out of scope.
+    """
+    from builder.tools._crate_mapping import LABPROCESS_PARAMETER_FIELDS
+
+    assert "units" not in LABPROCESS_PARAMETER_FIELDS
+
+
+def test_name_and_description_are_not_parameter_fields():
+    """HONESTY CONTROL — the constant is a filter, not the whole scalar set.
+
+    `name` drives the process `@id` via `_make_entity_id` and is merged
+    separately; `description` is never emitted by `_build_process`, so overlaying
+    it would create a dead state field.
+    """
+    from builder.tools._crate_mapping import LABPROCESS_PARAMETER_FIELDS
+
+    assert "name" not in LABPROCESS_PARAMETER_FIELDS
+    assert "description" not in LABPROCESS_PARAMETER_FIELDS

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -122,8 +122,21 @@ _PLAN: dict[str, Any] = {
     ],
     "process_chain": [
         {"process_type": "CellCulture", "name": "FRTL-5 cell culture"},
-        {"process_type": "Exposure", "name": "Methimazole exposure"},
-        {"process_type": "EndpointReadout", "name": "Amplex Red TPO readout"},
+        {
+            "process_type": "Exposure",
+            "name": "Methimazole exposure",
+            "parameters": {"duration": "30 minutes", "microplate": "96-well"},
+        },
+        {
+            "process_type": "EndpointReadout",
+            "name": "Amplex Red TPO readout",
+            "parameters": {
+                "detection_instrument": "Wizard2 gamma counter",
+                "instrument_manufacturer": "Perkin Elmer",
+                "endpoint": "TPO activity",
+                "technical_replicate": "3",
+            },
+        },
         {"process_type": "DataAnalysis", "name": "Dose-response IC50 analysis"},
     ],
     "aops": [{"aop_id": "610"}],
@@ -688,3 +701,95 @@ class TestExtractionContextFidelity:
         result = pipeline_mod._materialize_plan(engine)
         # No body marker reached the leaf, so it echoed no study name.
         assert result["study"] == 0
+
+
+class TestProcessParametersReachTheGraph:
+    """Plan parameters must survive all the way to the exported ParameterValues (#379).
+
+    Asserted on the BUILT ``@graph``, never on ``CrateState`` — the placeholders
+    are minted during assembly by ``_crate_mapping._build_process`` and
+    ``profiles/models/tox.py``, so a state-level assertion would not prove the
+    value travelled schema -> merge -> draft_process -> _build_process -> model.
+    """
+
+    @staticmethod
+    def _parameter_values(state) -> dict[str, str]:
+        """Every ``PropertyValue`` in the assembled crate, by display name."""
+        from builder.tools.builder import assemble_crate
+
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+        graph = crate.metadata.generate().get("@graph", [])
+        out: dict[str, str] = {}
+        for node in graph:
+            if not isinstance(node, dict) or "PropertyValue" not in str(node.get("@type")):
+                continue
+            name, value = node.get("name"), node.get("value")
+            if isinstance(name, str) and isinstance(value, str):
+                out[name] = value
+        return out
+
+    def test_exposure_parameter_value_carries_the_plan_duration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _stub_leaves(monkeypatch)
+        engine = _engine(_titled_state())
+        run_pipeline(engine)
+
+        assert self._parameter_values(engine.state)["Exposure Duration"] == "30 minutes"
+
+    def test_exposure_duration_is_unknown_without_a_plan_parameter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HONESTY CONTROL — the value travelled, it was not coincidentally present.
+
+        Identical run with the ``parameters`` key stripped from the plan: the
+        placeholder returns. If this stayed "30 minutes" the test above would be
+        asserting something the fixture supplied by another route.
+        """
+        import copy
+
+        import builder.agents.pipeline.pipeline as pipeline_mod
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _stub_leaves(monkeypatch)
+        stripped = copy.deepcopy(_PLAN)
+        for step in stripped["process_chain"]:
+            step.pop("parameters", None)
+        monkeypatch.setattr(
+            pipeline_mod, "extract_plan", lambda *a, **k: copy.deepcopy(stripped)
+        )
+
+        engine = _engine(_titled_state())
+        run_pipeline(engine)
+
+        assert self._parameter_values(engine.state)["Exposure Duration"] == "unknown"
+
+    def test_endpoint_readout_parameters_carry_plan_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Including `technical_replicate`, which only works if the shared
+        `ENTITY_DRAFT_SCHEMA` addition landed — it was read but never advertised."""
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _stub_leaves(monkeypatch)
+        engine = _engine(_titled_state())
+        run_pipeline(engine)
+
+        values = self._parameter_values(engine.state)
+        assert values["Detection Instrument"] == "Wizard2 gamma counter"
+        assert values["Instrument Manufacturer"] == "Perkin Elmer"
+        assert values["Endpoint"] == "TPO activity"
+        assert values["Technical replicate"] == "3"
+
+    def test_crate_still_conforms_with_parameters_supplied(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guards a regression that DROPS a ParameterValue instead of filling it."""
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _stub_leaves(monkeypatch)
+        result = run_pipeline(_engine(_titled_state()))
+
+        assert result["conformance"] == {"base": True, "isa": True, "tox": True}

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -96,6 +96,11 @@ _TOKEN_CELL_LINE_RRID = "cvcl_0214"
 _TOKEN_CHEMICAL_2 = "lesinurad"
 _TOKEN_CHEMICAL_5 = "diclofenac"
 _TOKEN_PERSON = "wagenaars"
+# Experimental parameters stated in the SOP .docx body prose — "After exposure to
+# 10 nM of 125I-T4 for 30 minutes …  quantified by measuring the radioactivity of
+# the cell lysate in a gamma counter." Neither occurs in any filename (#379).
+_TOKEN_SOP_DURATION = "30 minutes"
+_TOKEN_SOP_INSTRUMENT = "gamma counter"
 
 # The five test chemicals the workbook's Chemical Information sheet names, in sheet
 # order. Chemicals 2-5 sit past 2,600 compacted chars, so the leaf saw none of them
@@ -167,6 +172,21 @@ def _install_offline_seams(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
                 for token, label in _TEST_CHEMICALS
                 if token in low
             ]
+        # Process parameters, each gated on its own token from the SOP .docx BODY —
+        # "30 minutes" at char 1730, "gamma counter" at 1887, both inside the 2,000
+        # char slice that tier gets. Neither string occurs in any filename in the
+        # fixture, so they can only come from the real Word-document read (#379).
+        chain_params: dict[str, dict[str, str]] = {}
+        if _TOKEN_SOP_DURATION in low:
+            chain_params["Exposure"] = {"duration": "30 minutes"}
+        if _TOKEN_SOP_INSTRUMENT in low:
+            chain_params["EndpointReadout"] = {"detection_instrument": "gamma counter"}
+        if chain_params:
+            plan["process_chain"] = [
+                {"process_type": ptype, "parameters": params}
+                for ptype, params in chain_params.items()
+            ]
+
         if _TOKEN_SOP_BODY in low:
             # The SOP body (read from the .docx) drives a LabProtocol governing the
             # exposure — proposed only because the procedure text reached the leaf.
@@ -444,3 +464,85 @@ class TestRealInputPipeline:
 
         chems = engine.state.list_entities("MolecularEntity")
         assert not any(c.fields.get("name") == "Thyroxine" for c in chems)
+
+
+class TestRealSopParametersReachTheCrate:
+    """The SOP's stated conditions must replace the fabricated placeholders (#379).
+
+    Every default-arm crate published 11 ontology-typed PropertyValues asserting
+    conditions nobody stated — `Exposure Duration = "unknown"`, `Detection
+    Instrument = "unknown"`, `Technical replicate = "1"` — each carrying a real
+    BAO `propertyID`, with the tox SHACL pass reporting conformant. The real SOP
+    states the duration and the instrument in its body; before this the plan had
+    nowhere to put them.
+    """
+
+    @staticmethod
+    def _parameter_values(state) -> dict[str, str]:
+        from builder.tools.builder import assemble_crate
+
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+        graph = crate.metadata.generate().get("@graph", [])
+        out: dict[str, str] = {}
+        for node in graph:
+            if not isinstance(node, dict) or "PropertyValue" not in str(node.get("@type")):
+                continue
+            name, value = node.get("name"), node.get("value")
+            if isinstance(name, str) and isinstance(value, str):
+                out[name] = value
+        return out
+
+    def test_sop_body_tokens_reach_the_extraction_leaf(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard the input side first, so a budget regression fails legibly.
+
+        Without this, a `_gather_context` change that drops the SOP slice would
+        redden the crate assertions below opaquely.
+        """
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        capture = _install_offline_seams(monkeypatch)
+        run_pipeline(_scanning_engine(FIXTURE_DIR))
+
+        context = capture["context"].lower()
+        assert _TOKEN_SOP_DURATION in context
+        assert _TOKEN_SOP_INSTRUMENT in context
+
+    def test_process_parameters_from_the_real_sop_reach_the_crate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _install_offline_seams(monkeypatch)
+        engine = _scanning_engine(FIXTURE_DIR)
+        run_pipeline(engine)
+
+        values = self._parameter_values(engine.state)
+        assert values["Exposure Duration"] == "30 minutes"
+        assert values["Detection Instrument"] == "gamma counter"
+
+    def test_no_process_parameter_without_the_real_sop_body(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """HONESTY CONTROL — the values came from the scanned BODY, not the stub.
+
+        Mirrors `test_no_compound_without_the_real_document`: a folder holding an
+        empty file with the SOP's own FILENAME. The name is present, the body is
+        not, and the placeholders must return.
+        """
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        (tmp_path / _SOP.name).write_text("", encoding="utf-8")
+
+        _install_offline_seams(monkeypatch)
+        engine = _scanning_engine(tmp_path)
+        run_pipeline(engine)
+
+        values = self._parameter_values(engine.state)
+        # Asserted as the exact placeholder, not "absent or unknown": the standard
+        # chain is drafted unconditionally (the #262 never-hollow guarantee), so
+        # these ParameterValues always exist and a slack `in (None, ...)` would
+        # pass even if the chain vanished.
+        assert values["Exposure Duration"] == "unknown"
+        assert values["Detection Instrument"] == "unknown"


### PR DESCRIPTION
Closes #379.

## What was wrong

Every crate the default `--interactive` pipeline produced published **11 ontology-typed `schema:PropertyValue` nodes asserting experimental conditions nobody stated**:

```
CellCulture      Culture Medium       = "Standard medium"
Exposure         Exposure Duration    = "unknown"
Exposure         Cell Seeding Density = "NA"
EndpointReadout  Technical replicate  = "1"
EndpointReadout  Endpoint             = "unknown"
…
```

Each carries a real BAO `propertyID`, so a downstream consumer reads them as *measured conditions*. `"Standard medium"` and `"Technical replicate = 1"` are affirmative claims about an experiment; `"unknown"` is fabrication-by-omission. And the tox SHACL pass reports **conformant** — the placeholder itself satisfies `additionalProperty minCount 1` — so neither the deterministic fix loop nor the HITL guidance tail ever mentions them.

The pipeline was *structurally incapable* of doing better. The plumbing from `hints` all the way to the ParameterValue constructors already existed; only the **plan → hints** hop was missing, and it was missing twice: no schema slot, and a merge that read exactly one key (`step["name"]`). A cooperative model volunteering `{"duration": "30 minutes"}` had it silently discarded.

## The fix — open the channel, keep the placeholders

No new tool, no new mapping, no hand-rolled JSON-LD. Values flow through the existing `hints` → `draft_process_chain` → `draft_process` → `_build_process` → `profiles/models/tox.py` path.

- **`_crate_mapping`** gains `LABPROCESS_PARAMETER_FIELDS`, **derived** from the shared `ENTITY_DRAFT_SCHEMA["LabProcess"]` scalars rather than hand-written, so the two arms cannot drift.
- **`_plan_schema`**'s `process_chain[]` item gains a `parameters` sub-object whose properties come from that same vocabulary. It is **`additionalProperties: False`** unlike its open siblings: an unrecognised key would be overlaid onto LabProcess state, and an `entity_id` key would **hijack the process `@id`** through `_make_entity_id`.
- **`_merge_plan_chain_names`** overlays them onto each step's hints, with three guards — whitelisted (never splatted), non-empty stripped strings only, and `None` still yielding the canonical name-only chain.

The empty-value guard is load-bearing, not cosmetic: `_build_process` does `f.get("duration", "unknown")`, a default that applies only when the key is **absent**, so an empty overlaid value would ship an *empty* ParameterValue — worse than the placeholder.

## Two drift defects in the shared vocabulary

**`technical_replicate` was read but never advertised.** `_build_process` reads it; it was absent from `ENTITY_DRAFT_SCHEMA["LabProcess"]`. So `Technical replicate = "1"` was unfillable through the advertised vocabulary on **both** arms. Adding it fixes the ReAct arm too.

**`units` is deliberately excluded and remains broken.** It is advertised as `{"type": "string"}` while `profiles/models/tox.py` requires a dict keyed by ParameterValue **display name** (`units.get("Exposure Duration")`). A model following the advertised type raises `'str' object has no attribute 'get'`, which `build_and_validate` catches broadly and returns as an error with **zero routable issues** — a build the deterministic fix loop cannot act on. Out of scope per the issue; the exclusion is pinned by a test with the reasoning in its docstring.

## Verification

Five layers, all offline, no network.

- **Shared vocabulary** — the parameter constant is a subset of the advertised scalars, and `name`/`description`/`units` are excluded.
- **Plan schema** — the advertised keys equal `LABPROCESS_PARAMETER_FIELDS` **imported from `_crate_mapping`**, not a literal list. An **honesty control** injects a sentinel field into the shared schema and asserts it reaches the plan schema, proving derivation rather than a coincidentally-matching hard-coded list.
- **Merge overlay** — an **honesty control** passes `entity_id`, `units`, `cas` and `object_hint` both at step level and inside `parameters` and asserts none reaches the hints. This is the test that fails if someone "fixes" a red by splatting the step dict.
- **End-to-end on the built `@graph`**, never `CrateState` — the placeholders are minted during assembly, so a state assertion would not prove the value travelled. A **control** removes the `parameters` key from the plan and asserts `Exposure Duration` returns to `"unknown"`.
- **Real input** — the SOP `.docx` body's `"30 minutes"` (char 1730) and `"gamma counter"` (char 1887) drive the plan through the existing context-driven stub discipline, and reach the exported ParameterValues. A **control** scans a folder holding an empty file with the SOP's *filename* and asserts the placeholders return, proving the values came from the scanned body.

Full suite **1804 passed, 1 skipped, 1 xpassed**. `uvx ruff check` clean; `uv run ty check` unchanged at 9 pre-existing diagnostics.

## Out of scope

The `units` type/keying fix (needs its own issue — it is a live crash path with no routable issue), #372, #338, #337, and the `key_event` / `condition_table` gaps. The MIT `crate_slot: LabProcess*:param` type mismatch that forces those 68 parameters REPORT_ONLY is #311, not re-reported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)