### PR TITLE
fix(pipeline): wire the plan's condition_table role, guard the valueUrl it breaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -939,7 +939,15 @@ Lane D): `well_id`, `assay`, `cell_line`, `compound`, `concentration_value`,
 `control` — each with a `datatype` + ontology `propertyUrl` (and a `valueUrl`
 resolving the cell-line/compound columns to their in-crate Sample /
 MolecularEntity id). Population fills whatever columns the data provides; the
-schema describes all 10 and missing cells are written empty. It targets the
+schema describes all 10 and missing cells are written empty.
+
+A column's `valueUrl` is a claim about **every row in that column**, so it holds
+only while the column carries at most one distinct value. Once rows exist,
+`data_content.condition_table_multivalued_columns` reads the populated CSV back
+and any column with ≥2 distinct values **drops** its `valueUrl` rather than assert
+an unverified per-value mapping (D5, #408). The guard is per-column — a
+single-compound plate keeps its claim; a multi-compound one loses only `compound`.
+Per-value entity mapping is out of scope. It targets the
 exact path the build wires (`_crate_mapping._condition_table_rel`), so the #94
 CSVW typing (`tableSchema`) stays attached to the populated table. The companion
 bridge `data_content.csvw_to_frictionless(_CONDITION_TABLE_COLUMNS)` converts
@@ -1679,6 +1687,14 @@ re-implementation. Its parts:
   EndpointReadout/DataAnalysis outputs the build otherwise lacks (closing the §14.3
   Violation trap) and wires a whole chain in one idempotent call (§5 Derivation
   Chain Tools).
+- **Plan file roles** — the extraction leaf classifies each plan file
+  (`raw`/`processed`/`condition_table`/`other`) and the spine **consumes** that
+  classification: the single `condition_table` entry is written into the Exposure's
+  typed CSV via `populate_condition_table` (#408). A role the spine cannot act on is
+  a bug, not a spare field — the plan is not paid for in drafter tokens to be
+  discarded. Plan-named files resolve through `_scanned_path_for_name`: matched by
+  **basename** (the leaf only ever sees `f.filename`, never `f.path`) and fail-closed
+  to `approved_scan_roots`, since plan paths are LLM free text.
 - **The spine** — `run_pipeline` (`builder/agents/pipeline/pipeline.py`, §14.5), the
   code-driven orchestrator and the default `main.py --interactive` build (via
   `run_interactive_build`, §14.6.1); also selectable in the eval harness

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1066,19 +1066,37 @@ def _extract_title_from_pdf_text(text: str) -> str | None:
     return None
 
 
-def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
-    """Path of the scanned PDF a plan publication *title* refers to, or ``None``.
+def _scanned_path_for_name(
+    engine: AgentEngine, name: str, *, suffix: str | None = None
+) -> str | None:
+    """Path of the scanned file *name* refers to, matched by BASENAME, or ``None``.
 
-    A plan publication is treated as PDF-backed when its ``title`` itself names a
-    PDF (ends in ``.pdf``) and a scanned file matches it by basename — the common
-    #245 case where the extractor returned the filename as the title. The returned
-    path is **fail-closed to ``approved_scan_roots``** (the containment guard the
-    rest of the spine uses), so the publication path never widens filesystem
-    access. Returns ``None`` when the title is an ordinary article title (resolve
-    it directly) or names no scanned PDF.
+    The single resolver for "the plan named a file; which scanned file is that?"
+    — shared by the #245 publication-PDF path and the #408 condition table.
+
+    **Basename, deliberately.** :func:`_gather_context` shows the extraction leaf
+    only ``f.filename``, never ``f.path``, so a plan can only ever name a bare
+    basename. Comparing full paths would make any caller look wired and silently
+    never fire.
+
+    The result is **fail-closed to ``approved_scan_roots``** via the same
+    :func:`builder.tools.scanner._contain` guard the rest of the spine uses: plan
+    paths are LLM free text, so resolving one must never widen filesystem access.
+
+    Args:
+        engine: The engine whose ``state.scanned_files`` is the inventory.
+        name: The plan's file reference (a basename, possibly with directories).
+        suffix: When given, require *name* to end with it (case-insensitive) —
+            e.g. ``".pdf"`` for the publication case. ``None`` accepts any name.
+
+    Returns:
+        The scanned file's path, or ``None`` when *name* is empty, fails the
+        *suffix* test, matches no scanned file, or resolves outside the roots.
     """
-    candidate = title.strip()
-    if not candidate.lower().endswith(".pdf"):
+    candidate = (name or "").strip()
+    if not candidate:
+        return None
+    if suffix is not None and not candidate.lower().endswith(suffix.lower()):
         return None
 
     from pathlib import PurePath
@@ -1093,13 +1111,106 @@ def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
             continue
         # Fail-closed: only read a file that resolves inside an approved root.
         if _contain(f.path, roots) is None:
-            logger.debug(
-                "Publication PDF %s is outside approved scan roots — skipping (#245).",
-                f.path,
-            )
+            logger.debug("Scanned file %s is outside approved scan roots — refusing.", f.path)
             return None
         return f.path
     return None
+
+
+def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
+    """Path of the scanned PDF a plan publication *title* refers to, or ``None``.
+
+    A plan publication is treated as PDF-backed when its ``title`` itself names a
+    PDF (ends in ``.pdf``) and a scanned file matches it by basename — the common
+    #245 case where the extractor returned the filename as the title. Returns
+    ``None`` when the title is an ordinary article title (resolve it directly) or
+    names no scanned PDF inside the approved roots.
+    """
+    return _scanned_path_for_name(engine, title, suffix=".pdf")
+
+
+def _populate_condition_table_from_plan(
+    engine: AgentEngine, plan: dict[str, Any], exposure_id: str
+) -> dict[str, Any]:
+    """Write the plan's ``condition_table`` file into the Exposure's CSV (#408).
+
+    The extraction leaf classifies every plan file into
+    ``raw``/``processed``/``condition_table``/``other``, but the spine re-derived a
+    role from the filename (:func:`_file_role`, which only returns
+    ``raw_data``/``processed_data``) and dropped the answer — so ``condition_table``
+    was unreachable and every exported table shipped header-only while the per-well
+    payload sat beside it as an untyped ``File``.
+
+    Deterministic and conservative:
+
+    * exactly ONE ``condition_table`` entry is actionable — zero or several and the
+      spine records why and does nothing rather than guess which plate map is the
+      design table;
+    * the path is resolved through :func:`_scanned_path_for_name` (basename match,
+      fail-closed to ``approved_scan_roots``);
+    * the write goes through ``engine.run_tool("populate_condition_table", ...)``,
+      never a hand-rolled CSV, so it lands on the exact path
+      :func:`~builder.tools._crate_mapping._synth_condition_table` types as a
+      ``csvw:Table`` and the #94/#180 schema stays attached. ``output_dir`` is left
+      to the tool, which resolves it the same way ``export_crate`` does (#381).
+
+    Never raises: a tool failure is logged and reported as a reason, so one bad
+    plate map cannot break the spine.
+
+    Returns:
+        ``{"populated": bool, "reason": str}`` plus, on success, the tool's
+        ``rows`` / ``path`` / ``unmapped_source_columns``. Surfaced in
+        :func:`_materialize_plan`'s result so it reaches ``run_pipeline``.
+    """
+    entries = [f for f in (plan.get("files") or []) if isinstance(f, dict)]
+    candidates = [e for e in entries if str(e.get("role") or "").strip() == "condition_table"]
+    if not candidates:
+        return {"populated": False, "reason": "no plan file is classified as condition_table"}
+    if len(candidates) > 1:
+        names = ", ".join(sorted(str(c.get("path") or "?") for c in candidates))
+        return {
+            "populated": False,
+            "reason": f"{len(candidates)} condition_table candidates ({names}) — refusing to guess",
+        }
+
+    named = str(candidates[0].get("path") or "").strip()
+    if not named:
+        return {"populated": False, "reason": "the condition_table entry carries no path"}
+
+    path = _scanned_path_for_name(engine, named)
+    if path is None:
+        return {
+            "populated": False,
+            "reason": f"{named!r} matches no scanned file inside the approved scan roots",
+        }
+
+    try:
+        outcome = engine.run_tool(
+            "populate_condition_table",
+            exposure_id=exposure_id,
+            rows_or_csv_path=path,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("populate_condition_table failed for %s: %s", path, exc)
+        return {"populated": False, "reason": f"populate_condition_table raised: {exc}"}
+
+    outcome = outcome if isinstance(outcome, dict) else {}
+    if not outcome.get("ok"):
+        reason = str(outcome.get("error") or "populate_condition_table declined")
+        logger.info("Condition table not populated from %s: %s", named, reason)
+        return {"populated": False, "reason": reason}
+
+    logger.info(
+        "Populated condition table from %s: %s row(s) (#408).", named, outcome.get("rows")
+    )
+    return {
+        "populated": True,
+        "reason": "",
+        "source": named,
+        "rows": outcome.get("rows"),
+        "path": outcome.get("path"),
+        "unmapped_source_columns": outcome.get("unmapped_source_columns") or [],
+    }
 
 
 def _recover_publication_query(engine: AgentEngine, title: str) -> tuple[str, str] | None:
@@ -1206,6 +1317,14 @@ def _materialize_plan(
       ``process_chain``, each plan step's ``name`` is overlaid onto the matching
       ``process_type`` so the two paths share ONE chain (no duplicate processes).
       This runs even with NO provider, so the crate is never structurally hollow.
+    * **condition table (#408).** The ONE plan file classified
+      ``role == "condition_table"`` is written into the Exposure's typed CSVW table
+      via ``populate_condition_table``
+      (:func:`_populate_condition_table_from_plan`) — the leaf already emits that
+      role and the spine used to discard it, so every crate declared a ten-column
+      ``csvw:Table`` and shipped it header-only. Zero or several candidates → the
+      spine records why and writes nothing rather than guess. The outcome is
+      surfaced on this function's result.
     * **scanned files — ALWAYS, regardless of provider (#262).** Every
       ``engine.state.scanned_files`` entry is added as a ``File`` entity and placed
       under the scaffolded Assay (else Study) ``hasPart`` via the idempotent
@@ -1271,6 +1390,9 @@ def _materialize_plan(
         "people": 0,
         "publications": 0,
         "publications_deferred": [],
+        # #408: whether the plan's condition_table file reached the Exposure's CSV,
+        # and when it did not, why — never a silent skip.
+        "condition_table": {"populated": False, "reason": "not attempted"},
     }
 
     # Extract the candidate plan FIRST (when there is a provider + usable context),
@@ -1396,6 +1518,22 @@ def _materialize_plan(
         exposure_id = exposure_step.get("process_id") if exposure_step else None
         if exposure_id:
             _set_ref_field(engine, str(exposure_id), "chemicals", compound_ids)
+
+    # --- condition table (#408): the plan already classified one file as the
+    # per-well design table; write it into the Exposure's typed CSVW table rather
+    # than leaving the header-only placeholder beside an untyped payload File.
+    # Runs regardless of `compound_ids` — a plate map is worth populating even when
+    # no compound resolved. ---
+    exposure_for_table = (chain_by_type.get("Exposure") or {}).get("process_id")
+    if exposure_for_table:
+        result["condition_table"] = _populate_condition_table_from_plan(
+            engine, plan, str(exposure_for_table)
+        )
+    else:
+        result["condition_table"] = {
+            "populated": False,
+            "reason": "no Exposure in the process chain to attach a condition table to",
+        }
     if cell_line_ids:
         culture_step = chain_by_type.get("CellCulture")
         culture_id = culture_step.get("process_id") if culture_step else None

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1507,16 +1507,33 @@ def _build_csvw_schema(
 
 
 def _build_condition_table_schema(
-    crate: ROCrate, exp_slug: str, cells: list[Any], chems: list[Any]
+    crate: ROCrate,
+    exp_slug: str,
+    cells: list[Any],
+    chems: list[Any],
+    *,
+    multivalued: set[str] | None = None,
 ) -> ContextEntity:
     """The csvw:Schema entity describing the condition table's typed columns.
 
     The cell-line and compound columns resolve their ``valueUrl`` to the in-crate
     Sample / MolecularEntity id, so a row's value maps to its entity (#94, #180).
+
+    That is a claim about the **whole column** — ``cells[0]`` / ``chems[0]`` stand
+    for every row. It is vacuous while the table is header-only, but once rows
+    exist a multi-compound or multi-cell-line plate makes it false. *multivalued*
+    names the columns the populated CSV shows carrying more than one distinct value
+    (:func:`~builder.tools.data_content.condition_table_multivalued_columns`); each
+    one drops its ``valueUrl`` rather than assert an unverified mapping (D5, #408).
+    The guard is per-column: a single-valued ``cell_line`` keeps its claim even when
+    ``compound`` loses one.
     """
+    dropped = multivalued or set()
     value_urls: dict[str, str | None] = {
-        "cell_line": _node_id(cells[0]) if cells else None,
-        "compound": _node_id(chems[0]) if chems else None,
+        "cell_line": None
+        if "cell_line" in dropped
+        else (_node_id(cells[0]) if cells else None),
+        "compound": None if "compound" in dropped else (_node_id(chems[0]) if chems else None),
     }
     return _build_csvw_schema(
         crate,
@@ -1556,6 +1573,7 @@ def _synth_condition_table(
     # in-memory validate path (#87) skips the write; the File node below still
     # carries dest_path=rel so the metadata graph is complete for validation.
     source: str | None = None
+    multivalued: set[str] = set()
     if materialize_payload and output_dir is not None:
         dest = output_dir / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -1565,6 +1583,12 @@ def _synth_condition_table(
         # payload (its _copy_file no-ops when source and dest are the same file)
         # instead of warning "No source for …" (#128).
         source = str(dest)
+        # A pre-populated table (#408 (b)) may contradict the column-wide valueUrl
+        # the schema is about to assert; read it back and drop the claims it breaks.
+        # Local import: data_content already imports from this module.
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        multivalued = condition_table_multivalued_columns(str(dest))
     table = crate.add(
         File(
             crate,
@@ -1580,7 +1604,9 @@ def _synth_condition_table(
     # entity ids). The table points to it via tableSchema (canonical CSVW) and
     # conformsTo (RO-Crate conformance — not a bare inline tableSchema dict).
     # Issue #94.
-    schema = _build_condition_table_schema(crate, _slug(exp_pid), cells, chems)
+    schema = _build_condition_table_schema(
+        crate, _slug(exp_pid), cells, chems, multivalued=multivalued
+    )
     table["tableSchema"] = {"@id": schema.id}
     table.append_to("conformsTo", schema)
     return table

--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -394,6 +394,55 @@ def _has_value(value: Any) -> bool:
     return value is not None and str(value).strip() != ""
 
 
+def condition_table_multivalued_columns(csv_path: str) -> set[str]:
+    """Canonical columns in *csv_path* carrying more than one distinct value (#408).
+
+    The condition table's CSVW schema resolves the ``cell_line`` / ``compound``
+    columns to a single in-crate entity via ``valueUrl`` — a claim about the WHOLE
+    column. At zero rows that is vacuous; once rows exist it asserts that every
+    value in the column resolves to that one entity. On a multi-compound plate that
+    is false, so the build must drop the claim rather than inherit it (D5: never
+    assert an entity mapping that was not verified). Per-value mapping is out of
+    scope — this only reports which columns can no longer carry a column-wide
+    claim.
+
+    Blank cells are absence, not a second value, so a column of ``T4`` plus empties
+    stays single-valued. A missing/unreadable file or a header-only table yields an
+    empty set: the in-memory validate path has no CSV on disk, and no rows means
+    nothing to contradict.
+
+    Args:
+        csv_path: Path to the condition-table CSV.
+
+    Returns:
+        The canonical column titles carrying ≥2 distinct non-empty values.
+    """
+    from builder.tools._crate_mapping import _CONDITION_TABLE_HEADER
+
+    path = Path(csv_path)
+    if not path.is_file():
+        return set()
+
+    # Only canonical columns are described by the CSVW schema, so only they can
+    # carry (or lose) a valueUrl; a verbatim-copied plate map's extra headers are
+    # not the build's to reason about.
+    canonical = set(_CONDITION_TABLE_HEADER.strip("\n").split(","))
+    seen: dict[str, set[str]] = {}
+    try:
+        with path.open(newline="", encoding="utf-8") as fh:
+            for row in csv.DictReader(fh):
+                for key, value in row.items():
+                    name = str(key).strip() if key is not None else ""
+                    if name not in canonical or not _has_value(value):
+                        continue
+                    seen.setdefault(name, set()).add(str(value).strip())
+    except (OSError, UnicodeDecodeError, csv.Error) as exc:
+        logger.warning("Could not read condition table %s: %s", path, exc)
+        return set()
+
+    return {column for column, values in seen.items() if len(values) > 1}
+
+
 def populate_condition_table(
     state: Any,
     exposure_id: str,

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -2792,3 +2792,174 @@ class TestPlanChainParameterOverlay:
         assert len(chain) == len(pipeline_mod._STANDARD_CHAIN)
         for step in chain:
             assert set(step["hints"]) == {"name"}
+
+
+class TestConditionTableFromPlan:
+    """#408 (b) — the plan's ``condition_table`` role must reach the populator.
+
+    ``extract_plan`` classifies every plan file into
+    ``["raw", "processed", "condition_table", "other"]`` and the pipeline threw the
+    answer away: ``_attach_scanned_files`` re-derives a role from the filename via
+    ``_file_role``, which only ever returns ``processed_data``/``raw_data``. So
+    ``condition_table`` was unreachable by construction and every exported table
+    shipped header-only while the per-well payload sat one directory away.
+    """
+
+    _PLATE = "plate_map.csv"
+    _BODY = (
+        "well_id,assay,cell_line,compound,concentration_value,concentration_unit\n"
+        "A1,uptake,CHO-K1,Thyroxine,1.0,uM\n"
+        "A2,uptake,CHO-K1,Thyroxine,10.0,uM\n"
+    )
+
+    def _state(self, tmp_path: Path, *, name: str | None = None, body: str | None = None):
+        """A scanned state whose inventory holds a plate-map CSV under an approved root."""
+        plate = tmp_path / (name or self._PLATE)
+        plate.write_text(body if body is not None else self._BODY, encoding="utf-8")
+        state = CrateState()
+        state.metadata.title = "OATP1C1 uptake"
+        state.metadata.description = "An in vitro uptake assay."
+        state.approved_scan_roots.add(str(tmp_path.resolve()))
+        state.scanned_files = [
+            FileClassification(
+                path=str(plate),
+                filename=plate.name,
+                size=plate.stat().st_size,
+                mime_type="text/csv",
+                first_rows=None,
+            )
+        ]
+        return state, plate
+
+    def _run(self, monkeypatch, state, plan_files):
+        """Drive `_materialize_plan` with a stubbed leaf returning *plan_files*.
+
+        The backbone is scaffolded first exactly as the spine's step 1 does, so the
+        standard chain (#262) lays down the Exposure the table hangs off — without
+        it there is no Exposure and the test would pass vacuously.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        plan = {
+            "study": {"name": "OATP1C1 uptake", "description": "An uptake assay."},
+            "files": plan_files,
+        }
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+        monkeypatch.setattr(
+            pipeline_mod,
+            "extract_plan",
+            lambda context, *, overrides=None, usage_sink=None: dict(plan),
+        )
+        engine = _engine(state)
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+        assert any(
+            e.type == "LabProcess" and e.fields.get("process_type") == "Exposure"
+            for e in engine.state.list_entities()
+        ), "fixture is vacuous: no Exposure was scaffolded"
+        return engine, result
+
+    def _table_path(self, engine: AgentEngine) -> Path | None:
+        from builder.tools._crate_mapping import _condition_table_rel, _mint_id
+
+        for e in engine.state.list_entities():
+            if e.type == "LabProcess" and e.fields.get("process_type") == "Exposure":
+                out = engine.state.metadata.output_path
+                if not out:
+                    return None
+                return Path(out) / _condition_table_rel(_mint_id(e))
+        return None
+
+    def test_a_basename_match_populates_the_table(self, monkeypatch, tmp_path: Path) -> None:
+        """The core wiring: role=condition_table → real rows in the Exposure's CSV."""
+        state, _ = self._state(tmp_path)
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(
+            monkeypatch, state, [{"path": self._PLATE, "role": "condition_table"}]
+        )
+
+        table = self._table_path(engine)
+        assert table is not None and table.is_file(), "no condition table was written"
+        rows = table.read_text(encoding="utf-8").strip().splitlines()
+        assert len(rows) > 1, "the table is still header-only — the role never reached the tool"
+        assert "Thyroxine" in "\n".join(rows)
+        assert result.get("condition_table")
+
+    def test_the_model_can_only_return_a_basename_so_an_exact_path_would_never_fire(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The silent-no-op guard (#408).
+
+        ``_gather_context`` shows the leaf ``f.filename`` and never ``f.path``, so a
+        plan path is always a bare basename. Matching on full-path equality would
+        look wired and never fire once — this pins the basename contract by proving
+        the scanned path and the plan path are NOT equal, yet the table populates.
+        """
+        state, plate = self._state(tmp_path)
+        state.metadata.output_path = str(tmp_path / "crate")
+        assert str(plate) != self._PLATE, "fixture must exercise basename != full path"
+
+        engine, _ = self._run(
+            monkeypatch, state, [{"path": self._PLATE, "role": "condition_table"}]
+        )
+        table = self._table_path(engine)
+        assert table is not None and table.is_file()
+        assert len(table.read_text(encoding="utf-8").strip().splitlines()) > 1
+
+    def test_a_file_outside_the_approved_roots_is_refused(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Fail-closed: plan paths are LLM free text and must not widen file access."""
+        state, _ = self._state(tmp_path)
+        state.metadata.output_path = str(tmp_path / "crate")
+        # The inventory entry survives, but no approved root now contains it.
+        state.approved_scan_roots.clear()
+        state.approved_scan_roots.add(str((tmp_path / "elsewhere").resolve()))
+
+        engine, result = self._run(
+            monkeypatch, state, [{"path": self._PLATE, "role": "condition_table"}]
+        )
+        table = self._table_path(engine)
+        assert table is None or not table.is_file() or (
+            len(table.read_text(encoding="utf-8").strip().splitlines()) == 1
+        ), "a file outside the approved roots must never be read"
+        assert not (result.get("condition_table") or {}).get("populated")
+
+    def test_two_candidates_refuse_to_guess(self, monkeypatch, tmp_path: Path) -> None:
+        state, _ = self._state(tmp_path)
+        second = tmp_path / "other_map.csv"
+        second.write_text(self._BODY, encoding="utf-8")
+        state.scanned_files.append(
+            FileClassification(
+                path=str(second),
+                filename=second.name,
+                size=second.stat().st_size,
+                mime_type="text/csv",
+                first_rows=None,
+            )
+        )
+        state.metadata.output_path = str(tmp_path / "crate")
+
+        engine, result = self._run(
+            monkeypatch,
+            state,
+            [
+                {"path": self._PLATE, "role": "condition_table"},
+                {"path": "other_map.csv", "role": "condition_table"},
+            ],
+        )
+        outcome = result.get("condition_table") or {}
+        assert not outcome.get("populated"), "two candidates — the spine must not guess"
+        assert outcome.get("reason"), "the refusal must be recorded, not silent"
+
+    def test_no_condition_table_role_records_a_reason(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        state, _ = self._state(tmp_path)
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(
+            monkeypatch, state, [{"path": self._PLATE, "role": "raw"}]
+        )
+        outcome = result.get("condition_table") or {}
+        assert not outcome.get("populated")
+        assert outcome.get("reason")

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -354,3 +354,192 @@ class TestReactToolDescriptionMatchesTheCode:
 def test_alias_table_covers_the_documented_synonyms(source: str, canonical: str) -> None:
     got = project_condition_rows([{source: "X"}])["rows"][0]
     assert got[canonical] == "X"
+
+
+class TestMultivaluedColumns:
+    """#408 (c) — a populated column may no longer carry a column-wide ``valueUrl``.
+
+    ``_build_condition_table_schema`` asserts ``cells[0]`` / ``chems[0]`` for the
+    WHOLE cell_line / compound column. At zero rows that claim is vacuous. Once
+    rows exist it says every value in the column resolves to that one entity — so
+    populating a multi-compound plate converts unverified prose into false
+    entity-resolved claims. D5 says refuse the claim, not inherit it.
+    """
+
+    def _write(self, tmp_path: Path, rows: list[dict[str, str]]) -> Path:
+        csv_path = tmp_path / "condition_table.csv"
+        titles = [c["titles"] for c in _CONDITION_TABLE_COLUMNS]
+        with csv_path.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.DictWriter(fh, fieldnames=titles, extrasaction="ignore")
+            w.writeheader()
+            w.writerows(rows)
+        return csv_path
+
+    def test_a_single_valued_column_is_not_multivalued(self, tmp_path: Path) -> None:
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        csv_path = self._write(
+            tmp_path,
+            [
+                {"well_id": "A1", "cell_line": "CHO-K1", "compound": "T4"},
+                {"well_id": "A2", "cell_line": "CHO-K1", "compound": "T4"},
+            ],
+        )
+        got = condition_table_multivalued_columns(str(csv_path))
+        assert "compound" not in got
+        assert "cell_line" not in got
+        # Every well differs by design, so well_id IS multivalued — the function
+        # reports any canonical column, and the caller decides which ones matter.
+        assert got == {"well_id"}
+
+    def test_a_multi_compound_plate_reports_the_compound_column(self, tmp_path: Path) -> None:
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        csv_path = self._write(
+            tmp_path,
+            [
+                {"well_id": "A1", "cell_line": "CHO-K1", "compound": "T4"},
+                {"well_id": "A2", "cell_line": "CHO-K1", "compound": "T3"},
+            ],
+        )
+        got = condition_table_multivalued_columns(str(csv_path))
+        assert "compound" in got
+        assert "cell_line" not in got, "one cell line across both wells — still single-valued"
+
+    def test_non_canonical_source_columns_are_ignored(self, tmp_path: Path) -> None:
+        """A verbatim-copied plate map's extra headers have no CSVW column to guard."""
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        csv_path = tmp_path / "verbatim.csv"
+        csv_path.write_text(
+            "well_id,compound,tpo_activity_rfu\nA1,T4,101\nA2,T4,202\n", encoding="utf-8"
+        )
+        assert "tpo_activity_rfu" not in condition_table_multivalued_columns(str(csv_path))
+
+    def test_blanks_do_not_count_as_a_distinct_value(self, tmp_path: Path) -> None:
+        """An empty cell is absence, not a second compound."""
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        csv_path = self._write(
+            tmp_path,
+            [
+                {"well_id": "A1", "compound": "T4"},
+                {"well_id": "A2", "compound": ""},
+                {"well_id": "A3", "compound": "  "},
+            ],
+        )
+        assert "compound" not in condition_table_multivalued_columns(str(csv_path))
+
+    def test_a_header_only_table_is_not_multivalued(self, tmp_path: Path) -> None:
+        """The pre-#408 state: no rows, so nothing to contradict."""
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        assert condition_table_multivalued_columns(str(self._write(tmp_path, []))) == set()
+
+    def test_a_missing_file_is_not_multivalued(self, tmp_path: Path) -> None:
+        """The in-memory validate path has no CSV on disk — must not raise."""
+        from builder.tools.data_content import condition_table_multivalued_columns
+
+        assert condition_table_multivalued_columns(str(tmp_path / "nope.csv")) == set()
+
+
+class TestValueUrlDropsOnMultivaluedColumn:
+    """#408 (c), through the real crate mapping + export — not the helper alone.
+
+    The Exposure's ``chemicals`` ref field and its cultured-sample ``object`` are
+    what feed ``cells``/``chems`` into ``_build_condition_table_schema``, so these
+    build the same wiring ``_materialize_plan`` produces.
+    """
+
+    _REL = Path("data") / "LabProcess_proc_exp_condition_table.csv"
+
+    def _state(self, compound_ids: list[str]) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Exposure crate"
+
+        def add(eid: str, type_: str, **fields: object) -> None:
+            state.add_entity(
+                Entity(
+                    entity_id=eid,
+                    type=type_,  # ty: ignore[invalid-argument-type]
+                    fields=fields,
+                    _provenance=EntityProvenance(created_by="llm"),
+                )
+            )
+
+        add("samp_c", "Sample", name="Cultured CHO-K1")
+        for eid in compound_ids:
+            add(eid, "MolecularEntity", name=eid)
+        add(
+            "proc_exp",
+            "LabProcess",
+            process_type="Exposure",
+            name="Exposure step",
+            chemicals=compound_ids,
+            object=["samp_c"],
+        )
+        return state
+
+    def _export_value_urls(
+        self, out_dir: Path, csv_body: str, compound_ids: list[str]
+    ) -> dict[str, str | None]:
+        """Pre-populate the condition CSV, export, and read back column valueUrls."""
+        import json
+
+        from builder.tools.builder import export_crate
+
+        dest = out_dir / self._REL
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(csv_body, encoding="utf-8")
+
+        state = self._state(compound_ids)
+        state.metadata.output_path = str(out_dir)
+        export_crate(state)
+
+        doc = json.loads((out_dir / "ro-crate-metadata.json").read_text(encoding="utf-8"))
+        urls: dict[str, str | None] = {}
+        for node in doc["@graph"]:
+            if "csvw:Column" not in str(node.get("@type", "")):
+                continue
+            raw = node.get("valueUrl")
+            urls[str(node.get("titles") or "")] = (
+                raw.get("@id") if isinstance(raw, dict) else raw
+            )
+        return urls
+
+    _HEADER = "well_id,assay,cell_line,compound\n"
+
+    def test_single_valued_compound_column_keeps_its_valueurl(self, tmp_path: Path) -> None:
+        """The control: existing #94/#180 behaviour must survive the change."""
+        urls = self._export_value_urls(
+            tmp_path / "crate",
+            self._HEADER + "A1,uptake,CHO-K1,Thyroxine\n",
+            ["chem_t4"],
+        )
+        assert urls.get("compound"), "a single-compound plate must keep its column valueUrl"
+        assert urls.get("cell_line"), "a single-cell-line plate must keep its column valueUrl"
+
+    def test_multi_compound_column_drops_its_valueurl(self, tmp_path: Path) -> None:
+        urls = self._export_value_urls(
+            tmp_path / "crate",
+            self._HEADER + "A1,uptake,CHO-K1,Thyroxine\nA2,uptake,CHO-K1,Triiodothyronine\n",
+            ["chem_t4", "chem_t3"],
+        )
+        assert urls.get("compound") is None, (
+            "two compounds in the column — a column-wide valueUrl would be a false claim"
+        )
+        # cell_line is still single-valued, so that claim stands: the guard is
+        # per-column, not a blanket retreat.
+        assert urls.get("cell_line"), "single-valued cell_line must keep its valueUrl"
+
+    def test_header_only_table_keeps_its_valueurl(self, tmp_path: Path) -> None:
+        """The pre-#408 vacuous case is unchanged — no rows contradict the claim."""
+        urls = self._export_value_urls(tmp_path / "crate", self._HEADER, ["chem_t4"])
+        assert urls.get("compound"), "a header-only table asserts nothing to contradict"
+
+    def test_populated_rows_survive_the_export(self, tmp_path: Path) -> None:
+        """`if not dest.exists()` + ro-crate-py's samefile guard must not clobber rows."""
+        out = tmp_path / "crate"
+        body = self._HEADER + "A1,uptake,CHO-K1,Thyroxine\nA2,uptake,CHO-K1,Triiodothyronine\n"
+        self._export_value_urls(out, body, ["chem_t4", "chem_t3"])
+        assert (out / self._REL).read_text(encoding="utf-8") == body


### PR DESCRIPTION
Closes #408. Parts **(b)** and **(c)** of #381 — part (a) shipped in #407.

Branched off current `main` (`e0e2944`), no stacking this time.

## Why together

(b) manufactures the D5 breach that (c) closes: it is precisely the act of adding
rows that turns the column-wide `valueUrl` from a vacuous claim into a false one.
(c) alone would be harmless but pointless.

## (b) The pipeline never called the populator

The extraction leaf classifies every plan file into
`raw`/`processed`/`condition_table`/`other` and the spine **discarded the answer**:
`_attach_scanned_files` re-derives a role from the filename via `_file_role`, which
only ever returns `raw_data`/`processed_data`. `condition_table` was unreachable by
construction — the pipeline paid drafter-tier tokens for a classification it could
not use.

Measured: **32 of 32** condition tables under `sessions/` and `output/` were exactly
one line, while the per-well payload sat one directory away as an untyped `File`.

`_populate_condition_table_from_plan` writes the single `condition_table` entry via
`engine.run_tool("populate_condition_table", ...)` — never a hand-rolled CSV, so it
lands on the exact path `_synth_condition_table` types as a `csvw:Table` and the
#94/#180 schema stays attached. `output_dir` is left to the tool, which since #407
resolves it exactly as `export_crate` does.

Conservative by construction: zero or ≥2 candidates record a **reason** and write
nothing rather than guess which plate map is the design table. The outcome is
surfaced on `_materialize_plan`'s result so it reaches `run_pipeline`.

### Path resolution

Plan paths resolve through a new shared `_scanned_path_for_name`, hoisted from
`_pdf_path_for_publication` (#245) so both callers share one resolver:

- **Basename match, deliberately.** `_gather_context` shows the leaf only
  `f.filename`, never `f.path`, so a plan can only ever name a basename. An
  exact-path check would make the feature look wired and **silently never fire** —
  this has its own test.
- **Fail-closed to `approved_scan_roots`** via `scanner._contain`, since plan paths
  are LLM free text and must not widen filesystem access.

## (c) Populated rows turn a vacuous valueUrl into a false one

`_build_condition_table_schema` asserts `cells[0]` / `chems[0]` for the **whole**
column. At zero rows that is vacuous; once rows exist it claims every value in the
column resolves to that one entity. Populating a multi-compound plate would convert
unverified prose into false entity-resolved claims.

The build now reads the populated CSV back through
`data_content.condition_table_multivalued_columns` and drops the `valueUrl` on any
column carrying ≥2 distinct non-empty values. **Per-column**: a single-valued
`cell_line` keeps its claim while `compound` loses one. Blanks are absence, not a
second value. Per-value entity mapping stays explicitly out of scope.

## Verified end-to-end

On a real aliased plate map (`well`,`substance`,`cell`,`dose_uM` — none canonical):

```
OUTCOME: {"populated": true, "source": "plate_map.csv", "rows": 2, "unmapped_source_columns": []}

well_id,assay,cell_line,compound,concentration_value,concentration_unit,...
A1,,CHO-K1,Thyroxine,1.0,uM,,,,
A2,,CHO-K1,Triiodothyronine,10.0,uM,,,,

valueUrl cell_line -> {'@id': '#Sample_sample_proc_cell_culture_output_sample'}
valueUrl compound  -> None
```

Both halves in one pass: #381's aliasing populates real values, and the now
multi-valued `compound` column correctly loses its column-wide claim while
single-valued `cell_line` keeps its own.

## Tests

TDD, red confirmed first for both halves. 15 new tests:

**(b)** `TestConditionTableFromPlan` — the role reaches the tool and rows land; the
basename contract (asserting scanned path ≠ plan path, so an exact-path check could
not pass); fail-closed refusal outside `approved_scan_roots`; ≥2 candidates refuse
to guess **with a recorded reason**; no role records a reason. The helper asserts an
Exposure was actually scaffolded, so the fixture cannot pass vacuously.

**(c)** `TestMultivaluedColumns` (helper: single/multi/blank/header-only/missing
file/non-canonical headers) and `TestValueUrlDropsOnMultivaluedColumn` (through the
real crate mapping **and export**, not the helper alone) — including two controls
that pass before the change: single-valued keeps its `valueUrl`, header-only keeps
it, and populated rows survive export (the `if not dest.exists()` + `samefile`
contract).

Full suite: **1892 passed, 1 skipped, 1 xpassed, 0 failed.** Ruff clean.

## Docs

AGENTS.md gains the `valueUrl`-validity rule beside the condition-table section, and
a §14.4 bullet stating that plan file roles are **consumed** — a role the spine
cannot act on is a bug, not a spare field — plus the basename/fail-closed contract
for plan-named files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)