### PR TITLE
feat(ui): interactive chrome, live progress, and cost reporting

### DIFF
--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -205,7 +205,25 @@ def run_interactive_build(
     #     engine.run_tool, not LangChain, so this is the only per-tool signal), and
     #   * receives the existing #253 phase-progress strings via set_current.
     # The prior engine.on_tool_event hook is restored afterwards.
-    spinner: ProgressSpinner | None = ProgressSpinner() if interactive else None
+    # The pinned status footer is started BEFORE the spinner so the spinner can
+    # delegate its line to the footer's activity row (one painter owns the bottom
+    # of the terminal). Bound here so the finally can always tear it down.
+    from builder.agents import ui
+
+    footer: Any | None = None
+    if interactive:
+        footer = ui.make_status_footer(engine)
+        footer.start()
+    delegated = bool(footer is not None and footer.active)
+
+    spinner: ProgressSpinner | None = (
+        ProgressSpinner(
+            tick_interval=0.12 if delegated else 0.5,
+            activity_sink=footer.set_activity if delegated else None,
+        )
+        if interactive
+        else None
+    )
     emit = _spinner_emit(base_emit, spinner)
     prior_tool_event = engine.on_tool_event
     if spinner is not None:
@@ -223,8 +241,6 @@ def run_interactive_build(
         # — one implementation, no per-arm copy. The per-prompt status bar the
         # ReAct loop shows before every input is added to the guidance tail by
         # wrapping the human (see _run_build_body / _StatusBarHuman).
-        from builder.agents import ui
-
         if interactive:
             ui.print_resume_summary(engine, resumed=resumed)
         with spinner_ctx:
@@ -239,12 +255,14 @@ def run_interactive_build(
                 overrides=overrides,
             )
         if interactive:
-            ui.print_status_bar(engine)
+            ui.print_status_bar(engine, footer)
             ui.print_goodbye(engine)
         return result
     finally:
         # Restore the prior tool-event hook even if the build raised (#266).
         engine.on_tool_event = prior_tool_event
+        if footer is not None:
+            footer.stop()
 
 
 def run_build(

--- a/builder/agents/llm.py
+++ b/builder/agents/llm.py
@@ -146,6 +146,7 @@ def _build_chat_model(
     max_retries: int | None = None,
     role: str = "orchestrator",
     timeout: float | None = None,
+    streaming: bool = False,
 ) -> Any:
     """Build a LangChain chat model for the given or detected provider.
 
@@ -175,6 +176,15 @@ def _build_chat_model(
             (Issue #263). Falls back to ``VITRO_REQUEST_TIMEOUT`` then a finite
             built-in default so the model is never built without one — a silent
             provider stall can never hang a turn forever.
+        streaming: Stream the response token-by-token so a
+            ``on_llm_new_token`` callback can show the reply as it is written
+            (the interactive footer's live tail). ``invoke`` still returns one
+            aggregated message, so callers are unaffected. Set only by the
+            interactive ReAct loop; the pipeline's bounded leaves have nothing
+            to display and stay non-streaming. Off by default, and
+            ``VITRO_NO_STREAM=1`` forces it off everywhere — a provider that
+            mishandles streamed tool calls must be recoverable without a code
+            change.
 
     Returns:
         A LangChain ``BaseChatModel`` instance.
@@ -185,6 +195,9 @@ def _build_chat_model(
     if max_retries is None:
         env_val = os.environ.get("VITRO_MAX_RETRIES")
         max_retries = int(env_val) if env_val is not None else 3
+
+    if (os.environ.get("VITRO_NO_STREAM") or "").strip().lower() in ("1", "true", "yes", "on"):
+        streaming = False
 
     if timeout is None:
         timeout = _get_request_timeout()
@@ -253,6 +266,13 @@ def _build_chat_model(
             # "timeout" is the public alias of ChatOpenAI.request_timeout (#263).
             "timeout": timeout,
         }
+        if streaming:
+            kwargs["streaming"] = True
+            # OpenAI omits usage from a streamed response unless it is asked for.
+            # Without this the token counts silently become zero — and the status
+            # footer's tokens/cost, the profiler's accounting and the session
+            # cost report all read from that same usage metadata.
+            kwargs["stream_usage"] = True
         if use_responses:
             kwargs["use_responses_api"] = True
         if reasoning_effort:
@@ -309,6 +329,10 @@ def _build_chat_model(
             # .default_request_timeout (#263).
             "timeout": timeout,
         }
+        if streaming:
+            # Anthropic reports usage on the streamed message_start /
+            # message_delta events, so no extra opt-in is needed here.
+            kwargs["streaming"] = True
         if api_key:
             kwargs["api_key"] = api_key
         return ChatAnthropic(**kwargs)

--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import logging
 import random
 import threading
+from collections.abc import Callable
 from time import monotonic
 from typing import Any
 
@@ -41,6 +42,15 @@ from builder.tools.hitl import (
 logger = logging.getLogger(__name__)
 
 __all__ = ["ProgressSpinner", "TOX_SPINNER_PHRASES"]
+
+# Animation frames for the delegated (footer-painted) line. Rich's "dots"
+# spinner draws these itself in Live mode; the footer needs them spelled out.
+_DELEGATED_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+# Characters of streamed reply text kept on the spinner line. Sized to leave
+# room for the phrase, the elapsed counter and the quotes on an 80-column
+# terminal; the footer truncates anything wider anyway.
+_PREVIEW_WIDTH = 40
 
 
 # The single toxicology-themed phrase list, shared by both build arms (#344).
@@ -109,6 +119,7 @@ class ProgressSpinner:
         phrase: str | None = None,
         *,
         tick_interval: float = 0.5,
+        activity_sink: Callable[[str | None], None] | None = None,
     ) -> None:
         """Build a spinner.
 
@@ -119,6 +130,15 @@ class ProgressSpinner:
                 :data:`TOX_SPINNER_PHRASES`.
             tick_interval: Seconds between elapsed-time repaints by the daemon
                 thread. Kept configurable so tests can tick quickly.
+            activity_sink: When given, the spinner **delegates** its display:
+                it opens no Rich ``Live`` region and instead pushes its rendered
+                line to this callback (``None`` when it finishes), which the
+                pinned footer paints on its own reserved row. Two wins beyond
+                tidiness — the working line stops drifting up the transcript
+                with the output it interleaves with, and since the footer sits
+                OUTSIDE the terminal's scrolling region it cannot clobber a
+                prompt, so nothing has to be suspended to read stdin. Without a
+                sink the spinner behaves exactly as before.
         """
         if console is None:
             from rich.console import Console
@@ -127,7 +147,11 @@ class ProgressSpinner:
         self._console = console
         self._phrase = phrase or random.choice(TOX_SPINNER_PHRASES)
         self._current: str | None = None
+        self._preview: str | None = None
+        self._preview_buffer = ""
         self._tick_interval = tick_interval
+        self._sink = activity_sink
+        self._frame = 0
         self._start = monotonic()
         self._stop = threading.Event()
         # Set while a HITL prompt owns the terminal: the tick thread must not
@@ -138,11 +162,19 @@ class ProgressSpinner:
         # refresh thread, no daemon tick thread — nothing to hang on teardown.
         # A console missing ``is_terminal`` (a test fake) defaults to animated.
         self._active: bool = bool(getattr(console, "is_terminal", True))
-        if self._active:
-            self._status: Any | None = console.status(
+        if self._sink is not None:
+            # Delegated: the footer owns the pixels, so there is no Live region
+            # to build — but the tick thread still runs, because the elapsed
+            # counter and the spinner frame have to keep moving.
+            self._status: Any | None = None
+            self._thread: threading.Thread | None = threading.Thread(
+                target=self._tick, daemon=True
+            )
+        elif self._active:
+            self._status = console.status(
                 self._render(), spinner="dots", spinner_style="green"
             )
-            self._thread: threading.Thread | None = threading.Thread(target=self._tick, daemon=True)
+            self._thread = threading.Thread(target=self._tick, daemon=True)
         else:
             self._status = None
             self._thread = None
@@ -152,12 +184,37 @@ class ProgressSpinner:
     # ------------------------------------------------------------------
 
     def _render(self) -> str:
-        """Render the spinner line: phrase, elapsed seconds, and the current op."""
+        """Render the spinner line: phrase, elapsed seconds, and the current op.
+
+        A running tool wins over the reply tail: they never overlap in time
+        (the model finishes writing before a tool starts), and when both are
+        somehow set the concrete tool is the more informative of the two.
+        """
         elapsed = int(monotonic() - self._start)
         line = f"[green]{self._phrase}…[/green] [dim]({elapsed}s)[/dim]"
         if self._current:
             line += f"  [dim]·[/dim] [cyan]{self._current}[/cyan]"
+        elif self._preview:
+            line += f'  [dim]·[/dim] [dim]writing:[/dim] [white]"{self._preview}"[/white]'
         return line
+
+    def _render_delegated(self) -> str:
+        """The delegated line — the animation frame Rich would otherwise draw.
+
+        ``console.status`` supplies the turning glyph in Live mode; when the
+        footer paints the line instead, the frame has to come from here.
+        """
+        glyph = _DELEGATED_FRAMES[self._frame % len(_DELEGATED_FRAMES)]
+        return f"[green]{glyph}[/green] {self._render()}"
+
+    def _publish(self) -> None:
+        """Push the current line to the activity sink (best-effort)."""
+        if self._sink is None:
+            return
+        try:
+            self._sink(self._render_delegated())
+        except Exception:  # noqa: BLE001 — UI chrome must never break the build
+            logger.debug("spinner publish failed", exc_info=True)
 
     def _tick(self) -> None:
         """Daemon loop: repaint the elapsed time roughly every tick_interval.
@@ -167,6 +224,10 @@ class ProgressSpinner:
         """
         while not self._stop.wait(self._tick_interval):
             if self._paused.is_set():
+                continue
+            if self._sink is not None:
+                self._frame += 1
+                self._publish()
                 continue
             status = self._status
             if status is None:  # silent mode never starts this thread; belt-and-braces
@@ -189,6 +250,10 @@ class ProgressSpinner:
         the op is still remembered but there is no Live region to repaint.
         """
         self._current = text
+        if self._sink is not None:
+            if not self._paused.is_set():
+                self._publish()
+            return
         if not self._active or self._status is None:
             return  # silent mode: remember the op, paint nothing
         if self._paused.is_set():
@@ -198,6 +263,26 @@ class ProgressSpinner:
         except Exception:  # noqa: BLE001 — UI chrome must never break the build
             logger.debug("spinner set_current: status.update failed", exc_info=True)
 
+    def append_preview(self, token: str) -> None:
+        """Append a streamed token to the live reply tail.
+
+        Deliberately does NOT repaint: a fast stream would otherwise mean a
+        terminal write per token. The tick thread picks the text up on its next
+        pass, so the tail advances at the animation rate whatever the token rate.
+        """
+        if not token:
+            return
+        self._preview_buffer += token
+        # Keep a moving window of the most recent characters: a fixed head
+        # would freeze after the first few words and stop reading as live.
+        window = self._preview_buffer.replace("\n", " ")[-_PREVIEW_WIDTH:]
+        self._preview = window.lstrip()
+
+    def set_preview(self, text: str | None) -> None:
+        """Replace (``None`` clears) the reply tail shown while the model writes."""
+        self._preview_buffer = text or ""
+        self._preview = (text or "").replace("\n", " ")[-_PREVIEW_WIDTH:] or None
+
     def pause(self) -> None:
         """Tear down the Live region and stop ticking so a HITL prompt is clean.
 
@@ -206,6 +291,11 @@ class ProgressSpinner:
         no-op in silent mode (there is no Live region owning the terminal).
         """
         self._paused.set()
+        if self._sink is not None:
+            # Delegated: the footer lives outside the scrolling region, so it
+            # never overwrites a prompt. Freeze the line (the elapsed counter
+            # stops while the user reads) but leave it visible.
+            return
         if not self._active or self._status is None:
             return
         try:
@@ -218,6 +308,10 @@ class ProgressSpinner:
 
         A no-op in silent mode (there was no Live region to restart).
         """
+        if self._sink is not None:
+            self._paused.clear()
+            self._publish()
+            return
         if not self._active or self._status is None:
             self._paused.clear()
             return
@@ -234,7 +328,11 @@ class ProgressSpinner:
     def __enter__(self) -> "ProgressSpinner":
         # In silent mode (non-TTY) there is no Live region and no tick thread to
         # start — just register so a HITL prompt's suspend/resume stays valid.
-        if self._active and self._status is not None and self._thread is not None:
+        if self._sink is not None:
+            if self._thread is not None:
+                self._thread.start()
+            self._publish()
+        elif self._active and self._status is not None and self._thread is not None:
             self._status.__enter__()
             self._thread.start()
         register_console_animation(self)
@@ -242,6 +340,17 @@ class ProgressSpinner:
 
     def __exit__(self, *exc: Any) -> None:
         unregister_console_animation(self)
+        if self._sink is not None:
+            # Stop ticking and clear the footer's activity row — the work this
+            # line described is over, so leaving it up would misreport.
+            self._stop.set()
+            if self._thread is not None:
+                self._thread.join(timeout=1.0)
+            try:
+                self._sink(None)
+            except Exception:  # noqa: BLE001 — teardown must never raise
+                logger.debug("spinner exit: sink clear failed", exc_info=True)
+            return
         # Silent mode: nothing was started, so nothing to stop or join.
         if not self._active:
             return

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -156,6 +156,24 @@ class _ToolSpinnerCallback(BaseCallbackHandler):
     def on_tool_end(self, output: Any, **kwargs: Any) -> None:
         self.spinner.set_current(None)
 
+    def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:
+        # A new generation begins: drop the previous reply's tail so the line
+        # never shows text from the step before.
+        self.spinner.set_preview(None)
+
+    on_chat_model_start = on_llm_start
+
+    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+        # Only fires when the model was built with streaming. The spinner keeps
+        # the running text and repaints it on its own tick, so a fast token
+        # stream cannot turn into a write per token.
+        self.spinner.append_preview(token)
+
+    def on_llm_end(self, response: Any, **kwargs: Any) -> None:
+        # The reply is about to be printed in full to the transcript; a stale
+        # tail of it hanging around under the spinner would just be noise.
+        self.spinner.set_preview(None)
+
 
 # ---------------------------------------------------------------------------
 # LangChain tool wrapper
@@ -2104,8 +2122,16 @@ def run_interactive_agent(
     # wired onto the chat model, so the loop-level guard and the provider-level
     # request timeout agree.
     request_timeout = _get_request_timeout()
+    # Streaming feeds the footer's live reply tail via on_llm_new_token. invoke()
+    # still returns one aggregated message, so the graph, the timeout guard and
+    # tool-call handling are unchanged — the only visible difference is that the
+    # user can watch a long turn being written instead of staring at a timer.
     llm = _build_chat_model(
-        provider=provider, model=model, base_url=base_url, timeout=request_timeout
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        timeout=request_timeout,
+        streaming=True,
     )
 
     # Build the explicit StateGraph instead of using create_agent()
@@ -2389,7 +2415,16 @@ def run_interactive_agent(
         old_root_level = root_logger.level
         root_logger.setLevel(logging.ERROR)
 
-        spinner = ProgressSpinner(console)
+        # With the footer up, the spinner paints onto its activity row instead of
+        # opening a Live region in the scrolling area: the working line then
+        # holds still at the bottom rather than drifting up with the transcript.
+        # It ticks faster there because the footer, not Rich, animates the frame.
+        delegated = footer.active
+        spinner = ProgressSpinner(
+            console,
+            tick_interval=0.12 if delegated else 0.5,
+            activity_sink=footer.set_activity if delegated else None,
+        )
         main_config = {
             **_thread_config(),
             "callbacks": [_ToolSpinnerCallback(spinner)],
@@ -2485,108 +2520,127 @@ def run_interactive_agent(
     # read (#412); everything after it is an ordinary typed turn. Blank is absent.
     pending_input: str | None = (initial_prompt or "").strip() or None
 
-    while True:
-        try:
-            # Compact status header above each prompt (counts live here now,
-            # so the prompt line stays clean).
-            ui.print_status_bar(engine)
-            console.print()
-            if pending_input is not None:
-                # Echo the seeded line so the transcript shows what drove the
-                # turn, exactly as boxed_input echoes a typed one.
-                user_input, pending_input = pending_input, None
-                console.print(f"[bold cyan]❯[/bold cyan] {user_input}")
-            else:
-                # Rounded input box (Claude Code style); falls back to a plain
-                # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
-                user_input = ui.boxed_input(console)
-        except KeyboardInterrupt:
-            # Ctrl+C: clear the line and re-prompt
-            console.print()
-            continue
-        except EOFError:
-            # Ctrl+D: exit
-            console.print()
-            _finalize_on_exit()
-            ui.print_goodbye(engine)
-            break
-
-        if user_input.lower() in ("quit", "exit", "q"):
-            _finalize_on_exit()
-            ui.print_goodbye(engine)
-            break
-
-        if not user_input:
-            continue
-
-        # ── One user message → possibly several model turns ─────────────────
-        # Fix B (#263): after the first (user-driven) turn, decide deterministically
-        # whether to PROMPT the user (a genuine question) or AUTO-CONTINUE the
-        # agent without reading stdin (it just narrated/worked). The autonomous
-        # run is bounded by _MAX_AUTONOMOUS_TURNS and stops as soon as the crate
-        # is complete. Fix A (#263): consecutive empty completions (the stall
-        # symptom) end the run after one retry so the #254 backstop can land the
-        # crate. _run_turn never raises and never hangs past request_timeout, so
-        # an exception can never escape this loop body.
-        try:
-            message = user_input
-            empty_streak = 0
-            for _autonomous_turn in range(_MAX_AUTONOMOUS_TURNS + 1):
-                reply, outcome = _run_turn(message)
-
-                # A non-ok outcome (timeout / error / recursion) ends the turn
-                # gracefully; fall back to prompting the user.
-                if outcome != "ok":
-                    break
-
-                # Empty-completion recovery (Fix A): retry ONCE, then stop.
-                if _reply_is_empty_completion(reply):
-                    empty_streak += 1
-                    if empty_streak >= _MAX_EMPTY_COMPLETIONS:
-                        logger.info(
-                            "Ending turn after %d consecutive empty completions",
-                            empty_streak,
-                        )
-                        break
-                    message = _AUTO_CONTINUE_DIRECTIVE
-                    continue
-                empty_streak = 0
-
-                # A genuine question → stop and prompt the user (current
-                # behavior). A user-typed message still overrides next loop.
-                if _reply_is_question(reply):
-                    break
-
-                # The crate is finished → stop auto-continuing and check in.
-                if _crate_is_complete(engine):
-                    logger.info("Crate complete — ending autonomous run")
-                    break
-
-                # Otherwise the agent just narrated/worked → AUTO-CONTINUE with
-                # an internal directive, WITHOUT reading stdin. The cap on the
-                # enclosing range bounds this so it can never spin forever.
-                message = _AUTO_CONTINUE_DIRECTIVE
-            else:
-                # The for-loop exhausted the cap without breaking → check in.
-                logger.info(
-                    "Reached max autonomous turns (%d) — checking in with the user",
-                    _MAX_AUTONOMOUS_TURNS,
-                )
-                console.print(
-                    "[dim]I've worked autonomously for a while — let me know how "
-                    "you'd like to proceed.[/dim]"
-                )
+    # The status footer is pinned to the bottom rows for the whole session so
+    # entities, validation dots, tokens and cost keep advancing while the agent
+    # works — the scrolling bar only ever refreshed when the user was prompted,
+    # which on a 15-turn autonomous run meant minutes of frozen numbers. It is a
+    # no-op on a non-TTY, where print_status_bar falls back to the scrolling bar.
+    footer = ui.make_status_footer(engine, console)
+    footer.start()
+    try:
+        while True:
+            try:
+                # Status before each prompt: a repaint of the pinned footer when
+                # it owns the bottom rows, otherwise the scrolling header (counts
+                # live there, so the prompt line stays clean).
+                ui.print_status_bar(engine, footer)
                 console.print()
-        except KeyboardInterrupt:
-            # Ctrl+C during a turn / the autonomous run: stop working and return
-            # to the prompt so the user can interject (preserve interruptibility).
-            console.print()
-            console.print("[dim]Stopped — back to you.[/dim]")
-            console.print()
-        except Exception as exc:  # noqa: BLE001 — the loop must never crash.
-            logger.exception("Agent error")
-            console.print(f"[red bold]Error:[/red bold] {exc}")
-            console.print()
+                if pending_input is not None:
+                    # Echo the seeded line so the transcript shows what drove the
+                    # turn, exactly as boxed_input echoes a typed one.
+                    user_input, pending_input = pending_input, None
+                    console.print(f"[bold cyan]❯[/bold cyan] {user_input}")
+                else:
+                    # Rounded input box (Claude Code style); falls back to a plain
+                    # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
+                    # prompt_toolkit erases to the end of the screen on every
+                    # repaint, so the footer repaints on the same beat.
+                    user_input = ui.boxed_input(console, on_render=footer.refresh)
+            except KeyboardInterrupt:
+                # Ctrl+C: clear the line and re-prompt
+                console.print()
+                continue
+            except EOFError:
+                # Ctrl+D: exit
+                console.print()
+                _finalize_on_exit()
+                ui.print_goodbye(engine)
+                break
+
+            if user_input.lower() in ("quit", "exit", "q"):
+                _finalize_on_exit()
+                ui.print_goodbye(engine)
+                break
+
+            if not user_input:
+                continue
+
+            # ── One user message → possibly several model turns ─────────────────
+            # Fix B (#263): after the first (user-driven) turn, decide deterministically
+            # whether to PROMPT the user (a genuine question) or AUTO-CONTINUE the
+            # agent without reading stdin (it just narrated/worked). The autonomous
+            # run is bounded by _MAX_AUTONOMOUS_TURNS and stops as soon as the crate
+            # is complete. Fix A (#263): consecutive empty completions (the stall
+            # symptom) end the run after one retry so the #254 backstop can land the
+            # crate. _run_turn never raises and never hangs past request_timeout, so
+            # an exception can never escape this loop body.
+            try:
+                message = user_input
+                empty_streak = 0
+                for _autonomous_turn in range(_MAX_AUTONOMOUS_TURNS + 1):
+                    reply, outcome = _run_turn(message)
+                    # Land the turn's work in the footer immediately rather than
+                    # waiting up to a tick — the reply and the counts it produced
+                    # should appear together.
+                    footer.refresh()
+
+                    # A non-ok outcome (timeout / error / recursion) ends the turn
+                    # gracefully; fall back to prompting the user.
+                    if outcome != "ok":
+                        break
+
+                    # Empty-completion recovery (Fix A): retry ONCE, then stop.
+                    if _reply_is_empty_completion(reply):
+                        empty_streak += 1
+                        if empty_streak >= _MAX_EMPTY_COMPLETIONS:
+                            logger.info(
+                                "Ending turn after %d consecutive empty completions",
+                                empty_streak,
+                            )
+                            break
+                        message = _AUTO_CONTINUE_DIRECTIVE
+                        continue
+                    empty_streak = 0
+
+                    # A genuine question → stop and prompt the user (current
+                    # behavior). A user-typed message still overrides next loop.
+                    if _reply_is_question(reply):
+                        break
+
+                    # The crate is finished → stop auto-continuing and check in.
+                    if _crate_is_complete(engine):
+                        logger.info("Crate complete — ending autonomous run")
+                        break
+
+                    # Otherwise the agent just narrated/worked → AUTO-CONTINUE with
+                    # an internal directive, WITHOUT reading stdin. The cap on the
+                    # enclosing range bounds this so it can never spin forever.
+                    message = _AUTO_CONTINUE_DIRECTIVE
+                else:
+                    # The for-loop exhausted the cap without breaking → check in.
+                    logger.info(
+                        "Reached max autonomous turns (%d) — checking in with the user",
+                        _MAX_AUTONOMOUS_TURNS,
+                    )
+                    console.print(
+                        "[dim]I've worked autonomously for a while — let me know how "
+                        "you'd like to proceed.[/dim]"
+                    )
+                    console.print()
+            except KeyboardInterrupt:
+                # Ctrl+C during a turn / the autonomous run: stop working and return
+                # to the prompt so the user can interject (preserve interruptibility).
+                console.print()
+                console.print("[dim]Stopped — back to you.[/dim]")
+                console.print()
+            except Exception as exc:  # noqa: BLE001 — the loop must never crash.
+                logger.exception("Agent error")
+                console.print(f"[red bold]Error:[/red bold] {exc}")
+                console.print()
+    finally:
+        # Always hand the bottom rows (and the scrolling region) back, on every
+        # exit path — quit, EOF, or an exception escaping the loop.
+        footer.stop()
 
 
 def _format_entity_summary(entities: list[Any]) -> str:

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -22,10 +22,17 @@ Design contract:
 
 from __future__ import annotations
 
+import atexit
+import io
+import json
 import logging
+import os
 import sys
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING, Any
 
 from rich.console import Console, Group, RenderableType
@@ -33,6 +40,7 @@ from rich.markdown import Markdown
 from rich.padding import Padding
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
@@ -131,27 +139,77 @@ class UiSnapshot:
     cost_usd: float | None = None
 
 
+@dataclass
+class _TokenTail:
+    """Where the incremental profile reader stopped, and the totals so far."""
+
+    inode: int
+    offset: int
+    tokens_in: int
+    tokens_out: int
+    last_model: str
+
+
+# Per-profile-file resume points for :func:`_read_token_totals`, keyed by the
+# resolved path (so a monkeypatched ``SESSION_DIR`` gets its own entry).
+_TOKEN_TAILS: dict[str, _TokenTail] = {}
+
+
 def _read_token_totals(session_id: str) -> tuple[int, int, str]:
     """Best-effort cumulative ``(input, output, last_model)`` from the profile.
 
-    Reads ``profile.ndjson`` for the session and sums ``model`` ``node_end``
-    token counts. Returns zeros on any failure — token display is advisory.
+    Sums the ``input_tokens`` / ``output_tokens`` of ``model`` ``node_end``
+    events in the session's ``profile.ndjson``. Returns zeros on any failure —
+    token display is advisory.
+
+    The read is **incremental**: only bytes appended since the previous call are
+    parsed, and only up to the last complete line (a half-written record is
+    re-read next time). The pinned footer repaints about once a second over a
+    file that grows to hundreds of KB in a long session, so re-parsing the whole
+    profile per repaint would burn real CPU for an unchanged prefix. The cache
+    resets itself whenever the file is replaced (inode change) or truncated.
     """
     try:
-        from builder.tools.dashboard import read_profile
         from builder.tools.profiler import SESSION_DIR
 
         profile_path = SESSION_DIR / session_id / "profile.ndjson"
         if not profile_path.exists():
             return 0, 0, ""
-        records = read_profile(profile_path)
-        model_ends = [
-            r for r in records if r.get("event") == "node_end" and r.get("node") == "model"
-        ]
-        total_in = sum(int(r.get("input_tokens", 0) or 0) for r in model_ends)
-        total_out = sum(int(r.get("output_tokens", 0) or 0) for r in model_ends)
-        last_model = (model_ends[-1].get("model_name") or "") if model_ends else ""
-        return total_in, total_out, last_model
+
+        stat = profile_path.stat()
+        key = str(profile_path)
+        tail = _TOKEN_TAILS.get(key)
+        if tail is None or tail.inode != stat.st_ino or stat.st_size < tail.offset:
+            tail = _TokenTail(
+                inode=stat.st_ino, offset=0, tokens_in=0, tokens_out=0, last_model=""
+            )
+            _TOKEN_TAILS[key] = tail
+
+        if stat.st_size > tail.offset:
+            with profile_path.open("rb") as handle:
+                handle.seek(tail.offset)
+                chunk = handle.read(stat.st_size - tail.offset)
+            complete = chunk.rfind(b"\n")
+            if complete >= 0:
+                tail.offset += complete + 1
+                for raw in chunk[: complete + 1].splitlines():
+                    if not raw.strip():
+                        continue
+                    try:
+                        record = json.loads(raw)
+                    except (ValueError, UnicodeDecodeError):
+                        continue  # a torn/foreign line is skipped, never fatal
+                    if (
+                        not isinstance(record, dict)
+                        or record.get("event") != "node_end"
+                        or record.get("node") != "model"
+                    ):
+                        continue
+                    tail.tokens_in += int(record.get("input_tokens", 0) or 0)
+                    tail.tokens_out += int(record.get("output_tokens", 0) or 0)
+                    tail.last_model = record.get("model_name") or tail.last_model
+
+        return tail.tokens_in, tail.tokens_out, tail.last_model
     except Exception:
         logger.debug("token totals unavailable for %s", session_id, exc_info=True)
         return 0, 0, ""
@@ -215,34 +273,152 @@ def _dot(ok: bool) -> str:
     return _PASS_DOT if ok else _PENDING_DOT
 
 
-def render_status_bar(snap: UiSnapshot) -> RenderableType:
-    """A compact one-line status header (session · counts · validation · tokens).
+def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None = None) -> str:
+    """The status line as one line of Rich markup (no padding, no newline).
 
-    Rendered as a re-printed dim line (not a pinned bar, which would conflict
-    with ``console.input``/``console.status``); includes one blank line above
-    for breathing room.
+    The single composition of the status fields, shared by the scrolling
+    :func:`render_status_bar` and the :class:`PinnedFooter`, so the pinned line
+    and the printed line can never drift apart.
+
+    Args:
+        snap: The state to render.
+        highlight: Optional ``field key -> Rich style`` overrides, replacing that
+            field's normal dim styling. :class:`StatusFader` uses this to tint
+            the fields that just changed. Keys are the ones in
+            :func:`status_field_values`.
     """
+    styles = highlight or {}
+
+    def field(key: str, text: str, style: str = "dim") -> str:
+        return f"[{styles.get(key, style)}]{text}[/]"
+
     token_str = ""
     if snap.tokens_in + snap.tokens_out > 0:
         from builder.pricing import format_cost
 
         cost_str = f"@{format_cost(snap.cost_usd)}" if snap.cost_usd is not None else ""
         total = snap.tokens_in + snap.tokens_out
-        token_str = (
-            f"  {_SEP}  [dim]tok {snap.tokens_in}→{snap.tokens_out} ({total})"
-            f"{cost_str}[/dim]"
+        token_str = "  " + _SEP + "  " + field(
+            "tokens", f"tok {snap.tokens_in}→{snap.tokens_out} ({total}){cost_str}"
         )
 
-    status = (
-        f"[dim]{snap.session_id}[/dim]  {_SEP}  "
-        f"[dim]{snap.entity_count} entities[/dim]  {_SEP}  "
-        f"[dim]{snap.file_count} files[/dim]  {_SEP}  "
-        f"{_dot(snap.base_passed)} [dim]base[/dim]  "
-        f"{_dot(snap.isa_passed)} [dim]ISA[/dim]  "
-        f"{_dot(snap.tox_passed)} [dim]Tox[/dim]"
+    return (
+        f"{field('session', snap.session_id)}  {_SEP}  "
+        f"{field('entities', f'{snap.entity_count} entities')}  {_SEP}  "
+        f"{field('files', f'{snap.file_count} files')}  {_SEP}  "
+        f"{_dot(snap.base_passed)} {field('base', 'base')}  "
+        f"{_dot(snap.isa_passed)} {field('isa', 'ISA')}  "
+        f"{_dot(snap.tox_passed)} {field('tox', 'Tox')}"
         f"{token_str}"
     )
-    return Group("", Padding(status, (0, 0, 0, 1)))
+
+
+def status_field_values(snap: UiSnapshot) -> dict[str, Any]:
+    """The comparable value behind each status field, keyed as in *highlight*."""
+    return {
+        "session": snap.session_id,
+        "entities": snap.entity_count,
+        "files": snap.file_count,
+        "base": snap.base_passed,
+        "isa": snap.isa_passed,
+        "tox": snap.tox_passed,
+        "tokens": (snap.tokens_in, snap.tokens_out, snap.cost_usd),
+    }
+
+
+# How a just-changed field cools off: (age in seconds below which it applies,
+# style). Bright at the moment of change, deepening, then back to normal dim —
+# enough to catch the eye mid-run without the line ever looking like an error.
+_FADE_STEPS: tuple[tuple[float, str], ...] = (
+    (0.7, "bold #9cc3ff"),
+    (1.6, "#5f87ff"),
+    (2.6, "#4a5f9e"),
+    (3.5, "#3b4a72"),
+)
+
+# The same ramp in red, for a change that made things WORSE — entities or files
+# disappearing, or a validation layer that used to pass and no longer does. Blue
+# for both would report "something moved" while hiding which way, and losing a
+# passing profile is the one event in this line worth interrupting someone for.
+_FADE_STEPS_WORSE: tuple[tuple[float, str], ...] = (
+    (0.7, "bold #ff9c9c"),
+    (1.6, "#ff5f5f"),
+    (2.6, "#b34a4a"),
+    (3.5, "#7d3838"),
+)
+
+
+def _fade_style(age: float, *, worse: bool = False) -> str | None:
+    """The highlight style for a change *age* seconds old (``None`` once cold)."""
+    for limit, style in _FADE_STEPS_WORSE if worse else _FADE_STEPS:
+        if age < limit:
+            return style
+    return None
+
+
+def _is_worse(key: str, previous: Any, current: Any) -> bool:
+    """Whether *key* moving from *previous* to *current* is a regression.
+
+    Counts fewer entities or files, and a validation profile that stops
+    passing. Token/cost growth is deliberately NOT a regression: it only ever
+    goes up, so painting it red would make the normal case look alarming.
+    """
+    if key in ("entities", "files"):
+        try:
+            return int(current) < int(previous)
+        except (TypeError, ValueError):
+            return False
+    if key in ("base", "isa", "tox"):
+        return bool(previous) and not bool(current)
+    return False
+
+
+class StatusFader:
+    """Tracks which status fields changed and fades their highlight over time.
+
+    A pinned line is easy to stop reading: the numbers move, but nothing draws
+    the eye to WHICH number moved. This tints each field for a few seconds after
+    it changes — entities climbing, a validation dot flipping, cost ticking up —
+    and lets the tint decay back to normal, so the footer reports change without
+    becoming a permanent light show. Blue for ordinary progress, red when the
+    change is a regression (see :func:`_is_worse`), so direction is visible at a
+    glance rather than needing the number to be read.
+
+    Pure apart from the clock, which is injectable for tests.
+    """
+
+    def __init__(self, clock: Callable[[], float] | None = None) -> None:
+        self._clock = clock or monotonic
+        self._values: dict[str, Any] = {}
+        # key -> (when it changed, whether that change was a regression)
+        self._changed_at: dict[str, tuple[float, bool]] = {}
+
+    def markup(self, snap: UiSnapshot) -> str:
+        """Render *snap*, highlighting fields that changed since the last call."""
+        now = self._clock()
+        for key, value in status_field_values(snap).items():
+            if key in self._values and self._values[key] != value:
+                self._changed_at[key] = (now, _is_worse(key, self._values[key], value))
+            self._values[key] = value
+
+        highlight: dict[str, str] = {}
+        for key, (changed_at, worse) in list(self._changed_at.items()):
+            style = _fade_style(now - changed_at, worse=worse)
+            if style is None:
+                del self._changed_at[key]  # cold: stop tracking it
+            else:
+                highlight[key] = style
+        return render_status_markup(snap, highlight=highlight)
+
+
+def render_status_bar(snap: UiSnapshot) -> RenderableType:
+    """A compact one-line status header (session · counts · validation · tokens).
+
+    The scrolling form: a re-printed dim line with one blank line above for
+    breathing room. Used when the terminal cannot host the pinned footer
+    (non-TTY, dumb terminal, or the footer explicitly disabled).
+    """
+    return Group("", Padding(render_status_markup(snap), (0, 0, 0, 1)))
 
 
 def render_reply(content: Any) -> RenderableType:
@@ -341,6 +517,314 @@ def render_goodbye(
 
 
 # ---------------------------------------------------------------------------
+# Pinned footer — a status line held on the bottom rows of the terminal
+# ---------------------------------------------------------------------------
+
+# Set to 1/true/yes to force the scrolling status bar instead of the pinned
+# footer. The escape sequences below are standard (DECSTBM), but a terminal that
+# mishandles them corrupts the whole session, so there must be an off switch
+# that needs no code change.
+FOOTER_DISABLE_ENV = "VITRO_NO_PINNED_FOOTER"
+
+# Rows the footer reserves at the bottom: a rule, the activity line (the
+# spinner, when work is running), and the status line.
+_FOOTER_ROWS = 3
+
+# Below this terminal height the footer is not worth three of the user's rows.
+_FOOTER_MIN_HEIGHT = 10
+
+# Consecutive write failures after which the footer disables itself for good
+# rather than fighting a terminal that clearly does not want it.
+_FOOTER_MAX_FAILURES = 3
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+class PinnedFooter:
+    """A status line pinned to the bottom rows of the terminal.
+
+    Mechanism: a DEC scrolling region (``CSI 1;{h-2} r``) shrinks the terminal's
+    scroll area to everything above the last two rows, so ordinary output —
+    Rich prints, the spinner's ``Live`` region, the ``prompt_toolkit`` input box
+    — scrolls underneath a footer that is repainted in place. Nothing else in
+    the session has to know the footer exists.
+
+    Every paint is a single ``write`` wrapped in save-cursor/restore-cursor, and
+    is taken under the Rich console's own lock, so it cannot interleave with a
+    Rich repaint and cannot move the cursor out from under one.
+
+    The footer is **best-effort chrome**: it is inactive unless stdout is a real
+    terminal, it disables itself after a few failed writes, and
+    :meth:`stop` — which is also registered with :mod:`atexit` — always restores
+    the full scrolling region. Callers never need to branch on any of that,
+    except to fall back to the scrolling status bar when :attr:`active` is
+    false.
+    """
+
+    def __init__(
+        self,
+        console: Console,
+        provider: Callable[[], str],
+        *,
+        interval: float = 1.0,
+    ) -> None:
+        """Build a footer.
+
+        Args:
+            console: The Rich console that owns the terminal.
+            provider: Called on every repaint; returns one line of Rich markup.
+                Kept as a callback (not a value) so the footer always paints
+                *current* state, whoever triggers the repaint.
+            interval: Seconds between background repaints.
+        """
+        self._console = console
+        self._provider = provider
+        self._interval = interval
+        self._file = getattr(console, "file", sys.stdout)
+        # Rich serialises its own output on Console._lock; sharing it is what
+        # keeps a footer paint from landing inside a Live repaint.
+        self._lock: Any = getattr(console, "_lock", None) or threading.RLock()
+        self._active = False
+        self._failures = 0
+        self._size: tuple[int, int] = (0, 0)
+        self._activity: str | None = None
+        self._paused = threading.Event()
+        self._stopping = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    # -- capability ----------------------------------------------------------
+
+    @staticmethod
+    def supported(console: Console) -> bool:
+        """Whether *console* can host a pinned footer (fail-closed)."""
+        if _truthy(os.environ.get(FOOTER_DISABLE_ENV)):
+            return False
+        if not getattr(console, "is_terminal", False):
+            return False
+        if getattr(console, "is_dumb_terminal", False):
+            return False
+        if (os.environ.get("TERM") or "").strip().lower() in {"", "dumb"}:
+            return False
+        stream = getattr(console, "file", None)
+        try:
+            return bool(stream is not None and stream.isatty())
+        except Exception:
+            return False
+
+    @property
+    def active(self) -> bool:
+        """Whether the footer currently owns the bottom rows."""
+        return self._active
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def start(self) -> None:
+        """Reserve the bottom rows and begin repainting (no-op if unsupported)."""
+        if self._active or not self.supported(self._console):
+            return
+        width, height = self._terminal_size()
+        if height < _FOOTER_MIN_HEIGHT:
+            return
+        # Scroll the reserved rows into existence FIRST, then step back up into
+        # what is about to become the region: without this the footer would be
+        # painted over whatever occupied the bottom rows.
+        if not self._write("\n" * _FOOTER_ROWS + f"\x1b[{_FOOTER_ROWS}A"):
+            return
+        self._active = True
+        self._apply_region(width, height)
+        atexit.register(self.stop)
+        self._thread = threading.Thread(target=self._tick, daemon=True)
+        self._thread.start()
+        self.refresh()
+
+    def stop(self) -> None:
+        """Restore the full scrolling region and clear the footer rows.
+
+        Idempotent, and safe to call from ``atexit`` or an exception path — a
+        session that ends without this leaves the user's terminal unable to
+        scroll its bottom rows.
+        """
+        if not self._active:
+            return
+        self._active = False
+        self._stopping.set()
+        _, height = self._terminal_size()
+        cleared = "".join(
+            f"\x1b[{max(1, height - offset)};1H\x1b[2K" for offset in range(_FOOTER_ROWS)
+        )
+        self._write("\x1b7" + cleared + "\x1b[r" + "\x1b8")
+        try:
+            atexit.unregister(self.stop)
+        except Exception:  # noqa: BLE001 — teardown must never raise
+            logger.debug("footer: atexit.unregister failed", exc_info=True)
+
+    def __enter__(self) -> PinnedFooter:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()
+
+    # -- painting ------------------------------------------------------------
+
+    def refresh(self) -> None:
+        """Repaint the footer now (safe to call from any thread; never raises)."""
+        if not self._active or self._paused.is_set():
+            return
+        try:
+            width, height = self._terminal_size()
+            if height < _FOOTER_MIN_HEIGHT:
+                # The window shrank below the point where reserving two rows is
+                # reasonable — give them back rather than squatting on them.
+                self.stop()
+                return
+            if (width, height) != self._size:
+                self._apply_region(width, height)
+            markup = self._provider()
+        except Exception:  # noqa: BLE001 — chrome must never break a build
+            logger.debug("footer: refresh failed", exc_info=True)
+            return
+
+        line = self._to_ansi(markup, width - 1)
+        rule = self._to_ansi(f"[grey35]{'─' * max(0, width - 1)}[/grey35]", width - 1)
+        activity = self._to_ansi(self._activity or "", width - 1)
+        self._write(
+            "\x1b7"
+            + f"\x1b[{height - 2};1H\x1b[2K"
+            + rule
+            + f"\x1b[{height - 1};1H\x1b[2K"
+            + activity
+            + f"\x1b[{height};1H\x1b[2K"
+            + line
+            + "\x1b8"
+        )
+
+    def set_activity(self, markup: str | None) -> None:
+        """Show (``None`` clears) the working line on the footer's middle row.
+
+        The spinner pushes here instead of opening its own Rich ``Live`` region,
+        so the "what is running right now" line holds still at the bottom
+        instead of scrolling away with the transcript.
+        """
+        self._activity = markup or None
+        self.refresh()
+
+    def pause(self) -> None:
+        """Stop repainting (the rows keep their last paint) — for a full-screen op."""
+        self._paused.set()
+
+    def resume(self) -> None:
+        """Resume repainting after :meth:`pause` and paint immediately."""
+        self._paused.clear()
+        self.refresh()
+
+    # -- internals -----------------------------------------------------------
+
+    def _terminal_size(self) -> tuple[int, int]:
+        """The output terminal's real ``(width, height)``, straight from the fd.
+
+        Deliberately NOT ``console.size``: Rich prefers the ``COLUMNS``/``LINES``
+        environment variables, which many shells set once and never update, so a
+        resized window would leave the footer painting over live content or off
+        the bottom of the screen. The ioctl is always current, which also makes
+        resize handling fall out for free. Falls back to Rich when the stream has
+        no usable descriptor (a captured stream in a test).
+        """
+        try:
+            size = os.get_terminal_size(self._file.fileno())
+            if size.columns > 0 and size.lines > 0:
+                return size.columns, size.lines
+        except Exception:  # noqa: BLE001 — not a real fd; fall through to Rich
+            logger.debug("footer: terminal size unavailable", exc_info=True)
+        width, height = self._console.size
+        return width, height
+
+    def _apply_region(self, width: int, height: int) -> None:
+        """(Re-)set the scrolling region to everything above the footer rows.
+
+        Setting DECSTBM homes the cursor, so the sequence is wrapped in
+        save/restore — otherwise the next print would land at the top of the
+        screen and overwrite the transcript.
+        """
+        bottom = max(1, height - _FOOTER_ROWS)
+        if self._write("\x1b7" + f"\x1b[1;{bottom}r" + "\x1b8"):
+            self._size = (width, height)
+
+    def _to_ansi(self, markup: str, width: int) -> str:
+        """Render one line of Rich markup to ANSI, truncated to *width* columns.
+
+        Truncation is to ``width`` (already one short of the terminal) so the
+        write can never reach the final column: on an auto-wrap terminal that
+        would scroll the screen out from under the region.
+        """
+        if width <= 0:
+            return ""
+        try:
+            text = Text.from_markup(markup)
+            text.truncate(width, overflow="ellipsis")
+            buffer = io.StringIO()
+            scratch = Console(
+                file=buffer,
+                width=width,
+                force_terminal=True,
+                color_system=self._console.color_system,  # type: ignore[arg-type]
+                highlight=False,
+                soft_wrap=True,
+                legacy_windows=False,
+            )
+            scratch.print(text, end="")
+            return buffer.getvalue()
+        except Exception:  # noqa: BLE001 — fall back to unstyled text
+            logger.debug("footer: markup render failed", exc_info=True)
+            return Text.from_markup(markup).plain[:width]
+
+    def _write(self, payload: str) -> bool:
+        """Write one escape payload under the console lock; disable on repeat failure."""
+        try:
+            with self._lock:
+                self._file.write(payload)
+                self._file.flush()
+            self._failures = 0
+            return True
+        except Exception:  # noqa: BLE001 — a terminal that rejects this loses the footer
+            logger.debug("footer: write failed", exc_info=True)
+            self._failures += 1
+            if self._failures >= _FOOTER_MAX_FAILURES and self._active:
+                logger.debug("footer: disabling after %d failed writes", self._failures)
+                self._active = False
+                self._stopping.set()
+            return False
+
+    def _tick(self) -> None:
+        """Daemon loop: repaint so tokens/cost advance while the agent works."""
+        while not self._stopping.wait(self._interval):
+            if self._active and not self._paused.is_set():
+                self.refresh()
+
+
+def make_status_footer(engine: AgentEngine, console: Console | None = None) -> PinnedFooter:
+    """A :class:`PinnedFooter` showing *engine*'s live status line (both arms).
+
+    The provider re-snapshots the engine on every repaint, so entity counts,
+    validation dots, tokens and cost track the run without any call site having
+    to push updates, and a :class:`StatusFader` tints whatever just changed.
+
+    The repaint interval is well under the fade so the highlight decays smoothly
+    rather than stepping; each repaint is a state read plus an incremental
+    profile tail-read, which is why that is affordable.
+    """
+    target = console or get_console()
+    fader = StatusFader()
+    return PinnedFooter(
+        target,
+        lambda: fader.markup(snapshot_from_engine(engine)),
+        interval=0.25,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Print-for-engine helpers — the ONE place "snapshot → render → print to the
 # shared console" lives, so both build arms call the same code instead of each
 # inlining its own copy (#344). The pure render_* above stay unit-testable; these
@@ -348,7 +832,7 @@ def render_goodbye(
 # ---------------------------------------------------------------------------
 
 
-def print_status_bar(engine: AgentEngine) -> None:
+def print_status_bar(engine: AgentEngine, footer: PinnedFooter | None = None) -> None:
     """Print the one-line status bar for *engine*'s current state (both arms).
 
     The per-prompt status line the ReAct loop shows before every input and the
@@ -356,7 +840,14 @@ def print_status_bar(engine: AgentEngine) -> None:
     authoritative by the time either arm calls this (the pipeline's final
     ``build_and_validate`` runs via ``engine.run_tool``, whose #153 write-back
     folds conformance into state), so the base/ISA/Tox dots read real values.
+
+    When an active *footer* is passed, the same information is already pinned to
+    the bottom of the terminal, so this repaints it instead of printing a second
+    copy into the transcript.
     """
+    if footer is not None and footer.active:
+        footer.refresh()
+        return
     get_console().print(render_status_bar(snapshot_from_engine(engine)))
 
 
@@ -400,7 +891,12 @@ def print_goodbye(engine: AgentEngine, *, resumable: bool | None = None) -> None
 # ---------------------------------------------------------------------------
 
 
-def boxed_input(console: Console, label: str = "❯") -> str:
+def boxed_input(
+    console: Console,
+    label: str = "❯",
+    *,
+    on_render: Callable[[], None] | None = None,
+) -> str:
     """Read one line of input inside a rounded box (Claude Code style).
 
     Renders an ephemeral rounded box via ``prompt_toolkit``; once submitted the
@@ -408,6 +904,15 @@ def boxed_input(console: Console, label: str = "❯") -> str:
     Falls back to ``console.input`` when stdin is not a TTY or ``prompt_toolkit``
     is unavailable. Raises ``KeyboardInterrupt`` (Ctrl+C) and ``EOFError``
     (Ctrl+D on an empty line), matching ``input()``.
+
+    Args:
+        console: The Rich console to fall back to and echo through.
+        label: The prompt glyph shown inside the box.
+        on_render: Called after every ``prompt_toolkit`` repaint. The pinned
+            footer passes its refresh here: prompt_toolkit erases from the
+            cursor to the end of the screen when it redraws, which wipes the
+            footer rows, so they are repainted on the same beat instead of
+            waiting for the next background tick (which would read as flicker).
     """
 
     def _fallback() -> str:
@@ -484,12 +989,26 @@ def boxed_input(console: Console, label: str = "❯") -> str:
         ]
     )
     style = Style.from_dict({"box": "fg:#5f5f5f", "prompt": "bold ansicyan"})
+
+    def _after_render(_app: Any) -> None:
+        if on_render is None:
+            return
+        try:
+            on_render()
+        except Exception:  # noqa: BLE001 — chrome must never break the prompt
+            logger.debug("boxed_input: on_render failed", exc_info=True)
+
     app: Any = Application(
         layout=Layout(root, focused_element=buf_window),
         key_bindings=kb,
         style=style,
         full_screen=False,
         output=output,
+        after_render=_after_render,
+        # Without this the box is NOT ephemeral: prompt_toolkit leaves it on
+        # screen, and the echo below then prints the same line a second time, so
+        # every answered prompt appeared twice in the transcript.
+        erase_when_done=True,
     )
     try:
         text = app.run()
@@ -503,3 +1022,191 @@ def boxed_input(console: Console, label: str = "❯") -> str:
         # The box was ephemeral — echo the submitted line into the transcript.
         console.print(f"[bold cyan]{label}[/bold cyan] {text}")
     return text
+
+
+def select_option(
+    console: Console,
+    options: list[str],
+    *,
+    default: int = 0,
+    hint: str | None = None,
+    on_render: Callable[[], None] | None = None,
+) -> int | None:
+    """Choose one of *options* in a rounded box; return its index (``None`` = cancel).
+
+    The choice starts on *default* and moves with ↑/↓ (or j/k); Enter takes the
+    highlighted row and a number key jumps straight to it. This replaces the
+    "print a numbered list, then ask ``Approve? [Y/n]``" prompt, which asked two
+    different questions at once — a menu and a yes/no — and left the user unsure
+    which one the answer applied to.
+
+    Falls back to a plain numbered ``input()`` (Enter = the default) when stdin
+    is not a TTY or ``prompt_toolkit`` is unavailable, so piped and CI runs keep
+    working unchanged.
+
+    Args:
+        console: The Rich console to render the fallback and the echo through.
+        options: The choices, in display order. Must be non-empty.
+        default: Index highlighted first — the safe/expected answer. Callers that
+            must fail closed (a filesystem-scope escalation) pass the denying
+            option here so Enter cannot widen access by accident.
+        hint: Optional one-line prompt shown above the choices.
+        on_render: Called after every repaint (the pinned footer's refresh).
+
+    Returns:
+        The selected index, or ``None`` when the user cancelled (Ctrl+C / Esc)
+        or gave no answer.
+    """
+    if not options:
+        return None
+    default = max(0, min(default, len(options) - 1))
+
+    def _fallback() -> int | None:
+        if hint:
+            console.print(f"[bold]{hint}[/bold]")
+        for index, option in enumerate(options, start=1):
+            marker = "❯" if index - 1 == default else " "
+            console.print(f" {marker} [cyan]{index}[/cyan]. {option}")
+        try:
+            raw = console.input(
+                f"[bold cyan]Select[/bold cyan] [dim][1-{len(options)}, "
+                f"Enter = {default + 1}][/dim] "
+            )
+        except EOFError:
+            return None
+        # Same answer grammar as the plain-terminal chooser (number, yes/no word,
+        # or a prefix), so a piped run behaves like an interactive one.
+        from builder.tools.hitl import match_choice
+
+        return match_choice(raw, options, default)
+
+    if not sys.stdin.isatty():
+        return _fallback()
+    try:
+        from prompt_toolkit import Application
+        from prompt_toolkit.application.current import get_app
+        from prompt_toolkit.output import create_output
+
+        output = create_output()
+        if not getattr(output, "responds_to_cpr", True):
+            return _fallback()
+        from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.layout import HSplit, Layout, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+        from prompt_toolkit.styles import Style
+    except Exception:
+        return _fallback()
+
+    cursor = {"index": default}
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    @kb.add("k")
+    def _(event: Any) -> None:
+        cursor["index"] = (cursor["index"] - 1) % len(options)
+
+    @kb.add("down")
+    @kb.add("j")
+    def _(event: Any) -> None:
+        cursor["index"] = (cursor["index"] + 1) % len(options)
+
+    @kb.add("enter")
+    def _(event: Any) -> None:
+        event.app.exit(result=cursor["index"])
+
+    @kb.add("c-c")
+    @kb.add("escape", eager=True)
+    def _(event: Any) -> None:
+        event.app.exit(result=None)
+
+    for position in range(min(len(options), 9)):
+
+        @kb.add(str(position + 1))
+        def _(event: Any, position: int = position) -> None:
+            cursor["index"] = position
+            event.app.exit(result=position)
+
+    def _hline(left: str, right: str):
+        def _get() -> list[tuple[str, str]]:
+            width = get_app().output.get_size().columns
+            return [("class:box", left + "─" * max(0, width - 2) + right)]
+
+        return _get
+
+    def _rows() -> list[tuple[str, str]]:
+        width = get_app().output.get_size().columns
+        inner = max(0, width - 4)  # the two border columns on each side
+        fragments: list[tuple[str, str]] = []
+        for index, option in enumerate(options):
+            selected = index == cursor["index"]
+            marker = "❯ " if selected else "  "
+            body = f"{marker}{index + 1}. {option}"[:inner].ljust(inner)
+            fragments.append(("class:box", "│ "))
+            fragments.append(("class:selected" if selected else "class:option", body))
+            fragments.append(("class:box", " │"))
+            fragments.append(("", "\n"))
+        return fragments
+
+    def _hint_row() -> list[tuple[str, str]]:
+        width = get_app().output.get_size().columns
+        inner = max(0, width - 4)
+        return [
+            ("class:box", "│ "),
+            ("class:hint", str(hint)[:inner].ljust(inner)),
+            ("class:box", " │"),
+        ]
+
+    body_rows = [Window(FormattedTextControl(_rows), height=len(options))]
+    header = [Window(FormattedTextControl(_hint_row), height=1)] if hint else []
+    root = HSplit(
+        [
+            Window(FormattedTextControl(_hline("╭", "╮")), height=1),
+            *header,
+            *body_rows,
+            Window(FormattedTextControl(_hline("╰", "╯")), height=1),
+            Window(
+                FormattedTextControl(
+                    [("class:help", "  ↑/↓ move · enter select · 1-9 jump · esc cancel")]
+                ),
+                height=1,
+            ),
+        ]
+    )
+    style = Style.from_dict(
+        {
+            "box": "fg:#5f5f5f",
+            "hint": "bold",
+            "option": "",
+            "selected": "bold ansicyan",
+            "help": "fg:#5f5f5f",
+        }
+    )
+
+    def _after_render(_app: Any) -> None:
+        if on_render is None:
+            return
+        try:
+            on_render()
+        except Exception:  # noqa: BLE001 — chrome must never break the prompt
+            logger.debug("select_option: on_render failed", exc_info=True)
+
+    app: Any = Application(
+        layout=Layout(root),
+        key_bindings=kb,
+        style=style,
+        full_screen=False,
+        output=output,
+        after_render=_after_render,
+        erase_when_done=True,
+    )
+    try:
+        chosen = app.run()
+    except Exception:
+        return _fallback()
+
+    if chosen is None:
+        return None
+    # The box was ephemeral — echo the choice so the transcript records it.
+    console.print(f"[bold cyan]❯[/bold cyan] {options[chosen]}")
+    return int(chosen)

--- a/builder/pricing.py
+++ b/builder/pricing.py
@@ -14,6 +14,7 @@ import json
 import logging
 import re
 import ssl
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -108,6 +109,7 @@ def _weighted_cost(entry: dict[str, Any]) -> float:
     return 10.0 * in_rate + 1.0 * out_rate
 
 
+@lru_cache(maxsize=64)
 def get_model_cost(
     model_name: str,
     provider: str | None = None,
@@ -131,6 +133,10 @@ def get_model_cost(
         A dict with pricing keys (``input_cost_per_token``,
         ``output_cost_per_token``, ``max_input_tokens``, etc.) or *None* if
         no match found.
+
+    Memoized: the fallback searches scan every key in a table of thousands of
+    models, and the pinned status footer asks for the cost of the same model
+    several times a second.
     """
     _ensure_loaded()
     if not _PRICES:

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -208,6 +208,94 @@ def _default_console_show(text: str) -> None:
     print(text)
 
 
+# The choices used when a caller presents a decision without naming its own.
+# Stated as full sentences: "yes"/"no" alone forced the user to re-read the
+# question to work out what a bare "yes" would agree to.
+_APPROVE_CHOICES = ["Yes, go ahead", "No, don't do that"]
+
+# The scan-root escalation names the consequence instead of asking yes/no, and
+# lists the refusal FIRST so the pre-selected answer denies (#197 fail-closed).
+_DENY_ALLOW_CHOICES = ["No, keep the current access", "Yes, allow this folder"]
+
+_AFFIRMATIVE = {"y", "yes", "approve", "approved", "ok", "okay", "confirm", "continue"}
+_NEGATIVE = {"n", "no", "reject", "rejected", "deny", "decline", "cancel"}
+
+
+def _choice_stance(choice: str) -> bool | None:
+    """Whether *choice* is a plain yes (True) / no (False), else ``None``.
+
+    Recognises both a bare word (the ``["yes", "no"]`` options callers pass) and
+    the sentence forms above, by reading the leading word. A real menu entry
+    ("Use different names") matches neither and comes back ``None`` so it is
+    returned to the caller as a selection rather than collapsed to a verdict.
+    """
+    lead = choice.strip().casefold().replace(",", " ").split()
+    if not lead:
+        return None
+    if lead[0] in _AFFIRMATIVE:
+        return True
+    if lead[0] in _NEGATIVE:
+        return False
+    return None
+
+
+def _default_choice_index(choices: list[str], *, deny_by_default: bool) -> int:
+    """Index to pre-select: the refusal when denying by default, else the first.
+
+    Fail-closed matters more than convenience here — for a scan-root escalation
+    the pre-selected row must be one that does NOT widen access, so an
+    absent-minded Enter cannot grant it. When no negative choice can be
+    identified, nothing is safe to pre-approve, so the last option is used.
+    """
+    if not deny_by_default:
+        return 0
+    for index, choice in enumerate(choices):
+        if _choice_stance(choice) is False:
+            return index
+    return len(choices) - 1
+
+
+def match_choice(raw: str, choices: list[str], default: int) -> int | None:
+    """Resolve a typed answer to a choice index (``None`` = no match).
+
+    Accepts what people actually type at a prompt like this: nothing (the
+    default), a number, or a yes/no word — ``y`` still means yes even though the
+    choices are now sentences, so muscle memory keeps working. Also matches a
+    leading-word prefix of a choice, so ``rev`` picks "Revise the names".
+    """
+    answer = raw.strip().casefold()
+    if not answer:
+        return default
+    if answer.isdigit() and 1 <= int(answer) <= len(choices):
+        return int(answer) - 1
+    stance = _choice_stance(answer)
+    if stance is not None:
+        for index, choice in enumerate(choices):
+            if _choice_stance(choice) is stance:
+                return index
+    for index, choice in enumerate(choices):
+        if choice.strip().casefold().startswith(answer):
+            return index
+    return None
+
+
+def _default_console_select(choices: list[str], default: int) -> int | None:
+    """Plain-terminal chooser — the default when no UI selector is injected.
+
+    Prints the numbered choices with the default marked and reads one line;
+    empty takes the default. The CLI injects the arrow-navigable rounded box
+    (:func:`builder.agents.ui.select_option`) instead.
+    """
+    for index, choice in enumerate(choices, start=1):
+        marker = "❯" if index - 1 == default else " "
+        print(f" {marker} {index}. {choice}")
+    try:
+        raw = input(f"Select [1-{len(choices)}, Enter = {default + 1}]: ")
+    except EOFError:
+        return None
+    return match_choice(raw, choices, default)
+
+
 class ConsoleHumanInterface:
     """A REAL interactive HITL interface that prompts on the terminal (stdin).
 
@@ -240,6 +328,7 @@ class ConsoleHumanInterface:
         self,
         prompt_func: Callable[[str], str] | None = None,
         show_func: Callable[[str], None] | None = None,
+        select_func: Callable[[list[str], int], int | None] | None = None,
     ) -> None:
         """Build the interface, optionally injecting the prompt reader + display.
 
@@ -252,9 +341,18 @@ class ConsoleHumanInterface:
                 Defaults to :func:`_default_console_show` (a plain ``print``). The
                 CLI passes a renderer that styles it as a green-● reply
                 (:func:`builder.agents.ui.render_reply`).
+            select_func: A ``(choices, default_index) -> index | None`` chooser
+                used by :meth:`present`. Defaults to
+                :func:`_default_console_select` (numbered lines + ``input()``).
+                The CLI passes the arrow-navigable rounded box
+                (:func:`builder.agents.ui.select_option`), so a decision and a
+                free-text answer look like the same control.
         """
         self._read: Callable[[str], str] = prompt_func or _default_console_prompt
         self._show: Callable[[str], None] = show_func or _default_console_show
+        self._select: Callable[[list[str], int], int | None] = (
+            select_func or _default_console_select
+        )
         self._done = False
 
     def is_done(self) -> bool:
@@ -281,39 +379,57 @@ class ConsoleHumanInterface:
         options: list[str] | None = None,
         purpose: str | None = None,
     ) -> HumanResponse:
-        """Show *context* + *options* and read an approve/reject decision."""
-        suffix = " [y/N]: " if purpose == SCAN_ROOT_PURPOSE else " [Y/n]: "
+        """Show *context* and read a decision as a single navigable choice.
+
+        One question, not two. The previous prompt printed a numbered menu and
+        then asked ``Approve? [Y/n]``, so the answer could plausibly mean either
+        "yes to the whole thing" or "option 1" — and typing ``2`` was read as an
+        approval whatever option 2 actually said. Here the choices ARE the
+        question: the expected answer starts selected and the user arrows to
+        another, so the decision is unambiguous both ways.
+
+        Fail-closed is preserved for a scan-root escalation: its default lands on
+        the denying choice, so an accidental Enter never widens filesystem
+        access. It is also the one prompt whose choices are stated as an explicit
+        allow/deny rather than a yes/no.
+        """
+        deny_by_default = purpose == SCAN_ROOT_PURPOSE
+        choices = list(options or [])
+        if not choices:
+            choices = _DENY_ALLOW_CHOICES if deny_by_default else _APPROVE_CHOICES
+        # The safe answer is first except when denying by default, where it is
+        # the refusal — whatever it is, it must be the pre-selected row.
+        default_index = _default_choice_index(choices, deny_by_default=deny_by_default)
+
         # Suspend any active terminal spinner so the prompt is readable and stdin
         # is not fighting a Rich Live repaint (legacy loop scan-root approval).
         with suspend_console_animation():
-            print(context)
-            if options:
-                print("Choose one of the following:")
-                for index, option in enumerate(options, start=1):
-                    print(f"  {index}. {option}")
-            try:
-                answer = input(f"Approve?{suffix}").strip().lower()
-            except EOFError:
-                self._done = True
-                answer = ""
+            self._show(context)
+            chosen = self._select(choices, default_index)
+
+        if chosen is None:
+            # Cancelled / EOF: decline without ending guidance, and fail closed.
+            return {"action": "rejected", "comments": None, "edits": None}
+        answer = choices[chosen]
         if self._is_stop_command(answer):
             self._done = True
             return {"action": "skipped", "comments": None, "edits": None}
-        if purpose == SCAN_ROOT_PURPOSE:
-            # Fail-closed: a new scan root requires an explicit affirmative.
-            approved = answer in ("y", "yes")
-            comments = None
-        elif options and answer.isdigit() and 1 <= int(answer) <= len(options):
-            # Preserve the selected option so callers can resolve a real menu
-            # choice (for example, an ambiguous publication author) rather than
-            # reducing every response to a yes/no approval.
-            comments = options[int(answer) - 1]
-            approved = True
-        else:
-            approved = answer in ("", "y", "yes")
-            comments = None
-        action = "approved" if approved else "rejected"
-        return {"action": action, "comments": comments, "edits": None}
+
+        stance = _choice_stance(answer)
+        if stance is not None:
+            # A plain yes/no choice is a decision, not a payload: returning "no"
+            # as comments used to read as an APPROVAL carrying the text "no".
+            return {
+                "action": "approved" if stance else "rejected",
+                "comments": None,
+                "edits": None,
+            }
+        if deny_by_default:
+            # Anything that is not an explicit affirmative denies (#197).
+            return {"action": "rejected", "comments": None, "edits": None}
+        # A real menu choice: hand the selected option back so callers can act on
+        # WHICH option was picked (e.g. an ambiguous publication author).
+        return {"action": "approved", "comments": answer, "edits": None}
 
     def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
         """Prompt the user for a value; an empty answer (or EOF) is a skip.

--- a/main.py
+++ b/main.py
@@ -477,6 +477,11 @@ def main(argv: list[str] | None = None) -> int:
             human_interface=ConsoleHumanInterface(
                 prompt_func=lambda _field_type: ui.boxed_input(ui.get_console()),
                 show_func=lambda text: ui.get_console().print(ui.render_reply(text)),
+                # Decisions render as the same rounded box as free text, with the
+                # expected answer pre-selected and arrow keys to change it.
+                select_func=lambda choices, default: ui.select_option(
+                    ui.get_console(), choices, default=default
+                ),
             )
         )
     else:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1716,7 +1716,7 @@ class _LoopHarness:
 
         # Stdin reader: record every read; raise EOFError when exhausted so the
         # loop exits its main while-True deterministically.
-        def fake_boxed_input(console, label="❯"):
+        def fake_boxed_input(console, label="❯", **kwargs):
             if not harness.stdin_lines:
                 raise EOFError
             line = harness.stdin_lines.pop(0)
@@ -1873,7 +1873,7 @@ class TestTimeoutEndsTurnGracefully:
 
         stdin = ["build"]
 
-        def fake_boxed_input(console, label="❯"):
+        def fake_boxed_input(console, label="❯", **kwargs):
             if not stdin:
                 raise EOFError
             return stdin.pop(0)
@@ -1931,7 +1931,7 @@ class TestTimeoutEndsTurnGracefully:
         monkeypatch.setattr(agent_loop, "_build_agent_graph", lambda *a, **k: _PoisonedApp())
         stdin = ["start", "continue", "quit"]
 
-        def fake_boxed_input(console, label="❯"):
+        def fake_boxed_input(console, label="❯", **kwargs):
             return stdin.pop(0)
 
         monkeypatch.setattr(agent_loop.ui, "boxed_input", fake_boxed_input)
@@ -1984,7 +1984,7 @@ class TestTimeoutEndsTurnGracefully:
         monkeypatch.setenv("VITRO_REQUEST_TIMEOUT", "0.05")
         stdin = ["start", "continue", "quit"]
 
-        def fake_boxed_input(console, label="❯"):
+        def fake_boxed_input(console, label="❯", **kwargs):
             return stdin.pop(0)
 
         monkeypatch.setattr(agent_loop.ui, "boxed_input", fake_boxed_input)
@@ -2042,7 +2042,7 @@ class TestGreetingProvenance:
                 seen.append(str(payload["messages"][0].content))
                 return {"messages": [AIMessage(content="ok")]}
 
-        def _eof(console, label="❯"):
+        def _eof(console, label="❯", **kwargs):
             raise EOFError
 
         monkeypatch.setattr(agent_loop, "_build_chat_model", lambda **kw: object())


### PR DESCRIPTION
## Summary

Interactive-session work in progress, lifted off a dirty working tree onto its own branch.

- **`ui.py`** — the bulk of the change: `boxed_input` gains an `on_render` callback so a live footer repaints on the same beat as prompt_toolkit's screen erase, plus surrounding status/summary chrome.
- **`progress_spinner.py`** — delegated-frame rendering the footer drives.
- **`hitl.py` / `build.py`** — thread the interactive interface through to the new chrome.
- **`llm.py` / `pricing.py` / `main.py`** — cost-reporting additions.

## Test stub fix

The `boxed_input` stubs in `tests/test_agent_loop.py` pinned the pre-`on_render` signature `(console, label="❯")`, so every test reaching the input path raised `TypeError: unexpected keyword argument 'on_render'` — **15 failures** across the greeting, initial-prompt and timeout suites.

All five stubs now take `**kwargs`, which also stops them re-breaking the next time the real signature grows a keyword-only argument.

## Verification

`ruff` clean; 178 tests pass locally across `test_agent_loop` / `test_agents_build` / `test_path_traversal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)