### PR TITLE
fix(data): alias real plate-map headers, refuse to write a blank condition table

### DIFF
--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -688,7 +688,7 @@ TOOL_SPECS = [
     },
     {
         "name": "populate_condition_table",
-        "description": "Write per-well rows into an Exposure's CSVW condition table (replacing the header-only placeholder). Pass rows_or_csv_path as a list of row dicts keyed by the columns cell_line/compound/concentration/unit/duration, or a path to a user-supplied plate-map CSV. The table's CSVW typing (tableSchema) is preserved. Returns {ok, path, rows}. Validate the result with validate_table using the inferred schema.",
+        "description": "Write per-well rows into an Exposure's CSVW condition table (replacing the header-only placeholder). Pass rows_or_csv_path as a list of row dicts, or a path to a user-supplied plate-map CSV. The canonical columns are well_id, assay, cell_line, compound, concentration_value, concentration_unit, exposure_duration, experiment, technical_replicate, control. Common synonyms are aliased for you (well->well_id, concentration/conc/dose->concentration_value, unit(s)->concentration_unit, duration/exposure_time->exposure_duration, cell->cell_line, chemical/substance/test_item->compound, replicate->technical_replicate), and a unit-suffixed dose header like concentration_uM fills concentration_value AND concentration_unit. Source columns with no canonical home (e.g. a measurement column) are reported in unmapped_source_columns, not written. The tool REFUSES and writes nothing if no canonical column maps or if no row has a well_id — a blank table is worse than the honest header. The table's CSVW typing (tableSchema) is preserved. Returns {ok, path, rows, unmapped_source_columns}. Validate the result with validate_table using the inferred schema.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -697,7 +697,7 @@ TOOL_SPECS = [
                     "description": "entity_id of the Exposure LabProcess.",
                 },
                 "rows_or_csv_path": {
-                    "description": "A list of row dicts (keys: cell_line/compound/concentration/unit/duration) OR a path to a plate-map CSV.",
+                    "description": "A list of row dicts (canonical keys: well_id/assay/cell_line/compound/concentration_value/concentration_unit/exposure_duration/experiment/technical_replicate/control; common synonyms are aliased) OR a path to a plate-map CSV.",
                     "anyOf": [
                         {"type": "array", "items": {"type": "object"}},
                         {"type": "string"},

--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -27,11 +27,44 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Source-header synonyms -> the canonical condition-table title (#381). Real plate
+# maps do not use the ten canonical names, and the writer below drops anything that
+# does not match one exactly, so without this map a genuine plate map produces a
+# table of blank cells — strictly worse than the honest header-only placeholder.
+#
+# ``concentration`` / ``unit`` / ``duration`` are the pre-#180 five-column names the
+# ReAct tool description advertised long after they stopped existing; a model that
+# obeyed that description had every one of its values silently discarded.
+_CONDITION_TABLE_ALIASES: dict[str, str] = {
+    "well": "well_id",
+    "well_position": "well_id",
+    "concentration": "concentration_value",
+    "conc": "concentration_value",
+    "dose": "concentration_value",
+    "unit": "concentration_unit",
+    "units": "concentration_unit",
+    "duration": "exposure_duration",
+    "exposure_time": "exposure_duration",
+    "cell": "cell_line",
+    "cell line": "cell_line",
+    "chemical": "compound",
+    "substance": "compound",
+    "test_item": "compound",
+    "replicate": "technical_replicate",
+}
+
+# A dose column that carries its unit in the header (``concentration_uM``,
+# ``dose_mM``): the value feeds concentration_value and the suffix becomes the
+# literal concentration_unit. D5 — the suffix is prose from a filename, so it is
+# carried verbatim and never lifted to a UO IRI; that needs an authoritative lookup.
+_UNIT_SUFFIX_RE = re.compile(r"^(?:concentration|conc|dose)_(?P<unit>[A-Za-zµ%/]+)$", re.IGNORECASE)
 
 # CSVW datatype (from #94's _CONDITION_TABLE_COLUMNS) -> Frictionless field type.
 # Anything unmapped falls back to "string" (Frictionless's permissive default).
@@ -281,6 +314,86 @@ def csvw_to_frictionless(columns: Iterable[Mapping[str, Any]]) -> dict[str, Any]
     return {"fields": fields}
 
 
+def project_condition_rows(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Project source rows onto the canonical condition-table columns (#381).
+
+    Maps each source header to its canonical title via
+    :data:`_CONDITION_TABLE_ALIASES` and the suffix-unit rule
+    (:data:`_UNIT_SUFFIX_RE`), so a real plate map populates real columns instead
+    of being dropped by the writer's ``extrasaction="ignore"``.
+
+    Precedence is deliberate: a **canonical** source name always wins, and an alias
+    never overwrites a canonical value already set on that row. So a row carrying
+    both ``well_id`` and ``well`` keeps ``well_id``, and an explicit
+    ``concentration_unit`` survives a ``dose_uM`` header.
+
+    Args:
+        rows: Source row mappings, keyed by whatever headers the source used.
+
+    Returns:
+        ``{"rows": [...], "mapped_columns": [...], "unmapped_source_columns": [...]}``
+        — the projected rows, the canonical columns any row populated, and the
+        source columns nothing could be done with (reported, never silently
+        swallowed: a measurement column like ``tpo_activity_rfu`` has no canonical
+        home and the caller deserves to know it was skipped).
+    """
+    from builder.tools._crate_mapping import _CONDITION_TABLE_HEADER
+
+    canonical = _CONDITION_TABLE_HEADER.strip("\n").split(",")
+    canonical_set = set(canonical)
+
+    projected: list[dict[str, Any]] = []
+    mapped: set[str] = set()
+    unmapped: set[str] = set()
+
+    for row in rows:
+        out: dict[str, Any] = {}
+        # Canonical headers first, so an alias can never displace them.
+        for key, value in row.items():
+            name = str(key).strip()
+            if name in canonical_set and _has_value(value):
+                out[name] = value
+                mapped.add(name)
+        for key, value in row.items():
+            name = str(key).strip()
+            if name in canonical_set:
+                continue
+            lowered = name.lower()
+            target = _CONDITION_TABLE_ALIASES.get(lowered)
+            if target is not None:
+                if _has_value(value) and target not in out:
+                    out[target] = value
+                    mapped.add(target)
+                continue
+            # Match the ORIGINAL header, not the lower-cased one: the regex is
+            # already case-insensitive, and the captured suffix must keep its case
+            # because uM / mM / nM differ by three orders of magnitude each.
+            suffix = _UNIT_SUFFIX_RE.match(name)
+            if suffix is not None:
+                if _has_value(value) and "concentration_value" not in out:
+                    out["concentration_value"] = value
+                    mapped.add("concentration_value")
+                    if "concentration_unit" not in out:
+                        out["concentration_unit"] = suffix.group("unit")
+                        mapped.add("concentration_unit")
+                continue
+            unmapped.add(name)
+        projected.append(out)
+
+    return {
+        "rows": projected,
+        "mapped_columns": sorted(mapped),
+        "unmapped_source_columns": sorted(unmapped),
+    }
+
+
+def _has_value(value: Any) -> bool:
+    """True when *value* carries content (not ``None`` and not blank/whitespace)."""
+    return value is not None and str(value).strip() != ""
+
+
 def populate_condition_table(
     state: Any,
     exposure_id: str,
@@ -339,11 +452,15 @@ def populate_condition_table(
     base_dir = Path(output_dir) if output_dir else None
     if base_dir is None:
         out_path = getattr(getattr(state, "metadata", None), "output_path", None)
-        base_dir = Path(out_path) if out_path else Path.cwd()
+        if out_path:
+            base_dir = Path(out_path)
+        else:
+            # Resolve exactly as export_crate does (#381). The old Path.cwd()
+            # fallback let populate and export target different roots, so rows
+            # written here vanished at export with nothing reported.
+            from builder.tools.builder import _default_crate_path
 
-    rel = _condition_table_rel(_mint_id(proc))
-    dest = base_dir / rel
-    dest.parent.mkdir(parents=True, exist_ok=True)
+            base_dir = Path(_default_crate_path(state))
 
     header_cols = _CONDITION_TABLE_HEADER.strip("\n").split(",")
 
@@ -357,14 +474,53 @@ def populate_condition_table(
     else:
         rows = rows_or_csv_path
 
+    # Alias source headers onto the canonical titles BEFORE deciding to write, so
+    # a real plate map is populated rather than dropped by extrasaction="ignore".
+    projection = project_condition_rows(rows)
+    projected = projection["rows"]
+    unmapped = projection["unmapped_source_columns"]
+
+    # Refusal contract (#381): a table of blank cells is worse than the honest
+    # header-only placeholder, because the CSVW schema then advertises typed
+    # columns backed by nothing. Refuse, write NOTHING, and say what was skipped.
+    if not projection["mapped_columns"]:
+        return {
+            "ok": False,
+            "error": (
+                "No source column maps to a condition-table column; refusing to write "
+                "a blank table. Expected one of: " + ", ".join(header_cols)
+            ),
+            "unmapped_source_columns": unmapped,
+        }
+    if not any(_has_value(row.get("well_id")) for row in projected):
+        return {
+            "ok": False,
+            "error": (
+                "No row resolves a well_id; a per-well design table without a well key "
+                "is not a design table. Refusing to write."
+            ),
+            "unmapped_source_columns": unmapped,
+        }
+
+    rel = _condition_table_rel(_mint_id(proc))
+    dest = base_dir / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
     with dest.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=header_cols, extrasaction="ignore")
         writer.writeheader()
-        for row in rows:
+        for row in projected:
             writer.writerow({c: row.get(c, "") for c in header_cols})
 
-    logger.debug("Wrote %d condition-table rows to %s", len(rows), dest)
-    return {"ok": True, "path": str(dest), "rows": len(rows)}
+    logger.debug("Wrote %d condition-table rows to %s", len(projected), dest)
+    if unmapped:
+        logger.info("Condition table: skipped unmapped source columns %s", unmapped)
+    return {
+        "ok": True,
+        "path": str(dest),
+        "rows": len(projected),
+        "unmapped_source_columns": unmapped,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -9,13 +9,26 @@ shape so ``validate_table`` needs no hand-authored schema.
 from __future__ import annotations
 
 import csv
+from pathlib import Path
+
+import pytest
 
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools._crate_mapping import _CONDITION_TABLE_COLUMNS
 from builder.tools.data_content import (
     csvw_to_frictionless,
     populate_condition_table,
+    project_condition_rows,
     validate_table,
+)
+
+# The committed per-well fixture the pipeline actually meets in the corpus. Anchored
+# to this file, not the CWD — a test below deliberately chdirs. The fixture is owned
+# by the eval corpus, so ``test_the_corpus_fixture_still_requires_aliasing`` guards
+# against it drifting to canonical column names and quietly making the end-to-end
+# case below vacuous.
+_FIXTURE_CSV = (
+    Path(__file__).parent / "fixtures" / "svhps22_input" / "raw_data" / "dose_response_raw.csv"
 )
 
 
@@ -116,3 +129,228 @@ def test_populated_table_rejects_non_numeric_concentration(tmp_path):
         or "concentration_value" in str(issue.get("message", ""))
         for issue in report["issues"]
     ), report["issues"]
+
+
+class TestProjectConditionRows:
+    """Source headers are aliased onto the ten canonical titles (#381a).
+
+    ``populate_condition_table`` writes through ``csv.DictWriter(...,
+    extrasaction="ignore")``, so any source column not named *exactly* like a
+    canonical title was silently dropped and its canonical slot written empty.
+    Real plate maps do not use the canonical names.
+    """
+
+    def test_projects_the_committed_fixture_header(self) -> None:
+        # The real corpus fixture: well,compound,cell_line,concentration_uM,
+        # tpo_activity_rfu. Only 2 of 10 titles matched before aliasing, so the
+        # dose axis — the entire point of the table — landed blank.
+        rows = [
+            {
+                "well": "A1",
+                "compound": "Methimazole",
+                "cell_line": "FRTL-5",
+                "concentration_uM": "0.3",
+                "tpo_activity_rfu": "15110",
+            }
+        ]
+        result = project_condition_rows(rows)
+        got = result["rows"][0]
+        assert got["well_id"] == "A1"
+        assert got["compound"] == "Methimazole"
+        assert got["cell_line"] == "FRTL-5"
+        assert got["concentration_value"] == "0.3"
+        assert got["concentration_unit"] == "uM"
+
+    def test_reports_measurement_columns_as_unmapped_never_swallowed(self) -> None:
+        rows = [{"well": "A1", "tpo_activity_rfu": "15110"}]
+        result = project_condition_rows(rows)
+        assert "tpo_activity_rfu" in result["unmapped_source_columns"]
+
+    def test_suffix_unit_rule_splits_value_and_unit(self) -> None:
+        result = project_condition_rows([{"well": "A1", "dose_mM": "2.5"}])
+        assert result["rows"][0]["concentration_value"] == "2.5"
+        assert result["rows"][0]["concentration_unit"] == "mM"
+
+    def test_unit_stays_a_literal_string_never_an_ontology_iri(self) -> None:
+        # D5: normalising a unit to a UO IRI needs an authoritative lookup. The
+        # suffix is prose from a filename — it is carried verbatim, never lifted.
+        unit = project_condition_rows([{"well": "A1", "conc_uM": "1"}])["rows"][0][
+            "concentration_unit"
+        ]
+        assert unit == "uM"
+        assert "://" not in unit and ":" not in unit
+
+    def test_canonical_name_wins_over_an_alias(self) -> None:
+        # Both present: the canonical column is authoritative, the alias is ignored.
+        rows = [{"well_id": "CANON", "well": "ALIAS"}]
+        assert project_condition_rows(rows)["rows"][0]["well_id"] == "CANON"
+
+    def test_alias_does_not_overwrite_a_populated_canonical_value(self) -> None:
+        rows = [{"concentration_value": "10", "concentration_unit": "nM", "dose_uM": "99"}]
+        got = project_condition_rows(rows)["rows"][0]
+        assert got["concentration_value"] == "10"
+        assert got["concentration_unit"] == "nM"
+
+    def test_reports_which_canonical_columns_were_mapped(self) -> None:
+        result = project_condition_rows([{"well": "A1", "chemical": "Aspirin"}])
+        assert set(result["mapped_columns"]) == {"well_id", "compound"}
+
+    def test_the_stale_react_tool_column_names_now_land(self) -> None:
+        # react/tools_spec.py advertised the pre-#180 names concentration / unit /
+        # duration. All three were dropped by extrasaction="ignore", so a model
+        # obeying the tool description verbatim wrote an empty table.
+        rows = [
+            {
+                "well": "A1",
+                "cell_line": "HepG2",
+                "compound": "Aspirin",
+                "concentration": "10",
+                "unit": "uM",
+                "duration": "24h",
+            }
+        ]
+        got = project_condition_rows(rows)["rows"][0]
+        assert got["concentration_value"] == "10"
+        assert got["concentration_unit"] == "uM"
+        assert got["exposure_duration"] == "24h"
+
+
+class TestPopulateRefusesRatherThanBlanking:
+    """Writing a table of blank cells is worse than the honest header (#381a)."""
+
+    def _dest(self, tmp_path: Path) -> Path:
+        return tmp_path / "data" / "proc_exp_condition_table.csv"
+
+    def test_refuses_when_no_canonical_column_maps(self, tmp_path) -> None:
+        state = _exposure_state()
+        rows = [{"instrument": "plate reader", "operator": "JH"}]
+        result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
+        assert result["ok"] is False
+        assert result["unmapped_source_columns"]
+
+    def test_refusal_writes_nothing_at_all(self, tmp_path) -> None:
+        # The critical half: a refusal must not leave a blanked file behind, and
+        # must not clobber a header the build already wrote.
+        state = _exposure_state()
+        populate_condition_table(
+            state, "proc_exp", [{"instrument": "plate reader"}], output_dir=str(tmp_path)
+        )
+        assert not self._dest(tmp_path).exists()
+
+    def test_refuses_when_no_row_resolves_a_well_id(self, tmp_path) -> None:
+        # A per-well design table without a well key is not a design table.
+        state = _exposure_state()
+        rows = [{"compound": "Aspirin", "cell_line": "HepG2"}]
+        result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
+        assert result["ok"] is False
+        assert not self._dest(tmp_path).exists()
+
+    def test_success_still_reports_the_skipped_columns(self, tmp_path) -> None:
+        state = _exposure_state()
+        rows = [{"well": "A1", "compound": "Aspirin", "tpo_activity_rfu": "18420"}]
+        result = populate_condition_table(state, "proc_exp", rows, output_dir=str(tmp_path))
+        assert result["ok"] is True
+        assert "tpo_activity_rfu" in result["unmapped_source_columns"]
+
+    def test_the_corpus_fixture_still_requires_aliasing(self) -> None:
+        """Anti-drift guard for the end-to-end case below.
+
+        The fixture belongs to the eval corpus, not to this test. If its header
+        ever became canonical, the end-to-end assertion would still pass while
+        exercising no aliasing at all — a tautology. Pin the two properties the
+        end-to-end case actually depends on: the header is non-canonical, and it
+        carries a suffix-unit dose column.
+        """
+        with open(_FIXTURE_CSV, newline="", encoding="utf-8") as fh:
+            header = next(csv.reader(fh))
+        canonical = {c["titles"] for c in _CONDITION_TABLE_COLUMNS}
+        assert set(header) - canonical, (
+            f"fixture header {header} is now fully canonical — the end-to-end test "
+            "below no longer exercises aliasing and must be rewritten"
+        )
+        assert "well" in header and "well_id" not in header
+        assert any(c.startswith(("concentration_", "conc_", "dose_")) for c in header)
+
+    def test_aliased_plate_map_lands_real_values_end_to_end(self, tmp_path) -> None:
+        # The whole point: the committed fixture, read from disk, produces a table
+        # whose dose axis is populated rather than blank.
+        state = _exposure_state()
+        result = populate_condition_table(
+            state, "proc_exp", str(_FIXTURE_CSV), output_dir=str(tmp_path)
+        )
+        assert result["ok"] is True, result
+        with open(result["path"], newline="", encoding="utf-8") as fh:
+            written = list(csv.DictReader(fh))
+        assert len(written) > 1
+        assert [r["concentration_value"] for r in written] != [""] * len(written)
+        assert all(r["well_id"] for r in written)
+        assert {r["concentration_unit"] for r in written} == {"uM"}
+
+
+class TestPopulatePathResolution:
+    def test_falls_back_to_the_session_crate_path_not_cwd(self, tmp_path, monkeypatch) -> None:
+        # data_content resolved a missing output_dir to Path.cwd() while
+        # export_crate resolves it to _default_crate_path(state). Rows written to
+        # the wrong root are silently lost at export.
+        from builder.tools.builder import _default_crate_path
+
+        state = _exposure_state()
+        state.session_id = "sess-381"
+        monkeypatch.chdir(tmp_path)
+        result = populate_condition_table(
+            state, "proc_exp", [{"well": "A1", "compound": "Aspirin"}]
+        )
+        assert result["ok"] is True, result
+        assert Path(result["path"]).is_relative_to(Path(_default_crate_path(state)))
+
+
+class TestReactToolDescriptionMatchesTheCode:
+    """The advertised columns must be the real ones (#381a).
+
+    The ReAct description named the pre-#180 five-column set long after those
+    columns stopped existing, so a model that obeyed it verbatim had every value
+    discarded by ``extrasaction="ignore"``. Nothing tested the description, which
+    is precisely how it drifted. These pin it to the code.
+    """
+
+    def _spec(self) -> dict:
+        from builder.agents.react.tools_spec import TOOL_SPECS
+
+        return next(t for t in TOOL_SPECS if t["name"] == "populate_condition_table")
+
+    def test_every_canonical_column_is_advertised(self) -> None:
+        text = str(self._spec())
+        for column in (c["titles"] for c in _CONDITION_TABLE_COLUMNS):
+            assert column in text, f"tool description does not mention {column!r}"
+
+    def test_retired_column_names_are_not_advertised_as_keys(self) -> None:
+        # "concentration"/"unit"/"duration" survive only as substrings of the
+        # canonical names, so assert on the delimited forms a model would copy.
+        text = str(self._spec())
+        for retired in ("concentration/unit/duration", "concentration/unit", "unit/duration"):
+            assert retired not in text, f"stale column list {retired!r} still advertised"
+
+    def test_the_refusal_contract_is_documented(self) -> None:
+        # A tool that can refuse must say so, or the caller reads a failure as a bug.
+        description = self._spec()["description"].lower()
+        assert "refus" in description
+        assert "unmapped_source_columns" in description
+
+
+@pytest.mark.parametrize(
+    "source,canonical",
+    [
+        ("well", "well_id"),
+        ("well_position", "well_id"),
+        ("conc", "concentration_value"),
+        ("units", "concentration_unit"),
+        ("exposure_time", "exposure_duration"),
+        ("cell", "cell_line"),
+        ("substance", "compound"),
+        ("test_item", "compound"),
+        ("replicate", "technical_replicate"),
+    ],
+)
+def test_alias_table_covers_the_documented_synonyms(source: str, canonical: str) -> None:
+    got = project_condition_rows([{source: "X"}])["rows"][0]
+    assert got[canonical] == "X"


### PR DESCRIPTION
## What

Part **(a)** of #381 — the shared layer. Teaches `populate_condition_table` to alias real plate-map headers onto the ten canonical condition-table columns, and to **refuse rather than write a blank table**.

Does not close #381: the pipeline caller (b), the `valueUrl` D5 guard (c) and the Frictionless payload pass (d) follow in separate PRs. (b) and (c) must ship together.

## Why this part first

It stands alone and fixes a **live bug in the ReAct arm today**. `react/tools_spec.py` advertised the pre-#180 five-column names — `cell_line/compound/concentration/unit/duration`. Three of those five stopped existing in #180, and the writer uses `csv.DictWriter(..., extrasaction="ignore")`, so a model obeying the tool description verbatim had its values silently discarded and wrote an empty table.

It is also the prerequisite for (b). Wiring the pipeline to the populator *without* this would make things actively worse: on the committed corpus fixture only 2 of 10 canonical titles match, so the dose axis — the entire point of the table — would land blank, and a blank typed table is worse than the honest header-only placeholder.

Measured on `tests/fixtures/svhps22_input/raw_data/dose_response_raw.csv`
(`well,compound,cell_line,concentration_uM,tpo_activity_rfu`):

```
BEFORE   well_id='',   compound='Methimazole', concentration_value='',    concentration_unit=''
         -> rows with a BLANK dose: 4/4
AFTER    well_id='A1', compound='Methimazole', concentration_value='0.0', concentration_unit='uM'
         -> rows with a BLANK dose: 0/4
         -> reported as skipped   : ['tpo_activity_rfu']
```

## Changes

**`project_condition_rows(rows)`** — new shared projection returning `{rows, mapped_columns, unmapped_source_columns}`.

- Alias table for the documented synonyms (`well`→`well_id`, `concentration`/`conc`/`dose`→`concentration_value`, `unit(s)`→`concentration_unit`, `duration`/`exposure_time`→`exposure_duration`, `cell`→`cell_line`, `chemical`/`substance`/`test_item`→`compound`, `replicate`→`technical_replicate`).
- Suffix-unit rule: `concentration_uM` fills `concentration_value` **and** `concentration_unit="uM"`.
- Precedence is explicit — a canonical source name always wins, and an alias never overwrites a canonical value already set on the row.
- `unmapped_source_columns` reports what had no canonical home (a measurement column like `tpo_activity_rfu`) instead of swallowing it.

**Refusal contract** — `populate_condition_table` returns `ok: False` and **writes nothing** when no canonical column maps, or when no row resolves a `well_id`. Writing nothing matters as much as refusing: the build already wrote an honest header there, and a blanked file would replace it with a typed schema backed by nothing.

**Path-resolution footgun** — the missing-`output_dir` fallback was `Path.cwd()` while `export_crate` resolves to `_default_crate_path(state)`. Rows written to the wrong root vanished at export with nothing reported. Both now resolve identically.

**Tool description** — rewritten to name the real ten columns, the aliases, and the refusal contract, so both arms read a true contract.

## D5

The unit suffix is carried **verbatim** as a literal string, never lifted to a UO IRI — that needs an authoritative lookup and is out of scope. Pinned by `test_unit_stays_a_literal_string_never_an_ontology_iri`.

## A bug the tests caught

First implementation matched the suffix regex against the lower-cased header, yielding `um` instead of `uM`. Unit case is load-bearing — `uM`, `mM` and `nM` differ by three orders of magnitude each. Now matched against the original header (the regex is already case-insensitive).

## Tests

TDD, red first (import error → the function did not exist), then the behavioural reds.

- 31 tests: projection precedence, the suffix-unit rule, the D5 literal-unit guard, both refusal arms plus *"writes nothing"*, path resolution, a parametrised sweep of every documented synonym, and an end-to-end run of the committed fixture.
- **Anti-tautology guard.** The fixture belongs to the eval corpus, not to this test. `test_the_corpus_fixture_still_requires_aliasing` asserts its header is *not* canonical, so if the corpus ever renames those columns the end-to-end case fails loudly instead of passing while exercising no aliasing.
- **Tool-description guards, revert-proofed.** Nothing tested the description before — which is exactly how it drifted and stayed wrong. Reverting `tools_spec.py` alone fails all three new guards.

Local: `uvx ruff check` clean, `ty check` at the baseline 9.

Note: the full local suite shows the pre-existing load-sensitive flakes filed as #406 (they fail on clean `main` too, and pass in CI's 16 shards).

Refs #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
