### PR TITLE
feat(react): add --prompt so the agent can start without a typed line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2029,8 +2029,8 @@ HITL and lives **outside** the spine, in the interactive entrypoint
 
 `BuildMode` (`PIPELINE` / `REACT`) is the single switch that selects a variant, and
 `run_build(mode, engine, *, provider=None, model=None, base_url=None, output=None,
-resumed=False)` dispatches to it — `PIPELINE` → `run_interactive_build` (below),
-`REACT` → `run_interactive_agent` (§4). `main.py` derives the mode from
+resumed=False, initial_prompt=None)` dispatches to it — `PIPELINE` →
+`run_interactive_build` (below), `REACT` → `run_interactive_agent` (§4). `main.py` derives the mode from
 `--legacy-react` (`BuildMode.from_cli`) and the eval harness maps its `--arch`
 string onto the same enum (`BuildMode(arch)`), so A/B is chosen in **one** place
 (#309).
@@ -2045,6 +2045,15 @@ its offline fallback) takes this flag; `ui.print_resume_summary(engine, *, resum
 makes it a **required** keyword so no call site can quietly re-derive it from state
 content. Content emptiness still decides whether the banner appears at all — that
 is a separate question from where the content came from.
+
+**The ReAct arm needs a kickoff; the pipeline does not (#412).** `run_pipeline` is
+code-driven and starts unprompted, but the ReAct loop's greeting invoke sits
+*outside* the autonomous-continuation loop (§4), which is keyed on a user message —
+so the loop greets and then blocks on stdin having done no work. `initial_prompt`
+(CLI `--prompt/-P`, `REACT`-only) seeds that first turn in place of the first stdin
+read; blank is treated as absent, and control passes to the ordinary autonomous
+loop immediately afterwards. It is opt-in by design: auto-continuing every greeting
+would erase the conversational character that makes ReAct a distinct arm.
 
 `run_interactive_build(engine, *, pipeline_runner=None, guidance_runner=None,
 exporter=None, output=None) -> dict` joins the two halves into the end-to-end

--- a/README.md
+++ b/README.md
@@ -138,7 +138,18 @@ uv run python -m main --interactive --provider openai --api-base http://localhos
 
 # Conversational ReAct agent (supported alternative):
 uv run python -m main --interactive --legacy-react
+
+# …and start it working straight away instead of waiting for you to type:
+uv run python -m main --interactive --legacy-react -i /path/to/experiment/ \
+    --prompt "build the crate"
 ```
+
+**Starting the ReAct agent.** The conversational arm greets you and then waits for
+an instruction — on its own it does no work, so a run left at the prompt builds
+nothing. Give it an opening instruction with `--prompt/-P` (or just type one) and
+it works autonomously from there, checking back only when it genuinely needs you.
+The session stays interactive afterwards. The default pipeline build needs none of
+this: it runs unprompted.
 
 **Where the crate is written.** The completed build is written to disk as a valid
 RO-Crate (`ro-crate-metadata.json` plus payload), and the **absolute** output path

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -255,6 +255,7 @@ def run_build(
     base_url: str | None = None,
     output: OutputChannel | None = None,
     resumed: bool = False,
+    initial_prompt: str | None = None,
 ) -> dict[str, Any] | None:
     """Dispatch a build to *mode*'s entrypoint — the single A/B switch (#309).
 
@@ -287,6 +288,9 @@ def run_build(
         output: Progress/summary sink for the pipeline path (e.g. ``print``).
         resumed: True iff this run was started from a saved session
             (``--resume``), as opposed to a fresh scan.
+        initial_prompt: ReAct-only opening message, so the loop starts working
+            instead of blocking on stdin (#412). Ignored for ``PIPELINE``, which
+            has no stdin gate — the spine runs unprompted.
 
     Returns:
         The pipeline result dict for :attr:`BuildMode.PIPELINE`; ``None`` for
@@ -301,6 +305,7 @@ def run_build(
             model=model,
             base_url=base_url,
             resumed=resumed,
+            initial_prompt=initial_prompt,
         )
         return None
 

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -1417,6 +1417,7 @@ def run_interactive_agent(
     max_iterations: int | None = None,
     *,
     resumed: bool = False,
+    initial_prompt: str | None = None,
 ) -> None:
     """Run an interactive LangChain agent loop reading from stdin.
 
@@ -1440,6 +1441,12 @@ def run_interactive_agent(
             the time the loop starts, so the old content-based guess greeted new
             sessions as resumes and asked the model to recap work that did not
             exist — which produced a passive summary instead of a build (#410).
+        initial_prompt: An opening message to drive the first turn with, instead
+            of waiting for stdin. The greeting invoke is deliberately outside the
+            autonomous-continuation loop (which is keyed on a user message), so
+            without a kickoff the loop greets and blocks having done no work
+            (#412). Blank/whitespace is treated as absent. After this seeded turn
+            the autonomous loop takes over exactly as it does for a typed line.
     """
     from langchain_core.messages import AIMessage, HumanMessage
     from langchain_core.runnables import RunnableConfig
@@ -1730,15 +1737,25 @@ def run_interactive_agent(
         return reply, outcome
 
     # ── Main loop ───────────────────────────────────────────────────────
+    # A caller-supplied kickoff drives the first turn in place of the first stdin
+    # read (#412); everything after it is an ordinary typed turn. Blank is absent.
+    pending_input: str | None = (initial_prompt or "").strip() or None
+
     while True:
         try:
             # Compact status header above each prompt (counts live here now,
             # so the prompt line stays clean).
             ui.print_status_bar(engine)
             console.print()
-            # Rounded input box (Claude Code style); falls back to a plain
-            # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
-            user_input = ui.boxed_input(console)
+            if pending_input is not None:
+                # Echo the seeded line so the transcript shows what drove the
+                # turn, exactly as boxed_input echoes a typed one.
+                user_input, pending_input = pending_input, None
+                console.print(f"[bold cyan]❯[/bold cyan] {user_input}")
+            else:
+                # Rounded input box (Claude Code style); falls back to a plain
+                # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
+                user_input = ui.boxed_input(console)
         except KeyboardInterrupt:
             # Ctrl+C: clear the line and re-prompt
             console.print()

--- a/main.py
+++ b/main.py
@@ -143,6 +143,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "see AGENTS.md §14)",
     )
     parser.add_argument(
+        "--prompt",
+        "-P",
+        help="With --interactive --legacy-react, an opening instruction (e.g. "
+        "'build the crate') that starts the agent working immediately instead of "
+        "waiting for you to type one. The session stays interactive afterwards. "
+        "Ignored by the default pipeline build, which runs unprompted.",
+    )
+    parser.add_argument(
         "--provider",
         "-p",
         type=str,
@@ -528,6 +536,10 @@ def main(argv: list[str] | None = None) -> int:
             # freshly scanned; both arms are told rather than left to infer it
             # from state that --input has already populated (#410).
             resumed=bool(args.resume),
+            # ReAct-only kickoff: without it the loop greets and blocks on stdin
+            # having done no work, because the greeting invoke sits outside the
+            # autonomous-continuation loop (#412).
+            initial_prompt=args.prompt,
         )
         return 0
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1466,7 +1466,9 @@ class _LoopHarness:
     assert auto-continuation vs prompting without any real network.
     """
 
-    def __init__(self, monkeypatch, *, replies, stdin_lines, complete_after=None):
+    def __init__(
+        self, monkeypatch, *, replies, stdin_lines, complete_after=None, initial_prompt=None
+    ):
         from builder.agents.react import agent_loop
         from builder.engine import AgentEngine
         from builder.state import Entity
@@ -1476,9 +1478,13 @@ class _LoopHarness:
         self.replies = list(replies)
         self.stdin_lines = list(stdin_lines)
         self.complete_after = complete_after
+        self.initial_prompt = initial_prompt
 
         self.invoke_count = 0
         self.stdin_reads: list[str] = []
+        # The human message that drove each counted turn, in order — lets a test
+        # assert WHAT started the work, not just that something did.
+        self.turn_messages: list[str] = []
         self.backstop_calls = 0
 
         engine = AgentEngine()
@@ -1514,6 +1520,7 @@ class _LoopHarness:
                 if _is_greeting(payload):
                     return {"messages": [AIMessage(content="Welcome back!")]}
                 harness.invoke_count += 1
+                harness.turn_messages.append(str(payload["messages"][0].content))
                 text = harness._fake_reply()
                 # Optionally mark the crate complete after N invocations so the
                 # autonomous loop can short-circuit on completion.
@@ -1557,7 +1564,7 @@ class _LoopHarness:
 
     def run(self):
         self.install()
-        self.agent_loop.run_interactive_agent(self.engine)
+        self.agent_loop.run_interactive_agent(self.engine, initial_prompt=self.initial_prompt)
 
 
 class TestAutonomousContinuation:
@@ -1788,6 +1795,81 @@ class TestGreetingProvenance:
         """Conversation mode (no --input) keeps the plain greeting."""
         prompt = self._capture_greeting(monkeypatch, resumed=False, scanned=0)
         assert "resumed" not in prompt.lower()
+
+
+class TestInitialPrompt:
+    """`--prompt` seeds the first turn so ReAct can start unattended (#412).
+
+    The greeting invoke sits OUTSIDE the autonomous-continuation loop, which is
+    keyed on a user-typed message — so without a kickoff the agent greets and then
+    blocks on stdin forever, having done no work. A caller-supplied opening message
+    drives the first turn; from there the existing loop takes over unchanged.
+    """
+
+    def test_initial_prompt_starts_work_without_reading_stdin(self, monkeypatch):
+        """The bug: no kickoff meant no work. A kickoff must not consume stdin."""
+        h = _LoopHarness(
+            monkeypatch,
+            replies=["Drafted the ISA backbone."],
+            stdin_lines=[],  # any stdin read would raise EOFError
+            complete_after=1,
+            initial_prompt="build the crate",
+        )
+        h.run()
+
+        assert h.invoke_count >= 1, "the agent never started working"
+        assert h.stdin_reads == [], "the kickoff must not consume a stdin line"
+        assert h.turn_messages[0] == "build the crate"
+
+    def test_initial_prompt_hands_over_to_the_autonomous_loop(self, monkeypatch):
+        """After the seeded turn, narration auto-continues as usual — no stdin."""
+        h = _LoopHarness(
+            monkeypatch,
+            replies=["Scanned the files.", "Drafted entities."],
+            stdin_lines=[],
+            complete_after=2,
+            initial_prompt="go",
+        )
+        h.run()
+
+        assert h.invoke_count >= 2, "the autonomous loop did not take over"
+        assert h.stdin_reads == []
+        assert h.turn_messages[0] == "go"
+        # The follow-up turn is the internal directive, not another user message.
+        assert h.turn_messages[1] == self._directive()
+
+    def test_without_an_initial_prompt_the_loop_still_waits_for_stdin(self, monkeypatch):
+        """The conversational default is unchanged — this is opt-in."""
+        h = _LoopHarness(
+            monkeypatch,
+            replies=["Working."],
+            stdin_lines=["start building"],
+            complete_after=1,
+        )
+        h.run()
+
+        assert h.stdin_reads == ["start building"]
+        assert h.turn_messages[0] == "start building"
+
+    def test_a_blank_initial_prompt_is_not_a_kickoff(self, monkeypatch):
+        """Empty/whitespace must fall through to stdin, not fire an empty turn."""
+        h = _LoopHarness(
+            monkeypatch,
+            replies=["Working."],
+            stdin_lines=["typed instead"],
+            complete_after=1,
+            initial_prompt="   ",
+        )
+        h.run()
+
+        assert h.stdin_reads == ["typed instead"]
+        assert h.turn_messages[0] == "typed instead"
+
+    @staticmethod
+    def _directive():
+        from builder.agents.react.agent_loop import _AUTO_CONTINUE_DIRECTIVE
+
+        return _AUTO_CONTINUE_DIRECTIVE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -78,11 +78,14 @@ class TestRunBuildDispatch:
         # run_build returns None rather than a structured pipeline result.
         # `resumed` rides along on every dispatch and defaults to False — a build
         # that was not told it is a resume must not present itself as one (#410).
+        # `initial_prompt` likewise defaults to None: no kickoff means the loop
+        # keeps its conversational default and waits for a typed line (#412).
         assert captured == {
             "provider": "openai",
             "model": "m",
             "base_url": "u",
             "resumed": False,
+            "initial_prompt": None,
         }
         assert result is None
 
@@ -101,6 +104,39 @@ class TestRunBuildDispatch:
         run_build(BuildMode.REACT, object(), resumed=True)
 
         assert captured["resumed"] is True
+
+    def test_initial_prompt_reaches_the_react_arm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--prompt` is the ReAct kickoff and must survive the dispatch (#412)."""
+        import builder.agents.react.agent_loop as agent_loop
+
+        captured: dict[str, Any] = {}
+
+        def _fake_agent(engine: Any, **kw: Any) -> None:
+            captured.update(kw)
+
+        monkeypatch.setattr(agent_loop, "run_interactive_agent", _fake_agent)
+        run_build(BuildMode.REACT, object(), initial_prompt="build the crate")
+
+        assert captured["initial_prompt"] == "build the crate"
+
+    def test_initial_prompt_is_not_forwarded_to_the_pipeline_arm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The pipeline auto-runs and takes no opening message — mode-specific kwarg."""
+        import builder.agents.build as build_mod
+
+        captured: dict[str, Any] = {}
+
+        def _fake_build(engine: Any, **kw: Any) -> dict[str, Any]:
+            captured.update(kw)
+            return {}
+
+        monkeypatch.setattr(build_mod, "run_interactive_build", _fake_build)
+        run_build(BuildMode.PIPELINE, object(), initial_prompt="ignored here")
+
+        assert "initial_prompt" not in captured
 
     def test_resume_provenance_reaches_the_pipeline_arm(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,6 +135,28 @@ class TestInteractiveDispatch:
         args = parse_args(["--interactive", "--legacy-react"])
         assert args.legacy_react is True
 
+    def test_prompt_flag_is_parsed(self):
+        """`--prompt/-P` carries the ReAct kickoff message (#412)."""
+        assert parse_args(["--interactive"]).prompt is None
+        assert parse_args(["--interactive", "--prompt", "build it"]).prompt == "build it"
+        assert parse_args(["--interactive", "-P", "go"]).prompt == "go"
+
+    def test_prompt_flag_reaches_the_react_loop(self, monkeypatch):
+        """The kickoff must survive main -> run_build -> the loop (#412)."""
+        self._stub_config(monkeypatch)
+        captured: dict = {}
+
+        import builder.agents.react.agent_loop as agent_loop
+
+        monkeypatch.setattr(
+            agent_loop,
+            "run_interactive_agent",
+            lambda engine, **kw: captured.update(kw),
+        )
+
+        assert main(["--interactive", "--legacy-react", "--prompt", "build the crate"]) == 0
+        assert captured["initial_prompt"] == "build the crate"
+
     def test_default_interactive_routes_to_pipeline_build(self, monkeypatch, tmp_path):
         """--interactive (no opt-in) runs the deterministic pipeline + guidance.
 


### PR DESCRIPTION
Closes #412. **Recovery PR — supersedes #413, which never reached `main`.**

## Why this PR exists

#413 was stacked on `jh-410-resume-flag-provenance`. #411 was **squash**-merged,
which closes a PR without merging its *branch*, so GitHub never retargeted #413 to
`main` — it merged into the orphaned base instead. Net effect: `--prompt` is absent
from `main` and #412 stayed open. This is the same commit (`0e0f759`) cherry-picked
onto current `main`; it applied cleanly, and the #410 resume fix already on `main`
(`e7617be`) is untouched and coexists correctly.

Verified: `git merge-base --is-ancestor` showed neither commit on `main`; `--prompt`
absent from `main:main.py`; both changes now present together on this branch.

---

## The bug

`--interactive --legacy-react -i <folder>` scans the input, greets you, and then
**stops at an empty prompt having done no work**.

Measured on `tests/fixtures/svhps26_real_input` (6 files) — the ReAct session's
`profile.ndjson` holds exactly **2 records: one model call, zero tool calls**. The
pipeline arm on the same input reached 62 entities with base/ISA/Tox green.

The greeting invoke sits **outside** the autonomous-continuation loop
(`agent_loop.py:1589` vs the loop seeded at :1751), and that loop is keyed on a
user-*typed* message. Nothing but a human at a keyboard can start the agent.

The continuation heuristics would have carried on correctly: the greeting reply
ends in "." and matches no `_INTERROGATIVE_OPENERS` entry, so `_reply_is_question`
→ False, and with 0 entities `_crate_is_complete` → False. Both auto-continue
conditions held. The code simply never asks.

## The fix

`--prompt/-P TEXT`, threaded `main.py → run_build → run_interactive_agent`, seeds
the first turn in place of the first stdin read:

```bash
uv run python -m main --interactive --legacy-react -i tests/fixtures/svhps26_real_input \
    --prompt "build the crate"
```

- Blank/whitespace is treated as absent — it falls through to stdin rather than
  firing an empty turn.
- The seeded line is echoed (`❯ build the crate`) so the transcript shows what
  drove the turn, exactly as a typed line is echoed.
- Control passes to the ordinary autonomous loop immediately afterwards, and **the
  session stays interactive** — unlike the `echo … |` workaround, which hits EOF
  right after the turn and exits.

**Opt-in on purpose.** Auto-continuing every greeting would erase the
conversational character that makes ReAct a distinct arm; the flag gives
determinism when you want it (scripted runs, fair A/B) and leaves the default
alone. ReAct-only — the pipeline spine already runs unprompted.

## Tests

TDD, 8 red first (`TypeError: unexpected keyword argument 'initial_prompt'`,
`'Namespace' object has no attribute 'prompt'`).

- `test_initial_prompt_starts_work_without_reading_stdin` — the regression itself:
  work happens **and** `stdin_reads == []`.
- `test_initial_prompt_hands_over_to_the_autonomous_loop` — turn 2 is the internal
  `_AUTO_CONTINUE_DIRECTIVE`, not another user message.
- `test_without_an_initial_prompt_the_loop_still_waits_for_stdin` — the
  conversational default is unchanged.
- `test_a_blank_initial_prompt_is_not_a_kickoff`.
- `test_initial_prompt_{reaches_the_react_arm,is_not_forwarded_to_the_pipeline_arm}`.
- `test_prompt_flag_{is_parsed,reaches_the_react_loop}` — end-to-end through `main`.

`_LoopHarness` gains a `turn_messages` recorder so a test can assert *what* started
the work, not merely that something did. `test_react_dispatches_to_agent_loop` pins
exact forwarded kwargs, which now legitimately include `initial_prompt`.

Full suite on this branch: **1877 passed, 1 skipped, 1 xpassed, 0 failed.** Ruff clean.

## Docs

README gains the flag, an example, and a short "Starting the ReAct agent" note —
that the conversational arm does nothing until instructed is exactly the trap this
fixes. AGENTS.md §14.6.1 gains the signature and the contract, including why it is
opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)