### PR TITLE
fix(eval): report the spread and the real spend, not repeat #1

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -95,7 +95,15 @@ Per case, across `repeats` runs ([`metrics.py`](metrics.py), [`runner.py`](runne
 - **model + cost** (#331) — `model_name` mined from `profile.ndjson`, and `cost_usd`
   from `eval.metrics.MODEL_PRICES` (or the `--price-input`/`--price-output` override
   for an unlisted model). An unpriced model records `cost_usd = None` — never a
-  guessed `0`;
+  guessed `0`. Every repeat is priced into `cost_usd_per_repeat`, and their sum is
+  the case's `total_cost_usd` — the money actually spent (#401). `cost_usd` itself
+  stays repeat #1's, matching the token fields, so existing consumers are unmoved;
+- **per-repeat spread** (#335, #400) — `total_tokens_per_repeat`,
+  `latency_per_repeat`, `stop_reasons`, `input_tokens_per_repeat` /
+  `output_tokens_per_repeat`, plus a `variance` block (`mean`/`min`/`max`/`stdev`
+  for tokens and latency). Note `stop_reasons` beside the singular `stop_reason`:
+  a case that self-terminated once and hit the cap twice must not read as a clean
+  win;
 - **transient retries** (#331) — how many transient network/API failures were re-run
   before the result counted (a connection drop / timeout / rate-limit is not an
   architecture failure);
@@ -105,8 +113,15 @@ Per case, across `repeats` runs ([`metrics.py`](metrics.py), [`runner.py`](runne
 
 The aggregate `EvalReport.summary()` reports **success rate**, **mean/median tokens**,
 **mean/median latency**, the **determinism rate**, the **stop-reason breakdown**
-(`num_completed` / `num_cap_hit` / `num_error`), and **`total_cost_usd`** (summed over
-priced cases, `None` when no case was priced).
+(`num_completed` / `num_cap_hit` / `num_error`), **`mean_total_tokens_cv`** (the
+arm-level "how stochastic" number), and two cost figures: **`total_cost_usd`** — the
+run's actual spend, every repeat of every priced case, `None` when no case was priced
+— and **`mean_cost_usd_per_repeat`**, the same money divided by `repeats` so runs made
+with different `--repeats` stay comparable.
+
+`compare_reports` carries the per-case spread through to the A/B diff, not just the
+means (#400) — without it a real tweak is indistinguishable from run-to-run noise on
+the stochastic ReAct arm, which is the whole reason `--repeats` defaults to 3.
 
 ## Report format
 

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -244,10 +244,14 @@ def run_main(
 
     write_report(report, out_path)
     summary = report.summary()
+    # total_spend is every repeat of every case — what the API actually billed —
+    # and cost_per_repeat is that divided by --repeats, so runs made with different
+    # repeat counts stay comparable (#401). Naming both keeps either unmistakable.
     cost = summary["total_cost_usd"]
+    per_repeat = summary["mean_cost_usd_per_repeat"]
     logger.info(
         "Done: success_rate=%.2f mean_tokens=%.0f determinism_rate=%.2f "
-        "completed=%d cap_hit=%d error=%d total_cost=%s -> %s",
+        "completed=%d cap_hit=%d error=%d total_spend=%s cost_per_repeat=%s -> %s",
         summary["success_rate"],
         summary["mean_total_tokens"],
         summary["determinism_rate"],
@@ -255,6 +259,7 @@ def run_main(
         summary["num_cap_hit"],
         summary["num_error"],
         f"${cost:.4f}" if cost is not None else "n/a",
+        f"${per_repeat:.4f}" if per_repeat is not None else "n/a",
         out_path,
     )
     return 0

--- a/eval/report.py
+++ b/eval/report.py
@@ -86,6 +86,20 @@ def compare_reports(*reports: EvalReport) -> dict[str, Any]:
                 # Additive content-quality signal — ``None`` for cases that do not
                 # declare a min_entities quota.
                 "meets_quota": result.meets_quota,
+                # Spread across repeats (#400). Without these the diff reports
+                # means with no dispersion, so a real tweak is indistinguishable
+                # from run-to-run noise on the stochastic ReAct arm. Note
+                # ``stop_reasons`` (all repeats) beside ``stop_reason`` (repeat #1):
+                # a case that self-terminated once and hit the cap twice must not
+                # read as a clean win.
+                "variance": result.variance(),
+                "total_tokens_per_repeat": result.total_tokens_per_repeat,
+                "latency_per_repeat": [round(x, 4) for x in result.latency_per_repeat],
+                "stop_reasons": result.stop_reasons,
+                "transient_retries": result.transient_retries,
+                # Cost of every repeat, and the case's true spend (#401).
+                "cost_usd_per_repeat": result.cost_usd_per_repeat,
+                "total_cost_usd": result.total_cost_usd,
             }
 
     return {"labels": labels, "summaries": summaries, "cases": cases}

--- a/eval/reprice.py
+++ b/eval/reprice.py
@@ -35,11 +35,20 @@ def reprice_records(
 ) -> list[dict[str, Any]]:
     """Return *records* with cost fields recomputed under the given price.
 
-    Each ``record == "case"`` line's ``cost_usd`` is re-derived from its
-    ``input_tokens`` / ``output_tokens`` via :func:`compute_cost` with the price
-    override; the ``record == "summary"`` line's ``total_cost_usd`` becomes the sum
-    of the repriced case costs (``None`` only when there are no case lines). Every
-    other field is left untouched, and the input list is **not** mutated.
+    Each ``record == "case"`` line is repriced across **every** repeat (#401): its
+    ``input_tokens_per_repeat`` / ``output_tokens_per_repeat`` arrays are priced
+    into ``cost_usd_per_repeat``, whose sum becomes the case's ``total_cost_usd``.
+    ``cost_usd`` stays repeat #1's representative figure, matching the runner. The
+    ``record == "summary"`` line's ``total_cost_usd`` becomes the sum of the case
+    totals (``None`` only when no case had a known price), plus a
+    ``mean_cost_usd_per_repeat`` derived from the summary's ``repeats``.
+
+    A report written before #401 carries no per-repeat arrays; it reprices from
+    ``input_tokens`` / ``output_tokens`` alone, exactly as before — one repeat is
+    the only figure such a report holds. Ragged arrays (differing lengths) are
+    treated the same way rather than zipped into an invented price.
+
+    Every other field is left untouched, and the input list is **not** mutated.
 
     Args:
         records: Parsed ndjson report lines (case lines followed by one summary).
@@ -47,29 +56,40 @@ def reprice_records(
         price_output: USD price per 1M output tokens.
 
     Returns:
-        A new list of new dicts with ``cost_usd`` / ``total_cost_usd`` recomputed.
+        A new list of new dicts with the cost fields recomputed.
     """
     override = (price_input, price_output)
     repriced: list[dict[str, Any]] = []
-    case_costs: list[float] = []
+    case_totals: list[float] = []
     for rec in records:
         new = dict(rec)
         if new.get("record") == "case":
-            cost = compute_cost(
-                int(new.get("input_tokens", 0) or 0),
-                int(new.get("output_tokens", 0) or 0),
-                new.get("model_name"),
-                price_override=override,
-            )
-            new["cost_usd"] = cost
-            if cost is not None:
-                case_costs.append(cost)
+            model = new.get("model_name")
+            ins = new.get("input_tokens_per_repeat") or []
+            outs = new.get("output_tokens_per_repeat") or []
+            if not (ins and len(ins) == len(outs)):
+                # Pre-#401 or corrupt: repeat #1 is all we can honestly price.
+                ins = [new.get("input_tokens", 0) or 0]
+                outs = [new.get("output_tokens", 0) or 0]
+            per_repeat = [
+                compute_cost(int(i or 0), int(o or 0), model, price_override=override)
+                for i, o in zip(ins, outs)
+            ]
+            known = [c for c in per_repeat if c is not None]
+            case_total = sum(known) if known else None
+            new["cost_usd_per_repeat"] = per_repeat
+            new["cost_usd"] = per_repeat[0]
+            new["total_cost_usd"] = case_total
+            if case_total is not None:
+                case_totals.append(case_total)
         repriced.append(new)
 
-    total = sum(case_costs) if case_costs else None
+    total = sum(case_totals) if case_totals else None
     for new in repriced:
         if new.get("record") == "summary":
             new["total_cost_usd"] = total
+            repeats = max(1, int(new.get("repeats", 1) or 1))
+            new["mean_cost_usd_per_repeat"] = None if total is None else total / repeats
     return repriced
 
 

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -77,8 +77,16 @@ class CaseResult:
 
     For the stochastic ReAct arm one draw is noisy, so ``total_tokens_per_repeat``
     / ``latency_per_repeat`` / ``stop_reasons`` additionally record **every**
-    repeat (trap 4, #335); :meth:`to_dict` derives a mean ± spread block from them.
+    repeat (trap 4, #335); :meth:`variance` derives a mean ± spread block from them.
     The headline fields above stay repeat #1's so existing consumers are unchanged.
+
+    Cost follows the same additive shape (#401): ``cost_usd`` remains repeat #1's
+    — one representative build, consistent with the token fields — while
+    ``cost_usd_per_repeat`` prices **every** repeat and :attr:`total_cost_usd` sums
+    them into what the run actually spent. ``input_tokens_per_repeat`` /
+    ``output_tokens_per_repeat`` are recorded alongside so an offline reprice
+    (:mod:`eval.reprice`) can rebuild that total under a different price instead of
+    silently falling back to repeat #1.
 
     ``meets_quota`` / ``entity_counts`` are the additive content-quality signal:
     for cases that declare ``min_entities`` they say whether the build drafted the
@@ -110,11 +118,41 @@ class CaseResult:
     total_tokens_per_repeat: list[int] = field(default_factory=list)
     latency_per_repeat: list[float] = field(default_factory=list)
     stop_reasons: list[str | None] = field(default_factory=list)
+    input_tokens_per_repeat: list[int] = field(default_factory=list)
+    output_tokens_per_repeat: list[int] = field(default_factory=list)
+    cost_usd_per_repeat: list[float | None] = field(default_factory=list)
 
     @property
     def total_tokens(self) -> int:
         """Combined input + output token count for the representative run."""
         return self.input_tokens + self.output_tokens
+
+    @property
+    def total_cost_usd(self) -> float | None:
+        """USD actually spent on this case across **all** repeats (#401).
+
+        Sums the priced repeats in :attr:`cost_usd_per_repeat`. ``None`` when no
+        repeat had a known price, so an unpriced case reads as "cost unknown"
+        rather than a misleading ``$0`` (trap 5). Falls back to the representative
+        :attr:`cost_usd` when no per-repeat prices were recorded at all — a
+        hand-built or pre-#401 result, where one draw is the only figure there is.
+        """
+        known = [c for c in self.cost_usd_per_repeat if c is not None]
+        if known:
+            return sum(known)
+        return None if self.cost_usd_per_repeat else self.cost_usd
+
+    def variance(self) -> dict[str, dict[str, float]]:
+        """Mean ± spread across repeats for the noisy metrics (trap 4, #335).
+
+        The single definition shared by :meth:`to_dict` (the ndjson case line) and
+        :func:`eval.report.compare_reports` (the A/B diff), so the written report
+        and the comparison can never drift apart.
+        """
+        return {
+            "total_tokens": _spread(self.total_tokens_per_repeat),
+            "latency_seconds": _spread(self.latency_per_repeat),
+        }
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict (one ndjson line per case)."""
@@ -143,10 +181,11 @@ class CaseResult:
             "total_tokens_per_repeat": self.total_tokens_per_repeat,
             "latency_per_repeat": [round(x, 4) for x in self.latency_per_repeat],
             "stop_reasons": self.stop_reasons,
-            "variance": {
-                "total_tokens": _spread(self.total_tokens_per_repeat),
-                "latency_seconds": _spread(self.latency_per_repeat),
-            },
+            "input_tokens_per_repeat": self.input_tokens_per_repeat,
+            "output_tokens_per_repeat": self.output_tokens_per_repeat,
+            "cost_usd_per_repeat": self.cost_usd_per_repeat,
+            "total_cost_usd": self.total_cost_usd,
+            "variance": self.variance(),
         }
 
 
@@ -179,8 +218,15 @@ class EvalReport:
         num_error = sum(1 for r in self.results if r.stop_reason == "error")
         # Total $ over cases with a KNOWN price; ``None`` when no case was priced,
         # so an unpriced run reads as "cost unknown", not a misleading $0 (trap 5).
-        known_costs = [r.cost_usd for r in self.results if r.cost_usd is not None]
+        # Each case contributes ALL its repeats (#401) — this is the run's actual
+        # spend, matching what the API bills, not one repeat presented as the total.
+        known_costs = [r.total_cost_usd for r in self.results if r.total_cost_usd is not None]
         total_cost_usd = sum(known_costs) if known_costs else None
+        # The same money divided by the repeat count, so runs made with different
+        # ``--repeats`` remain comparable to each other.
+        mean_cost_usd_per_repeat = (
+            total_cost_usd / max(1, self.repeats) if total_cost_usd is not None else None
+        )
         # Per-repeat spread (trap 4, #335): the mean coefficient of variation of
         # total tokens across cases — one arm-level "how stochastic" number. ~0 for
         # a deterministic arm, high for a stochastic one. A case with a zero mean (no
@@ -206,6 +252,7 @@ class EvalReport:
             "num_cap_hit": num_cap_hit,
             "num_error": num_error,
             "total_cost_usd": total_cost_usd,
+            "mean_cost_usd_per_repeat": mean_cost_usd_per_repeat,
             "mean_total_tokens_cv": mean_total_tokens_cv,
         }
 
@@ -339,15 +386,19 @@ def _run_case(
 
     # Mine every repeat's profile so the report carries the spread, not just one
     # noisy draw (trap 4, #335). The representative headline fields below stay
-    # repeat #1's (cost, dashboards read those) — the per-repeat arrays are additive.
+    # repeat #1's (dashboards read those) — the per-repeat arrays are additive.
     per_repeat_metrics = [
         mine_profile_metrics(profile_reader(o.session_id) if o.session_id else [])
         for o, _ in repeat_runs
     ]
     pm = per_repeat_metrics[0]
-    cost_usd = compute_cost(
-        pm.input_tokens, pm.output_tokens, pm.model_name, price_override=price_override
-    )
+    # Price EVERY repeat (#401). Summing these is what the run actually cost;
+    # ``cost_usd`` below stays repeat #1's representative figure.
+    cost_usd_per_repeat = [
+        compute_cost(m.input_tokens, m.output_tokens, m.model_name, price_override=price_override)
+        for m in per_repeat_metrics
+    ]
+    cost_usd = cost_usd_per_repeat[0]
 
     deterministic: bool | None = None
     if len(hashes) > 1:
@@ -377,6 +428,9 @@ def _run_case(
         total_tokens_per_repeat=[m.total_tokens for m in per_repeat_metrics],
         latency_per_repeat=[lat for _, lat in repeat_runs],
         stop_reasons=[o.stop_reason for o, _ in repeat_runs],
+        input_tokens_per_repeat=[m.input_tokens for m in per_repeat_metrics],
+        output_tokens_per_repeat=[m.output_tokens for m in per_repeat_metrics],
+        cost_usd_per_repeat=cost_usd_per_repeat,
     )
 
 

--- a/eval/tests/test_cost.py
+++ b/eval/tests/test_cost.py
@@ -139,3 +139,118 @@ class TestRunnerCapturesCost:
             price_override=(4.0, 20.0),
         )
         assert report.results[0].cost_usd == pytest.approx(4.0)
+
+
+def _varying_gpt4o_reader(input_tokens_per_call: list[int]):
+    """Return a priced profile reader yielding a different token count per call.
+
+    The runner reads the profile once per repeat, so call ``k`` reports
+    ``input_tokens_per_call[k]`` — modelling a stochastic arm whose repeats cost
+    genuinely *different* amounts. Deliberately unequal so a total can distinguish
+    "sum of every repeat" from "repeat #1 multiplied by the repeat count".
+    """
+    calls = {"n": 0}
+
+    def reader(_sid: str) -> list[dict]:
+        i = calls["n"]
+        calls["n"] += 1
+        value = (
+            input_tokens_per_call[i]
+            if i < len(input_tokens_per_call)
+            else input_tokens_per_call[-1]
+        )
+        return [
+            {
+                "event": "node_end",
+                "node": "model",
+                "input_tokens": value,
+                "output_tokens": 0,
+                "model_name": "gpt-4o",
+            }
+        ]
+
+    return reader
+
+
+# gpt-4o input is $2.50/Mtok, so 1M/2M/3M input tokens cost $2.50/$5.00/$7.50.
+_UNEQUAL_REPEATS = [1_000_000, 2_000_000, 3_000_000]
+_PER_REPEAT_COSTS = [2.50, 5.00, 7.50]
+
+
+class TestCostAcrossRepeats:
+    """``total_cost_usd`` must bill every repeat, not repeat #1 alone (#401).
+
+    A 3-repeat run previously reported repeat #1's cost as the run total — a ~3x
+    understatement of the headline efficiency number the whole A/B rests on.
+    """
+
+    def _report(self, repeats: int = 3):
+        return run_eval(
+            lambda: _ProfiledAgent(),
+            DEFAULT_CORPUS[:1],
+            repeats=repeats,
+            profile_reader=_varying_gpt4o_reader(_UNEQUAL_REPEATS),
+        )
+
+    def test_case_records_the_cost_of_every_repeat(self) -> None:
+        res = self._report().results[0]
+        assert res.cost_usd_per_repeat == pytest.approx(_PER_REPEAT_COSTS)
+
+    def test_case_total_cost_sums_all_repeats(self) -> None:
+        res = self._report().results[0]
+        assert res.total_cost_usd == pytest.approx(15.00)
+
+    def test_summary_total_is_actual_spend_not_repeat_one(self) -> None:
+        # The bug: this reported 2.50 (repeat #1) for a run that spent 15.00.
+        summary = self._report().summary()
+        assert summary["total_cost_usd"] == pytest.approx(15.00)
+
+    def test_summary_total_is_not_repeat_one_scaled_by_repeat_count(self) -> None:
+        # Guards against the tempting wrong fix: repeats * cost_usd == 7.50, which
+        # is right only when every repeat costs the same. Real repeats do not.
+        summary = self._report().summary()
+        assert summary["total_cost_usd"] != pytest.approx(2.50 * 3)
+
+    def test_summary_reports_mean_cost_per_repeat_for_comparability(self) -> None:
+        # Comparable across runs that used different --repeats values.
+        summary = self._report().summary()
+        assert summary["mean_cost_usd_per_repeat"] == pytest.approx(5.00)
+
+    def test_representative_cost_usd_stays_repeat_one(self) -> None:
+        # Additive contract, matching total_tokens (#335): the headline per-case
+        # field remains one representative build so reprice/dashboards are unmoved.
+        res = self._report().results[0]
+        assert res.cost_usd == pytest.approx(2.50)
+        assert res.cost_usd == pytest.approx(res.cost_usd_per_repeat[0])
+
+    def test_to_dict_carries_the_per_repeat_costs(self) -> None:
+        as_dict = self._report().results[0].to_dict()
+        assert as_dict["cost_usd_per_repeat"] == pytest.approx(_PER_REPEAT_COSTS)
+        assert as_dict["total_cost_usd"] == pytest.approx(15.00)
+
+    def test_single_repeat_total_equals_the_one_cost(self) -> None:
+        # Honesty control: with one repeat the fix must change nothing at all.
+        summary = self._report(repeats=1).summary()
+        assert summary["total_cost_usd"] == pytest.approx(2.50)
+        assert summary["mean_cost_usd_per_repeat"] == pytest.approx(2.50)
+
+    def test_unpriced_model_totals_none_across_repeats(self) -> None:
+        # Honesty control: an unpriced run still reads "cost unknown", never $0.
+        def reader(_sid: str) -> list[dict]:
+            return [
+                {
+                    "event": "node_end",
+                    "node": "model",
+                    "input_tokens": 1_000,
+                    "output_tokens": 0,
+                    "model_name": "mystery-model",
+                }
+            ]
+
+        report = run_eval(
+            lambda: _ProfiledAgent(), DEFAULT_CORPUS[:1], repeats=3, profile_reader=reader
+        )
+        assert report.results[0].cost_usd_per_repeat == [None, None, None]
+        assert report.results[0].total_cost_usd is None
+        assert report.summary()["total_cost_usd"] is None
+        assert report.summary()["mean_cost_usd_per_repeat"] is None

--- a/eval/tests/test_report.py
+++ b/eval/tests/test_report.py
@@ -106,3 +106,101 @@ class TestCompareReports:
         assert c2["stop_reason"] == "cap_hit"
         assert c2["model_name"] == "gpt-4o"
         assert c2["cost_usd"] == 0.5
+
+
+def _noisy_case(
+    case_id: str = "noisy",
+    *,
+    stop_reasons: list[str | None] | None = None,
+) -> CaseResult:
+    """A three-repeat case whose repeats genuinely diverge.
+
+    Tokens and latency differ per repeat, and ``stop_reason`` (repeat #1) disagrees
+    with the full ``stop_reasons`` list — the exact shape that makes a spread-blind
+    comparison misleading.
+    """
+    return CaseResult(
+        case_id=case_id,
+        kind="minimal",
+        success=True,
+        conformance={"base": True, "isa": True, "tox": True},
+        issues=[],
+        input_tokens=100,
+        output_tokens=0,
+        tool_calls=5,
+        iterations=3,
+        latency_seconds=1.0,
+        crate_hashes=["a", "b", "c"],
+        deterministic=False,
+        repeats=3,
+        stop_reason="completed",
+        model_name="gpt-4o",
+        cost_usd=0.5,
+        transient_retries=2,
+        total_tokens_per_repeat=[100, 300, 200],
+        latency_per_repeat=[1.0, 3.0, 2.0],
+        stop_reasons=stop_reasons if stop_reasons is not None else ["completed"] * 3,
+    )
+
+
+def _noisy_report(label: str, **kwargs) -> EvalReport:
+    return EvalReport(label=label, repeats=3, results=[_noisy_case(**kwargs)])
+
+
+class TestCompareReportsCarriesSpread:
+    """The A/B diff must show spread, not means alone (#400).
+
+    ``--repeats`` defaults to 3 so variance can be reported; publishing only
+    repeat #1 spends the compute and discards the result.
+    """
+
+    def test_per_case_carries_the_variance_block(self) -> None:
+        diff = compare_reports(_noisy_report("react"), _noisy_report("pipeline"))
+        variance = diff["cases"]["noisy"]["react"]["variance"]
+        assert variance["total_tokens"]["mean"] == 200.0
+        assert variance["total_tokens"]["min"] == 100
+        assert variance["total_tokens"]["max"] == 300
+        assert variance["total_tokens"]["stdev"] > 0
+        assert set(variance["latency_seconds"]) == {"mean", "min", "max", "stdev"}
+
+    def test_per_case_carries_every_repeat_not_just_the_first(self) -> None:
+        entry = compare_reports(_noisy_report("react"))["cases"]["noisy"]["react"]
+        assert entry["total_tokens_per_repeat"] == [100, 300, 200]
+        assert entry["latency_per_repeat"] == [1.0, 3.0, 2.0]
+
+    def test_per_case_carries_transient_retries(self) -> None:
+        # A case that needed two network retries is not comparable to one that
+        # needed none, even at identical tokens.
+        entry = compare_reports(_noisy_report("react"))["cases"]["noisy"]["react"]
+        assert entry["transient_retries"] == 2
+
+    def test_mixed_termination_is_not_hidden_by_repeat_one(self) -> None:
+        # The issue's headline case: self-terminated once, hit the cap twice. Read
+        # through repeat #1's stop_reason alone that is a clean win; it is not.
+        mixed = _noisy_report("react", stop_reasons=["completed", "cap_hit", "cap_hit"])
+        entry = compare_reports(mixed)["cases"]["noisy"]["react"]
+        assert entry["stop_reason"] == "completed"
+        assert entry["stop_reasons"] == ["completed", "cap_hit", "cap_hit"]
+        assert entry["stop_reasons"].count("cap_hit") == 2
+
+    def test_variance_block_matches_the_ndjson_line(self) -> None:
+        # One definition of spread: the compared entry and the written case line
+        # must not drift apart.
+        report = _noisy_report("react")
+        entry = compare_reports(report)["cases"]["noisy"]["react"]
+        assert entry["variance"] == report.results[0].to_dict()["variance"]
+
+    def test_summary_already_carries_the_arm_level_cv(self) -> None:
+        # Guards the claim in #400 that mean_total_tokens_cv "never reaches the
+        # comparison" — it does, via the summaries block. Pinned so it stays true.
+        diff = compare_reports(_noisy_report("react"))
+        assert diff["summaries"]["react"]["mean_total_tokens_cv"] > 0
+
+    def test_per_case_carries_cost_of_every_repeat(self) -> None:
+        # The cost counterpart of the same fix (#401): a per-case entry shows what
+        # every repeat cost, not repeat #1 alone.
+        case = _noisy_case()
+        case.cost_usd_per_repeat = [0.5, 1.0, 1.5]
+        entry = compare_reports(EvalReport(label="react", repeats=3, results=[case]))
+        assert entry["cases"]["noisy"]["react"]["cost_usd_per_repeat"] == [0.5, 1.0, 1.5]
+        assert entry["cases"]["noisy"]["react"]["total_cost_usd"] == 3.0

--- a/eval/tests/test_reprice.py
+++ b/eval/tests/test_reprice.py
@@ -72,6 +72,79 @@ class TestRepriceRecords:
         assert records[0]["cost_usd"] is None  # original untouched
 
 
+class TestRepriceAcrossRepeats:
+    """A reprice must rebuild the ALL-repeat total, not repeat #1's (#401).
+
+    ``reprice_records`` re-derives cost from the tokens already in the report. If
+    it only ever read the repeat-#1 token fields it would quietly re-introduce the
+    understatement #401 fixes, on every report it touched.
+    """
+
+    def _multi_repeat_case(self):
+        # 1M / 2M / 3M input tokens at $2.50/Mtok -> $2.50 / $5.00 / $7.50.
+        return _case(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            input_tokens_per_repeat=[1_000_000, 2_000_000, 3_000_000],
+            output_tokens_per_repeat=[0, 0, 0],
+        )
+
+    def test_prices_every_repeat(self) -> None:
+        out = reprice_records(
+            [self._multi_repeat_case()], price_input=2.50, price_output=10.00
+        )
+        assert out[0]["cost_usd_per_repeat"] == pytest.approx([2.50, 5.00, 7.50])
+
+    def test_case_total_sums_all_repeats(self) -> None:
+        out = reprice_records(
+            [self._multi_repeat_case()], price_input=2.50, price_output=10.00
+        )
+        assert out[0]["total_cost_usd"] == pytest.approx(15.00)
+
+    def test_representative_cost_stays_repeat_one(self) -> None:
+        out = reprice_records(
+            [self._multi_repeat_case()], price_input=2.50, price_output=10.00
+        )
+        assert out[0]["cost_usd"] == pytest.approx(2.50)
+
+    def test_summary_total_is_the_all_repeat_spend(self) -> None:
+        records = [
+            self._multi_repeat_case(),
+            {"record": "summary", "repeats": 3, "total_cost_usd": None},
+        ]
+        out = reprice_records(records, price_input=2.50, price_output=10.00)
+        assert out[-1]["total_cost_usd"] == pytest.approx(15.00)
+        assert out[-1]["mean_cost_usd_per_repeat"] == pytest.approx(5.00)
+
+    def test_legacy_report_without_per_repeat_arrays_still_reprices(self) -> None:
+        # Backwards compatible: the stored *-luna.ndjson baselines predate #401 and
+        # carry no per-repeat token arrays. They reprice from repeat #1 as before —
+        # the only figure such a report contains.
+        records = [
+            _case(input_tokens=1_000_000, output_tokens=0),
+            {"record": "summary", "repeats": 3, "total_cost_usd": None},
+        ]
+        out = reprice_records(records, price_input=2.50, price_output=10.00)
+        assert out[0]["cost_usd"] == pytest.approx(2.50)
+        assert out[0]["total_cost_usd"] == pytest.approx(2.50)
+        assert out[-1]["total_cost_usd"] == pytest.approx(2.50)
+
+    def test_ragged_arrays_fall_back_rather_than_mispricing(self) -> None:
+        # Honesty control: mismatched input/output lengths are corrupt data, not a
+        # licence to zip them and invent a price.
+        records = [
+            _case(
+                input_tokens=1_000_000,
+                output_tokens=0,
+                input_tokens_per_repeat=[1_000_000, 2_000_000, 3_000_000],
+                output_tokens_per_repeat=[0, 0],
+            )
+        ]
+        out = reprice_records(records, price_input=2.50, price_output=10.00)
+        assert out[0]["cost_usd"] == pytest.approx(2.50)
+        assert out[0]["total_cost_usd"] == pytest.approx(2.50)
+
+
 class TestRepriceFile:
     def test_roundtrips_a_report_in_place(self, tmp_path) -> None:
         path = tmp_path / "r.ndjson"


### PR DESCRIPTION
## What

Two last-mile defects in the A/B harness, both "data already collected, discarded at the final aggregation step". No new measurement and no new runs — the numbers were always there.

Closes #400. Closes #401.

### #401 — `total_cost_usd` billed one repeat and called it the run

`_run_case` mined every repeat's profile, then priced `per_repeat_metrics[0]` only. The arm-level total summed those repeat-1 figures, so a 3-repeat run reported roughly a third of what it spent — and unequally, since the deterministic pipeline's repeats cost near-identical amounts while ReAct's vary. Cost is the headline efficiency claim the whole comparison rests on.

Reproduced from the stored artifact, not just asserted: `eval_reports/react-luna.ndjson` carries `total_cost_usd = $2.0721` at `repeats: 3` — the "$2.07 against ~$6" in the issue.

**Semantics, now explicit** (the issue asked for a decision, not a guess):

| field | meaning |
|---|---|
| `cost_usd` | repeat #1 — one representative build, unchanged, consistent with `input_tokens`/`total_tokens` |
| `cost_usd_per_repeat` | every repeat priced |
| `total_cost_usd` (case + summary) | **actual spend**, all repeats — what the API billed |
| `mean_cost_usd_per_repeat` | that divided by `repeats`, so runs at different `--repeats` stay comparable |

Both totals are named so neither can be misread, and the CLI's `Done:` line now prints `total_spend=` and `cost_per_repeat=` instead of one ambiguous `total_cost=`.

### #400 — the A/B diff was spread-blind

`compare_reports` emitted means with no dispersion, so a real tweak was indistinguishable from run-to-run noise on the stochastic arm — which is the entire reason `--repeats` defaults to 3. Now passes through `variance`, `total_tokens_per_repeat`, `latency_per_repeat`, `stop_reasons` and `transient_retries`.

`stop_reasons` (all repeats) beside `stop_reason` (repeat #1) is the one that changes a reading: a case that self-terminated once and hit the cap twice previously showed as a clean win.

## Scope I extended, deliberately

**`eval/reprice.py`.** It recomputes `total_cost_usd` from repeat-1 tokens, so left alone it would silently re-introduce #401 on every report it touched. It now prices each repeat from new `input_tokens_per_repeat` / `output_tokens_per_repeat` arrays. Pre-#401 reports carry no such arrays and reprice from repeat #1 exactly as before — one repeat is the only figure they hold. Ragged arrays take the same fallback rather than being zipped into an invented price.

**Extracted `CaseResult.variance()`**, so the ndjson case line and the A/B diff share one definition of spread and cannot drift.

## Corrections to the issues

- **#400 claims `mean_total_tokens_cv` "never reaches the comparison".** It does — `runner.py` puts it in `summary()`, and `compare_reports` embeds full summaries. Pinned with a test so it stays true. The per-case drops the issue lists are all real.
- **#400's "related, same remedy" is not done here.** All 8 stored baselines have `variance: None` and no per-repeat arrays on every case (verified: `with_variance=0` across all of them). Recovering spread needs a live re-run against a paid API, which this offline PR cannot do.

## Found but not fixed — worth its own issue

`success`, `conformance` and `meets_quota` are computed from repeat #1's state alone (`runner.py:381-385`). A case that succeeded once and failed twice reports `success=True` and contributes a full 1.0 to `success_rate`. That is the same defect class as #401 but on the headline **validity** number rather than the cost one. Out of scope here — changing it changes what `success_rate` means.

## Tests

TDD, red first. The cost red was the issue's own number:

```
assert summary["total_cost_usd"] == pytest.approx(15.00)
E   assert 2.5 == 15.0
```

Per-repeat costs are deliberately **unequal** ($2.50 / $5.00 / $7.50) so the tests pin "sum of every repeat" and reject the tempting wrong fix of `repeat#1 × repeats` ($7.50). Honesty controls cover the single-repeat case (the fix must change nothing), an unpriced model (still `None`, never `$0`), a legacy report, and ragged arrays.

End-to-end probe on a 2-case / 3-repeat run: reports **$22.50** actual spend where the old code reported **$5.00**.

- `eval/` suite: 170 passed
- `uvx ruff check` clean
- `ty check` at the baseline 9

### Pre-existing flaky tests (not from this PR)

The full local suite under `-n auto` shows a few failures. They are **pre-existing and
load-sensitive**, confirmed by a control run on clean `main`, which failed *more* tests
than this branch:

| | failures |
|---|---|
| `main` (control) | `test_concurrent_calls_do_not_exceed_rate_cap`, `TestAutoFixable::test_auto_fixable_must_fixed_without_prompt`, `test_verifications_run_concurrently`, `test_resolved_count_only_includes_gaps_that_actually_cleared` |
| this branch | 3 of the same 4 |

Two are explicit concurrency/timing tests. The failing set also *changed* between two
runs of identical code, which is non-determinism by definition. All of them pass in
isolation and pass when their own file runs alone. Nothing in this PR can reach them:
every change is under `eval/`, `tests/test_agents_guidance.py` imports nothing from
`eval`, and `builder/` never imports `eval`.

Worth its own issue — 16 xdist workers on a loaded machine is enough to trip them, and
flakes at this level can mask a real regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
