### PR TITLE
fix(provenance): credit the lookup for values the lookup supplied

### DIFF
--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -1443,10 +1443,15 @@ def resolve_compound(
     # Identifier/source fields win over caller hints so a verified value from the
     # source is never clobbered by a (possibly stale) hint.
     merged_hints: dict[str, Any] = dict(hints or {})
+    # Tracked separately from the merged hints so the values the AUTHORITY
+    # supplied can be recorded as such. Everything else in ``merged_hints`` is
+    # the caller's (a plan value, a model-drafted hint) and keeps that origin.
+    looked_up: dict[str, Any] = {}
     for key in _COMPOUND_DATA_FIELDS:
         value = data.get(key)
         if value not in (None, ""):
             merged_hints[key] = value
+            looked_up[key] = value
 
     # Dedup by chemical IDENTITY first (Issue #179): two DIFFERENT names that
     # resolve to the SAME molecule (e.g. 'Indocyanine green' / 'ICG' -> same CID /
@@ -1480,6 +1485,14 @@ def resolve_compound(
             entity.set_fields_from_dict(refreshed, source="lookup")
         else:
             entity = draft_molecular_entity(state, display_name, merged_hints)
+            # ``draft_molecular_entity`` stamps every hint it is handed with
+            # ``source="llm"`` — correct for a drafted hint, wrong for the PubChem
+            # response we just merged in. Re-record that subset as looked-up, so a
+            # D5 audit reading ``_completion`` does not see four fabricated
+            # structural identifiers per compound. Matches the two reuse branches
+            # above, which already record these as ``"lookup"`` (#424).
+            if looked_up:
+                entity.set_fields_from_dict(looked_up, source="lookup")
 
     # Best-effort EPA DTXSID enrichment (#179). DTXSID is a first-class ISA-Tox
     # chemical identifier that the deterministic pipeline otherwise never

--- a/tests/test_tools_resolve_compound.py
+++ b/tests/test_tools_resolve_compound.py
@@ -99,6 +99,75 @@ def offline_lookup(monkeypatch):
     return calls
 
 
+class TestLookupProvenanceIsRecordedHonestly:
+    """Looked-up values must not be recorded as if the model wrote them (#424).
+
+    ``_completion`` is the record of what was asserted versus what was verified —
+    it is what a D5 audit reads. ``draft_molecular_entity`` stamps every hint it
+    is given with ``source="llm"``, but ``resolve_compound`` hands it the PubChem
+    response, so a freshly minted compound claimed the model had produced its
+    InChI, InChIKey, formula and mass.
+
+    The two reuse branches already record these as ``"lookup"``; only the
+    mint-a-new-entity branch did not, so recorded provenance also depended on
+    whether the entity happened to exist already.
+    """
+
+    # Everything in _PUBCHEM_HIT that comes from the authority rather than from
+    # the caller or the model.
+    _FROM_PUBCHEM = ("cas", "smiles", "inchikey", "inchi", "formula", "mass", "pubchem_cid")
+
+    @staticmethod
+    def _sources(state: CrateState) -> dict[str, str | None]:
+        mol = _by_type(state, "MolecularEntity")[0]
+        out: dict[str, str | None] = {}
+        for field in TestLookupProvenanceIsRecordedHonestly._FROM_PUBCHEM:
+            status = mol.get_field_status(field)
+            out[field] = status.source if status is not None else None
+        return out
+
+    def test_a_newly_minted_compound_credits_the_lookup(self, offline_lookup):
+        state = CrateState()
+        resolve_compound(state, name="Silychristin A")
+
+        for field, source in self._sources(state).items():
+            assert source is not None, f"{field} has no recorded provenance"
+            assert source == "lookup", (
+                f"{field} came from PubChem but is recorded as source={source!r} "
+                "— a D5 audit would read it as fabricated"
+            )
+
+    def test_provenance_does_not_depend_on_whether_the_entity_existed(self, offline_lookup):
+        """Resolving twice must not change the recorded source.
+
+        The second call takes the reuse branch. Before the fix the branches
+        disagreed, so the same compound read as model-written or lookup-derived
+        depending only on call order.
+        """
+        state = CrateState()
+        resolve_compound(state, name="Silychristin A")
+        first = self._sources(state)
+
+        resolve_compound(state, name="Silychristin A")
+        assert len(_by_type(state, "MolecularEntity")) == 1, "the second resolve must reuse"
+
+        assert first == self._sources(state)
+
+    def test_the_caller_supplied_name_is_not_credited_to_the_lookup(self, offline_lookup):
+        """The opposite error: ``name`` is what the caller asked for, not
+        something PubChem returned, so it must not be laundered into 'lookup'."""
+        state = CrateState()
+        resolve_compound(state, name="Silychristin A")
+        mol = _by_type(state, "MolecularEntity")[0]
+
+        status = mol.get_field_status("name")
+        assert status is not None
+        assert status.source != "lookup", (
+            "the display name came from the caller; recording it as a lookup "
+            "result overstates what the authority confirmed"
+        )
+
+
 class TestResolveCompoundHappyPath:
     def test_mints_verified_molecular_entity(self, offline_lookup):
         state = CrateState()


### PR DESCRIPTION
Closes #424.

## What was wrong

`resolve_compound` merges the PubChem response into `merged_hints` and hands the
lot to `draft_molecular_entity`, which stamps **every** hint `source="llm"`. So a
freshly minted compound recorded its InChI, InChIKey, formula, mass and SMILES as
model output. They came from the authority.

On a real S-VHPS26 build, all 19 compounds carried:

```json
"MolecularEntity:inchikey": {"status": "filled", "source": "llm"}
```

`chem_silychristin` reported `source: "llm"` for a full stereochemical InChI with
`/t`, `/m1`, `/s1` layers — which the drafter schema does not even accept as a
field.

## Why it matters

`_completion` is what a D5 audit reads to tell asserted from verified. This
understated the crate's trustworthiness in the worst possible place: it reports
four fabricated structural identifiers per compound where in fact **none** were
fabricated. Only `cas` and `pubchem_cid` were corrected later, by the
verification pass.

## What the failing test found that the issue missed

Provenance depended on **call order**. The two reuse branches in
`resolve_compound` already recorded these as `"lookup"` — only the
mint-a-new-entity branch did not. So resolving the same compound twice *changed*
its recorded provenance:

```
first resolve  (mint)   inchikey: llm
second resolve (reuse)  inchikey: lookup
```

All three branches now agree.

## What changed

The looked-up subset is tracked as it is merged, rather than recomputed
afterwards, so the two cannot drift. `name` deliberately keeps its
caller-supplied origin: it is what the plan asked for, not something PubChem
confirmed, and laundering it into `"lookup"` would be the same error in the
other direction — there is a test for that.

## Verification

20/20 in `tests/test_tools_resolve_compound.py` (3 new), plus the composites,
provenance and state-serializer modules green. `ruff check` clean. Full suite was
still running locally at push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
