### PR TITLE
fix(engine): make reader de-duplication work and resolve bare filenames

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -892,8 +892,18 @@ def _format_compact_state_summary(engine: AgentEngine, *, limit: int = 8) -> str
 
 
 def _reader_evidence_key(engine: AgentEngine, path: str) -> str:
-    """Normalize an approved reader path the same way engine storage does."""
+    """Normalize an approved reader path the same way engine storage does.
+
+    A bare filename is resolved inside the approved roots first, exactly as the
+    engine's gate does. Without that the two normalizations disagree: the engine
+    stores evidence under ``Assay_OATP1C1/SOP.docx`` while this returned the raw
+    ``SOP.docx``, so the "already loaded" check never matched and the model was
+    free to re-read the same document indefinitely.
+    """
     try:
+        resolved_bare = engine._resolve_within_roots(path)
+        if resolved_bare is not None:
+            path = resolved_bare
         resolved = Path(path).resolve()
         for root in getattr(engine.state, "approved_scan_roots", set()):
             try:

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -182,6 +182,13 @@ def _validation_input_hash(state: CrateState) -> str:
 _DOCUMENT_EVIDENCE_MAX_CHARS = 12000
 _DOCUMENT_EVIDENCE_MAX_TOTAL_CHARS = 30000
 
+# Readers whose successful output is kept as bounded session evidence, so the
+# "already loaded this document" guard can suppress an identical re-read. These
+# take a single ``path`` kwarg and return text.
+_DOCUMENT_EVIDENCE_TOOLS = frozenset(
+    {"read_file", "read_excel", "read_docx", "read_file_sample"}
+)
+
 _FILE_READ_TOOLS: dict[str, str] = {
     "read_file": "path",
     "read_excel": "path",
@@ -454,6 +461,53 @@ class AgentEngine:
             evidence.pop(next(iter(evidence)))
         self.state.document_evidence = evidence
 
+    def _resolve_within_roots(self, path: Any) -> str | None:
+        """Resolve a bare filename to an absolute path inside an approved root.
+
+        Returns ``None`` unless *path* has no directory component and exactly one
+        file with that name exists under the approved roots — an ambiguous name
+        (the same basename in two subfolders) is left for the caller to refuse,
+        because picking one would silently read a file the agent did not ask for.
+
+        Prefers the scanned-file inventory (already built, no disk walk) and falls
+        back to a bounded ``rglob`` when the inventory is empty or predates the
+        file. Containment is re-checked on the result, so this can only ever widen
+        the agent's reach to files the sandbox would already have allowed.
+        """
+        from builder.tools.scanner import _contain
+
+        if not isinstance(path, str) or not path.strip():
+            return None
+        name = Path(path).name
+        # Only a BARE name is resolved. A path with directories in it was a real
+        # (wrong) location, not a filename the model read off the inventory.
+        if not name or name != path.strip():
+            return None
+
+        matches: list[str] = []
+        for scanned in self.state.scanned_files:
+            candidate = getattr(scanned, "path", None)
+            if candidate and Path(candidate).name == name:
+                matches.append(str(candidate))
+
+        if not matches:
+            for root in self.state.approved_scan_roots:
+                try:
+                    matches.extend(str(p) for p in Path(root).rglob(name) if p.is_file())
+                except (OSError, RuntimeError, ValueError):
+                    continue
+
+        unique = sorted({str(Path(m).resolve()) for m in matches})
+        if len(unique) != 1:
+            if len(unique) > 1:
+                logger.info(
+                    "Not resolving bare filename %r — %d files share that name",
+                    path,
+                    len(unique),
+                )
+            return None
+        return unique[0] if _contain(unique[0], self.state.approved_scan_roots) else None
+
     def _gate_file_read(self, tool_name: str, kwargs: dict[str, Any]) -> Any:
         """Sandbox a file-reading tool to ``approved_scan_roots`` (#167).
 
@@ -491,8 +545,28 @@ class AgentEngine:
                 kwargs["paths"] = allowed
             return _GATE_OK
 
-        path = kwargs.get(_FILE_READ_TOOLS[tool_name])
+        path_kwarg = _FILE_READ_TOOLS[tool_name]
+        path = kwargs.get(path_kwarg)
         if path is not None and _contain(path, roots) is not None:
+            return _GATE_OK
+
+        # A bare filename ("OATP1C1 SOP TH 250425.docx") is what the model
+        # naturally emits — it sees filenames in the scanned-file inventory, not
+        # absolute paths. Resolving it relative to the CWD puts it outside every
+        # approved root, so the read was refused, and because a refusal is never
+        # recorded as evidence the model simply tried again: one session spent 226
+        # of 235 reader calls re-reading three files it could never open this way.
+        # Resolve the basename inside the approved roots instead. Only an
+        # UNAMBIGUOUS match is accepted — several files sharing a name give no
+        # basis to pick one, so that still refuses rather than guessing.
+        resolved_path = self._resolve_within_roots(path)
+        if resolved_path is not None:
+            kwargs[path_kwarg] = resolved_path
+            logger.info(
+                "Resolved bare filename %r to %s inside an approved scan root",
+                path,
+                resolved_path,
+            )
             return _GATE_OK
 
         logger.warning(
@@ -798,8 +872,6 @@ class AgentEngine:
             if tool_name == "scan_files":
                 tool_kwargs["approved_roots"] = self.state.approved_scan_roots.copy()
             result = tool_fn(**tool_kwargs)
-            if tool_name in {"read_file", "read_excel", "read_docx", "read_file_sample"}:
-                self._store_document_evidence(tool_name, kwargs.get("path", ""), result, kwargs)
             # Fold sandbox-refused paths back into read_multiple_files' own
             # ``skipped`` list so the agent sees them as unread (#167).
             if (
@@ -844,6 +916,18 @@ class AgentEngine:
                 result = spec.fn(self.state, **call_kwargs)
             else:
                 result = spec.fn(**call_kwargs)
+
+        # Record successful reader output as bounded session evidence. This sits
+        # AFTER every dispatch branch on purpose: `read_file`/`read_excel`/
+        # `read_docx` resolve through the generic registry below, not through
+        # `scanner_tools`, so hooking this inside the scanner branch (where it
+        # used to live) meant it only ever fired for `read_file_sample` and the
+        # evidence store stayed permanently empty — taking the "already loaded
+        # this document" de-duplication down with it.
+        if tool_name in _DOCUMENT_EVIDENCE_TOOLS:
+            self._store_document_evidence(
+                tool_name, str(kwargs.get("path", "")), result, kwargs
+            )
 
         # Memoize a fresh, non-error build_and_validate result for the debounce
         # above (#155). Bounded so a long session cannot grow the cache without

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -151,6 +151,108 @@ class TestArbitraryReadRefused:
         assert "a,b,c" in result
 
 
+class TestBareFilenameResolution:
+    """A bare filename resolves inside the approved roots — without widening them.
+
+    The model reads filenames off the scanned-file inventory, so it naturally
+    calls ``read_docx("SOP.docx")`` rather than passing an absolute path. That
+    resolved against the CWD, landed outside every approved root, and was
+    refused with a bare ``None`` that taught it nothing — one real session burnt
+    226 of 235 reader calls retrying three files it could never open that way.
+    """
+
+    def test_bare_filename_inside_approved_root_is_read(self, tmp_path):
+        approved = tmp_path / "approved"
+        (approved / "nested").mkdir(parents=True)
+        target = approved / "nested" / "notes.txt"
+        target.write_text("REAL CONTENT", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        assert engine.run_tool("read_file", path="notes.txt") == "REAL CONTENT"
+
+    def test_bare_filename_outside_approved_roots_is_still_refused(self, tmp_path):
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("TOP SECRET", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        # Resolution searches the approved roots only — a name that exists solely
+        # outside them stays unreadable.
+        assert engine.run_tool("read_file", path="secret.txt") is None
+
+    def test_ambiguous_bare_filename_is_refused_rather_than_guessed(self, tmp_path):
+        approved = tmp_path / "approved"
+        (approved / "a").mkdir(parents=True)
+        (approved / "b").mkdir(parents=True)
+        (approved / "a" / "dup.txt").write_text("FROM A", encoding="utf-8")
+        (approved / "b" / "dup.txt").write_text("FROM B", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        # Two files share the name, so there is no basis to pick one. Reading
+        # either would silently return a document the agent did not ask for.
+        assert engine.run_tool("read_file", path="dup.txt") is None
+
+    def test_a_path_with_directories_is_not_treated_as_a_bare_name(self, tmp_path):
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        (approved / "notes.txt").write_text("REAL CONTENT", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        # A wrong LOCATION is a genuine miss, not a filename off the inventory —
+        # resolving it by basename would mask the error.
+        assert engine.run_tool("read_file", path="../elsewhere/notes.txt") is None
+
+
+class TestReaderEvidenceSuppressesRereads:
+    """Successful reads are recorded, so an identical re-read is short-circuited.
+
+    The storage hook used to live inside the ``scanner_tools`` dispatch branch,
+    which does not carry ``read_file``/``read_excel``/``read_docx`` — they route
+    through the generic registry. So it only ever fired for ``read_file_sample``,
+    the evidence store stayed permanently empty, and the "already loaded" guard
+    it backs could never match.
+    """
+
+    def test_successful_read_is_recorded_as_evidence(self, tmp_path):
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        (approved / "notes.txt").write_text("REAL CONTENT", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        engine.run_tool("read_file", path=str(approved / "notes.txt"))
+        assert list(engine.state.document_evidence) == ["notes.txt"]
+
+    def test_refused_read_is_not_recorded(self, tmp_path):
+        approved = tmp_path / "approved"
+        approved.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("TOP SECRET", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        engine.run_tool("read_file", path=str(outside / "secret.txt"))
+        assert engine.state.document_evidence == {}
+
+    def test_bare_and_absolute_paths_share_one_evidence_key(self, tmp_path):
+        from builder.agents.react.agent_loop import _build_langchain_tools
+
+        approved = tmp_path / "approved"
+        (approved / "nested").mkdir(parents=True)
+        target = approved / "nested" / "notes.txt"
+        target.write_text("REAL CONTENT", encoding="utf-8")
+
+        engine = _engine_with_root(approved)
+        read_file = {t.name: t for t in _build_langchain_tools(engine)}["read_file"]
+
+        assert read_file.invoke({"path": "notes.txt"}) == "REAL CONTENT"
+        # Both spellings must normalise to the stored key, or the guard misses
+        # and the model re-reads the same document indefinitely.
+        for spelling in ("notes.txt", str(target)):
+            assert "Already loaded" in str(read_file.invoke({"path": spelling}))
+
+
 class TestSymlinkEscapeRefused:
     """Vector 3: a symlink whose realpath escapes the approved tree is refused
     for reads (its resolved target is what gets matched)."""


### PR DESCRIPTION
## Summary

The agent re-read the same documents endlessly. Measured on session `20260806_115705`:

| | |
|---|---|
| Reader calls attempted | 235 |
| Completed | 9 |
| Refused | 226 |
| Distinct files involved | 3 |

Three compounding faults:

1. **The de-duplication cache was wired to dead code.** `_store_document_evidence` lived in the `scanner_tools` dispatch branch, which does not carry `read_file` / `read_excel` / `read_docx` — those route through the generic registry. It only ever fired for `read_file_sample`, so `document_evidence` stayed empty and the "already loaded" guard never matched.
2. **Bare filenames were unreadable.** The model names files as the inventory shows them; those resolved against the CWD, landed outside the approved roots, and were refused with a bare `None` that taught it nothing.
3. **The loop-breaker could not catch it.** It counts *consecutive* identical calls (threshold 3); the model cycled three readers, so the longest identical run was 2.

## The sandbox is not widened

Only a name with **no directory component** is resolved, only an **unambiguous** match is accepted, and containment is re-checked on the result. Still refused: `/etc/passwd`, a bare `passwd`, a duplicate basename, `../elsewhere/notes.txt`.

## Tests

7 new regressions in `tests/test_path_traversal.py`; 187 pass locally across `test_path_traversal` / `test_engine` / `test_agent_loop` / `test_state_serializer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)