### PR TITLE
fix(ui): pass resume provenance down instead of inferring it from state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2028,11 +2028,23 @@ HITL and lives **outside** the spine, in the interactive entrypoint
 #### 14.6.1 The interactive entrypoint (`builder/agents/build.py`)
 
 `BuildMode` (`PIPELINE` / `REACT`) is the single switch that selects a variant, and
-`run_build(mode, engine, *, provider=None, model=None, base_url=None, output=None)`
-dispatches to it — `PIPELINE` → `run_interactive_build` (below), `REACT` →
-`run_interactive_agent` (§4). `main.py` derives the mode from `--legacy-react`
-(`BuildMode.from_cli`) and the eval harness maps its `--arch` string onto the same
-enum (`BuildMode(arch)`), so A/B is chosen in **one** place (#309).
+`run_build(mode, engine, *, provider=None, model=None, base_url=None, output=None,
+resumed=False)` dispatches to it — `PIPELINE` → `run_interactive_build` (below),
+`REACT` → `run_interactive_agent` (§4). `main.py` derives the mode from
+`--legacy-react` (`BuildMode.from_cli`) and the eval harness maps its `--arch`
+string onto the same enum (`BuildMode(arch)`), so A/B is chosen in **one** place
+(#309).
+
+**Session provenance is passed, never inferred (#410).** `resumed` states whether
+the run was loaded from a saved session (`--resume`) or started fresh, and reaches
+**both** arms. Only the CLI knows: `engine.initialize(--input)` populates
+`scanned_files` — and the drafters may populate entities — before either arm
+begins, so a populated `CrateState` is *not* evidence of a resume. Anything that
+branches on resume-ness (the session banner's title, the ReAct greeting prompt and
+its offline fallback) takes this flag; `ui.print_resume_summary(engine, *, resumed)`
+makes it a **required** keyword so no call site can quietly re-derive it from state
+content. Content emptiness still decides whether the banner appears at all — that
+is a separate question from where the content came from.
 
 `run_interactive_build(engine, *, pipeline_runner=None, guidance_runner=None,
 exporter=None, output=None) -> dict` joins the two halves into the end-to-end

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -116,6 +116,7 @@ def run_interactive_build(
     exporter: Exporter | None = None,
     output: OutputChannel | None = None,
     overrides: ModelOverrides | None = None,
+    resumed: bool = False,
 ) -> dict[str, Any]:
     """Run the automated pipeline, the HITL guidance tail, then export to disk.
 
@@ -224,7 +225,7 @@ def run_interactive_build(
         from builder.agents import ui
 
         if interactive:
-            ui.print_resume_summary(engine)
+            ui.print_resume_summary(engine, resumed=resumed)
         with spinner_ctx:
             result = _run_build_body(
                 engine,
@@ -253,6 +254,7 @@ def run_build(
     model: str | None = None,
     base_url: str | None = None,
     output: OutputChannel | None = None,
+    resumed: bool = False,
 ) -> dict[str, Any] | None:
     """Dispatch a build to *mode*'s entrypoint — the single A/B switch (#309).
 
@@ -270,6 +272,12 @@ def run_build(
     ``--model X`` A/B ran the two arms on two different models (#399). ``output``
     remains pipeline-only; the ReAct loop has no progress sink.
 
+    ``resumed`` likewise reaches **both** modes. It is the caller's fact — in the
+    CLI, ``bool(args.resume)`` — and must never be re-derived downstream from how
+    populated ``engine.state`` looks: ``initialize(--input)`` scans files before
+    either arm starts, so content-based inference reports every fresh run as a
+    resume (#410).
+
     Args:
         mode: Which variant to run.
         engine: An initialized :class:`~builder.engine.AgentEngine`.
@@ -277,6 +285,8 @@ def run_build(
         model: Model-name override.
         base_url: Custom OpenAI-compatible base URL.
         output: Progress/summary sink for the pipeline path (e.g. ``print``).
+        resumed: True iff this run was started from a saved session
+            (``--resume``), as opposed to a fresh scan.
 
     Returns:
         The pipeline result dict for :attr:`BuildMode.PIPELINE`; ``None`` for
@@ -285,7 +295,13 @@ def run_build(
     if mode is BuildMode.REACT:
         from builder.agents.react.agent_loop import run_interactive_agent
 
-        run_interactive_agent(engine, provider=provider, model=model, base_url=base_url)
+        run_interactive_agent(
+            engine,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            resumed=resumed,
+        )
         return None
 
     from builder.agents.llm import ModelOverrides
@@ -294,6 +310,7 @@ def run_build(
         engine,
         output=output,
         overrides=ModelOverrides(provider=provider, model=model, base_url=base_url),
+        resumed=resumed,
     )
 
 

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -1415,6 +1415,8 @@ def run_interactive_agent(
     model: str | None = None,
     base_url: str | None = None,
     max_iterations: int | None = None,
+    *,
+    resumed: bool = False,
 ) -> None:
     """Run an interactive LangChain agent loop reading from stdin.
 
@@ -1432,6 +1434,12 @@ def run_interactive_agent(
         max_iterations: Maximum tool-calling iterations. Falls back to
             ``VITRO_MAX_ITERATIONS`` env var, then config file
             ``[agent.max_iterations]``, then built-in default (100).
+        resumed: True iff the session was loaded with ``--resume``. Selects the
+            greeting and the banner title. It is passed in, never inferred from
+            ``engine.state``: a fresh ``--input`` run has already scanned files by
+            the time the loop starts, so the old content-based guess greeted new
+            sessions as resumes and asked the model to recap work that did not
+            exist — which produced a passive summary instead of a build (#410).
     """
     from langchain_core.messages import AIMessage, HumanMessage
     from langchain_core.runnables import RunnableConfig
@@ -1505,21 +1513,25 @@ def run_interactive_agent(
             return
         console.print(ui.render_reply(content))
 
-    # ── Resume summary vs fresh greeting ────────────────────────────────
+    # ── Session banner + greeting ───────────────────────────────────────
+    # `resumed` is the caller's fact (--resume), never a guess from how populated
+    # the state looks: initialize(--input) scans files before the loop starts, so
+    # the old `entity_count > 0 or file_count > 0` inference called every fresh
+    # run a resume and told the model to summarise work that did not exist — the
+    # model duly recapped instead of building (#410).
     entity_count = len(engine.state.list_entities())
     file_count = len(engine.state.scanned_files)
-    is_resume = entity_count > 0 or file_count > 0
+    val = engine.state.validation
+    # Per-type entity breakdown (feeds the greeting prompt + the fallback panels).
+    counts: dict[str, int] = {}
+    for e in engine.state.list_entities():
+        typ = getattr(e, "type", "Unknown")
+        counts[typ] = counts.get(typ, 0) + 1
 
-    if is_resume:
-        val = engine.state.validation
-        # Per-type entity breakdown (also feeds the greeting prompt + fallback).
-        counts: dict[str, int] = {}
-        for e in engine.state.list_entities():
-            typ = getattr(e, "type", "Unknown")
-            counts[typ] = counts.get(typ, 0) + 1
+    # A no-op when there is nothing to show; the title reflects real provenance.
+    ui.print_resume_summary(engine, resumed=resumed)
 
-        ui.print_resume_summary(engine)
-
+    if resumed:
         # Tell the LLM about the current state so it can give a contextual greeting
         greeting_prompt = (
             f"The user has resumed a session with {entity_count} entities and "
@@ -1531,6 +1543,15 @@ def run_interactive_agent(
             f"Entity breakdown: {counts}. "
             "Briefly welcome them back and summarise what has been done "
             "and what the next logical step is."
+        )
+    elif file_count:
+        # New session whose input folder is already scanned. Say what WILL be
+        # built — asking for a recap here is what made the agent go passive.
+        greeting_prompt = (
+            f"The user has just started a new session; {file_count} input files "
+            "have been scanned and no entities have been drafted yet. "
+            "Briefly say what you will build from those files and invite them to "
+            "start. Do not imply any prior work exists."
         )
     else:
         greeting_prompt = "Greet the user and tell them what you can help build."
@@ -1596,11 +1617,10 @@ def run_interactive_agent(
         reply = _extract_reply(result) if (outcome == "ok" and result) else ""
         if reply:
             _print_reply(reply)
+        elif resumed:
+            _print_resume_fallback()
         else:
-            if is_resume:
-                _print_resume_fallback()
-            else:
-                _print_fresh_fallback()
+            _print_fresh_fallback()
     except Exception as exc:
         logger.debug("Greeting skipped: %s", exc)
         console.print(
@@ -1612,7 +1632,7 @@ def run_interactive_agent(
                 border_style="yellow",
             )
         )
-        if is_resume:
+        if resumed:
             _print_resume_fallback()
         else:
             _print_fresh_fallback()

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -266,8 +266,15 @@ def render_reply(content: Any) -> RenderableType:
     return Group("", "", grid, "")
 
 
-def render_resume_summary(snap: UiSnapshot) -> RenderableType:
-    """The "Resumed Session" panel — session id, counts, MIT, validation, breakdown."""
+def render_resume_summary(snap: UiSnapshot, *, resumed: bool) -> RenderableType:
+    """The session summary panel — session id, counts, MIT, validation, breakdown.
+
+    *resumed* is the panel's provenance and is **mandatory**: it decides only the
+    title ("Resumed Session" vs "Session"), never the body. It cannot be derived
+    from *snap* — a fresh ``--input`` run has already scanned files (and may have
+    drafted entities) by the time this renders, so a populated snapshot is not
+    evidence of a resume (#410). The caller knows; the renderer must be told.
+    """
     summary = Table.grid(padding=(0, 2))
     summary.add_column(style="bold", width=16)
     summary.add_column(style="white")
@@ -298,7 +305,8 @@ def render_resume_summary(snap: UiSnapshot) -> RenderableType:
         )
         summary.add_row("Breakdown:", parts)
 
-    return Panel(summary, title="[yellow]Resumed Session[/yellow]", border_style="yellow")
+    title = "Resumed Session" if resumed else "Session"
+    return Panel(summary, title=f"[yellow]{title}[/yellow]", border_style="yellow")
 
 
 def render_goodbye(
@@ -352,16 +360,20 @@ def print_status_bar(engine: AgentEngine) -> None:
     get_console().print(render_status_bar(snapshot_from_engine(engine)))
 
 
-def print_resume_summary(engine: AgentEngine) -> None:
-    """Print the resume summary panel when the session carries prior work (both arms).
+def print_resume_summary(engine: AgentEngine, *, resumed: bool) -> None:
+    """Print the session summary panel when there is anything to show (both arms).
 
-    A no-op on a fresh session (no entities, no scanned files) — there is nothing
-    to summarise — so callers need no guard of their own.
+    A no-op on an empty session (no entities, no scanned files) — there is nothing
+    to summarise — so callers need no guard of their own. That emptiness check is
+    about *content*; it is not a resume test. *resumed* carries provenance and is
+    mandatory precisely so no call site can fall back to inferring it from content
+    (#410) — the two are independent, and conflating them is what labelled every
+    fresh ``--input`` run a resume.
     """
     snap = snapshot_from_engine(engine)
     if snap.entity_count or snap.file_count:
         console = get_console()
-        console.print(render_resume_summary(snap))
+        console.print(render_resume_summary(snap, resumed=resumed))
         console.print()
 
 

--- a/main.py
+++ b/main.py
@@ -524,6 +524,10 @@ def main(argv: list[str] | None = None) -> int:
             model=args.model,
             base_url=args.api_base,
             output=print,
+            # This is the only place that knows whether the session was loaded or
+            # freshly scanned; both arms are told rather than left to infer it
+            # from state that --input has already populated (#410).
+            resumed=bool(args.resume),
         )
         return 0
 

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -20,6 +20,7 @@ import dataclasses
 import io
 from types import SimpleNamespace
 
+import pytest
 from rich.console import Console, RenderableType
 
 from builder.agents import ui
@@ -251,7 +252,7 @@ def test_render_reply_flattens_structured_content_no_leak() -> None:
 
 
 def test_render_resume_summary_shows_session_and_breakdown() -> None:
-    text = _render(ui.render_resume_summary(_snapshot()))
+    text = _render(ui.render_resume_summary(_snapshot(), resumed=True))
     assert "Resumed Session" in text
     assert "sess-1" in text
     assert "Investigation" in text
@@ -262,8 +263,26 @@ def test_render_resume_summary_shows_session_and_breakdown() -> None:
 
 def test_render_resume_summary_hides_mit_when_unassessed() -> None:
     """An unassessed crate omits the MIT row rather than showing a misleading 0%."""
-    text = _render(ui.render_resume_summary(_snapshot(mit_assessed=False, mit_score=0.0)))
+    text = _render(
+        ui.render_resume_summary(_snapshot(mit_assessed=False, mit_score=0.0), resumed=True)
+    )
     assert "MIT score" not in text
+
+
+def test_render_resume_summary_does_not_claim_resume_on_a_fresh_session() -> None:
+    """A never-resumed session must not be titled "Resumed" (#410).
+
+    The panel is still worth showing on a fresh ``--input`` run — session id and
+    scanned-file count are a useful preflight — but the *same populated snapshot*
+    must read as a plain session when the run did not come from ``--resume``.
+    """
+    snap = _snapshot()
+    assert "Resumed" in _render(ui.render_resume_summary(snap, resumed=True))
+    text = _render(ui.render_resume_summary(snap, resumed=False))
+    assert "Resumed" not in text
+    # The body still carries the useful preflight facts.
+    assert "sess-1" in text
+    assert "Investigation" in text
 
 
 # ---------------------------------------------------------------------------
@@ -305,15 +324,35 @@ def test_print_status_bar_prints_for_engine(monkeypatch) -> None:
 def test_print_resume_summary_prints_when_populated(monkeypatch) -> None:
     rec = _rec()
     monkeypatch.setattr(ui, "get_console", lambda: rec)
-    ui.print_resume_summary(_real_engine())
+    ui.print_resume_summary(_real_engine(), resumed=True)
     assert "Resumed Session" in rec.export_text()
 
 
 def test_print_resume_summary_is_noop_on_fresh_session(monkeypatch) -> None:
     rec = _rec()
     monkeypatch.setattr(ui, "get_console", lambda: rec)
-    ui.print_resume_summary(_real_engine(populated=False))
+    ui.print_resume_summary(_real_engine(populated=False), resumed=False)
     assert rec.export_text() == ""
+
+
+def test_print_resume_summary_does_not_claim_resume_after_a_scan(monkeypatch) -> None:
+    """Scanned files alone must not read as a resume (#410).
+
+    ``engine.initialize(--input)`` fills ``scanned_files`` before either arm prints
+    its banner, so the old content-based gate (``entity_count or file_count``) made
+    a brand-new session indistinguishable from a resumed one. Provenance is a
+    caller fact, so the adapter must be *told*, never left to infer.
+    """
+    rec = _rec()
+    monkeypatch.setattr(ui, "get_console", lambda: rec)
+    ui.print_resume_summary(_real_engine(), resumed=False)
+    assert "Resumed" not in rec.export_text()
+
+
+def test_print_resume_summary_requires_explicit_provenance() -> None:
+    """``resumed`` is keyword-only and mandatory — no silently-wrong default (#410)."""
+    with pytest.raises(TypeError):
+        ui.print_resume_summary(_real_engine())  # ty: ignore[missing-argument]
 
 
 def test_print_goodbye_prints_for_engine(monkeypatch) -> None:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1714,6 +1714,82 @@ class TestTimeoutEndsTurnGracefully:
         assert backstop_calls["n"] >= 1
 
 
+class TestGreetingProvenance:
+    """The greeting reflects real ``--resume`` provenance, not inferred state (#410).
+
+    ``engine.initialize(--input)`` populates ``scanned_files`` before the loop
+    starts, so the old ``is_resume = entity_count > 0 or file_count > 0`` inference
+    told the model a brand-new session had been *resumed* and asked it to
+    "summarise what has been done" — work that does not exist. The observed
+    consequence was a passive recap instead of a build.
+    """
+
+    @staticmethod
+    def _capture_greeting(monkeypatch, *, resumed, scanned=6, entities=0):
+        """Run the loop to its one-shot greeting and return the prompt it sent."""
+        from langchain_core.messages import AIMessage
+
+        from builder.agents.react import agent_loop
+        from builder.engine import AgentEngine
+        from builder.state import Entity, FileClassification
+
+        engine = AgentEngine()
+        engine.state.session_id = "test_greeting_410"
+        for i in range(entities):
+            engine.state.add_entity(Entity(entity_id=f"e{i}", type="Investigation"))
+        engine.state.scanned_files = [
+            FileClassification(
+                path=f"/d/f{i}.csv", filename=f"f{i}.csv", size=10, mime_type="text/csv"
+            )
+            for i in range(scanned)
+        ]
+
+        seen: list[str] = []
+
+        class _RecordingApp:
+            def invoke(self, payload, config):
+                seen.append(str(payload["messages"][0].content))
+                return {"messages": [AIMessage(content="ok")]}
+
+        def _eof(console, label="❯"):
+            raise EOFError
+
+        monkeypatch.setattr(agent_loop, "_build_chat_model", lambda **kw: object())
+        monkeypatch.setattr(agent_loop, "_build_agent_graph", lambda *a, **k: _RecordingApp())
+        monkeypatch.setattr(agent_loop.ui, "boxed_input", _eof)
+        monkeypatch.setattr(agent_loop, "_finish_backstop", lambda eng, *, emit=None: None)
+
+        import builder.tools.session as session_mod
+
+        monkeypatch.setattr(session_mod, "save_session", lambda *a, **k: {"success": True})
+
+        agent_loop.run_interactive_agent(engine, resumed=resumed)
+        assert seen, "the greeting invoke never happened"
+        return seen[0]
+
+    def test_a_fresh_scan_is_not_greeted_as_a_resume(self, monkeypatch):
+        """Scanned files with no entities is a NEW session, however full state looks."""
+        prompt = self._capture_greeting(monkeypatch, resumed=False, scanned=6)
+        lowered = prompt.lower()
+        assert "resumed" not in lowered
+        assert "welcome them back" not in lowered
+        # The bug's active ingredient: asking for a recap of nonexistent work.
+        assert "summarise what has been done" not in lowered
+        # It should still know the files are there, so it can offer to build them.
+        assert "6" in prompt
+
+    def test_a_real_resume_is_greeted_as_a_resume(self, monkeypatch):
+        """``--resume`` still gets the recap greeting — the fix is provenance, not removal."""
+        prompt = self._capture_greeting(monkeypatch, resumed=True, scanned=6, entities=2)
+        assert "resumed" in prompt.lower()
+        assert "2" in prompt
+
+    def test_an_empty_fresh_session_greets_plainly(self, monkeypatch):
+        """Conversation mode (no --input) keeps the plain greeting."""
+        prompt = self._capture_greeting(monkeypatch, resumed=False, scanned=0)
+        assert "resumed" not in prompt.lower()
+
+
 # ---------------------------------------------------------------------------
 # Issue #287: export-on-completed-build (Fix A) + repeated-non-progress
 # loop-breaker (Fix B). The engine/tools are stubbed; no SHACL / LLM / network.

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -943,12 +943,44 @@ class TestSharedChrome:
 
         build.run_interactive_build(
             engine,
+            resumed=True,
             pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
             guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
             exporter=_stub_export,
         )
 
         assert "Resumed Session" in rec.export_text()
+
+    def test_interactive_fresh_scan_does_not_render_a_resume_banner(self, monkeypatch) -> None:
+        """A populated state is not a resume unless the CLI says so (#410).
+
+        Same engine shape as the resume case above — entities present — but the run
+        did not come from ``--resume``, so the banner must not claim one.
+        """
+        from builder.agents import build, ui
+        from builder.state import Entity, EntityProvenance
+
+        rec = _rec_console()
+        monkeypatch.setattr(ui, "get_console", lambda: rec)
+        engine = _engine(_InteractiveHuman())
+        engine.state.add_entity(
+            Entity(
+                entity_id="inv_001",
+                type="Investigation",
+                fields={"title": "I"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+
+        build.run_interactive_build(
+            engine,
+            resumed=False,
+            pipeline_runner=lambda eng, **kw: dict(_PIPELINE_RESULT),
+            guidance_runner=lambda eng, human, **kw: dict(_GUIDANCE_RESULT),
+            exporter=_stub_export,
+        )
+
+        assert "Resumed" not in rec.export_text()
 
     def test_interactive_build_renders_goodbye(self, monkeypatch) -> None:
         from builder.agents import build, ui

--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -76,8 +76,48 @@ class TestRunBuildDispatch:
 
         # ReAct-only kwargs are forwarded; the loop mutates state in place, so
         # run_build returns None rather than a structured pipeline result.
-        assert captured == {"provider": "openai", "model": "m", "base_url": "u"}
+        # `resumed` rides along on every dispatch and defaults to False — a build
+        # that was not told it is a resume must not present itself as one (#410).
+        assert captured == {
+            "provider": "openai",
+            "model": "m",
+            "base_url": "u",
+            "resumed": False,
+        }
         assert result is None
+
+    def test_resume_provenance_reaches_the_react_arm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--resume` is a caller fact and must survive the dispatch (#410)."""
+        import builder.agents.react.agent_loop as agent_loop
+
+        captured: dict[str, Any] = {}
+
+        def _fake_agent(engine: Any, **kw: Any) -> None:
+            captured.update(kw)
+
+        monkeypatch.setattr(agent_loop, "run_interactive_agent", _fake_agent)
+        run_build(BuildMode.REACT, object(), resumed=True)
+
+        assert captured["resumed"] is True
+
+    def test_resume_provenance_reaches_the_pipeline_arm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The same fact must reach the other arm, or the banner lies there instead."""
+        import builder.agents.build as build_mod
+
+        captured: dict[str, Any] = {}
+
+        def _fake_build(engine: Any, **kw: Any) -> dict[str, Any]:
+            captured.update(kw)
+            return {}
+
+        monkeypatch.setattr(build_mod, "run_interactive_build", _fake_build)
+        run_build(BuildMode.PIPELINE, object(), resumed=True)
+
+        assert captured["resumed"] is True
 
 
 class TestPipelineModelOverrides:


### PR DESCRIPTION
Closes #410.

## The bug

A fresh `--input` run printed a **"Resumed Session"** banner, in both arms:

```
uv run python -m main --interactive --legacy-react -i tests/fixtures/svhps26_real_input
→ ╭─ Resumed Session ─╮  Session: 20260803_102635 · Entities: 0 · Files: 6
```

The session id is the launch timestamp — nothing was resumed.

Resume-ness was **inferred from how populated the state looked**
(`entity_count > 0 or file_count > 0`, `agent_loop.py:1511` and the
`print_resume_summary` gate). `engine.initialize(--input)` scans files *before*
either arm starts, so a brand-new session was indistinguishable from a resumed
one. `args.resume` was never plumbed past `main.py`.

## Why it was not cosmetic

The same inferred flag selected ReAct's greeting prompt, which told the model the
user had *"resumed a session with **0 entities** and 6 scanned files"* and to
*"summarise what has been done"* — a recap of work that does not exist. Observed
on a fresh run: it narrated a plan and stopped. **1 model call, 0 tool calls, 0
entities.** The pipeline arm on the same input reached 62 entities with
base/ISA/Tox green.

## The fix

Thread `resumed` from the one place that knows it — `bool(args.resume)` in
`main.py` — through `run_build` into **both** arms.

- `ui.print_resume_summary(engine, *, resumed)` takes it as a **required**
  keyword, so no call site can quietly re-derive it from state content.
- A fresh run keeps the panel (session id + scanned-file count is a useful
  preflight) titled **"Session"**, and gets a greeting that says what *will* be
  built rather than what was.
- Content emptiness still decides whether the banner renders at all — that stays
  independent of where the content came from.

Verified against the real fixture (6 scanned files, 0 entities):

| `resumed` | banner | greeting |
|---|---|---|
| `False` | `Session` | "…just started a new session; 6 input files have been scanned… Do not imply any prior work exists." |
| `True` | `Resumed Session` | "…has resumed a session with N entities… summarise what has been done" |

## Tests

TDD, red confirmed first (`TypeError: unexpected keyword argument 'resumed'`).
New coverage:

- `test_render_resume_summary_does_not_claim_resume_on_a_fresh_session` — the
  *same populated snapshot* reads differently by provenance.
- `test_print_resume_summary_does_not_claim_resume_after_a_scan` — the real
  regression: scanned files alone are not a resume.
- `test_print_resume_summary_requires_explicit_provenance` — the keyword is
  mandatory, so the bug cannot return by omission.
- `TestGreetingProvenance` (3) — drives `run_interactive_agent` to its one-shot
  greeting and asserts the fresh prompt never asks for a recap.
- `test_resume_provenance_reaches_the_{react,pipeline}_arm` — the flag survives
  dispatch to both arms.

Two existing tests changed: `test_interactive_resume_renders_banner` and
`test_print_resume_summary_prints_when_populated` now pass `resumed=True`
explicitly. Their old contract — "populated state ⇒ resumed" — *is* the bug; no
assertion was weakened. `test_react_dispatches_to_agent_loop` pins the exact
forwarded kwargs, which now legitimately include `resumed`.

**Why the old tests missed it:** `test_print_resume_summary_is_noop_on_fresh_session`
used an engine with zero entities **and** zero scanned files. The real case — a
new session that has just scanned — was untested.

## Docs

AGENTS.md §14.6.1 gains the `run_build` signature and the invariant: *session
provenance is passed, never inferred*. README needs no change — the panel is not
documented there.

## Not in scope

The separate ReAct auto-start gap (the greeting invoke sits outside the
autonomous-continuation loop, so ReAct cannot self-start) is untouched here and
will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)