### PR TITLE
fix(lookups): repoint CompTox at the search path that still exists

### DIFF
--- a/lookups/comptox.py
+++ b/lookups/comptox.py
@@ -13,13 +13,21 @@ Follows the same shape as the other raw lookup modules (``http_get_json`` +
 from __future__ import annotations
 
 import functools
+import logging
 from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
+logger = logging.getLogger(__name__)
+
 # Public CompTox Dashboard search endpoint (no API key required). An exact
 # ("equal") match is tried first; the response is a list of candidate hits.
-_BASE = "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal"
+#
+# The search moved from ``ccdapp2`` to ``ccdapp1``: every path under the former
+# now 404s, including its own base, so every DTXSID lookup silently failed
+# (#426). ``ccdapp2`` still exists as an application root, which is why the
+# breakage was not obvious from the host being up.
+_BASE = "https://comptox.epa.gov/dashboard-api/ccdapp1/search/chemical/equal"
 
 
 def _first_hit(data: object) -> dict | None:
@@ -60,6 +68,17 @@ def lookup_dtxsid(query: str) -> dict:
     try:
         data = http_get_json(f"{_BASE}/{quote(query.strip())}")
         if data is NOT_FOUND:
+            # CompTox answers an unknown chemical with 200 + [], so a 404 is the
+            # SEARCH PATH being gone, not the chemical. Say so: the previous
+            # endpoint died exactly this way and, because a miss is non-fatal by
+            # design, a permanently dead API was indistinguishable from "this
+            # compound isn't in CompTox" for as long as nobody checked (#426).
+            logger.warning(
+                "CompTox search returned 404 for %r — the endpoint has likely moved "
+                "again (%s); every DTXSID lookup will fail until it is repointed.",
+                query,
+                _BASE,
+            )
             return {}
 
         hit = _first_hit(data)

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -10,6 +10,7 @@ the real parsing logic in each lookup module. Each test class covers:
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -620,14 +621,53 @@ class TestOntologyTermContract:
 
 
 class TestCompToxContract:
-    """Contract tests for lookups/comptox.py."""
+    """Contract tests for lookups/comptox.py.
+
+    The mocked URL is part of the contract here: these tests replay against
+    whatever path the module requests, so pinning a retired one lets the suite
+    pass for years against an endpoint that 404s in production (#426). The
+    payloads are the shape CompTox actually returns today — a bare list of hits
+    carrying `dtxsid`/`dtxcid`/`searchMatch`/`rank`, with no name, CAS or
+    InChIKey.
+    """
+
+    _SEARCH = "https://comptox.epa.gov/dashboard-api/ccdapp1/search/chemical/equal"
 
     @responses.activate
-    def test_resolves_dtxsid_from_list(self):
-        """A list response yields the first hit's DTXSID."""
+    def test_resolves_dtxsid_from_the_real_response_shape(self):
+        """The live response carries no preferredName/casrn/inchikey."""
         responses.add(
             responses.GET,
-            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/Bisphenol%20A",
+            f"{self._SEARCH}/Bisphenol%20A",
+            json=[
+                {
+                    "dtxsid": "DTXSID7020182",
+                    "dtxcid": "DTXCID30182",
+                    "searchMatch": "Approved Name",
+                    "rank": 9,
+                    "hasStructureImage": True,
+                    "searchWord": "Bisphenol A",
+                }
+            ],
+            status=200,
+        )
+
+        result = lookup_dtxsid("Bisphenol A")
+        assert result["dtxsid"] == "DTXSID7020182"
+        assert result["@type"] == "MolecularEntity"
+        assert result["@id"].endswith("DTXSID7020182")
+        # No name in the payload — fall back to the query rather than inventing one.
+        assert result["name"] == "Bisphenol A"
+        # Absent optional fields are omitted, not stored empty.
+        assert "casrn" not in result
+        assert "inchikey" not in result
+
+    @responses.activate
+    def test_uses_the_enriched_fields_when_present(self):
+        """Some deployments do return them; take them when they are there."""
+        responses.add(
+            responses.GET,
+            f"{self._SEARCH}/Bisphenol%20A",
             json=[
                 {
                     "dtxsid": "DTXSID7020182",
@@ -640,36 +680,39 @@ class TestCompToxContract:
         )
 
         result = lookup_dtxsid("Bisphenol A")
-        assert result["dtxsid"] == "DTXSID7020182"
-        assert result["@type"] == "MolecularEntity"
         assert result["casrn"] == "80-05-7"
         assert result["inchikey"] == "IISBACLAFKSPIT-UHFFFAOYSA-N"
-        assert result["@id"].endswith("DTXSID7020182")
 
     @responses.activate
-    def test_no_hits_returns_empty(self):
-        responses.add(
-            responses.GET,
-            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/Nope",
-            json=[],
-            status=200,
-        )
-        assert lookup_dtxsid("Nope") == {}
+    def test_a_genuine_miss_is_an_empty_list_and_is_quiet(self, caplog):
+        """CompTox answers an unknown chemical with 200 + []. That is a normal
+        answer, not a fault, and must not be reported as one."""
+        responses.add(responses.GET, f"{self._SEARCH}/Nope", json=[], status=200)
+
+        with caplog.at_level(logging.WARNING):
+            assert lookup_dtxsid("Nope") == {}
+        assert not caplog.records, f"a genuine miss logged: {caplog.text}"
 
     @responses.activate
-    def test_404_returns_empty(self):
-        responses.add(
-            responses.GET,
-            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/Nope",
-            status=404,
-        )
-        assert lookup_dtxsid("Nope") == {}
+    def test_a_404_is_reported_as_an_integration_breakage(self, caplog):
+        """A 404 means the search PATH is gone, not that the chemical is.
+
+        This is exactly how the previous endpoint died: every lookup 404'd,
+        `http_get_json` mapped it to "not found", and three layers of
+        by-design tolerance turned a dead API into silence for months (#426).
+        """
+        responses.add(responses.GET, f"{self._SEARCH}/Nope", status=404)
+
+        with caplog.at_level(logging.WARNING):
+            assert lookup_dtxsid("Nope") == {}
+        assert caplog.records, "a 404 from the search endpoint was not reported"
+        assert "404" in caplog.text or "endpoint" in caplog.text.lower()
 
     @responses.activate
     def test_timeout_raises_transient(self):
         responses.add(
             responses.GET,
-            "https://comptox.epa.gov/dashboard-api/ccdapp2/search/chemical/equal/BPA",
+            f"{self._SEARCH}/BPA",
             body=Timeout("timed out"),
         )
         with pytest.raises(TransientLookupError):
@@ -678,6 +721,7 @@ class TestCompToxContract:
     @responses.activate
     def test_empty_query_no_http(self):
         assert lookup_dtxsid("") == {}
+
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #426.

## What was wrong

**Every DTXSID lookup had been failing.** `lookup_dtxsid` targeted
`dashboard-api/ccdapp2/search/chemical/equal`, and every path under `ccdapp2` now
returns **404** — including its own base. The search moved to `ccdapp1`.
`ccdapp2` still answers as an application root, which is why the host being up
said nothing about the endpoint being there.

```
.../ccdapp2/search/chemical/equal/Bisphenol%20A   -> 404
.../ccdapp2/search/chemical/equal/                -> 404
.../ccdapp1/search/chemical/equal/Bisphenol%20A   -> 200  [{"dtxsid": "DTXSID7020182", ...}]
```

Correction to the issue as filed: I wrote that the endpoint was *retired* and
that finding a replacement was open work. It had simply **moved** — same host,
same response shape, no API key, one word different.

## Why nothing noticed

Three individually-correct tolerances compose into silence:

1. `comptox.py` — bare `except Exception: return {}`
2. `composites.py` — DTXSID is non-fatal enrichment; only logs on an *exception*,
   not on a clean `found: False`
3. `lookup_dtxsid` is `lru_cache`-wrapped, so the empty result is held for the run

A permanently dead API was indistinguishable from "this chemical isn't in
CompTox". Both arms were affected — `lookup_dtxsid` is a registered ReAct tool
advertised in the system prompt, so the agent could call it and was always told
the chemical was not found.

## What changed

- `_BASE` repointed to `ccdapp1`.
- **A 404 is now reported as an integration breakage.** CompTox answers an
  unknown chemical with `200` and an empty list, so a 404 means the search *path*
  is gone, not the chemical. That is the signal that was missing when this broke.
  A genuine miss stays quiet — there is a test for each.

## The contract tests were part of the problem

They mocked the retired URL, so they'd have passed forever against a dead
endpoint. They now replay against the path the module actually requests, using
the payload CompTox really returns — a bare list of hits with
`dtxsid`/`dtxcid`/`searchMatch`/`rank` and **no** name, CAS or InChIKey. The old
mock invented all three, so the parser's fallback paths were never exercised.

## Verification

Live — every query shape `resolve_compound` uses:

```
52-53-9                       -> DTXSID9041152
Verapamil                     -> DTXSID9041152
IISBACLAFKSPIT-UHFFFAOYSA-N   -> DTXSID7020182
zzzznotachemical              -> {}   (quiet)
```

120/120 across the lookup modules (6 CompTox contract tests, 4 new).
`ruff check` clean. Full suite was still running locally at push time.

## Follow-up worth considering

A contract test that hits the real endpoint and is allowed to fail loudly, kept
out of the offline suite, so the next retirement is caught rather than absorbed.
Not included here — it needs a CI policy decision about network-dependent tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
