### PR TITLE
fix(context): carry the whole compound table to the extraction leaf (#419)

### DIFF
--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -295,15 +295,21 @@ _MAX_CONTEXT_CHARS = 16000
 # A tier claims its share only if it HAS files; an absent or under-spending tier
 # flows its headroom down to the next (see `_gather_context`). That flow-down is
 # what keeps a bulk-data-only deposit safe — with no metadata/doc files, the
-# first priority-3 file inherits 10,500 chars rather than being held to 500.
+# first priority-3 file inherits its own share plus every unclaimed one, rather
+# than being held to 500.
 #
 # Tier 0 was raised 6000 -> 9000 with #419. At 6000 it cut the real S-VHPS26
 # chemical table at chemical 15 of 19 — and because carry flows DOWNWARD only
 # (tier 0 is weighted first, with `carry = 0`), no other tier's headroom could
-# ever reach it. The raise is paid for entirely by the two new compaction rules,
-# which took that workbook from 22,007 chars to 8,675: the shares now total
-# 13,500 and still fit inside the unchanged `_MAX_CONTEXT_CHARS`, so the whole
-# table costs no more tokens than five chemicals used to.
+# ever reach it. Most of the raise is paid for by the two new compaction rules,
+# which took that workbook from 22,007 chars to 8,675; the rest is paid in
+# tokens, `_MAX_CONTEXT_CHARS` having moved 14000 -> 16000 in the same change.
+# The shares total 13,500 and the real deposit's emitted context grows 13,242 ->
+# 16,224 chars, about +750 tokens, for 5 chemicals -> 19.
+#
+# A share is granted PER FILE, not per tier, so raising this one starves the
+# tiers below on a multi-metadata deposit unless their shares are reserved
+# first — see the `reserved` computation in `_gather_context`.
 _TIER_SHARES: dict[int, int] = {0: 9000, 1: 2000, 2: 2000, 3: 500}
 
 # Tiers whose body is worth a full `read_file` with compaction rather than the
@@ -554,8 +560,22 @@ def _gather_context(engine: AgentEngine) -> str:
                 # Nobody claimed this tier's share; hand it to the tiers below.
                 carry += _TIER_SHARES[tier]
                 continue
+            # Reserve the shares of the POPULATED tiers below this one before
+            # sizing each file (#419). A tier's share is granted per FILE, so
+            # without this a deposit holding two `*metadata*` workbooks let them
+            # claim the whole ceiling between them and the BioStudies descriptor,
+            # SOP and README all emitted nothing — the same silent starvation
+            # this issue exists to remove, only pointed at a different document.
+            # Counted PER FILE, because the share is granted per file: a tier
+            # holding two documents needs two shares, and reserving only one
+            # still left the second (the README, behind the SOP) at zero.
+            reserved = sum(
+                share * len(by_tier.get(lower) or ())
+                for lower, share in _TIER_SHARES.items()
+                if lower > tier
+            )
             for f in files:
-                allowance = min(_TIER_SHARES[tier] + carry, budget)
+                allowance = min(_TIER_SHARES[tier] + carry, max(0, budget - reserved))
                 slice_text = _file_slice(f, approved_roots, allowance, tier)
                 # Unused headroom flows down rather than being forfeited.
                 carry = max(0, allowance - len(slice_text))

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -276,7 +276,14 @@ _DEFAULT_ASSAY_NAME = "Assay"
 # metadata workbook: compaction pays most of it back (-41% on the grid, -73% on
 # the BioStudies descriptor), but chemicals 2-5 of the real S-VHPS26 deposit sit
 # past 2,600 compacted chars and cannot be reached at 8000 under any weighting.
-_MAX_CONTEXT_CHARS = 14000
+#
+# Raised 14000 -> 16000 with #419. The two new compaction rules cut the S-VHPS26
+# workbook from 22,007 chars to 8,675, but a tier's share is granted PER FILE, so
+# seating the whole chemical table in tier 0 left the second tier-2 document (the
+# README) only 1,000 chars — below the offset its own regression token sits at.
+# The +2,000 restores that second document. Net against the old ceiling: 4x the
+# chemicals for ~500 extra tokens on one bounded cheap-model call.
+_MAX_CONTEXT_CHARS = 16000
 
 # Per-file share by `_metadata_read_priority` tier (#378). Metadata-first was
 # previously an ORDERING only: every file got an equal `_MAX_CONTEXT_CHARS // n`
@@ -289,7 +296,15 @@ _MAX_CONTEXT_CHARS = 14000
 # flows its headroom down to the next (see `_gather_context`). That flow-down is
 # what keeps a bulk-data-only deposit safe — with no metadata/doc files, the
 # first priority-3 file inherits 10,500 chars rather than being held to 500.
-_TIER_SHARES: dict[int, int] = {0: 6000, 1: 2000, 2: 2000, 3: 500}
+#
+# Tier 0 was raised 6000 -> 9000 with #419. At 6000 it cut the real S-VHPS26
+# chemical table at chemical 15 of 19 — and because carry flows DOWNWARD only
+# (tier 0 is weighted first, with `carry = 0`), no other tier's headroom could
+# ever reach it. The raise is paid for entirely by the two new compaction rules,
+# which took that workbook from 22,007 chars to 8,675: the shares now total
+# 13,500 and still fit inside the unchanged `_MAX_CONTEXT_CHARS`, so the whole
+# table costs no more tokens than five chemicals used to.
+_TIER_SHARES: dict[int, int] = {0: 9000, 1: 2000, 2: 2000, 3: 500}
 
 # Tiers whose body is worth a full `read_file` with compaction rather than the
 # scanner's 20-rows-per-sheet preview (#378). The preview cap loses chemicals 3-5
@@ -297,6 +312,15 @@ _TIER_SHARES: dict[int, int] = {0: 6000, 1: 2000, 2: 2000, 3: 500}
 # ROW before any of this budgeting runs. `_EXCEL_PREVIEW_ROWS` deliberately stays
 # at 20 — the binding constraint is chars, and raising it slows every scan.
 _COMPACTED_READ_TIERS = frozenset({0, 1})
+
+# `read_file` defaults to 100 rows per sheet, which is a *row* cut made before any
+# char budgeting runs — so it cannot be traded against the budget and leaves no
+# trace in the emitted slice. The real S-VHPS26 chemical sheet needs ~240 rows to
+# state its 19 chemicals, and the 100-row default silently cut it at chemical 8
+# (#419). Compacted tiers read to `read_excel`'s own ceiling instead; series
+# folding, not a row cut, is what keeps the result affordable.
+_COMPACTED_READ_MAX_ROWS = 500
+_DEFAULT_READ_MAX_ROWS = 100
 
 
 def _backbone_hints(engine: AgentEngine) -> dict[str, dict[str, str]]:
@@ -403,7 +427,11 @@ def _read_body_excerpt(
         return None
 
     try:
-        body = read_file(path, compact=compact)
+        body = read_file(
+            path,
+            compact=compact,
+            max_lines=_COMPACTED_READ_MAX_ROWS if compact else _DEFAULT_READ_MAX_ROWS,
+        )
     except (OSError, ValueError, ImportError) as exc:
         logger.warning("Body read failed for %s; skipping: %s", path, exc)
         return None

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -411,22 +411,49 @@ def _collapse_numbered_series(rows: list[str]) -> list[str]:
 
     A run folds only when the rows are CONSECUTIVE, share a prefix, number
     contiguously, agree on every cell but the last, and are at least
-    :data:`_MIN_SERIES_RUN` long. Anything else is emitted untouched — so a sheet
-    without a series is returned byte-identical.
+    :data:`_MIN_SERIES_RUN` long. A run that qualifies structurally is still
+    REFUSED when folding it would not round-trip:
+
+    * **a value containing the join separator.** ``1,2-dichloroethane`` and the
+      decimal comma an EU depositor may well type (``0,03``) both make the joined
+      list unreadable — the reader cannot recover how many members there were,
+      let alone which index each belongs to.
+    * **a value that is a bare ontology IRI.** The dedup pass above removes an
+      annotation cell, so a row whose value was blank collapses to
+      ``[label, IRI]`` and looks the same shape as its neighbours; folding then
+      presents the IRI *as a dose*. Refusing the run keeps the rows honest.
+    * **inconsistent zero-padding** across the run's indices, which a numeric
+      range label cannot express.
+
+    Rows are re-emitted VERBATIM whenever a run does not fold, so the index token
+    is never rewritten — ``Aliquot_007`` must not come back as ``Aliquot_7`` — and
+    a sheet without a series is returned byte-identical.
     """
     out: list[str] = []
-    run: list[tuple[str, int, list[str]]] = []
+    # (prefix, numeric index, raw index token, cells after the label, original row)
+    run: list[tuple[str, int, str, list[str], str]] = []
+
+    def _foldable() -> bool:
+        if len(run) < _MIN_SERIES_RUN:
+            return False
+        values = [cells[-1] for *_rest, cells, _row in run]
+        if any("," in v for v in values):
+            return False
+        if any(_IRI_CELL.match(v) for v in values):
+            return False
+        widths = {len(token) for _p, _i, token, _c, _r in run}
+        return len(widths) == 1 or not any(t.startswith("0") for _p, _i, t, _c, _r in run)
 
     def _flush() -> None:
         if not run:
             return
-        if len(run) < _MIN_SERIES_RUN:
-            out.extend("| " + " | ".join([f"{p}_{i}", *rest]) + " |" for p, i, rest in run)
+        if not _foldable():
+            out.extend(row for *_rest, row in run)
         else:
             prefix = run[0][0]
-            shared = run[0][2][:-1]
-            values = ", ".join(cells[-1] for _p, _i, cells in run)
-            label = f"{prefix}_{run[0][1]}-{run[-1][1]}"
+            shared = run[0][3][:-1]
+            values = ", ".join(cells[-1] for _p, _i, _t, cells, _r in run)
+            label = f"{prefix}_{run[0][2]}-{run[-1][2]}"
             out.append("| " + " | ".join([label, *shared, values]) + " |")
         run.clear()
 
@@ -443,12 +470,13 @@ def _collapse_numbered_series(rows: list[str]) -> list[str]:
             out.append(row)
             continue
 
-        prefix, index, rest = match["prefix"], int(match["index"]), cells[1:]
+        prefix, token, rest = match["prefix"], match["index"], cells[1:]
+        index = int(token)
         contiguous = run and run[-1][0] == prefix and run[-1][1] == index - 1
-        same_shape = run and run[-1][2][:-1] == rest[:-1]
+        same_shape = run and run[-1][3][:-1] == rest[:-1]
         if not (contiguous and same_shape):
             _flush()
-        run.append((prefix, index, rest))
+        run.append((prefix, index, token, rest, row))
 
     _flush()
     return out

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -322,9 +323,11 @@ def compact_grid_text(text: str) -> str:
     real S-VHPS26 workbook that noise pushes the cell line, RRID, author and
     chemicals 2-5 past any affordable context slice.
 
-    Three rules, in order: drop the repeated header row; drop the trailing
+    Four rules, in order: drop the repeated header row; drop the trailing
     Comments column **only when that sheet's own header names it** ``Comments``;
-    drop empty cells, then drop rows left with fewer than two non-empty cells.
+    drop empty cells, then drop rows left with fewer than two non-empty cells;
+    finally fold a numbered series into one row (see
+    :func:`_collapse_numbered_series`).
 
     **Rows are never dropped on the emptiness of one named column.** That rule
     looks right and destroys the General information sheet, because this
@@ -336,6 +339,7 @@ def compact_grid_text(text: str) -> str:
     out: list[str] = []
     drop_last_column = False
     seen_header = False
+    seen_iris: set[str] = set()
 
     for line in lines:
         stripped = line.strip()
@@ -344,6 +348,7 @@ def compact_grid_text(text: str) -> str:
             # per-sheet property, not a workbook-wide one.
             seen_header = False
             drop_last_column = False
+            seen_iris = set()
             out.append(line)
             continue
         if not stripped.startswith("|"):
@@ -362,9 +367,91 @@ def compact_grid_text(text: str) -> str:
         kept = [c for c in cells if c]
         if len(kept) < 2:
             continue
+        # An ontology IRI annotating a column repeats verbatim on every row it
+        # types — four of them account for 4,133 chars on the real S-VHPS26
+        # workbook. State each once per sheet (#419). Never at the cost of the
+        # row's last identifying cell: a row that would fall below two cells
+        # keeps its IRI, so no label is ever traded away for the saving.
+        deduped = [c for c in kept if not (c in seen_iris and _IRI_CELL.match(c))]
+        if len(deduped) >= 2:
+            kept = deduped
+        seen_iris.update(c for c in kept if _IRI_CELL.match(c))
         out.append("| " + " | ".join(kept) + " |")
 
-    return "\n".join(out).strip()
+    return "\n".join(_collapse_numbered_series(out)).strip()
+
+
+# A numbered series must be at least this long to be folded. Two consecutive rows
+# that merely happen to end in 1 and 2 are far more likely to be distinct
+# parameters than a series, and folding them would lose a label.
+_MIN_SERIES_RUN = 3
+
+_SERIES_KEY = re.compile(r"^(?P<prefix>.+)_(?P<index>\d+)$")
+
+# A cell that is nothing but an ontology/identifier IRI — the annotation form a
+# depositor workbook repeats per row. Deliberately anchored and whole-cell: a cell
+# that merely CONTAINS a URL alongside prose is real content and is never deduped.
+_IRI_CELL = re.compile(r"^https?://\S+$")
+
+
+def _collapse_numbered_series(rows: list[str]) -> list[str]:
+    """Fold ``<prefix>_1 … <prefix>_N`` rows that differ only in their value (#419).
+
+    A depositor-filled workbook states a dose series one row per level, repeating
+    the same ontology IRI every time::
+
+        | Chemical_1_Concentration_1 | http://nmrML.org/nmrCV#NMR:1000095 | 0.003 |
+        | Chemical_1_Concentration_2 | http://nmrML.org/nmrCV#NMR:1000095 | 0.01  |
+
+    On the real S-VHPS26 workbook 160 such rows carry 11,693 characters — 53% of
+    the whole compacted sheet — to express 19 dose series. Folding each run to one
+    row is what makes the full chemical table affordable inside the existing
+    context budget, instead of buying it with a budget increase that would cost
+    tokens on every run.
+
+    A run folds only when the rows are CONSECUTIVE, share a prefix, number
+    contiguously, agree on every cell but the last, and are at least
+    :data:`_MIN_SERIES_RUN` long. Anything else is emitted untouched — so a sheet
+    without a series is returned byte-identical.
+    """
+    out: list[str] = []
+    run: list[tuple[str, int, list[str]]] = []
+
+    def _flush() -> None:
+        if not run:
+            return
+        if len(run) < _MIN_SERIES_RUN:
+            out.extend("| " + " | ".join([f"{p}_{i}", *rest]) + " |" for p, i, rest in run)
+        else:
+            prefix = run[0][0]
+            shared = run[0][2][:-1]
+            values = ", ".join(cells[-1] for _p, _i, cells in run)
+            label = f"{prefix}_{run[0][1]}-{run[-1][1]}"
+            out.append("| " + " | ".join([label, *shared, values]) + " |")
+        run.clear()
+
+    for row in rows:
+        stripped = row.strip()
+        cells = (
+            [c.strip() for c in stripped.strip("|").split("|")]
+            if stripped.startswith("|")
+            else []
+        )
+        match = _SERIES_KEY.match(cells[0]) if len(cells) >= 2 else None
+        if match is None:
+            _flush()
+            out.append(row)
+            continue
+
+        prefix, index, rest = match["prefix"], int(match["index"]), cells[1:]
+        contiguous = run and run[-1][0] == prefix and run[-1][1] == index - 1
+        same_shape = run and run[-1][2][:-1] == rest[:-1]
+        if not (contiguous and same_shape):
+            _flush()
+        run.append((prefix, index, rest))
+
+    _flush()
+    return out
 
 
 def _flatten_attributes(attrs: Any, out: list[str], indent: str = "") -> None:

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -10,10 +10,33 @@ bounded; the byte ceiling is unified to 100 MB.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from builder.tools import file_readers
 from builder.tools.file_readers import _MAX_BYTES, _TEXT_BUDGET_BYTES, read_file
+
+
+def _folded_series_covers(cell: str, compacted: str) -> bool:
+    """True when *cell* is a series label ``X_N`` folded into a present ``X_A-B`` (#419).
+
+    Deliberately checks the RANGE rather than just the prefix: a fold that
+    silently narrowed to ``Chemical_1_Concentration_1-2`` would leave levels 3-8
+    genuinely lost, and this returns False for those.
+    """
+    match = re.match(r"^(?P<prefix>.+)_(?P<index>\d+)$", cell)
+    if match is None:
+        return False
+    index = int(match["index"])
+    for lo, hi in re.findall(rf"{re.escape(match['prefix'])}_(\d+)-(\d+)", compacted):
+        if int(lo) <= index <= int(hi):
+            return True
+    return False
+
+
+def _iri_stated_once(cell: str, compacted: str) -> bool:
+    """True when *cell* is a bare ontology IRI that survives elsewhere in the sheet."""
+    return bool(re.match(r"^https?://\S+$", cell)) and cell in compacted
 
 
 class TestSizeCeiling:
@@ -199,6 +222,19 @@ class TestCompactGridText:
         Value cell is empty looks right and silently destroys the author, the
         ORCID, the DOI, the assay name and the description. Every non-empty cell
         outside the Comments column must survive.
+
+        Two shapes are exempt, both introduced deliberately by #419 and both
+        checked here rather than merely skipped, so the control cannot be used to
+        wave through a real loss:
+
+        * a **series label** ``X_N`` folded into ``X_A-B`` — the exemption is
+          granted only when the folded label is present AND ``A <= N <= B``;
+        * a repeated **ontology IRI**, stated once per sheet — granted only when
+          that exact IRI still appears somewhere in the compacted text.
+
+        Neither exemption can hide the trap this control exists for: the author,
+        ORCID, DOI, assay name and description are none of these things, so the
+        "drop rows with an empty Value cell" rule still reddens the assertion.
         """
         from builder.tools.file_readers import compact_grid_text, read_excel
 
@@ -224,9 +260,20 @@ class TestCompactGridText:
             if len(payload) < 2:
                 continue
             for cell in payload:
-                if cell not in compacted:
-                    dropped.append(cell)
+                if cell in compacted:
+                    continue
+                if _folded_series_covers(cell, compacted) or _iri_stated_once(cell, compacted):
+                    continue
+                dropped.append(cell)
         assert not dropped, f"compaction dropped non-empty cells: {dropped[:5]}"
+
+        # The exemptions must be EARNED, not assumed: prove the fixture actually
+        # exercises both, or a future compaction change could silently start
+        # dropping cells into an exemption nobody is testing.
+        assert "Chemical_2_Concentration_1-8" in compacted, "series folding never fired"
+        assert compacted.count("http://semanticscience.org/resource/CHEMINF_000446") == 1, (
+            "the repeated CAS IRI should be stated exactly once per sheet"
+        )
 
     def test_is_a_noop_on_text_that_is_not_a_grid(self):
         """HONESTY CONTROL: the compactor must not mangle arbitrary prose."""

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -20,23 +20,28 @@ from builder.tools.file_readers import _MAX_BYTES, _TEXT_BUDGET_BYTES, read_file
 def _folded_series_covers(cell: str, compacted: str) -> bool:
     """True when *cell* is a series label ``X_N`` folded into a present ``X_A-B`` (#419).
 
-    Deliberately checks the RANGE rather than just the prefix: a fold that
-    silently narrowed to ``Chemical_1_Concentration_1-2`` would leave levels 3-8
-    genuinely lost, and this returns False for those.
+    Checks the RANGE, not just the prefix, and checks the PAYLOAD, not just the
+    label. A fold that narrowed to ``…_1-2`` leaves levels 3-8 lost; a fold that
+    kept a wide ``…_1-8`` label while emitting three values loses five. Both
+    return False here — the second is the exact shape an earlier version of this
+    helper waved through.
+
+    The label is matched at a cell boundary so a *suffix* of some other row's
+    prefix cannot claim the exemption: a bare ``Concentration_3`` must not be
+    excused by ``Chemical_1_Concentration_2-8``.
     """
     match = re.match(r"^(?P<prefix>.+)_(?P<index>\d+)$", cell)
     if match is None:
         return False
     index = int(match["index"])
-    for lo, hi in re.findall(rf"{re.escape(match['prefix'])}_(\d+)-(\d+)", compacted):
-        if int(lo) <= index <= int(hi):
+    pattern = rf"\| {re.escape(match['prefix'])}_(\d+)-(\d+) \|([^|]*)\|"
+    for lo, hi, payload in re.findall(pattern, compacted):
+        if not (int(lo) <= index <= int(hi)):
+            continue
+        # The folded row must still carry one member per index it claims.
+        if len(payload.split(",")) == int(hi) - int(lo) + 1:
             return True
     return False
-
-
-def _iri_stated_once(cell: str, compacted: str) -> bool:
-    """True when *cell* is a bare ontology IRI that survives elsewhere in the sheet."""
-    return bool(re.match(r"^https?://\S+$", cell)) and cell in compacted
 
 
 class TestSizeCeiling:
@@ -223,30 +228,55 @@ class TestCompactGridText:
         ORCID, the DOI, the assay name and the description. Every non-empty cell
         outside the Comments column must survive.
 
-        Two shapes are exempt, both introduced deliberately by #419 and both
-        checked here rather than merely skipped, so the control cannot be used to
-        wave through a real loss:
+        Survival is checked PER SHEET, not against the whole document, because
+        #419's dedup is sheet-scoped: a future change that widened it to the whole
+        workbook would erase every later sheet's annotations while a document-wide
+        substring check stayed green.
 
-        * a **series label** ``X_N`` folded into ``X_A-B`` — the exemption is
-          granted only when the folded label is present AND ``A <= N <= B``;
-        * a repeated **ontology IRI**, stated once per sheet — granted only when
-          that exact IRI still appears somewhere in the compacted text.
+        One shape is exempt: a **series label** ``X_N`` folded into ``X_A-B``, and
+        only when the folded row still carries one value per index it claims (see
+        :func:`_folded_series_covers`). A deduped IRI needs no exemption — it is
+        still stated once in its own sheet, so the per-sheet check finds it.
 
-        Neither exemption can hide the trap this control exists for: the author,
-        ORCID, DOI, assay name and description are none of these things, so the
+        The exemption cannot hide the trap this control exists for: the author,
+        ORCID, DOI, assay name and description are not series labels, so the
         "drop rows with an empty Value cell" rule still reddens the assertion.
-        """
-        from builder.tools.file_readers import compact_grid_text, read_excel
 
-        raw = read_excel(_METADATA_XLSX, max_rows=100)
-        assert raw is not None
-        compacted = compact_grid_text(raw)
+        Run at BOTH read depths — the suite used to inspect 100 rows while the
+        pipeline read 500, leaving the lossy rules unexercised over 5x the rows
+        they actually run on in production.
+        """
+        from builder.tools.file_readers import _MAX_ROWS, compact_grid_text, read_excel
+
+        for max_rows in (100, _MAX_ROWS):
+            raw = read_excel(_METADATA_XLSX, max_rows=max_rows)
+            assert raw is not None
+            self._assert_no_cell_dropped(raw, compact_grid_text(raw), max_rows)
+
+    @staticmethod
+    def _sheet_blocks(text: str) -> dict[str, str]:
+        """Split ``[Sheet: name]`` output into one block of text per sheet."""
+        blocks: dict[str, list[str]] = {}
+        current = ""
+        for line in text.split("\n"):
+            if line.strip().startswith("[Sheet:"):
+                current = line.strip()
+            blocks.setdefault(current, []).append(line)
+        return {name: "\n".join(lines) for name, lines in blocks.items()}
+
+    def _assert_no_cell_dropped(self, raw: str, compacted: str, max_rows: int) -> None:
+        raw_sheets = self._sheet_blocks(raw)
+        compact_sheets = self._sheet_blocks(compacted)
 
         dropped: list[str] = []
-        for line in raw.split("\n"):
-            if not line.startswith("|"):
-                continue
-            cells = [c.strip() for c in line.strip("|").split("|")]
+        for sheet, raw_block in raw_sheets.items():
+            # A sheet compacted to nothing keeps an empty block, which is a real
+            # answer (every row was label-only); missing entirely is not.
+            compact_block = compact_sheets.get(sheet, "")
+            for line in raw_block.split("\n"):
+                if not line.startswith("|"):
+                    continue
+                cells = [c.strip() for c in line.strip("|").split("|")]
             # Scoped to rows that actually CARRY data — two or more non-empty
             # cells outside Comments. A label-only row (`| Accession |  |  | … |`,
             # a field the depositor left blank) is legitimately compacted away,
@@ -254,26 +284,101 @@ class TestCompactGridText:
             # what this control exists to catch: `| Corresponding person | Dr.
             # Fabian Wagenaars |  | … |` has a blank *Value* cell and two
             # non-empty ones, so the trap rule still reddens this assertion.
-            if cells and cells[0] == "Parameter":
-                continue
-            payload = [c for c in cells[:-1] if c]
-            if len(payload) < 2:
-                continue
-            for cell in payload:
-                if cell in compacted:
+                if cells and cells[0] == "Parameter":
                     continue
-                if _folded_series_covers(cell, compacted) or _iri_stated_once(cell, compacted):
+                payload = [c for c in cells[:-1] if c]
+                if len(payload) < 2:
                     continue
-                dropped.append(cell)
-        assert not dropped, f"compaction dropped non-empty cells: {dropped[:5]}"
+                for cell in payload:
+                    if cell in compact_block:
+                        continue
+                    if _folded_series_covers(cell, compact_block):
+                        continue
+                    dropped.append(f"{sheet} {cell}")
+        assert not dropped, f"compaction dropped non-empty cells at {max_rows} rows: {dropped[:5]}"
 
-        # The exemptions must be EARNED, not assumed: prove the fixture actually
-        # exercises both, or a future compaction change could silently start
-        # dropping cells into an exemption nobody is testing.
+        # The exemption must be EARNED, not assumed: prove the fixture actually
+        # exercises folding, or a future change could start dropping cells into
+        # an exemption nobody is testing.
         assert "Chemical_2_Concentration_1-8" in compacted, "series folding never fired"
         assert compacted.count("http://semanticscience.org/resource/CHEMINF_000446") == 1, (
             "the repeated CAS IRI should be stated exactly once per sheet"
         )
+
+    _IRI = "http://nmrML.org/nmrCV#NMR:1000095"
+
+    def _series(self, values: list[str], iri: str | None = None) -> str:
+        """A `[Sheet:]` + header + one `Chemical_1_Concentration_N` row per value."""
+        rows = ["[Sheet: Chemical Information]", "| Parameter | Standard | Value |"]
+        for i, value in enumerate(values, 1):
+            middle = f" {iri} |" if iri else ""
+            rows.append(f"| Chemical_1_Concentration_{i} |{middle} {value} |")
+        return "\n".join(rows)
+
+    def test_refuses_to_fold_values_containing_the_separator(self):
+        """A comma inside a value makes the folded list unrecoverable (#419).
+
+        `1,2-dichloroethane` and the decimal comma an EU depositor may type
+        (`0,03`) both turn a 3-member fold into a 5- or 6-item string with no way
+        back. Folding must decline rather than emit an ambiguous row.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(self._series(["1,2-dichloroethane", "benzene", "0,03"]))
+
+        assert "1,2-dichloroethane" in out
+        assert "0,03" in out
+        assert "Concentration_1-3" not in out, f"folded a comma-bearing series: {out}"
+
+    def test_refuses_to_fold_when_a_value_slot_is_an_ontology_iri(self):
+        """A blank dose level must never be re-presented AS its column's IRI (#419).
+
+        The dedup pass strips the annotation from rows 2..N, so a row whose value
+        was blank collapses to `[label, IRI]` and looks the same shape as its
+        filled neighbours. Folding then joined the IRI into the value list and the
+        leaf read a URL as a concentration.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(self._series(["0.003", "", "0.03", "0.1"], iri=self._IRI))
+
+        folded = [ln for ln in out.split("\n") if re.search(r"_\d+-\d+ \|", ln)]
+        assert not any(self._IRI in ln for ln in folded), (
+            f"an ontology IRI was emitted inside a dose list: {out}"
+        )
+        # The blank level keeps its own row rather than vanishing into a fold.
+        assert "Chemical_1_Concentration_2 |" in out, out
+
+    def test_never_renumbers_a_zero_padded_index(self):
+        """`Aliquot_007` must not come back as `Aliquot_7` (#419).
+
+        The short-run path rebuilt the label from `int(index)`, rewriting
+        identifiers even when nothing folded — and two distinct rows could
+        collide on one label.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        grid = "[Sheet: S]\n| Aliquot_007 | James Bond |\n| Aliquot_1 | Jane Doe |"
+        out = compact_grid_text(grid)
+
+        assert "Aliquot_007" in out, f"zero-padded index was rewritten: {out}"
+        assert "Aliquot_1" in out
+
+    def test_folds_a_clean_series_with_consistent_padding(self):
+        """CONTROL for the three refusals above — the fold must still fire.
+
+        Without this, any of the guards could regress into "never fold" and the
+        refusal tests would all still pass while #419 silently came back.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(self._series(["0.003", "0.01", "0.03", "0.1"], iri=self._IRI))
+
+        # Row 1 states the IRI and so differs in shape from rows 2-4, which the
+        # dedup has stripped; the fold therefore starts at 2. That split is the
+        # documented interaction, not a miss.
+        assert "Chemical_1_Concentration_2-4" in out, f"clean series did not fold: {out}"
+        assert "0.01, 0.03, 0.1" in out
 
     def test_is_a_noop_on_text_that_is_not_a_grid(self):
         """HONESTY CONTROL: the compactor must not mangle arbitrary prose."""

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -63,6 +63,7 @@ from builder.tools.hitl import SimulatedHumanInterface
 pytestmark = pytest.mark.timeout(120)
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "svhps26_real_input"
+_METADATA_XLSX_NAME = "Assay-metadata-CHO-K1_OATP1C1-v1.1.xlsx"
 _DESCRIPTOR = FIXTURE_DIR / "S-VHPS26.json"
 _SOP = FIXTURE_DIR / "Assay_OATP1C1" / "OATP1C1 SOP TH 250425.docx"
 _RAW_DATA = (
@@ -434,6 +435,43 @@ class TestRealInputPipeline:
         metadata = _emitted_for("Assay-metadata-CHO-K1_OATP1C1")
         bulk = _emitted_for("220825_RA_CHO-K1_hOATP1C1_P1_Timecourse.pzfx")
         assert metadata > bulk, f"metadata {metadata} chars vs bulk {bulk} chars"
+
+    def test_a_second_metadata_file_does_not_starve_the_tiers_below(
+        self, tmp_path: Path
+    ) -> None:
+        """STARVATION CONTROL for the tier-0 raise (#419).
+
+        A tier's share is granted PER FILE, so raising tier 0 to 9,000 let two
+        `*metadata*` workbooks claim the whole 16,000 ceiling between them and the
+        BioStudies descriptor, the SOP and the README emitted nothing at all —
+        the same silent starvation #419 exists to remove, aimed at a different
+        document. A versioned or two-plate deposit is an ordinary shape and no
+        other test builds one.
+        """
+        import shutil
+
+        from builder.agents.pipeline.pipeline import _gather_context
+
+        deposit = tmp_path / "two_metadata"
+        shutil.copytree(FIXTURE_DIR, deposit)
+        workbook = deposit / "Assay_OATP1C1" / _METADATA_XLSX_NAME
+        shutil.copy(workbook, workbook.with_name("Assay-metadata-second-plate-v1.2.xlsx"))
+
+        context = _gather_context(_scanning_engine(deposit))
+
+        def _emitted_for(stem: str) -> int:
+            for block in context.split("\n- "):
+                if block.lstrip("- ").lower().startswith(stem.lower()):
+                    return len(block)
+            return 0
+
+        assert _emitted_for("Assay-metadata-CHO-K1_OATP1C1") > 0, "first workbook starved"
+        assert _emitted_for("Assay-metadata-second-plate") > 0, "second workbook starved"
+        # The descriptor is the deposit's only structured identity record; losing
+        # it to a duplicated workbook is a strictly worse trade than truncating
+        # either workbook.
+        assert _emitted_for("S-VHPS26.json") > 0, "the BioStudies descriptor was starved"
+        assert _TOKEN_SOP_BODY in context.lower(), "the tier-2 documents were starved"
 
     def test_pipeline_builds_conformant_crate_from_real_input(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -102,15 +102,45 @@ _TOKEN_PERSON = "wagenaars"
 _TOKEN_SOP_DURATION = "30 minutes"
 _TOKEN_SOP_INSTRUMENT = "gamma counter"
 
-# The five test chemicals the workbook's Chemical Information sheet names, in sheet
-# order. Chemicals 2-5 sit past 2,600 compacted chars, so the leaf saw none of them
-# before #378 — the crate carried the substrate alone.
+# The first five test chemicals in sheet order. Chemicals 2-5 sit past 2,600
+# compacted chars, so the leaf saw none of them before #378 — the crate carried the
+# substrate alone. These five drive the plan-stub gating below; the sheet holds many
+# more (see `_NAMED_CHEMICALS`), and gating the stub on all of them would be unsound
+# because several names are substrings of each other ("bisphenol-A" occurs inside
+# "tetrabromobisphenol-A").
 _TEST_CHEMICALS: tuple[tuple[str, str], ...] = (
     ("silychristin", "Silychristin"),
     (_TOKEN_CHEMICAL_2, "Lesinurad"),
     ("indocyanine", "Indocyanine green"),
     ("verapamil", "Verapamil"),
     (_TOKEN_CHEMICAL_5, "Diclofenac"),
+)
+
+# EVERY chemical the workbook actually names, by sheet row number (#419). The sheet
+# has 20 `Chemical_N` slots; row 6 has no `_Name` cell at all — "Probenecid" was
+# typed into `Chemical_6_CAS` instead — so 19 are named and slot 6 is unreachable at
+# any budget. Keyed by row number and asserted against the row label rather than the
+# bare name, because the names collide as substrings.
+_NAMED_CHEMICALS: tuple[tuple[int, str], ...] = (
+    (1, "Silychristin"),
+    (2, "Lesinurad"),
+    (3, "Indocyanine green"),
+    (4, "Verapamil"),
+    (5, "diclofenac"),
+    (7, "bromosulfophthalein"),
+    (8, "bisphenol-S"),
+    (9, "bisphenol-Z"),
+    (10, "bisphenol-AF"),
+    (11, "bisphenol-F"),
+    (12, "Sulforhodamine 101"),
+    (13, "pentachlorophenol"),
+    (14, "tetrabromobisphenol-A"),
+    (15, "bisphenol-A"),
+    (16, "perfluorooctanesulfonic acid (PFOA)"),
+    (17, "Perfluorooctanoic acid (PFOA)"),
+    (18, "Quercetin"),
+    (19, "Rifampicin"),
+    (20, "Triclosan"),
 )
 
 
@@ -355,6 +385,31 @@ class TestRealInputPipeline:
 
         cas_values = {e.fields.get("cas") for e in compounds if e.fields.get("cas")}
         assert len(cas_values) > 1, f"every compound got the same CAS: {cas_values}"
+
+    def test_every_named_chemical_reaches_the_extraction_leaf(self) -> None:
+        """The whole compound table must survive the context budget (#419).
+
+        The leaf can only propose what it was shown, so a chemical missing here is
+        unreachable at any temperature, prompt or model — silently. Three separate
+        truncations used to cut 19 named chemicals down to 5: `read_file`'s
+        `max_lines=100` row cap, the uncompacted concentration series, and the
+        tier-0 char share.
+
+        Asserted on the `Chemical_N_Name` row rather than the bare name because the
+        names collide as substrings — matching "bisphenol-A" alone would pass on
+        "tetrabromobisphenol-A" and hide a genuine miss.
+        """
+        from builder.agents.pipeline.pipeline import _gather_context
+
+        context = _gather_context(_scanning_engine(FIXTURE_DIR))
+
+        missing = [
+            f"Chemical_{row}_Name ({name})"
+            for row, name in _NAMED_CHEMICALS
+            if f"Chemical_{row}_Name".lower() not in context.lower()
+            or name.lower() not in context.lower()
+        ]
+        assert not missing, f"{len(missing)} of {len(_NAMED_CHEMICALS)} starved: {missing}"
 
     def test_bulk_data_does_not_consume_the_metadata_budget(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #419.

## What was wrong

The real S-VHPS26 workbook names **19 chemicals**. **Five** reached the extraction leaf, so the other 14 were unreachable at any temperature, prompt or model — silently, because nothing downstream can distinguish "the agent declined" from "the agent was never shown it".

Three truncations stacked, each invisible to the next:

| stage | chemicals surviving |
|---|---|
| `read_excel(max_rows=500)` | 19 |
| `read_file` (its `max_lines=100` default) | 7 |
| `+ compact_grid_text` | 7 |
| `+ tier-0 char share` | **5** |

`pipeline.py` described the workbook as holding "all five chemicals". The budget had been sized against that belief.

## What changed

**Two new compaction rules** take the workbook from 22,007 chars to 8,675:
- a numbered series (`Chemical_1_Concentration_1..8`, 160 rows / 11,693 chars on this workbook) folds to one row;
- an ontology IRI repeated per row (4 of them, 20x each, 4,133 chars) is stated once per sheet.

**Row cap**: compacted tiers now read to `read_excel`'s own 500-row ceiling instead of `read_file`'s 100. That cut was taken *before* any char budgeting, so it could not be traded against the budget and left no trace in the emitted slice.

**Budget**: tier 0 6000 → 9000, ceiling 14000 → 16000. Net ~750 extra tokens on one bounded cheap-model call, for 5 chemicals → 19.

## Second commit: what an adversarial review found

I ran a four-lens adversarial pass over the first commit. It found four real defects, all now fixed with regression tests:

- a **comma inside a value** (`1,2-dichloroethane`, or an EU decimal comma) made the folded list unrecoverable → such runs are refused;
- a **blank dose level** was re-presented *as* its column's ontology IRI, because dedup made the row look the same shape as its neighbours → runs whose values include a bare IRI are refused;
- **zero-padded indices were rewritten even when nothing folded** (`Aliquot_007` → `Aliquot_7`, and two rows could collide on one label) → rows are re-emitted verbatim unless they actually fold;
- the **tier-0 raise starved every tier below it** on a deposit with two `*metadata*` files — the descriptor, SOP and README all emitted zero. That is the same silent starvation this issue exists to remove, aimed at a different document. `_gather_context` now reserves populated lower tiers' shares, counted per file.

The honesty control in `test_file_readers.py` is strengthened, not loosened: survival is checked per sheet, folded labels match at a cell boundary, and a folded row must carry one value per index it claims. Two false comments are corrected.

## Verification

- All 19 named chemicals reach `_gather_context`; every pre-existing gate token (`sandell`, `slco1c1`, `cvcl_0214`, `wagenaars`, `gamma counter`, `30 minutes`) still present.
- `test_every_named_chemical_reaches_the_extraction_leaf` fails on main (`14 of 19 starved`) and passes here.
- 361 passed across the pipeline / reader / scanner / crate-mapping / e2e selection; `ruff check` and `ty check` clean.

## Known, not addressed here

`Chemical_6` has no `_Name` cell in the fixture workbook — "Probenecid" was typed into `Chemical_6_CAS` — so that compound is unreachable at any budget. That is a source-data defect, not a context-budget one.