### PR TITLE
fix(lookups): take the SMILES PubChem actually returns, not the retired name

### DIFF
--- a/lookups/pubchem.py
+++ b/lookups/pubchem.py
@@ -17,6 +17,15 @@ from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 _BASE = "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name"
 _CAS_PATTERN = re.compile(r"^\d{2,7}-\d{2}-\d$")
 
+# PubChem returns several SMILES flavours under the one ``SMILES`` label, keyed
+# by ``urn.name``, and has renamed them: the old ``Canonical`` was retired in
+# favour of ``Absolute`` (with stereochemistry) and ``Connectivity`` (without).
+# Lower rank wins. ``Absolute`` is preferred because we store a *stereochemical*
+# InChI alongside it, and a flat SMILES next to a stereo InChI describes two
+# different molecules. ``Canonical`` is kept so an older cached or mirrored
+# response still parses.
+_SMILES_PREFERENCE: dict[str, int] = {"Absolute": 0, "Canonical": 1, "Connectivity": 2}
+
 
 @functools.lru_cache(maxsize=512)
 def lookup_pubchem(name: str) -> dict:
@@ -37,13 +46,21 @@ def lookup_pubchem(name: str) -> dict:
         cid = str(compound["id"]["id"]["cid"])
 
         props: dict = {}
+        _smiles_rank = len(_SMILES_PREFERENCE)
         for p in compound.get("props", []):
             urn = p.get("urn", {})
             label = urn.get("label", "")
             name_key = urn.get("name", "")
             val = p.get("value", {})
-            if label == "SMILES" and name_key == "Canonical":
-                props["smiles"] = val.get("sval", "")
+            if label == "SMILES":
+                # PubChem ships several SMILES variants under one label and has
+                # renamed them before; take the most preferred one present rather
+                # than matching a single spelling. Matching only "Canonical" is
+                # what silently emptied this field for every compound (#425).
+                rank = _SMILES_PREFERENCE.get(name_key)
+                if rank is not None and rank < _smiles_rank:
+                    props["smiles"] = val.get("sval", "")
+                    _smiles_rank = rank
             elif label == "InChIKey":
                 props["inchikey"] = val.get("sval", "")
             elif label == "InChI" and name_key == "Standard":

--- a/tests/fixtures/pubchem_compound.json
+++ b/tests/fixtures/pubchem_compound.json
@@ -3,8 +3,9 @@
     {
       "id": {"id": {"cid": 5280863}},
       "props": [
-        {"urn": {"label": "SMILES", "name": "Canonical"}, "value": {"sval": "C1=CC(=C(C=C1[C@@H]2[C@H](C(=O)C3=C(O2)C=C(C=C3)O)O)O)O"}},
-        {"urn": {"label": "InChIKey"}, "value": {"sval": "VEEGZPWAAPPXRB-BJMVGYQFSA-N"}},
+        {"urn": {"label": "SMILES", "name": "Absolute"}, "value": {"sval": "C1=CC(=C(C=C1[C@@H]2[C@H](C(=O)C3=C(O2)C=C(C=C3)O)O)O)O"}},
+        {"urn": {"label": "SMILES", "name": "Connectivity"}, "value": {"sval": "C1=CC(=C(C=C1C2C(C(=O)C3=C(O2)C=C(C=C3)O)O)O)O"}},
+        {"urn": {"label": "InChIKey", "name": "Standard"}, "value": {"sval": "VEEGZPWAAPPXRB-BJMVGYQFSA-N"}},
         {"urn": {"label": "InChI", "name": "Standard"}, "value": {"sval": "InChI=1S/C15H12O5/c16-9-3-1-8(2-4-9)15-14(19)13(18)11-7-10(17)5-6-12(11)20-15/h1-7,14-17,19H/t14-,15+/m0/s1"}},
         {"urn": {"label": "Molecular Formula"}, "value": {"sval": "C15H12O5"}},
         {"urn": {"label": "Molecular Weight"}, "value": {"sval": "272.25"}},

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -85,10 +85,84 @@ class TestPubChemContract:
         assert result["formula"] == "C15H12O5"
         assert result["mass"] == "272.25"
         assert "VEEGZPWAAPPXRB" in result["inchikey"]
-        assert result["smiles"] != ""
+        # Pinned to the exact value, not `!= ""`: PubChem renamed this property
+        # and the parser silently stopped matching it, so every crate lost its
+        # SMILES while this test kept passing against a stale fixture (#425).
+        # The stereochemical ("Absolute") form is the one that agrees with the
+        # stereochemical InChI stored alongside it.
+        assert result["smiles"] == "C1=CC(=C(C=C1[C@@H]2[C@H](C(=O)C3=C(O2)C=C(C=C3)O)O)O)O"
         assert result["inchi"].startswith("InChI=")
         assert result["iupac_name"] != ""
         assert result["cas"] == "480-18-2"
+
+    @staticmethod
+    def _compound_with_smiles(*variants: tuple[str, str]) -> dict:
+        """A minimal PC_Compounds payload carrying only the given SMILES props.
+
+        ``variants`` are ``(urn.name, value)`` pairs, in the order PubChem would
+        emit them.
+        """
+        return {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 1}},
+                    "props": [
+                        {"urn": {"label": "SMILES", "name": key}, "value": {"sval": value}}
+                        for key, value in variants
+                    ],
+                }
+            ]
+        }
+
+    def _smiles_for(self, *variants: tuple[str, str], name: str = "x") -> str:
+        """Parse a payload carrying only *variants* and return the SMILES chosen.
+
+        ``name`` varies per call because ``lookup_pubchem`` is ``lru_cache``d on
+        it — two calls under one name in a single test would replay the first
+        result rather than parse the second payload.
+        """
+        responses.add(
+            responses.GET,
+            f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/JSON",
+            json=self._compound_with_smiles(*variants),
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{name}/synonyms/JSON",
+            status=404,
+        )
+        return lookup_pubchem(name)["smiles"]
+
+    @responses.activate
+    def test_prefers_the_stereochemical_smiles(self):
+        """`Absolute` wins over `Connectivity` however they are ordered.
+
+        We store a stereochemical InChI; a flat SMILES beside it would describe
+        a different molecule.
+        """
+        assert self._smiles_for(("Connectivity", "FLAT"), ("Absolute", "STEREO")) == "STEREO"
+
+    @responses.activate
+    def test_falls_back_to_connectivity_when_there_is_no_stereo_form(self):
+        """An achiral compound has no `Absolute` form — it must not come back
+        empty just because the preferred variant is absent."""
+        assert self._smiles_for(("Connectivity", "FLAT")) == "FLAT"
+
+    @responses.activate
+    def test_still_accepts_the_retired_canonical_name(self):
+        """A cached or mirrored older response must keep parsing."""
+        assert self._smiles_for(("Canonical", "LEGACY")) == "LEGACY"
+
+    @responses.activate
+    def test_an_unknown_smiles_variant_is_not_taken(self):
+        """Only known variants are accepted, so a future PubChem addition cannot
+        silently displace the one we deliberately prefer."""
+        assert (
+            self._smiles_for(("Absolute", "STEREO"), ("SomeNewVariant", "OTHER"), name="a")
+            == "STEREO"
+        )
+        assert self._smiles_for(("SomeNewVariant", "OTHER"), name="b") == ""
 
     @responses.activate
     def test_not_found_returns_empty(self):


### PR DESCRIPTION
Closes #425.

## What was wrong

`lookup_pubchem` matched `label == "SMILES" and name == "Canonical"`. PubChem
retired `Canonical` in favour of `Absolute` (with stereochemistry) and
`Connectivity` (without), so the condition stopped matching and **every compound
came back with an empty `smiles`** — silently. Nothing errored, the compound
still resolved, the field was simply gone. All 19 compounds on a real S-VHPS26
build are missing it, and the tox profile lists `schema:smiles` as a SHOULD.

Confirmed against the live API — the only SMILES properties PubChem returns
today:

```
label='SMILES'  name='Absolute'
label='SMILES'  name='Connectivity'
```

## Why the tests didn't catch it

The contract test's recorded fixture still carried the old `Canonical` name, so
the suite was pinned to a response shape upstream no longer sends. It would have
passed indefinitely.

The fixture is updated to the current shape (which also now carries
`name: "Standard"` on InChIKey), and the assertion pins the **exact** SMILES
rather than `!= ""` — so a dropped field fails instead of passing.

## What changed

Variants are **ranked** rather than matched by one spelling:

| rank | variant | why |
|---|---|---|
| 0 | `Absolute` | we store a stereochemical InChI beside it; a flat SMILES would describe a different molecule |
| 1 | `Canonical` | older cached/mirrored responses still parse |
| 2 | `Connectivity` | achiral compounds have no stereo form and must not come back empty |

Unknown variants are ignored, so a future PubChem addition cannot silently
displace the one we deliberately prefer.

## Verification

Live API — all three resolve, stereochemistry preserved where the compound has
it:

```
Verapamil     smiles='CC(C)C(CCCN(C)CCC1=CC(=C(C=C1)OC)OC)(C#N)C2=...'
Methimazole   smiles='CN1C=CNC1=S'
taxifolin     smiles='C1=CC(=C(C=C1[C@@H]2[C@H](C(=O)C3=C(C=C(C=C3...'
```

58/58 in `tests/test_lookups_contract.py` (4 new), 73/73 across the related
lookup modules. `ruff check` clean. Full suite was still running locally at push
time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
