### PR TITLE
feat(writers): provenance DAG rendering and maturity-report sections

### DIFF
--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -52,6 +52,12 @@ _DELEGATED_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 # terminal; the footer truncates anything wider anyway.
 _PREVIEW_WIDTH = 40
 
+# Minimum seconds an op stays on the line before a newer one may replace it.
+# Most tools return in milliseconds, so without this the line was a stream of
+# unreadable flashes; long enough to read a tool name, short enough that the
+# display never trails reality by more than a blink.
+_MIN_DWELL = 0.7
+
 
 # The single toxicology-themed phrase list, shared by both build arms (#344).
 # ``ProgressSpinner`` picks one at random when no explicit phrase is given.
@@ -146,8 +152,21 @@ class ProgressSpinner:
             console = Console()
         self._console = console
         self._phrase = phrase or random.choice(TOX_SPINNER_PHRASES)
-        self._current: str | None = None
-        self._preview: str | None = None
+        # The single "what is happening" slot. It holds the last thing that
+        # happened rather than only what is happening *right now*, so a tool that
+        # returns in 10ms is still readable afterwards.
+        self._item_text: str | None = None
+        self._item_kind = "tool"  # "tool" | "writing"
+        self._item_done = False
+        self._item_at = 0.0
+        # Newest item waiting for the current one to serve its minimum dwell.
+        # Only the newest is kept: the display may lag reality by up to
+        # _MIN_DWELL, but it never queues up a backlog to replay.
+        self._pending: tuple[str, str] | None = None
+        # Ops displaced before they were ever displayed — reported as "+N more"
+        # so a fast burst is not misread as a single tool call.
+        self._skipped = 0
+        self._shown_skipped = 0
         self._preview_buffer = ""
         self._tick_interval = tick_interval
         self._sink = activity_sink
@@ -186,16 +205,22 @@ class ProgressSpinner:
     def _render(self) -> str:
         """Render the spinner line: phrase, elapsed seconds, and the current op.
 
-        A running tool wins over the reply tail: they never overlap in time
-        (the model finishes writing before a tool starts), and when both are
-        somehow set the concrete tool is the more informative of the two.
+        The op **lingers**: it is shown in cyan while it runs and stays, dimmed,
+        once it finishes, until something newer takes its place. Clearing the
+        moment a tool returned meant most tools — which finish in milliseconds —
+        appeared only as an unreadable flash.
         """
         elapsed = int(monotonic() - self._start)
         line = f"[green]{self._phrase}…[/green] [dim]({elapsed}s)[/dim]"
-        if self._current:
-            line += f"  [dim]·[/dim] [cyan]{self._current}[/cyan]"
-        elif self._preview:
-            line += f'  [dim]·[/dim] [dim]writing:[/dim] [white]"{self._preview}"[/white]'
+        if self._item_text:
+            style = "grey62" if self._item_done else "cyan"
+            if self._item_kind == "writing":
+                label = "[dim]wrote:[/dim] " if self._item_done else "[dim]writing:[/dim] "
+                line += f'  [dim]·[/dim] {label}[{style}]"{self._item_text}"[/{style}]'
+            else:
+                line += f"  [dim]·[/dim] [{style}]{self._item_text}[/{style}]"
+                if self._shown_skipped:
+                    line += f" [dim](+{self._shown_skipped} more)[/dim]"
         return line
 
     def _render_delegated(self) -> str:
@@ -225,6 +250,7 @@ class ProgressSpinner:
         while not self._stop.wait(self._tick_interval):
             if self._paused.is_set():
                 continue
+            self._promote_pending()
             if self._sink is not None:
                 self._frame += 1
                 self._publish()
@@ -241,15 +267,64 @@ class ProgressSpinner:
     # Public API
     # ------------------------------------------------------------------
 
-    def set_current(self, text: str | None) -> None:
-        """Show (or clear, with ``None``) the currently-running tool/phase.
+    def _offer(self, text: str, kind: str) -> None:
+        """Display *text* now, or hold it until the current item has had its dwell."""
+        now = monotonic()
+        if self._item_text is None or (now - self._item_at) >= _MIN_DWELL:
+            self._item_text, self._item_kind, self._item_done = text, kind, False
+            self._item_at = now
+            self._pending = None
+            # Shown straight away, so nothing was displaced on its behalf: clear
+            # BOTH counters or the previous burst's tally rides along with it.
+            self._skipped = 0
+            self._shown_skipped = 0
+        else:
+            if self._pending is not None and self._pending[1] != "writing":
+                # An op is being displaced before it was ever shown. Count it —
+                # a burst of fast tools would otherwise look like one tool ran.
+                self._skipped += 1
+            self._pending = (text, kind)
 
-        Records the op and repaints immediately — unless paused, in which case the
-        op is remembered but the Live region is left alone so a HITL prompt stays
-        readable (the next resume/tick picks it up). On a non-TTY (silent mode)
-        the op is still remembered but there is no Live region to repaint.
+    def _mark_done(self) -> None:
+        """Mark the newest known item finished — it stays visible, dimmed."""
+        if self._pending is not None:
+            # It has not been shown yet; it still gets its dwell, already ended.
+            self._pending = (self._pending[0], self._pending[1])
+            self._item_done_pending = True
+        elif self._item_text is not None:
+            self._item_done = True
+
+    def _promote_pending(self) -> None:
+        """Move a waiting item into the display once the dwell has elapsed."""
+        if self._pending is None:
+            return
+        if (monotonic() - self._item_at) < _MIN_DWELL:
+            return
+        text, kind = self._pending
+        self._item_text, self._item_kind = text, kind
+        self._item_done = getattr(self, "_item_done_pending", False)
+        self._item_done_pending = False
+        self._item_at = monotonic()
+        self._pending = None
+        self._shown_skipped, self._skipped = self._skipped, 0
+
+    def set_current(self, text: str | None) -> None:
+        """Show the currently-running tool/phase; ``None`` marks it finished.
+
+        ``None`` no longer blanks the line — it dims what is there, so the last
+        thing that ran stays readable until something newer replaces it. A new op
+        arriving inside :data:`_MIN_DWELL` waits its turn rather than overwriting
+        a line the user has not had time to read.
+
+        Repaints immediately — unless paused, in which case the op is remembered
+        but the Live region is left alone so a HITL prompt stays readable (the
+        next resume/tick picks it up). On a non-TTY (silent mode) the op is still
+        remembered but there is no Live region to repaint.
         """
-        self._current = text
+        if text is None:
+            self._mark_done()
+        else:
+            self._offer(text, "tool")
         if self._sink is not None:
             if not self._paused.is_set():
                 self._publish()
@@ -272,16 +347,42 @@ class ProgressSpinner:
         """
         if not token:
             return
+        if not isinstance(token, str):
+            # Belt and braces: callers flatten content blocks, but a stray
+            # non-string must never raise inside a callback — LangChain would
+            # log a warning for every single token of the stream.
+            token = str(token)
         self._preview_buffer += token
         # Keep a moving window of the most recent characters: a fixed head
         # would freeze after the first few words and stop reading as live.
-        window = self._preview_buffer.replace("\n", " ")[-_PREVIEW_WIDTH:]
-        self._preview = window.lstrip()
+        window = self._preview_buffer.replace("\n", " ")[-_PREVIEW_WIDTH:].lstrip()
+        if self._item_kind == "writing" and self._item_text is not None:
+            # Same logical item, just more of it — update in place so the dwell
+            # rule (which exists to stop items REPLACING each other too fast)
+            # does not freeze a stream that is meant to look live.
+            self._item_text = window
+            self._item_done = False
+        else:
+            self._offer(window, "writing")
 
     def set_preview(self, text: str | None) -> None:
-        """Replace (``None`` clears) the reply tail shown while the model writes."""
+        """Seed the reply tail, or (with ``None``) end it.
+
+        Ending marks the tail finished rather than erasing it: the last thing
+        the model wrote stays on the line, dimmed, until the next tool or reply
+        replaces it.
+        """
         self._preview_buffer = text or ""
-        self._preview = (text or "").replace("\n", " ")[-_PREVIEW_WIDTH:] or None
+        if not text:
+            if self._item_kind == "writing":
+                self._mark_done()
+            return
+        window = text.replace("\n", " ")[-_PREVIEW_WIDTH:].lstrip()
+        if self._item_kind == "writing" and self._item_text is not None:
+            self._item_text = window
+            self._item_done = False
+        else:
+            self._offer(window, "writing")
 
     def pause(self) -> None:
         """Tear down the Live region and stop ticking so a HITL prompt is clean.

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -163,11 +163,16 @@ class _ToolSpinnerCallback(BaseCallbackHandler):
 
     on_chat_model_start = on_llm_start
 
-    def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
+    def on_llm_new_token(self, token: Any, **kwargs: Any) -> None:
         # Only fires when the model was built with streaming. The spinner keeps
         # the running text and repaints it on its own tick, so a fast token
         # stream cannot turn into a write per token.
-        self.spinner.append_preview(token)
+        #
+        # `token` is NOT always a string: the Responses API (every reasoning
+        # model) streams content-block lists, and concatenating one raised a
+        # TypeError per token. Flattening through the shared #341 helper also
+        # drops reasoning/tool-call blocks, so only real text reaches the line.
+        self.spinner.append_preview(ui.flatten_message_content(token))
 
     def on_llm_end(self, response: Any, **kwargs: Any) -> None:
         # The reply is about to be printed in full to the transcript; a stale
@@ -837,10 +842,48 @@ def _auto_export_after_build(engine: AgentEngine, build_result: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Marker in the corrective returned for a mutation that left the crate
+# unchanged. It doubles as the signal to _is_non_progress_result, so a repeated
+# no-op feeds the loop-breaker instead of resetting it.
+_NO_OP_MUTATION_MARKER = "changed nothing in the crate"
+
+
+def _no_op_mutation_message(tool_name: str, kwargs: dict[str, Any], engine: AgentEngine) -> str:
+    """The corrective for a mutation call that left the crate byte-identical.
+
+    A weak model can sit in a loop of a mutation that writes nothing —
+    ``set_crate_metadata`` with every field ``None`` was observed 33 times in
+    one session, burning ~990k input tokens — because the call looks successful:
+    it returns a normal dict, so nothing downstream treats it as a dead end.
+    This says plainly that nothing changed and what to do instead.
+    """
+    supplied = sorted(k for k, v in kwargs.items() if v not in (None, "", [], {}))
+    lines = [f"{tool_name} {_NO_OP_MUTATION_MARKER} — the state is identical to before the call."]
+    if not supplied:
+        lines.append(
+            "Every argument was empty, so there was nothing to write. Calling it "
+            "again with empty arguments will do nothing again."
+        )
+    else:
+        lines.append(
+            f"The fields you passed ({', '.join(supplied)}) already hold exactly "
+            "those values, so re-writing them is a no-op."
+        )
+    state_summary = _format_compact_state_summary(engine)
+    if state_summary:
+        lines.append(f"\nCurrent state:\n{state_summary}")
+    lines.append(
+        "\nDo NOT repeat this call. Either call it with a genuinely different "
+        "value, or move on to the next step toward a complete crate (draft the "
+        "missing entities, wire the process chain, then build_and_validate)."
+    )
+    return "\n".join(lines)
+
+
 def _is_non_progress_result(result: Any) -> bool:
     """Return True when a tool result represents NO forward progress (#287 Fix B).
 
-    A weak model loops when a tool keeps handing back the same dead-end. Three
+    A weak model loops when a tool keeps handing back the same dead-end. Four
     shapes count as non-progress:
 
     1. An ``error`` dict — the wrapper turns a recoverable tool-body exception
@@ -849,6 +892,10 @@ def _is_non_progress_result(result: Any) -> bool:
        ``"<path> is a directory, not a file …"`` (#240/#281).
     3. An unreadable/None string — a reader that could not return text returns
        ``"<tool> could not return text …"`` (#101/#148).
+    4. A no-op mutation corrective — a mutation whose call left the crate state
+       unchanged (:func:`_no_op_mutation_message`). Without this a tool that
+       writes nothing counts as progress and RESETS every loop guard, which is
+       exactly how a 33-call ``set_crate_metadata`` loop stayed alive.
 
     Anything else (real file content, a successful build dict, a list, …) is
     progress and resets the loop-breaker. The check is purely structural so it
@@ -857,7 +904,11 @@ def _is_non_progress_result(result: Any) -> bool:
     if isinstance(result, dict):
         return "error" in result
     if isinstance(result, str):
-        return "is a directory, not a file" in result or "could not return text" in result
+        return (
+            "is a directory, not a file" in result
+            or "could not return text" in result
+            or _NO_OP_MUTATION_MARKER in result
+        )
     return False
 
 
@@ -1095,6 +1146,19 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                         logger.info("Suppressed repeated unchanged %s", bv_sig)
                         return corrective
 
+                # Snapshot the state so a mutation that writes nothing can be
+                # recognised AFTER the fact. The tools reject the obvious cases
+                # themselves; this catches every other way a mutation can be a
+                # no-op (re-linking an existing edge, re-setting an identical
+                # field) — all of which otherwise read as progress and reset the
+                # loop guards.
+                mutation_fingerprint: str | None = None
+                if tool_name in _MUTATION_TOOLS:
+                    try:
+                        mutation_fingerprint = engine.state.validation_fingerprint()
+                    except Exception:  # noqa: BLE001 — best-effort bookkeeping
+                        logger.debug("no-op guard: fingerprint failed", exc_info=True)
+
                 try:
                     result = engine.run_tool(tool_name, **kwargs)
                     _raise_if_invocation_cancelled()
@@ -1164,11 +1228,25 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                             if escalation and isinstance(result, dict):
                                 result = {**result, "escalation": escalation}
 
-                # Track repeated list queries independently: this never stores or
-                # reuses their result, and mutations always reset the streak.
-                if tool_name in _MUTATION_TOOLS and not (
+                # A mutation that left the state byte-identical did NOT make
+                # progress, whatever its return value looks like. Swap in the
+                # corrective before the bookkeeping below, so it neither counts
+                # as a mutation (which would reset every guard) nor escapes the
+                # loop-breaker (_is_non_progress_result recognises the marker).
+                if mutation_fingerprint is not None and not (
                     isinstance(result, dict) and result.get("error")
                 ):
+                    try:
+                        unchanged = engine.state.validation_fingerprint() == mutation_fingerprint
+                    except Exception:  # noqa: BLE001 — best-effort bookkeeping
+                        unchanged = False
+                    if unchanged:
+                        logger.info("No-op mutation suppressed: %s(%s)", tool_name, signature)
+                        result = _no_op_mutation_message(tool_name, kwargs, engine)
+
+                # Track repeated list queries independently: this never stores or
+                # reuses their result, and mutations always reset the streak.
+                if tool_name in _MUTATION_TOOLS and not _is_non_progress_result(result):
                     _record_recent_mutation(engine, result)
                     setattr(engine, _LIST_ENTITIES_LAST_SIG_FLAG, None)
                     setattr(engine, _LIST_ENTITIES_COUNT_FLAG, 0)

--- a/builder/agents/react/system_prompt.py
+++ b/builder/agents/react/system_prompt.py
@@ -52,7 +52,7 @@ Entity drafting:
 
 Entity management & provenance:
 - set_fields: Set one or more fields on an existing entity (the single mutation tool)
-- set_crate_metadata: Set top-level crate metadata on the Root Data Entity — title/description/accession + the root dates release_date (schema:releaseDate) and date_modified (schema:dateModified); only the fields you pass are written
+- set_crate_metadata: Set top-level crate metadata on the Root Data Entity — title/description/accession + the root dates release_date (schema:releaseDate) and date_modified (schema:dateModified); only the fields you pass are written, and you must pass at least one (it writes, it does not read — use get_status to read)
 - remove_entity: Remove an entity (refuses if still referenced unless cascade=true)
 - list_entities: List entities, optionally filtered by type. Mutation results are authoritative; use this only to search for an entity not returned by the preceding tool. Do not repeat an identical list_entities call when no mutation occurred; use the live state summary and prior result instead.
 - list_scanned_files: Retrieve the full scanned-file inventory (path/filename/size/mime) — scan_files only shows a sample, so use this to browse the inventory and decide which files to place/annotate (paginated/filterable)

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -395,7 +395,7 @@ TOOL_SPECS = [
     },
     {
         "name": "set_crate_metadata",
-        "description": "Set top-level crate metadata on the Root Data Entity (./): title/description/accession plus the root dates release_date (schema:releaseDate) and date_modified (schema:dateModified). Pass ISO-8601 strings for the dates, e.g. release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z'. Only the fields you pass are written — never fabricate a date. datePublished is auto-set at build time and is not controlled here. Example: set_crate_metadata(accession='S-VHPS21', release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z').",
+        "description": "WRITE-ONLY setter for top-level crate metadata on the Root Data Entity (./): title/description/accession plus the root dates release_date (schema:releaseDate) and date_modified (schema:dateModified). You MUST pass at least one value to write — a call with all fields null writes nothing, is REJECTED with an error, and does not read anything back; use get_status to READ the current crate metadata. Pass ISO-8601 strings for the dates, e.g. release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z'. Only the fields you pass are written — never fabricate a date. datePublished is auto-set at build time and is not controlled here. Example: set_crate_metadata(accession='S-VHPS21', release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z').",
         "parameters": {
             "type": "object",
             "properties": {

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -137,6 +137,11 @@ class UiSnapshot:
     tokens_in: int = 0
     tokens_out: int = 0
     cost_usd: float | None = None
+    # The most recent model call on its own. The prompt is rebuilt every call,
+    # so this input figure IS the current context size — the number that shows
+    # context bloat, which the session total (a sum over every re-send) hides.
+    turn_tokens_in: int = 0
+    turn_tokens_out: int = 0
 
 
 @dataclass
@@ -148,6 +153,10 @@ class _TokenTail:
     tokens_in: int
     tokens_out: int
     last_model: str
+    # The last model call's own counts, kept alongside the running totals so the
+    # per-turn figures cost no extra parsing.
+    last_call_in: int = 0
+    last_call_out: int = 0
 
 
 # Per-profile-file resume points for :func:`_read_token_totals`, keyed by the
@@ -205,14 +214,32 @@ def _read_token_totals(session_id: str) -> tuple[int, int, str]:
                         or record.get("node") != "model"
                     ):
                         continue
-                    tail.tokens_in += int(record.get("input_tokens", 0) or 0)
-                    tail.tokens_out += int(record.get("output_tokens", 0) or 0)
+                    tail.last_call_in = int(record.get("input_tokens", 0) or 0)
+                    tail.last_call_out = int(record.get("output_tokens", 0) or 0)
+                    tail.tokens_in += tail.last_call_in
+                    tail.tokens_out += tail.last_call_out
                     tail.last_model = record.get("model_name") or tail.last_model
 
         return tail.tokens_in, tail.tokens_out, tail.last_model
     except Exception:
         logger.debug("token totals unavailable for %s", session_id, exc_info=True)
         return 0, 0, ""
+
+
+def _read_turn_tokens(session_id: str) -> tuple[int, int]:
+    """The last model call's ``(input, output)`` tokens, or ``(0, 0)``.
+
+    Reads the cache :func:`_read_token_totals` maintains, so it must be called
+    after it (as :func:`snapshot_from_engine` does) and costs no extra parsing.
+    """
+    try:
+        from builder.tools.profiler import SESSION_DIR
+
+        tail = _TOKEN_TAILS.get(str(SESSION_DIR / session_id / "profile.ndjson"))
+        return (tail.last_call_in, tail.last_call_out) if tail else (0, 0)
+    except Exception:
+        logger.debug("turn tokens unavailable for %s", session_id, exc_info=True)
+        return 0, 0
 
 
 def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
@@ -234,6 +261,7 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
     mit_assessed = bool(getattr(mit, "module_scores", None))
 
     tokens_in, tokens_out, last_model = _read_token_totals(state.session_id)
+    turn_in, turn_out = _read_turn_tokens(state.session_id)
     cost_usd: float | None = None
     if tokens_in + tokens_out > 0:
         try:
@@ -261,6 +289,8 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
         tokens_in=tokens_in,
         tokens_out=tokens_out,
         cost_usd=cost_usd,
+        turn_tokens_in=turn_in,
+        turn_tokens_out=turn_out,
     )
 
 
@@ -271,6 +301,20 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
 
 def _dot(ok: bool) -> str:
     return _PASS_DOT if ok else _PENDING_DOT
+
+
+def _compact_tokens(count: int) -> str:
+    """Token count in a fixed-width-ish compact form: ``842``, ``12.9k``, ``2.5M``.
+
+    A pinned line has one row to spend, and six-digit counts push the validation
+    dots off a narrow terminal. Counts under 1000 are shown exactly — rounding
+    the small numbers would lose the detail that matters at the start of a run.
+    """
+    if count < 1000:
+        return str(count)
+    if count < 1_000_000:
+        return f"{count / 1000:.1f}k".replace(".0k", "k")
+    return f"{count / 1_000_000:.1f}M".replace(".0M", "M")
 
 
 def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None = None) -> str:
@@ -296,10 +340,18 @@ def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None =
     if snap.tokens_in + snap.tokens_out > 0:
         from builder.pricing import format_cost
 
-        cost_str = f"@{format_cost(snap.cost_usd)}" if snap.cost_usd is not None else ""
+        cost_str = f" @{format_cost(snap.cost_usd)}" if snap.cost_usd is not None else ""
         total = snap.tokens_in + snap.tokens_out
+        # ↑/↓ are THIS turn — the prompt is rebuilt every call, so ↑ is the live
+        # context size and its drift is the bloat signal. Before the first call
+        # completes there is no turn figure, so fall back to the session numbers
+        # rather than showing a misleading pair of zeros.
+        turn_in = snap.turn_tokens_in or snap.tokens_in
+        turn_out = snap.turn_tokens_out or snap.tokens_out
         token_str = "  " + _SEP + "  " + field(
-            "tokens", f"tok {snap.tokens_in}→{snap.tokens_out} ({total}){cost_str}"
+            "tokens",
+            f"↑{_compact_tokens(turn_in)} ↓{_compact_tokens(turn_out)}"
+            f"  {_compact_tokens(total)} tok{cost_str}",
         )
 
     return (
@@ -322,7 +374,15 @@ def status_field_values(snap: UiSnapshot) -> dict[str, Any]:
         "base": snap.base_passed,
         "isa": snap.isa_passed,
         "tox": snap.tox_passed,
-        "tokens": (snap.tokens_in, snap.tokens_out, snap.cost_usd),
+        # The per-turn figures are included so the fader tints the segment when
+        # a new turn lands, not only when the cumulative cost ticks over.
+        "tokens": (
+            snap.tokens_in,
+            snap.tokens_out,
+            snap.cost_usd,
+            snap.turn_tokens_in,
+            snap.turn_tokens_out,
+        ),
     }
 
 

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -293,8 +293,28 @@ def set_crate_metadata(
 
     Returns:
         A token-bounded summary of the metadata values now in effect for the
-        fields this tool manages.
+        fields this tool manages, or an ``{"error": ...}`` dict when the call
+        supplies no value to write.
+
+    A call with every field empty is REFUSED rather than treated as a harmless
+    read. It cannot write anything, so it is always a mistake — and the
+    successful-looking summary it used to return read as progress to the caller,
+    which is how one session issued this call 33 times in a row (~990k input
+    tokens) without anything stopping it. Use ``get_status`` to read the current
+    metadata.
     """
+    supplied = (title, description, accession, release_date, date_modified)
+    if all(value in (None, "") for value in supplied):
+        return {
+            "error": (
+                "set_crate_metadata needs at least one value to write. Pass the "
+                "field(s) you want to set — title, description, accession, "
+                "release_date or date_modified — or use get_status to read the "
+                "current crate metadata."
+            ),
+            "tool": "set_crate_metadata",
+        }
+
     m = state.metadata
     if title not in (None, ""):
         m.title = title

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -6,7 +6,7 @@
   --good:#0ca30c; --good-ink:#0a7d0a; --warn:#fab219; --warn-ink:#8a6500;
   --low:#d03b3b; --low-ink:#b3261e; --na-a:#e6ebeb; --na-b:#f3f6f6; --na-ink:#7a8688;
   --cov:#0e7c86; --track:#e6ebeb;
-  --cat-process:#2a78d6; --cat-material:#008300; --cat-data:#c0407a;
+  --cat-process:#2a78d6; --cat-material:#008300; --cat-data:#c0407a; --cat-chemical:#9a5b00;
   --edge-object:#8a9698; --edge-result:#0e7c86;
   color-scheme: light;
   background:var(--page); color:var(--ink);
@@ -178,6 +178,47 @@
 .mat .prov-legend .lg { display:inline-flex; align-items:center; gap:.4rem; }
 .mat .prov-legend .gl { width:1.5rem; height:0; border-top:2px solid var(--edge-result); }
 .mat .prov-legend .gl.obj { border-top:2px dashed var(--edge-object); }
+
+/* chemicals — route diagram + identification matrix (#85) */
+.mat .prov.chem { min-width:34rem; }
+.mat .prov .n-chem { fill:color-mix(in srgb,var(--cat-chemical) 9%,var(--surface-2));
+  stroke:var(--cat-chemical); }
+.mat .prov .tag-chem { fill:var(--cat-chemical); }
+/* A compound the crate never links to a process: dashed outline + alarm colour,
+   so "described but unreachable" never reads like a wired one. */
+.mat .prov .n-chem.unwired { fill:color-mix(in srgb,var(--low) 7%,var(--surface-2));
+  stroke:var(--low); stroke-dasharray:5 3; }
+.mat .prov .tag-chem.unwired { fill:var(--low-ink); }
+.mat .prov .e-link { stroke:var(--edge-result); }
+.mat .prov .mk-link { fill:var(--edge-result); }
+.mat .prov .e-break { stroke:var(--low); stroke-dasharray:4 3; }
+.mat .prov .brk { fill:var(--low-ink); font-size:11px; font-weight:700; text-anchor:end; }
+.mat .prov .elabel { fill:var(--muted); font-size:8.5px; text-anchor:middle;
+  font-weight:600; letter-spacing:.03em; }
+.mat .prov-legend .gl.brk { border-top:2px dashed var(--low); }
+.mat .chem-warn { display:flex; gap:.55rem; align-items:flex-start; margin:.9rem 0 0;
+  font-size:.84rem; color:var(--ink-2); max-width:72ch; }
+.mat .chem-warn b { color:var(--low-ink); font-weight:640; }
+.mat .chem-warn code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.78rem;
+  background:var(--surface-2); border:1px solid var(--border); border-radius:3px;
+  padding:.02rem .3rem; color:var(--ink); }
+.mat .chem-tbl-scroll { overflow-x:auto; margin-top:.95rem; }
+.mat table.chem-tbl { border-collapse:collapse; width:100%; min-width:32rem; font-size:.82rem; }
+.mat .chem-tbl th, .mat .chem-tbl td { text-align:center; padding:.34rem .3rem;
+  border-bottom:1px solid var(--hairline); }
+.mat .chem-tbl thead th { font-size:.66rem; text-transform:uppercase; letter-spacing:.06em;
+  color:var(--muted); font-weight:650; white-space:nowrap; vertical-align:bottom; }
+.mat .chem-tbl th[scope="row"] { text-align:left; font-weight:550; color:var(--ink-2);
+  display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; padding-right:.7rem; }
+.mat .chem-tbl thead th:first-child { text-align:left; }
+.mat .chem-tbl .cn { font-weight:580; color:var(--ink); }
+.mat .chem-tbl tbody tr:last-child th, .mat .chem-tbl tbody tr:last-child td { border-bottom:none; }
+.mat .chem-tbl tr.more th { color:var(--muted); font-style:italic; font-weight:500; }
+.mat .chem-flag { font-size:.66rem; text-transform:uppercase; letter-spacing:.05em;
+  font-weight:650; color:var(--low-ink); background:color-mix(in srgb,var(--low) 11%,transparent);
+  border-radius:999px; padding:.05rem .42rem; white-space:nowrap; }
+.mat .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px;
+  overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; border:0; }
 
 /* graph-topology strip (relocated here from the header) */
 .mat .comp { display:flex; flex-wrap:wrap; gap:.5rem .9rem; align-items:center;

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -280,6 +280,7 @@ def _render_kpis(
     mit: MITReport,
     repro_ready: int,
     repro_total: int,
+    chem: dict[str, Any] | None = None,
 ) -> str:
     # Profile-adherence tile: severity mini-rows, or an "awaiting validation" row.
     if tiers is None:
@@ -353,7 +354,27 @@ def _render_kpis(
         "</article>"
     )
 
-    return f'<div class="kpis">{prof_tile}{fair_tile}{mit_tile}{repro_tile}</div>\n'
+    # Chemicals tile — only when the crate actually declares compounds, so a
+    # non-chemical crate isn't given a tile reading "0".
+    chem_tile = ""
+    if chem:
+        c = chem["counts"]
+        wired, total = c["wired"], c["total"]
+        id_pct = round(c["fields_met"] / c["fields_total"] * 100) if c["fields_total"] else 0
+        chem_tile = (
+            '<article class="kpi">'
+            '<div class="kpi-h"><span class="eyebrow">Chemicals</span>'
+            f'{_mk("ok" if wired == total else "no")}</div>'
+            f'<div class="kpi-v"><b>{wired}</b><span class="den">/ {total}</span> '
+            '<span class="tag-inline">wired</span></div>'
+            f'<div class="kpi-sub">{id_pct}% of identification fields filled</div>'
+            f'<div class="meter" role="img" aria-label="identification {id_pct}%">'
+            f'<i class="{_fill_class(c["fields_met"], c["fields_total"])}" '
+            f'style="width:{id_pct}%"></i></div>'
+            "</article>"
+        )
+
+    return f'<div class="kpis">{prof_tile}{fair_tile}{mit_tile}{chem_tile}{repro_tile}</div>\n'
 
 
 def _render_profile_section(val: ValidationReport, tiers: list[dict[str, str]] | None) -> str:
@@ -659,6 +680,138 @@ def _render_provenance_section(graph: dict[str, Any] | list[dict[str, Any]]) -> 
     )
 
 
+# Cap the per-compound matrix so a screening crate with hundreds of compounds
+# can't blow up the page; the tail is summarised as "+N more" (never dropped
+# silently). Unwired compounds sort first — they are the actionable ones.
+_CHEM_LIST_CAP = 12
+
+_CHEM_STATE_MARK = {"wired": "ok", "mentioned": "na", "unlinked": "no"}
+_CHEM_STATE_NOTE = {
+    "wired": "reachable from a process",
+    "mentioned": "named in the crate, but produced by no process",
+    "unlinked": "nothing in the crate references this compound",
+}
+
+
+def _render_chemicals_section(inv: dict[str, Any]) -> str:
+    """The Chemicals section: how each compound reaches the experiment, and how
+    completely it is identified.
+
+    Two views of the same inventory, because either alone misleads. The diagram
+    answers *can a reader get from a process to this compound* — the chain ISA
+    forces to run through the condition table rather than the process object, and
+    the one that quietly breaks. The matrix answers *could a reader obtain this
+    substance* — CAS / PubChem CID / DTXSID plus the structure fields. A crate can
+    score perfectly on one and fail the other, so the section never collapses them
+    into a single number.
+
+    Returns ``""`` when the crate declares no compounds — an empty chemicals
+    panel on a non-chemical crate would read as a failure rather than as
+    "not applicable".
+    """
+    from builder.writers.provenance_dag import CHEM_COVERAGE_FIELDS, render_chemicals_svg
+
+    chems = inv["chemicals"]
+    if not chems:
+        return ""
+    counts = inv["counts"]
+    total, wired = counts["total"], counts["wired"]
+    id_pct = (
+        round(counts["fields_met"] / counts["fields_total"] * 100)
+        if counts["fields_total"]
+        else 0
+    )
+
+    svg = render_chemicals_svg(inv)
+    unreached = total - wired
+    if unreached:
+        route_note = (
+            f'<p class="chem-warn">{_mk("no")}<span><b>{unreached} of {total} compounds '
+            "cannot be reached from any process.</b> ISA forbids a MolecularEntity as a "
+            "LabProcess <code>object</code>, so a compound is linked <em>through</em> the "
+            "Exposure&rsquo;s condition table — give the table an <code>about</code> "
+            "pointing at the compound (and the <code>compound</code> column a "
+            "<code>valueUrl</code>), or the substance stays described but unused.</span></p>"
+        )
+    else:
+        route_note = (
+            '<p class="good-note">Every compound is reachable from the process that used it.</p>'
+        )
+
+    # Per-compound identification matrix. Unwired first, then worst-covered, so
+    # the rows that survive the cap are the ones worth acting on.
+    ordered = sorted(
+        chems, key=lambda c: (c["state"] == "wired", c["met"], c["name"].casefold())
+    )
+    head = "".join(
+        f'<th scope="col" title="{html.escape(full)}">{html.escape(short)}</th>'
+        for full, short in CHEM_COVERAGE_FIELDS
+    )
+    rows = []
+    for c in ordered[:_CHEM_LIST_CAP]:
+        link = " 🔗" if c["resolvable"] else ""
+        flag = (
+            ""
+            if c["state"] == "wired"
+            else f'<span class="chem-flag" title="{html.escape(_CHEM_STATE_NOTE[c["state"]])}">'
+            f"{'not linked' if c['state'] == 'unlinked' else 'no process'}</span>"
+        )
+        cells = "".join(
+            f'<td>{_mk("ok" if c["fields"].get(full) else "no")}</td>'
+            for full, _short in CHEM_COVERAGE_FIELDS
+        )
+        rows.append(
+            f'<tr><th scope="row">{_mk(_CHEM_STATE_MARK[c["state"]])}'
+            f'<span class="cn">{c["label"]}{link}</span>{flag}</th>{cells}</tr>'
+        )
+    extra = len(ordered) - _CHEM_LIST_CAP
+    if extra > 0:
+        rows.append(
+            f'<tr class="more"><th scope="row">+{extra} more compounds</th>'
+            f'<td colspan="{len(CHEM_COVERAGE_FIELDS)}"></td></tr>'
+        )
+    matrix = (
+        '<div class="chem-tbl-scroll"><table class="chem-tbl">'
+        f'<caption class="sr-only">Identification fields carried by each compound</caption>'
+        f'<thead><tr><th scope="col">Compound</th>{head}</tr></thead>'
+        f'<tbody>{"".join(rows)}</tbody></table></div>'
+    )
+
+    diagram = (
+        f'<div class="prov-scroll">{svg}</div>\n'
+        '  <div class="prov-legend">'
+        '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
+        '<polygon points="4,1 14,1 18,7 14,13 4,13 1,7" fill="var(--accent-soft)" '
+        'stroke="var(--cat-process)" stroke-width="1.6"/></svg> Process</span>'
+        '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
+        '<rect x="1" y="1" width="15" height="12" rx="2" fill="var(--surface-2)" '
+        'stroke="var(--cat-data)" stroke-width="1.6"/></svg> Condition table</span>'
+        '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+        '<polygon points="4,1 18,1 21,4 21,10 18,13 4,13 1,10 1,4" '
+        'fill="var(--surface-2)" stroke="var(--cat-chemical)" stroke-width="1.6"/>'
+        "</svg> Compound</span>"
+        '<span class="lg"><span class="gl"></span> links to</span>'
+        '<span class="lg"><span class="gl brk"></span> ✗ route stops here</span>'
+        "</div>"
+        if svg
+        else ""
+    )
+
+    return (
+        "<section>\n"
+        '  <div class="sec-h"><h2>Chemicals</h2>'
+        f'<span class="sec-meta"><b>{total}</b> compound{"" if total == 1 else "s"} · '
+        f"<b>{wired}</b> wired · <b>{id_pct}%</b> identified</span></div>\n"
+        '  <p class="lead">The substances under test — whether each one is actually '
+        "connected to the experiment that used it, and whether a reader could obtain the "
+        "same material.</p>\n"
+        f"  {diagram}\n"
+        f"  {route_note}\n"
+        f"  {matrix}\n"
+        "</section>\n"
+    )
+
+
 def build_maturity_html(
     state: CrateState,
     *,
@@ -709,7 +862,16 @@ def build_maturity_html(
     repro_ready = sum(1 for _, ok, _ in checks if ok)
 
     header = _render_header(title, accession, tiers)
-    kpis = _render_kpis(tiers, fair, mit, repro_ready, len(checks))
+    if graph is not None:
+        from builder.writers.provenance_dag import build_chemical_inventory
+
+        chem_inv = build_chemical_inventory(graph)
+        chem_section = _render_chemicals_section(chem_inv)
+    else:
+        chem_inv, chem_section = None, ""
+    kpis = _render_kpis(
+        tiers, fair, mit, repro_ready, len(checks), chem_inv if chem_section else None
+    )
     prov_section = _render_provenance_section(graph) if graph is not None else ""
     prof_section = _render_profile_section(val, tiers)
     fair_section = _render_fair_section(fair)
@@ -724,6 +886,7 @@ def build_maturity_html(
         header
         + kpis
         + prov_section
+        + chem_section
         + prof_section
         + fair_section
         + mit_section

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import html
 import json
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -466,6 +467,13 @@ _SVG_CLASS = {
     "mat": ("n-material", "tag-material"),
     "data": ("n-data", "tag-data"),
     "ctx": ("n-ctx", "tag-ctx"),
+    # Contextual entities never appear in the derivation chain (ISA forbids a
+    # MolecularEntity as a process object, and people are not consumed by a
+    # process), but the chemicals and people diagrams reuse this geometry so
+    # every view in the report reads as one system.
+    "chem": ("n-chem", "tag-chem"),
+    "agent": ("n-agent", "tag-agent"),
+    "org": ("n-org", "tag-org"),
 }
 
 
@@ -475,18 +483,24 @@ def _svg_trunc(text: str, limit: int = 18) -> str:
     return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
-def _svg_node_shape(cls: str, x: int, y: int) -> str:
-    """The node's outline path/polygon for style bucket *cls* at ``(x, y)``."""
+def _svg_node_shape(cls: str, x: int, y: int, variant: str = "") -> str:
+    """The node's outline path/polygon for style bucket *cls* at ``(x, y)``.
+
+    ``variant`` appends an extra CSS class to the outline (used by the chemicals
+    diagram to mark a compound the crate never links to a process), so state is
+    carried by the stylesheet rather than by inline attributes.
+    """
     w, h = _SVG_NODE_W, _SVG_NODE_H
+    extra = f" {variant}" if variant else ""
     if cls == "proc":  # hexagon (chevron ends read as "a step")
         pts = (
             f"{x},{y + h // 2} {x + 13},{y} {x + w - 13},{y} "
             f"{x + w},{y + h // 2} {x + w - 13},{y + h} {x + 13},{y + h}"
         )
-        return f'<polygon class="n n-process" points="{pts}"/>'
+        return f'<polygon class="n n-process{extra}" points="{pts}"/>'
     if cls == "mat":  # stadium (rounded ends) — a sample/material
         return (
-            f'<rect class="n n-material" x="{x}" y="{y}" width="{w}" height="{h}" '
+            f'<rect class="n n-material{extra}" x="{x}" y="{y}" width="{w}" height="{h}" '
             f'rx="{h // 2}" ry="{h // 2}"/>'
         )
     if cls == "data":  # document with a folded corner — a File/Table
@@ -497,9 +511,28 @@ def _svg_node_shape(cls: str, x: int, y: int) -> str:
             f"Q{x},{y + h} {x},{y + h - 4} V{y + 4} Q{x},{y} {x + 4},{y} Z"
         )
         fold = f"M{x + w - f},{y} V{y + f} H{x + w} Z"
-        return f'<path class="n n-data" d="{body}"/><path class="fold" d="{fold}"/>'
+        return f'<path class="n n-data{extra}" d="{body}"/><path class="fold" d="{fold}"/>'
+    if cls == "agent":  # pill — a person (no materials share this view)
+        return (
+            f'<rect class="n n-agent{extra}" x="{x}" y="{y}" width="{w}" height="{h}" '
+            f'rx="{h // 2}" ry="{h // 2}"/>'
+        )
+    if cls == "org":  # square-shouldered block — an institution
+        return (
+            f'<rect class="n n-org{extra}" x="{x}" y="{y}" width="{w}" height="{h}" '
+            'rx="3" ry="3"/>'
+        )
+    if cls == "chem":  # octagon — a compound (distinct from the process hexagon)
+        c = 12
+        pts = (
+            f"{x + c},{y} {x + w - c},{y} {x + w},{y + c} {x + w},{y + h - c} "
+            f"{x + w - c},{y + h} {x + c},{y + h} {x},{y + h - c} {x},{y + c}"
+        )
+        return f'<polygon class="n n-chem{extra}" points="{pts}"/>'
     # ctx — a plain rounded rectangle for anything off the material/data axis.
-    return f'<rect class="n n-ctx" x="{x}" y="{y}" width="{w}" height="{h}" rx="8" ry="8"/>'
+    return (
+        f'<rect class="n n-ctx{extra}" x="{x}" y="{y}" width="{w}" height="{h}" rx="8" ry="8"/>'
+    )
 
 
 def render_provenance_svg(
@@ -970,6 +1003,1032 @@ def _external_label(uri: str) -> str:
     tail = uri.rstrip("/").rsplit("/", 1)[-1]
     host = uri.split("://", 1)[-1].split("/", 1)[0].replace("www.", "")
     return f"{tail} ({host})" if tail and tail != host else host
+
+
+# ---------------------------------------------------------------------------
+# Chemical inventory (#85) — which compounds a crate declares, how each one
+# reaches the experiment, and how completely it is identified.
+#
+# A tox crate's compounds are the one thing a receiving lab must be able to pin
+# down exactly, and they are also the easiest thing to leave dangling. ISA
+# forbids a MolecularEntity as a LabProcess ``object`` (objects MUST be
+# File/Sample/BioSample), so a compound is *never* wired to its Exposure
+# directly: it hangs off the produced condition table
+# (``table --about--> MolecularEntity``, see ``_crate_mapping._synth_condition_table``),
+# off that table's ``compound`` CSVW column via ``valueUrl``, and — at a glance —
+# off the Study via ``schema:mentions``. Miss that indirection and the crate
+# still validates while every compound sits orphaned: fully described, but
+# unreachable from the experiment that used it.
+#
+# This model therefore reports both halves, because either alone is misleading:
+#   * the ROUTE      — which process produced which table which names which
+#                      compound (or where that chain breaks), and
+#   * the IDENTITY   — CAS / PubChem CID / DTXSID plus the structure fields that
+#                      let someone else obtain the same substance.
+# ---------------------------------------------------------------------------
+
+_CHEMICAL_TYPES = frozenset({"MolecularEntity", "ChemicalSubstance"})
+
+_IDENTIFIER_KEYS: tuple[str, ...] = (
+    "identifier",
+    "http://schema.org/identifier",
+    "https://schema.org/identifier",
+)
+_VALUE_KEYS: tuple[str, ...] = ("value", "http://schema.org/value", "https://schema.org/value")
+_PROPERTYID_KEYS: tuple[str, ...] = (
+    "propertyID",
+    "http://schema.org/propertyID",
+    "https://schema.org/propertyID",
+)
+
+# A bare `identifier` string that is a CAS Registry Number (2-7 / 2 / 1 check
+# digit) — ro-crate-py serializes some crates that way instead of minting an
+# identifier PropertyValue, and dropping it would under-report identification.
+_CAS_RE = re.compile(r"\d{2,7}-\d{2}-\d")
+
+# Registry identifier schemes in the order ``_crate_mapping._MOLECULAR_IDENTIFIERS``
+# mints them (CAS → PubChem CID → EPA DTXSID). ``aliases`` are matched
+# case-folded against the identifier PropertyValue's ``name``; ``hosts`` against
+# its ``propertyID`` *and* against the compound's own ``@id``, so a crate whose
+# @id is the PubChem/CompTox page still counts as carrying that identifier even
+# when it never spells the scheme out as a PropertyValue.
+_CHEM_ID_SCHEMES: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("CAS", "CAS", ("cas", "casrn", "cas rn", "cas number", "cas registry number"), ()),
+    ("PubChem CID", "CID", ("pubchem cid", "pubchem", "cid"), ("pubchem.ncbi.nlm.nih.gov",)),
+    ("DTXSID", "DTXSID", ("dtxsid", "dsstox", "dsstox substance id"), ("comptox.epa.gov",)),
+)
+
+# Structure/characterisation fields carried directly on the compound. The
+# compact aliases are the ``profiles.context`` terms; the schema.org IRIs cover
+# an expanded document.
+_CHEM_STRUCTURE_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "InChIKey",
+        ("inchikey", "inChIKey", "http://schema.org/inChIKey", "https://schema.org/inChIKey"),
+    ),
+    ("SMILES", ("smiles", "http://schema.org/smiles", "https://schema.org/smiles")),
+    (
+        "Formula",
+        (
+            "formula",
+            "molecularFormula",
+            "molecular_formula",
+            "http://schema.org/molecularFormula",
+            "https://schema.org/molecularFormula",
+        ),
+    ),
+    (
+        "Mass",
+        (
+            "mass",
+            "molecularWeight",
+            "molecular_weight",
+            "http://schema.org/molecularWeight",
+            "https://schema.org/molecularWeight",
+        ),
+    ),
+)
+
+# The coverage matrix columns: (full name, column header). Registry identifiers
+# first (they are what makes a compound orderable), then structure.
+CHEM_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = tuple(
+    (scheme, short) for scheme, short, _a, _h in _CHEM_ID_SCHEMES
+) + tuple((label, label) for label, _keys in _CHEM_STRUCTURE_FIELDS)
+
+# Relations by which some other entity can point AT a compound, most canonical
+# first — the order decides which route is drawn when a compound is reachable
+# more than one way. ``about`` is the condition table's link, ``valueUrl`` the
+# per-well column link, ``mentions`` (which subsumes the ``chemicals`` alias) the
+# Study-level one; ``input``/``parameter`` are non-conformant but real, and a
+# crate that uses them should see them rather than be told it has no route.
+_CHEM_LINK_RELATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (_ABOUT_KEYS, "about"),
+    (_VALUEURL_KEYS, "valueUrl"),
+    (_MENTIONS_KEYS, "mentions"),
+    (_INPUT_KEYS, "input"),
+    (_PARAM_KEYS, "parameter"),
+)
+# Containment relations walked *upward* from a referrer to the entity a process
+# actually produced: a `compound` column is owned by a csvw:Schema, which is the
+# tableSchema of the condition table, which is the Exposure's result.
+_CHEM_CONTAINMENT_KEYS: tuple[tuple[str, ...], ...] = (_TABLESCHEMA_KEYS, _COLUMNS_KEYS)
+_CHEM_ANCHOR_HOPS = 3
+
+
+def _is_chemical(node: dict[str, Any]) -> bool:
+    return bool(_types(node) & _CHEMICAL_TYPES)
+
+
+def _literal(node: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    """First non-empty literal across ``keys``, unwrapping a list / ``@value``."""
+    for key in keys:
+        value = node.get(key)
+        if isinstance(value, list):
+            value = value[0] if value else None
+        if isinstance(value, dict):
+            value = value.get("@value")
+        if value not in (None, "", []):
+            return str(value)
+    return None
+
+
+def _registry_identifiers(
+    node: dict[str, Any],
+    nodes: dict[str, Any],
+    schemes: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...],
+) -> dict[str, str]:
+    """Persistent identifiers an entity carries, as ``{scheme: value}``.
+
+    Reads the ``identifier`` PropertyValues that ``_crate_mapping`` mints —
+    matching the scheme by the PropertyValue's ``name`` or its ``propertyID``
+    host — then falls back to the entity's own ``@id`` when that is itself a
+    registry URL (an ORCID, a ROR, a PubChem compound page). The @id fallback
+    matters: it is the *most* actionable form of the identifier, and a crate that
+    uses it without also minting a PropertyValue is better identified, not worse.
+    """
+    found: dict[str, str] = {}
+
+    def _scheme_of(name: str | None, url: str | None) -> str | None:
+        key = (name or "").strip().casefold().replace("_", " ")
+        for scheme, _short, aliases, hosts in schemes:
+            if key and key in aliases:
+                return scheme
+            if url and any(host in url for host in hosts):
+                return scheme
+        return None
+
+    for key in _IDENTIFIER_KEYS:
+        for item in _as_list(node.get(key)):
+            if not isinstance(item, dict):
+                continue
+            pv = nodes.get(item["@id"], item) if "@id" in item else item
+            prop_id = _first(pv, _PROPERTYID_KEYS)
+            if isinstance(prop_id, dict):
+                prop_id = prop_id.get("@id")
+            scheme = _scheme_of(
+                _literal(pv, _NAME_KEYS), prop_id if isinstance(prop_id, str) else None
+            )
+            value = _literal(pv, _VALUE_KEYS)
+            if scheme and value and scheme not in found:
+                found[scheme] = value
+
+    nid = str(node.get("@id", ""))
+    for scheme, _short, _aliases, hosts in schemes:
+        if scheme in found or not hosts:
+            continue
+        if any(host in nid for host in hosts):
+            tail = nid.rstrip("/").rsplit("/", 1)[-1]
+            if tail:
+                found[scheme] = tail
+    return found
+
+
+def _chem_identifiers(node: dict[str, Any], nodes: dict[str, Any]) -> dict[str, str]:
+    """Registry identifiers a compound carries: ``{scheme: value}``.
+
+    :func:`_registry_identifiers` plus the bare-string CAS fallback — some crates
+    serialize ``identifier`` as the literal Registry Number rather than as a
+    PropertyValue, and dropping it would under-report identification.
+    """
+    found = _registry_identifiers(node, nodes, _CHEM_ID_SCHEMES)
+    if "CAS" not in found:
+        for key in _IDENTIFIER_KEYS:
+            for item in _as_list(node.get(key)):
+                if isinstance(item, str) and _CAS_RE.fullmatch(item.strip()):
+                    found["CAS"] = item.strip()
+                    return found
+    return found
+
+
+def _chem_referrers(
+    nodes: dict[str, Any], chem_ids: set[str]
+) -> dict[str, list[tuple[str, str]]]:
+    """``chemical id -> [(referrer id, relation label)]``, deterministically ordered.
+
+    Compound→compound references are ignored: they are not a route into the
+    experiment, and counting them would let a cluster of mutually-referencing
+    compounds mask the fact that none of them reaches a process.
+    """
+    order = {label: i for i, (_keys, label) in enumerate(_CHEM_LINK_RELATIONS)}
+    out: dict[str, set[tuple[str, str]]] = {}
+    for nid, node in nodes.items():
+        if nid in chem_ids or str(nid).rsplit("/", 1)[-1] in _EXCLUDED_IDS:
+            continue
+        for keys, label in _CHEM_LINK_RELATIONS:
+            for ref in _refs(node, keys):
+                if ref in chem_ids:
+                    out.setdefault(ref, set()).add((nid, label))
+    return {
+        cid: sorted(pairs, key=lambda p: (order[p[1]], p[0])) for cid, pairs in out.items()
+    }
+
+
+def _chem_node_brief(nid: str, node: dict[str, Any]) -> dict[str, str]:
+    """The minimal description a drawn node needs.
+
+    ``name``/``tag`` are the RAW crate strings and ``label`` the escaped name.
+    Both are carried because the two consumers escape at different points: the
+    HTML matrix interpolates ``label`` directly, while the SVG must ellipsise
+    *before* escaping — truncating an escaped string can cut a character
+    reference (``&amp;``) in half.
+    """
+    return {"id": nid, "name": _name(node), "label": _escape(_name(node)), "tag": _tag(node)}
+
+
+def build_chemical_inventory(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Model the crate's compounds: their route into the experiment + their identity.
+
+    For every ``MolecularEntity`` the crate declares, resolve how it is reachable
+    from a ``LabProcess`` — normally ``process --result--> table --about--> compound``,
+    or via the condition table's ``compound`` column ``valueUrl`` — and how many
+    of the identification fields (CAS / PubChem CID / DTXSID / InChIKey / SMILES /
+    formula / mass) it actually carries.
+
+    Pure and cheap: one pass over the serialized ``@graph``, no validation and no
+    network. All crate-controlled text on the returned nodes is HTML-escaped
+    (#169) so it can be interpolated straight into the report.
+
+    Args:
+        metadata: Parsed ``ro-crate-metadata.json`` dict, the ``@graph`` list, or
+            the ``crate.metadata.generate()`` document.
+
+    Returns:
+        ``{"chemicals": [...], "groups": [...], "counts": {...}}``.
+
+        Each chemical: ``{id, label, tag, resolvable, identifiers, structure,
+        met, total, state, route}`` where ``state`` is ``"wired"`` (reachable
+        from a process), ``"mentioned"`` (referenced in-crate but by nothing a
+        process produced) or ``"unlinked"`` (referenced by nothing at all).
+
+        ``groups`` are the diagram's route bands — compounds sharing the same
+        ``(process, via)`` pair — ordered wired → mentioned → unlinked. ``counts``
+        carries ``total`` / ``wired`` / ``mentioned`` / ``unlinked`` plus
+        ``fields_met`` / ``fields_total`` for the identification coverage.
+    """
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    nodes: dict[str, dict[str, Any]] = {
+        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
+    }
+    chem_ids = {nid for nid, n in nodes.items() if _is_chemical(n)}
+    empty_counts = {
+        "total": 0,
+        "wired": 0,
+        "mentioned": 0,
+        "unlinked": 0,
+        "fields_met": 0,
+        "fields_total": 0,
+    }
+    if not chem_ids:
+        return {"chemicals": [], "groups": [], "counts": empty_counts}
+
+    referrers = _chem_referrers(nodes, chem_ids)
+
+    # Which process produced a given entity, and the CSVW containment chain used
+    # to walk a referrer up to such an entity.
+    producers: dict[str, list[str]] = {}
+    parents: dict[str, list[str]] = {}
+    for nid, node in nodes.items():
+        if _is_process(node):
+            for dst in _refs(node, _OUTPUT_KEYS):
+                producers.setdefault(dst, []).append(nid)
+        for keys in _CHEM_CONTAINMENT_KEYS:
+            for ref in _refs(node, keys):
+                parents.setdefault(ref, []).append(nid)
+
+    def _anchor_of(ref_id: str) -> str | None:
+        """Nearest ancestor of *ref_id* (itself included) that a process produced."""
+        seen: set[str] = set()
+        frontier = [ref_id]
+        for _ in range(_CHEM_ANCHOR_HOPS + 1):
+            nxt: list[str] = []
+            for cur in frontier:
+                if cur in seen:
+                    continue
+                seen.add(cur)
+                if cur in producers:
+                    return cur
+                nxt.extend(parents.get(cur, ()))
+            if not nxt:
+                break
+            frontier = sorted(nxt)
+        return None
+
+    def _route_of(cid: str) -> dict[str, Any] | None:
+        """The best route into *cid*: process-backed if one exists, else the first
+        in-crate referrer (a compound that is named but produced by nothing)."""
+        fallback: dict[str, Any] | None = None
+        for rid, label in referrers.get(cid, []):
+            if _is_process(nodes[rid]):
+                return {"process": rid, "via": rid, "link": rid, "edge": label}
+            anchor = _anchor_of(rid)
+            if anchor is not None:
+                return {
+                    "process": sorted(producers[anchor])[0],
+                    "via": anchor,
+                    "link": rid,
+                    "edge": label,
+                }
+            if fallback is None:
+                fallback = {"process": None, "via": rid, "link": rid, "edge": label}
+        return fallback
+
+    chemicals: list[dict[str, Any]] = []
+    for cid in sorted(chem_ids, key=lambda c: (_name(nodes[c]).casefold(), c)):
+        node = nodes[cid]
+        ids = _chem_identifiers(node, nodes)
+        structure = {
+            label: _literal(node, keys) is not None for label, keys in _CHEM_STRUCTURE_FIELDS
+        }
+        fields = {scheme: scheme in ids for scheme, _s, _a, _h in _CHEM_ID_SCHEMES}
+        fields.update(structure)
+        route = _route_of(cid)
+        state = "unlinked" if route is None else ("wired" if route["process"] else "mentioned")
+        chemicals.append(
+            {
+                **_chem_node_brief(cid, node),
+                "resolvable": _is_uri(cid),
+                "identifiers": ids,
+                "fields": fields,
+                "met": sum(1 for ok in fields.values() if ok),
+                "total": len(fields),
+                "state": state,
+                "route": route,
+            }
+        )
+
+    # Diagram bands: compounds sharing a (process, via) pair travel together —
+    # the relation is *not* part of the key, so a table that reaches some of its
+    # compounds by `about` and others by the column's `valueUrl` still draws one
+    # band; the band's edge label then names both mechanisms rather than the
+    # diagram repeating the same process and table twice.
+    order = {"wired": 0, "mentioned": 1, "unlinked": 2}
+    banded: dict[tuple[str, str | None, str | None], list[dict[str, Any]]] = {}
+    for chem in chemicals:
+        route = chem["route"] or {}
+        banded.setdefault(
+            (chem["state"], route.get("process"), route.get("via")), []
+        ).append(chem)
+    groups = [
+        {
+            "state": state,
+            "edge": " · ".join(
+                sorted({c["route"]["edge"] for c in members if c["route"]})
+            ),
+            "process": _chem_node_brief(proc, nodes[proc]) if proc else None,
+            "via": _chem_node_brief(via, nodes[via]) if via else None,
+            "chemicals": members,
+        }
+        for (state, proc, via), members in sorted(
+            banded.items(), key=lambda kv: (order[kv[0][0]], kv[0][1] or "", kv[0][2] or "")
+        )
+    ]
+
+    counts = {
+        "total": len(chemicals),
+        "wired": sum(1 for c in chemicals if c["state"] == "wired"),
+        "mentioned": sum(1 for c in chemicals if c["state"] == "mentioned"),
+        "unlinked": sum(1 for c in chemicals if c["state"] == "unlinked"),
+        "fields_met": sum(c["met"] for c in chemicals),
+        "fields_total": sum(c["total"] for c in chemicals),
+    }
+    return {"chemicals": chemicals, "groups": groups, "counts": counts}
+
+
+# --- chemicals diagram -----------------------------------------------------
+# Reuses the derivation chain's node geometry and shapes (see _SVG_NODE_W/H and
+# _svg_node_shape) so the two diagrams in the maturity report read as one system;
+# only the row pitch is tighter, because a compound band is a list rather than a
+# chain.
+_CHEM_COL_DX = 182
+_CHEM_ROW_DY = 66
+_CHEM_X0 = 16
+_CHEM_Y0 = 24
+_CHEM_BAND_GAP = 26
+# Length of the dashed "route stops here" stub. Must leave the ✗ glyph inside the
+# inter-column gap (_CHEM_COL_DX - _SVG_NODE_W = 44px), or a stub drawn next to a
+# populated column lands on top of that column's node.
+_CHEM_BREAK_DX = 30
+# Named compounds drawn per band before the tail is folded into one aggregate
+# node. A band of exactly _CHEM_MAX_NODES is drawn in full — aggregating a single
+# compound into "1 more" would cost a row and tell the reader less.
+_CHEM_MAX_NAMED = 3
+_CHEM_MAX_NODES = 4
+
+
+def _band_nodes(members: list[dict[str, Any]]) -> list[dict[str, Any] | None]:
+    """The entries drawn for one band: each member, or a named head then ``None``
+    standing for "and N more" — the diagram answers *how do these connect*, and a
+    long verbatim list is the matrix's job, not the picture's."""
+    if len(members) <= _CHEM_MAX_NODES:
+        return list(members)
+    return [*members[:_CHEM_MAX_NAMED], None]
+
+
+def _svg_place(
+    out: list[str], brief: dict[str, str], cls: str, x: int, y: int, variant: str = ""
+) -> None:
+    """Append one drawn node: shape, type tag above it, ellipsised name inside.
+
+    ``brief`` carries RAW crate text (see :func:`_chem_node_brief`); it is
+    ellipsised first and escaped after, so truncation can never cut a character
+    reference in half (#169).
+    """
+    cx = x + _SVG_NODE_W // 2
+    tag_cls = _SVG_CLASS[cls][1]
+    vcls = f" {variant}" if variant else ""
+    out.append(
+        f"<g><title>{_escape(brief['name'])} — {_escape(brief['tag'])}</title>"
+        f"{_svg_node_shape(cls, x, y, variant)}"
+        f'<text class="tag {tag_cls}{vcls}" x="{cx}" y="{y - 6}">'
+        f"{_escape(_svg_trunc(brief['tag'], 22).upper())}</text>"
+        f'<text class="name" x="{cx}" y="{y + 28}">'
+        f"{_escape(_svg_trunc(brief['name']))}</text></g>"
+    )
+
+
+def _svg_link(out: list[str], x1: int, y1: int, x2: int, y2: int, label: str = "") -> None:
+    """Append a labelled bezier edge between two node edges."""
+    dx = (x2 - x1) // 2 if y1 == y2 else max((x2 - x1) // 2, 30)
+    out.append(
+        f'<path class="e e-link" d="M{x1},{y1} C{x1 + dx},{y1} {x2 - dx},{y2} {x2},{y2}" '
+        'marker-end="url(#view-ar-link)"/>'
+    )
+    if label:
+        out.append(
+            f'<text class="elabel" x="{(x1 + x2) // 2}" y="{(y1 + y2) // 2 - 5}">'
+            f"{_escape(label)}</text>"
+        )
+
+
+def _svg_break(out: list[str], x_end: int, y: int, *, leading: bool = True) -> None:
+    """Append the dashed "the route stops here" stub ending in ✗.
+
+    Drawn rather than omitted: an absent edge and an absent *hop* look identical
+    once a diagram simply leaves things out, and the whole point of these views is
+    to make a missing link legible.
+    """
+    if leading:
+        out.append(
+            f'<path class="e e-break" d="M{x_end - _CHEM_BREAK_DX},{y} H{x_end}"/>'
+            f'<text class="brk" x="{x_end - _CHEM_BREAK_DX - 3}" y="{y + 4}">✗</text>'
+        )
+    else:
+        out.append(
+            f'<path class="e e-break" d="M{x_end},{y} H{x_end + _CHEM_BREAK_DX}"/>'
+            f'<text class="brk start" x="{x_end + _CHEM_BREAK_DX + 3}" y="{y + 4}">✗</text>'
+        )
+
+
+_VIEW_MARKER = (
+    '<marker id="view-ar-link" viewBox="0 0 10 10" refX="9" refY="5" '
+    'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+    '<path d="M0,0 L10,5 L0,10 z" class="mk-link"/></marker>'
+)
+
+
+def _svg_document(body_edges: list[str], body_nodes: list[str], w: int, h: int, aria: str) -> str:
+    """Wrap drawn edges/nodes in the finished, self-contained ``<svg>`` element."""
+    return (
+        f'<svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" '
+        f'role="img" aria-label="{_escape(aria)}" class="prov view">'
+        f"<title>{_escape(aria)}</title>"
+        f"<defs>{_VIEW_MARKER}</defs>"
+        f'<g class="edges">{"".join(body_edges)}</g>'
+        f'<g class="nodes">{"".join(body_nodes)}</g></svg>'
+    )
+
+
+def render_chemicals_svg(inventory: dict[str, Any]) -> str:
+    """Draw the compound routes as a self-contained inline ``<svg>``.
+
+    One band per route: ``process --result--> table --about--> compound``, with
+    the compounds of that route stacked on the right. A band whose compounds are
+    only *mentioned* loses its process column, and an unlinked band loses both —
+    in each case the missing hop is drawn as a dashed stub ending in ✗ rather
+    than silently omitted, so "described but unreachable" looks different from
+    "properly wired" at a glance.
+
+    Like :func:`render_provenance_svg` this emits finished SVG — no script, no
+    external assets — so it embeds in the offline maturity report and prints
+    as-is. All labels arrive pre-escaped from :func:`build_chemical_inventory`.
+
+    Args:
+        inventory: The result of :func:`build_chemical_inventory`.
+
+    Returns:
+        The ``<svg>…</svg>`` markup, or ``""`` when the crate declares no
+        compounds.
+    """
+    groups = inventory.get("groups") or []
+    if not groups:
+        return ""
+
+    # Drop the leading columns no band uses, so a crate whose compounds are all
+    # unlinked doesn't render a diagram that is mostly empty gutter. The reserved
+    # pad keeps room for the dashed ✗ stub once a left column is gone.
+    has_proc = any(g["process"] for g in groups)
+    has_via = any(g["via"] for g in groups)
+    first_col = 0 if has_proc else (1 if has_via else 2)
+    x0 = _CHEM_X0 + (_CHEM_BREAK_DX + 10 if first_col else 0)
+    col_x = [x0 + (i - first_col) * _CHEM_COL_DX for i in range(3)]
+
+    edges: list[str] = []
+    nodes_svg: list[str] = []
+    mid = _SVG_NODE_H // 2
+    band_y = _CHEM_Y0
+
+    for group in groups:
+        members = group["chemicals"]
+        drawn = _band_nodes(members)
+        span = (len(drawn) - 1) * _CHEM_ROW_DY
+        centre_y = band_y + span // 2
+        variant = "" if group["state"] == "wired" else "unwired"
+
+        for i, chem in enumerate(drawn):
+            y = band_y + i * _CHEM_ROW_DY
+            brief = (
+                {
+                    "id": "",
+                    "name": f"{len(members) - _CHEM_MAX_NAMED} more",
+                    "tag": "MolecularEntity",
+                }
+                if chem is None
+                else {"id": chem["id"], "name": chem["name"], "tag": chem["tag"]}
+            )
+            _svg_place(nodes_svg, brief, "chem", col_x[2], y, variant)
+            if group["via"] is not None:
+                _svg_link(
+                    edges,
+                    col_x[1] + _SVG_NODE_W,
+                    centre_y + mid,
+                    col_x[2],
+                    y + mid,
+                    group["edge"] if i == 0 else "",
+                )
+            else:  # nothing in the crate points at these compounds at all
+                _svg_break(edges, col_x[2], y + mid)
+
+        if group["via"] is not None:
+            _svg_place(
+                nodes_svg, group["via"], _node_class_for_brief(group["via"]), col_x[1], centre_y
+            )
+            if group["process"] is not None:
+                _svg_link(
+                    edges, col_x[0] + _SVG_NODE_W, centre_y + mid, col_x[1], centre_y + mid,
+                    "result",
+                )
+                _svg_place(nodes_svg, group["process"], "proc", col_x[0], centre_y)
+            else:  # named in the crate, but produced by no process
+                _svg_break(edges, col_x[1], centre_y + mid)
+
+        band_y += span + _SVG_NODE_H + _CHEM_BAND_GAP
+
+    counts = inventory.get("counts", {})
+    return _svg_document(
+        edges,
+        nodes_svg,
+        col_x[2] + _SVG_NODE_W + 16,
+        band_y - _CHEM_BAND_GAP + 18,
+        f"Compound routes: {counts.get('wired', 0)} of {counts.get('total', 0)} "
+        "compounds reachable from a process",
+    )
+
+
+# ---------------------------------------------------------------------------
+# People & organisations (#85) — who the crate credits, and whether that credit
+# is machine-actionable.
+#
+# Attribution is the part of a crate humans read and machines usually cannot.
+# A name string credits nobody a registry can resolve: without an ORCID the
+# author is unfindable, without a ROR the institution is unfindable, and without
+# an ``affiliation`` edge the two are never connected. The failure is quiet —
+# every profile still passes, because a bare `name` satisfies the shapes.
+#
+# The pattern also produces a specific, common defect this view is built to
+# expose: the same institution appearing twice, once as a resolvable ROR node and
+# once as a locally-minted `#Organization_…` node that nothing references. The
+# duplicate is invisible in a list of names and obvious in a picture where one
+# box has inbound edges and the other has none.
+# ---------------------------------------------------------------------------
+
+_PERSON_TYPES = frozenset({"Person"})
+_ORG_TYPES = frozenset(
+    {
+        "Organization",
+        "ResearchOrganization",
+        "EducationalOrganization",
+        "GovernmentOrganization",
+        "Corporation",
+        "NGO",
+        "Consortium",
+        "Project",
+        "FundingAgency",
+    }
+)
+
+_AFFILIATION_KEYS: tuple[str, ...] = (
+    "affiliation",
+    "memberOf",
+    "http://schema.org/affiliation",
+    "https://schema.org/affiliation",
+)
+
+# Persistent-identifier schemes for agents, resolved the same way compounds are
+# (PropertyValue name / propertyID host / the entity's own @id).
+_AGENT_ID_SCHEMES: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("ORCID", "ORCID", ("orcid", "orcid id", "orcid.org"), ("orcid.org",)),
+    ("ROR", "ROR", ("ror", "ror id"), ("ror.org",)),
+    ("ISNI", "ISNI", ("isni",), ("isni.org",)),
+    ("GRID", "GRID", ("grid", "grid id"), ("grid.ac",)),
+)
+# Which of those count as "identified" for each kind, most preferred first.
+_PID_FOR_KIND: dict[str, tuple[str, ...]] = {
+    "person": ("ORCID", "ISNI"),
+    "org": ("ROR", "GRID", "ISNI"),
+}
+
+# Ways an entity can credit an agent, most canonical first.
+_CREDIT_RELATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (_AUTHOR_KEYS, "author"),
+    (("contributor", "http://schema.org/contributor"), "contributor"),
+    (("publisher", "http://schema.org/publisher"), "publisher"),
+    (("funder", "http://schema.org/funder"), "funder"),
+    (("maintainer", "http://schema.org/maintainer"), "maintainer"),
+    (("sponsor", "provider", "sourceOrganization"), "provider"),
+)
+
+_NAMEPART_KEYS: tuple[str, ...] = (
+    "givenName",
+    "familyName",
+    "http://schema.org/givenName",
+    "http://schema.org/familyName",
+)
+
+# The agent matrix columns: (full name, header). ``Affiliation`` is n/a for an
+# organisation and scored as such — never as a miss.
+AGENT_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Persistent identifier", "PID"),
+    ("Name", "Name"),
+    ("Affiliation", "Affiliation"),
+    ("Credited in crate", "Credited"),
+)
+
+
+def _agent_kind(node: dict[str, Any]) -> str | None:
+    """``"person"`` / ``"org"`` for an agent node, else ``None``."""
+    types = _types(node)
+    if types & _PERSON_TYPES:
+        return "person"
+    if types & _ORG_TYPES:
+        return "org"
+    return None
+
+
+def build_people_inventory(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Model the crate's attribution: who is credited, by what, and how resolvably.
+
+    Resolves, for every ``Person`` and ``Organization``: the persistent
+    identifier it carries (ORCID / ROR / ISNI / GRID, from an ``identifier``
+    PropertyValue or from the entity's own ``@id``), whether a person declares an
+    ``affiliation``, and which entity credits it (``author`` / ``contributor`` /
+    ``publisher`` / ``funder`` / …). The Root Data Entity is preferred as a
+    person's credit source when several apply, so the common case — the crate
+    itself crediting its authors — is the one the diagram draws.
+
+    Pure and cheap: one pass over the serialized ``@graph``, no validation and no
+    network. Crate-controlled text is HTML-escaped in ``label`` (#169).
+
+    Args:
+        metadata: Parsed ``ro-crate-metadata.json`` dict, the ``@graph`` list, or
+            the ``crate.metadata.generate()`` document.
+
+    Returns:
+        ``{"agents": [...], "groups": [...], "counts": {...}}``.
+
+        Each agent: ``{id, name, label, tag, kind, pid, pid_scheme, resolvable,
+        affiliation, fields, met, total, state}`` where ``state`` is
+        ``"credited"`` (something in the crate credits it), ``"affiliated"`` (an
+        organisation reached only through a person's affiliation) or
+        ``"unattached"`` (nothing references it — the duplicate-institution
+        signature).
+
+        ``groups`` are the diagram's bands: a credit source, the people it
+        credits, and those people's organisations.
+    """
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    nodes: dict[str, dict[str, Any]] = {
+        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
+    }
+    kinds = {nid: _agent_kind(n) for nid, n in nodes.items()}
+    agent_ids = {nid for nid, kind in kinds.items() if kind}
+    empty_counts = {
+        "people": 0,
+        "orgs": 0,
+        "total": 0,
+        "credited": 0,
+        "unattached": 0,
+        "pid_backed": 0,
+        "fields_met": 0,
+        "fields_total": 0,
+    }
+    if not agent_ids:
+        return {"agents": [], "groups": [], "counts": empty_counts}
+
+    root_id = _find_root_id(nodes, list(graph))
+
+    # Who credits whom. An agent crediting another agent (a ScholarlyArticle's
+    # author list is fine, but Person --author--> Person is not attribution)
+    # is kept: the source is drawn, and a self-reference is skipped.
+    rel_order = {label: i for i, (_keys, label) in enumerate(_CREDIT_RELATIONS)}
+    credits: dict[str, set[tuple[str, str]]] = {}
+    for nid, node in nodes.items():
+        if str(nid).rsplit("/", 1)[-1] in _EXCLUDED_IDS:
+            continue
+        for keys, label in _CREDIT_RELATIONS:
+            for ref in _refs(node, keys):
+                if ref in agent_ids and ref != nid:
+                    credits.setdefault(ref, set()).add((nid, label))
+
+    # Person → organisation, and its inverse over the drawn subgraph.
+    affiliation: dict[str, str] = {}
+    affiliates: dict[str, list[str]] = {}
+    for nid in sorted(agent_ids):
+        if kinds[nid] != "person":
+            continue
+        for ref in _refs(nodes[nid], _AFFILIATION_KEYS):
+            if kinds.get(ref) == "org":
+                affiliation[nid] = ref
+                affiliates.setdefault(ref, []).append(nid)
+                break
+
+    def _credit_source(aid: str) -> tuple[str, str] | None:
+        """Best credit source: the crate root when it credits this agent (that is
+        the attribution a reader is looking for), else the most canonical other."""
+        found = credits.get(aid)
+        if not found:
+            return None
+        rooted = [p for p in found if p[0] == root_id]
+        return sorted(rooted or found, key=lambda p: (rel_order[p[1]], p[0]))[0]
+
+    agents: list[dict[str, Any]] = []
+    for aid in sorted(agent_ids, key=lambda a: (kinds[a] != "person", _name(nodes[a]).casefold())):
+        node = nodes[aid]
+        kind = kinds[aid]
+        assert kind is not None
+        ids = _registry_identifiers(node, nodes, _AGENT_ID_SCHEMES)
+        pid_scheme = next((s for s in _PID_FOR_KIND[kind] if s in ids), None)
+        source = _credit_source(aid)
+        if source is not None:
+            state = "credited"
+        elif kind == "org" and affiliates.get(aid):
+            state = "affiliated"
+        else:
+            state = "unattached"
+        fields: dict[str, bool | None] = {
+            "Persistent identifier": pid_scheme is not None,
+            "Name": _literal(node, _NAME_KEYS) is not None,
+            # An organisation has no affiliation of its own — n/a, not a miss.
+            "Affiliation": (aid in affiliation) if kind == "person" else None,
+            "Credited in crate": state != "unattached",
+        }
+        agents.append(
+            {
+                **_chem_node_brief(aid, node),
+                "kind": kind,
+                "pid": ids.get(pid_scheme) if pid_scheme else None,
+                "pid_scheme": pid_scheme,
+                "identifiers": ids,
+                "resolvable": _is_uri(aid),
+                "affiliation": affiliation.get(aid),
+                "fields": fields,
+                "met": sum(1 for ok in fields.values() if ok),
+                "total": sum(1 for ok in fields.values() if ok is not None),
+                "state": state,
+                "source": source[0] if source else None,
+                "edge": source[1] if source else "",
+            }
+        )
+    by_id = {a["id"]: a for a in agents}
+
+    # Bands: one per credit source, holding the people it credits plus those
+    # people's organisations. Organisations credited directly (a publisher or
+    # funder) join their crediting source's band with no person in between;
+    # everything nothing references falls into a trailing unattached band.
+    banded: dict[tuple[str | None, str], dict[str, list[dict[str, Any]]]] = {}
+    for agent in agents:
+        if agent["state"] == "unattached":
+            continue
+        if agent["kind"] == "person":
+            key = (agent["source"], agent["edge"])
+            banded.setdefault(key, {"persons": [], "orgs": []})["persons"].append(agent)
+        elif agent["state"] == "credited":
+            key = (agent["source"], agent["edge"])
+            banded.setdefault(key, {"persons": [], "orgs": []})["orgs"].append(agent)
+    # Affiliation organisations ride in the band(s) of the people that name them.
+    for key, band in banded.items():
+        seen = {o["id"] for o in band["orgs"]}
+        for person in band["persons"]:
+            org_id = person["affiliation"]
+            if org_id and org_id not in seen and org_id in by_id:
+                seen.add(org_id)
+                band["orgs"].append(by_id[org_id])
+
+    groups = [
+        {
+            "source": _chem_node_brief(src, nodes[src]) if src else None,
+            "edge": edge,
+            "persons": band["persons"],
+            "orgs": band["orgs"],
+            "state": "credited",
+        }
+        for (src, edge), band in sorted(
+            banded.items(), key=lambda kv: (kv[0][0] != root_id, kv[0][0] or "", kv[0][1])
+        )
+    ]
+    loose = [a for a in agents if a["state"] == "unattached"]
+    if loose:
+        groups.append(
+            {
+                "source": None,
+                "edge": "",
+                "persons": [a for a in loose if a["kind"] == "person"],
+                "orgs": [a for a in loose if a["kind"] == "org"],
+                "state": "unattached",
+            }
+        )
+
+    counts = {
+        "people": sum(1 for a in agents if a["kind"] == "person"),
+        "orgs": sum(1 for a in agents if a["kind"] == "org"),
+        "total": len(agents),
+        "credited": sum(1 for a in agents if a["state"] != "unattached"),
+        "unattached": sum(1 for a in agents if a["state"] == "unattached"),
+        "pid_backed": sum(1 for a in agents if a["pid_scheme"]),
+        "fields_met": sum(a["met"] for a in agents),
+        "fields_total": sum(a["total"] for a in agents),
+    }
+    return {"agents": agents, "groups": groups, "counts": counts}
+
+
+def render_people_svg(inventory: dict[str, Any]) -> str:
+    """Draw the attribution chain as a self-contained inline ``<svg>``.
+
+    One band per credit source: ``crate root --author--> Person --affiliation-->
+    Organization``. A person who declares no affiliation gets a dashed ✗ stub
+    where the institution should be; an agent nothing references at all sits in a
+    trailing band with the stub on its left. That trailing band is where a
+    duplicated institution shows up — the ROR-backed copy carries edges, the
+    locally-minted one carries none.
+
+    Args:
+        inventory: The result of :func:`build_people_inventory`.
+
+    Returns:
+        The ``<svg>…</svg>`` markup, or ``""`` when the crate credits nobody.
+    """
+    groups = inventory.get("groups") or []
+    if not groups:
+        return ""
+
+    has_source = any(g["source"] for g in groups)
+    first_col = 0 if has_source else 1
+    x0 = _CHEM_X0 + (_CHEM_BREAK_DX + 10 if first_col else 0)
+    col_x = [x0 + (i - first_col) * _CHEM_COL_DX for i in range(3)]
+
+    edges: list[str] = []
+    nodes_svg: list[str] = []
+    mid = _SVG_NODE_H // 2
+    band_y = _CHEM_Y0
+
+    def _row_y(row: int) -> int:
+        return band_y + row * _CHEM_ROW_DY
+
+    def _more(count: int, tag: str) -> dict[str, str]:
+        return {"id": "", "name": f"{count - _CHEM_MAX_NAMED} more", "tag": tag}
+
+    for group in groups:
+        persons, orgs = group["persons"], group["orgs"]
+        drawn_people = _band_nodes(persons)
+        drawn_orgs = _band_nodes(orgs)
+        unattached = group["state"] == "unattached"
+        variant = "unwired" if unattached else ""
+        person_rows = {p["id"]: i for i, p in enumerate(drawn_people) if p is not None}
+
+        # An organisation takes the row of its first drawn affiliate so the
+        # affiliation edge stays horizontal; collisions step down to the next
+        # free row. The aggregate ("+N more") is placed the same way.
+        org_rows: dict[str, int] = {}
+        used: set[int] = set()
+        for org in drawn_orgs:
+            oid = org["id"] if org is not None else ""
+            wanted = [
+                person_rows[p["id"]]
+                for p in drawn_people
+                if p is not None and org is not None and p["affiliation"] == org["id"]
+            ]
+            row = min(wanted) if wanted else 0
+            while row in used:
+                row += 1
+            org_rows[oid] = row
+            used.add(row)
+
+        rows = max(len(drawn_people), max(used, default=-1) + 1, 1)
+        centre = _row_y(0) + ((rows - 1) * _CHEM_ROW_DY) // 2
+
+        if group["source"] is not None:
+            _svg_place(
+                nodes_svg,
+                group["source"],
+                _node_class_for_brief(group["source"]),
+                col_x[0],
+                centre,
+            )
+
+        for i, person in enumerate(drawn_people):
+            y = _row_y(i)
+            brief = (
+                _more(len(persons), "Person")
+                if person is None
+                else {"id": person["id"], "name": person["name"], "tag": person["tag"]}
+            )
+            _svg_place(nodes_svg, brief, "agent", col_x[1], y, variant)
+            if group["source"] is not None:
+                _svg_link(
+                    edges,
+                    col_x[0] + _SVG_NODE_W,
+                    centre + mid,
+                    col_x[1],
+                    y + mid,
+                    group["edge"] if i == 0 else "",
+                )
+            elif unattached:
+                _svg_break(edges, col_x[1], y + mid)
+            if person is None:
+                continue
+            if person["affiliation"] in org_rows:
+                _svg_link(
+                    edges,
+                    col_x[1] + _SVG_NODE_W,
+                    y + mid,
+                    col_x[2],
+                    _row_y(org_rows[person["affiliation"]]) + mid,
+                    "affiliation" if i == 0 else "",
+                )
+            elif not unattached:
+                # Credited, but the institution behind the person is missing.
+                _svg_break(edges, col_x[1] + _SVG_NODE_W, y + mid, leading=False)
+
+        for org in drawn_orgs:
+            oid = org["id"] if org is not None else ""
+            y = _row_y(org_rows[oid])
+            brief = (
+                _more(len(orgs), "Organization")
+                if org is None
+                else {"id": org["id"], "name": org["name"], "tag": org["tag"]}
+            )
+            _svg_place(nodes_svg, brief, "org", col_x[2], y, variant)
+            if unattached:
+                _svg_break(edges, col_x[2], y + mid)
+            elif (
+                org is not None
+                and group["source"] is not None
+                and not any(p is not None and p["affiliation"] == org["id"] for p in drawn_people)
+            ):
+                # Credited straight from the source (a publisher or a funder),
+                # with no person in between.
+                _svg_link(edges, col_x[0] + _SVG_NODE_W, centre + mid, col_x[2], y + mid, "")
+
+        band_y += (rows - 1) * _CHEM_ROW_DY + _SVG_NODE_H + _CHEM_BAND_GAP
+
+    counts = inventory.get("counts", {})
+    return _svg_document(
+        edges,
+        nodes_svg,
+        col_x[2] + _SVG_NODE_W + 16,
+        band_y - _CHEM_BAND_GAP + 18,
+        f"Attribution: {counts.get('pid_backed', 0)} of {counts.get('total', 0)} agents "
+        "carry a persistent identifier",
+    )
+
+
+def _node_class_for_brief(brief: dict[str, str]) -> str:
+    """Style bucket for a drawn route hop, from the type tag already computed.
+
+    The tag is the only thing the band carries (the node itself is not re-read),
+    and it is enough: a condition table tags as ``Table``/``File``, an
+    Investigation/Study/Assay as ``Dataset``.
+    """
+    tag = brief.get("tag", "")
+    head = tag.split(" · ", 1)[0]
+    if head in ("Table", "File", "MediaObject"):
+        return "data"
+    if head == "Sample":
+        return "mat"
+    return "ctx"
 
 
 _HTML_TEMPLATE = """\

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2178,7 +2178,17 @@ class TestExportOnCompletedBuild:
 
     def _install_spy(self, engine, *, build_result, export_result):
         """Replace engine.run_tool with a recording spy returning canned results
-        for build_and_validate / export_crate; record the call order."""
+        for build_and_validate / export_crate; record the call order.
+
+        A mutation tool must actually CHANGE the state here. The spy replaces
+        ``run_tool`` wholesale, so without this a stubbed ``set_crate_metadata``
+        leaves ``validation_fingerprint()`` byte-identical — and the no-op
+        mutation guard then correctly reports it wrote nothing, which is the
+        opposite of what a test about mutations resetting the guard is driving.
+        Real tools write to state; the spy has to as well.
+        """
+        from builder.agents.react.agent_loop import _MUTATION_TOOLS
+
         calls: list[str] = []
 
         def fake_run_tool(tool_name: str, **kwargs):
@@ -2187,6 +2197,8 @@ class TestExportOnCompletedBuild:
                 return dict(build_result)
             if tool_name in ("export_crate", "build_crate"):
                 return dict(export_result)
+            if tool_name in _MUTATION_TOOLS:
+                engine.state.metadata.title = f"{engine.state.metadata.title or ''}·{len(calls)}"
             return {"ok": True}
 
         engine.run_tool = fake_run_tool  # type: ignore[method-assign]

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -284,6 +284,146 @@ class TestActionableTopology:
         assert "#loose11" not in page
 
 
+class TestChemicalsSection:
+    """The Chemicals section (#85): how each compound reaches the experiment and
+    how completely it is identified.
+
+    ISA forbids a MolecularEntity as a LabProcess ``object``, so a compound is
+    only ever connected *through* the Exposure's condition table. A crate can
+    therefore pass every profile while every compound sits orphaned — described
+    in full, but unreachable from the experiment that used it. The section must
+    make that state visible instead of scoring the compounds on description alone.
+    """
+
+    def _graph(self, *, wire: bool = True) -> dict:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#table"}]},
+                {"@id": "#cells", "@type": "Sample", "name": "Cultured cells"},
+                {
+                    "@id": "#exposure",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "name": "Exposure step",
+                    "object": {"@id": "#cells"},
+                    "result": {"@id": "#table"},
+                },
+                {
+                    "@id": "#table",
+                    "@type": ["File", "csvw:Table"],
+                    "name": "Condition table",
+                    **({"about": [{"@id": "#compound"}]} if wire else {}),
+                },
+                {
+                    "@id": "#compound",
+                    "@type": "MolecularEntity",
+                    "name": "Aflatoxin B1",
+                    "inchikey": "OQIQSTLJSLGHID-WNWIJWBNSA-N",
+                    "smiles": "CO",
+                    "formula": "C17H12O6",
+                    "mass": "312.3",
+                    "identifier": [{"@id": "#cas"}],
+                },
+                {"@id": "#cas", "@type": "PropertyValue", "name": "CAS", "value": "1162-65-8"},
+            ]
+        }
+        return graph
+
+    def _page(self, **kw: bool) -> str:
+        return build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph(**kw))
+
+    def test_section_renders_diagram_and_matrix(self) -> None:
+        page = self._page()
+        assert "<h2>Chemicals</h2>" in page
+        assert 'class="prov view"' in page  # the inline route diagram
+        assert 'class="chem-tbl"' in page  # the identification matrix
+        assert "Aflatoxin B1" in page
+        # Matrix columns name the identification fields.
+        for column in ("CAS", "CID", "DTXSID", "InChIKey", "SMILES", "Formula", "Mass"):
+            assert f">{column}</th>" in page, f"missing coverage column: {column}"
+
+    def test_wired_compound_reports_a_clean_route(self) -> None:
+        page = self._page(wire=True)
+        assert "Every compound is reachable from the process that used it." in page
+        assert "cannot be reached from any process" not in page
+
+    def test_unwired_compound_is_called_out_with_the_fix(self) -> None:
+        page = self._page(wire=False)
+        assert "1 of 1 compounds cannot be reached from any process." in page
+        # The callout names the actual remedy, not just the defect.
+        assert "condition table" in page
+        assert "<code>about</code>" in page
+        assert 'class="chem-flag"' in page
+
+    def test_identification_is_scored_separately_from_wiring(self) -> None:
+        # An unwired compound can still be perfectly identified; conflating the
+        # two would hide which of the two problems the crate actually has.
+        page = self._page(wire=False)
+        assert "cannot be reached from any process" in page
+        # CAS + InChIKey + SMILES + Formula + Mass of 7 fields — the compound is
+        # well described and still unreachable; both must be reported.
+        assert "<b>71%</b> identified" in page
+
+    def test_kpi_tile_reports_wired_over_total(self) -> None:
+        import re
+
+        page = self._page(wire=False)
+        assert re.search(
+            r'<span class="eyebrow">Chemicals</span>.*?<b>0</b><span class="den">/ 1</span>',
+            page,
+            re.S,
+        ), "chemicals KPI tile missing or not reporting 0 / 1 wired"
+
+    def test_crate_without_compounds_omits_the_section(self) -> None:
+        # "Not applicable" must not render as an empty panel scoring zero.
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#f"}]},
+                {"@id": "#f", "@type": "File", "name": "result.csv"},
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "<h2>Chemicals</h2>" not in page
+        assert '<span class="eyebrow">Chemicals</span>' not in page
+
+    def test_no_graph_omits_the_section(self) -> None:
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
+        assert "<h2>Chemicals</h2>" not in page
+
+    def test_matrix_is_bounded_with_more_marker(self) -> None:
+        graph = {"@graph": [{"@id": "./", "@type": "Dataset"}]}
+        for i in range(15):
+            graph["@graph"].append(
+                {"@id": f"#c{i}", "@type": "MolecularEntity", "name": f"Compound {i:02d}"}
+            )
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "+3 more compounds" in page
+
+    def test_escapes_compound_names(self) -> None:
+        graph = {
+            "@graph": [
+                {
+                    "@id": "#c",
+                    "@type": "MolecularEntity",
+                    "name": "<script>alert(1)</script>",
+                }
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "<script>alert(1)</script>" not in page
+        assert "&lt;script&gt;" in page
+
+    def test_section_stays_self_contained(self) -> None:
+        # The report is offline/no-script; the chemicals diagram must not break
+        # that (it is finished SVG, like the derivation chain).
+        page = self._page()
+        section = page.split("<h2>Chemicals</h2>", 1)[1].split("</section>", 1)[0]
+        assert "<script" not in section.lower()
+        assert "src=" not in section and "@import" not in section
+
+
 class TestSeverityTiers:
     """Profile adherence reported across Required / Recommended / Optional (#306).
 

--- a/tests/test_provenance_dag.py
+++ b/tests/test_provenance_dag.py
@@ -13,6 +13,8 @@ from rocrate.rocrate import ROCrate
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools._crate_mapping import populate_crate
 from builder.writers.provenance_dag import (
+    build_chemical_inventory,
+    render_chemicals_svg,
     render_mermaid_html,
     render_provenance_mermaid,
     render_provenance_svg,
@@ -252,6 +254,302 @@ class TestRenderProvenanceSvg:
     def test_accepts_bare_graph_list(self) -> None:
         svg = render_provenance_svg(_full_chain_graph()["@graph"])
         assert svg.startswith("<svg")
+
+
+def _chemicals_graph() -> dict:
+    """A crate exercising all four ways a compound can (fail to) reach a process.
+
+    ``#c_about`` is wired the canonical way (Exposure → condition table →
+    ``about``); ``#c_valueurl`` only through the table's ``compound`` column
+    (table → tableSchema → columns → ``valueUrl``); ``#c_mentioned`` is named by
+    the Study but produced by nothing; ``#c_orphan`` is referenced by nobody.
+    """
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#study"}]},
+            {
+                "@id": "#study",
+                "@type": "Dataset",
+                "additionalType": "Study",
+                "name": "Tox study",
+                "chemicals": [{"@id": "#c_mentioned"}],
+            },
+            {"@id": "#cells", "@type": "Sample", "name": "Cultured cells"},
+            {
+                "@id": "#exposure",
+                "@type": "LabProcess",
+                "additionalType": "Exposure",
+                "name": "Exposure step",
+                "object": {"@id": "#cells"},
+                "result": {"@id": "#table"},
+            },
+            {
+                "@id": "#table",
+                "@type": ["File", "csvw:Table"],
+                "name": "Condition table",
+                "about": [{"@id": "#c_about"}],
+                "tableSchema": {"@id": "#schema"},
+            },
+            {
+                "@id": "#schema",
+                "@type": ["csvw:Schema", "CreativeWork"],
+                "columns": [{"@id": "#col"}],
+            },
+            {
+                "@id": "#col",
+                "@type": "csvw:Column",
+                "titles": "compound",
+                "valueUrl": {"@id": "#c_valueurl"},
+            },
+            {
+                "@id": "#c_about",
+                "@type": "MolecularEntity",
+                "name": "Aflatoxin B1",
+                "inchikey": "OQIQSTLJSLGHID-WNWIJWBNSA-N",
+                "smiles": "CO",
+                "formula": "C17H12O6",
+                "mass": "312.3",
+                "identifier": [{"@id": "#cas"}, {"@id": "#cid"}, {"@id": "#dtx"}],
+            },
+            {"@id": "#c_valueurl", "@type": "MolecularEntity", "name": "Bisphenol A"},
+            {"@id": "#c_mentioned", "@type": "MolecularEntity", "name": "Mentioned only"},
+            {"@id": "#c_orphan", "@type": "MolecularEntity", "name": "Orphan compound"},
+            {"@id": "#cas", "@type": "PropertyValue", "name": "CAS", "value": "1162-65-8"},
+            {
+                "@id": "#cid",
+                "@type": "PropertyValue",
+                "name": "PubChem CID",
+                "propertyID": {"@id": "https://pubchem.ncbi.nlm.nih.gov/compound"},
+                "value": "186907",
+            },
+            {
+                "@id": "#dtx",
+                "@type": "PropertyValue",
+                "name": "DTXSID",
+                "value": "DTXSID9020035",
+            },
+        ]
+    }
+
+
+def _no_compound_graph() -> dict:
+    """A crate that declares no MolecularEntity at all — the Chemicals view is
+    not applicable, which must read differently from "declared but unwired"."""
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#f"}]},
+            {"@id": "#f", "@type": "File", "name": "result.csv"},
+        ]
+    }
+
+
+class TestBuildChemicalInventory:
+    """``build_chemical_inventory`` resolves each compound's route into the
+    experiment and how completely it is identified."""
+
+    def _by_name(self, inv: dict) -> dict:
+        return {c["name"]: c for c in inv["chemicals"]}
+
+    def test_classifies_every_route_state(self) -> None:
+        chems = self._by_name(build_chemical_inventory(_chemicals_graph()))
+        # The canonical ISA route: the compound hangs off the Exposure's result.
+        assert chems["Aflatoxin B1"]["state"] == "wired"
+        # Reached only through the condition table's compound column.
+        assert chems["Bisphenol A"]["state"] == "wired"
+        # Named by the Study, but no process produces the Study.
+        assert chems["Mentioned only"]["state"] == "mentioned"
+        # Referenced by nothing at all.
+        assert chems["Orphan compound"]["state"] == "unlinked"
+
+    def test_wired_route_names_the_producing_process(self) -> None:
+        route = self._by_name(build_chemical_inventory(_chemicals_graph()))["Aflatoxin B1"][
+            "route"
+        ]
+        assert route["process"] == "#exposure"
+        assert route["via"] == "#table"
+        assert route["edge"] == "about"
+
+    def test_valueurl_route_walks_the_csvw_containment_chain(self) -> None:
+        # column → schema → table → the process that produced it: the compound is
+        # three hops from anything a process results in, and must still resolve.
+        route = self._by_name(build_chemical_inventory(_chemicals_graph()))["Bisphenol A"][
+            "route"
+        ]
+        assert route["process"] == "#exposure"
+        assert route["via"] == "#table"
+        assert route["edge"] == "valueUrl"
+
+    def test_counts_summarise_routes_and_identification(self) -> None:
+        counts = build_chemical_inventory(_chemicals_graph())["counts"]
+        assert counts == {
+            "total": 4,
+            "wired": 2,
+            "mentioned": 1,
+            "unlinked": 1,
+            "fields_met": 7,  # only Aflatoxin B1 is fully identified
+            "fields_total": 28,  # 4 compounds × 7 fields
+        }
+
+    def test_identifier_property_values_are_resolved_by_scheme(self) -> None:
+        chem = self._by_name(build_chemical_inventory(_chemicals_graph()))["Aflatoxin B1"]
+        assert chem["identifiers"] == {
+            "CAS": "1162-65-8",
+            "PubChem CID": "186907",
+            "DTXSID": "DTXSID9020035",
+        }
+        assert chem["met"] == chem["total"] == 7
+
+    def test_registry_url_id_counts_as_that_identifier(self) -> None:
+        # The builder mints a PubChem compound URL as the @id; that identifies the
+        # substance whether or not a PubChem CID PropertyValue is also present.
+        graph = {
+            "@graph": [
+                {
+                    "@id": "https://pubchem.ncbi.nlm.nih.gov/compound/6623",
+                    "@type": "MolecularEntity",
+                    "name": "Bisphenol A",
+                }
+            ]
+        }
+        chem = build_chemical_inventory(graph)["chemicals"][0]
+        assert chem["identifiers"]["PubChem CID"] == "6623"
+        assert chem["resolvable"] is True
+
+    def test_bare_cas_string_identifier_is_counted(self) -> None:
+        graph = {
+            "@graph": [
+                {
+                    "@id": "#c",
+                    "@type": "MolecularEntity",
+                    "name": "Compound",
+                    "identifier": "1162-65-8",
+                }
+            ]
+        }
+        assert build_chemical_inventory(graph)["chemicals"][0]["identifiers"] == {
+            "CAS": "1162-65-8"
+        }
+
+    def test_compound_to_compound_reference_is_not_a_route(self) -> None:
+        # Two compounds referencing each other must not mask that neither is
+        # reachable from the experiment.
+        graph = {
+            "@graph": [
+                {"@id": "#a", "@type": "MolecularEntity", "name": "A", "about": {"@id": "#b"}},
+                {"@id": "#b", "@type": "MolecularEntity", "name": "B", "about": {"@id": "#a"}},
+            ]
+        }
+        inv = build_chemical_inventory(graph)
+        assert inv["counts"]["unlinked"] == 2
+
+    def test_crate_without_compounds_is_empty(self) -> None:
+        inv = build_chemical_inventory(_no_compound_graph())
+        assert inv["chemicals"] == []
+        assert inv["groups"] == []
+        assert inv["counts"]["total"] == 0
+
+    def test_full_chain_fixture_compound_is_wired(self) -> None:
+        # The realistic four-step fixture links its compound the canonical way
+        # (condition table --about--> MolecularEntity), so it must read as wired.
+        inv = build_chemical_inventory(_full_chain_graph())
+        assert [c["state"] for c in inv["chemicals"]] == ["wired"]
+
+    def test_accepts_bare_graph_list(self) -> None:
+        inv = build_chemical_inventory(_chemicals_graph()["@graph"])
+        assert inv["counts"]["total"] == 4
+
+
+class TestRenderChemicalsSvg:
+    """``render_chemicals_svg`` draws the compound routes as a self-contained,
+    offline inline ``<svg>`` — same shapes/geometry as the derivation chain."""
+
+    def test_returns_inline_svg_with_every_route_band(self) -> None:
+        svg = render_chemicals_svg(build_chemical_inventory(_chemicals_graph()))
+        assert svg.startswith("<svg") and svg.rstrip().endswith("</svg>")
+        for label in ("Exposure step", "Condition table", "Aflatoxin B1", "Orphan compound"):
+            assert label in svg, f"{label} missing from chemicals SVG"
+
+    def test_unwired_compounds_are_visually_distinguished(self) -> None:
+        svg = render_chemicals_svg(build_chemical_inventory(_chemicals_graph()))
+        # A broken route is drawn as a dashed stub ending in ✗, never omitted.
+        assert "e-break" in svg
+        assert "✗" in svg
+        assert "unwired" in svg
+
+    def test_fully_wired_crate_has_no_break_marker(self) -> None:
+        graph = _chemicals_graph()
+        graph["@graph"] = [
+            n for n in graph["@graph"] if n["@id"] not in ("#c_mentioned", "#c_orphan")
+        ]
+        svg = render_chemicals_svg(build_chemical_inventory(graph))
+        assert "e-break" not in svg
+        assert "unwired" not in svg
+
+    def test_one_band_per_route_not_per_relation(self) -> None:
+        # `about` and `valueUrl` reach different compounds through the SAME table:
+        # one band, one process node, both mechanisms named on the edge.
+        svg = render_chemicals_svg(build_chemical_inventory(_chemicals_graph()))
+        assert svg.count('class="n n-process"') == 1
+        assert "about · valueUrl" in svg
+
+    def test_large_group_folds_its_tail_into_an_aggregate(self) -> None:
+        graph = {"@graph": [{"@id": "./", "@type": "Dataset"}]}
+        for i in range(9):
+            graph["@graph"].append(
+                {"@id": f"#c{i}", "@type": "MolecularEntity", "name": f"Compound {i}"}
+            )
+        svg = render_chemicals_svg(build_chemical_inventory(graph))
+        # 3 named + an aggregate naming the remainder — nothing silently dropped.
+        assert "Compound 0" in svg and "Compound 2" in svg
+        assert "Compound 8" not in svg
+        assert "6 more" in svg
+
+    def test_escapes_crate_controlled_names(self) -> None:
+        graph = {
+            "@graph": [
+                {
+                    "@id": "#c",
+                    "@type": "MolecularEntity",
+                    "name": "<script>alert(1)</script>",
+                }
+            ]
+        }
+        svg = render_chemicals_svg(build_chemical_inventory(graph))
+        assert "<script>alert(1)</script>" not in svg
+        assert "&lt;script&gt;" in svg
+
+    def test_self_contained_no_external_assets(self) -> None:
+        svg = render_chemicals_svg(build_chemical_inventory(_chemicals_graph()))
+        assert "http://" not in svg and "https://" not in svg
+        assert "<script" not in svg.lower()
+
+    def test_geometry_stays_inside_the_viewbox(self) -> None:
+        # The page scrolls the SVG horizontally; anything drawn outside the
+        # viewBox would simply be invisible.
+        import xml.etree.ElementTree as ET
+
+        svg = render_chemicals_svg(build_chemical_inventory(_chemicals_graph()))
+        root = ET.fromstring(svg)  # also asserts well-formedness
+        _, _, width, height = (float(v) for v in root.get("viewBox").split())
+        xs: list[float] = []
+        ys: list[float] = []
+        for el in root.iter():
+            if el.tag == "polygon" and el.get("class", "").startswith("n "):
+                for point in el.get("points").split():
+                    px, py = point.split(",")
+                    xs.append(float(px))
+                    ys.append(float(py))
+            elif el.tag == "text":
+                xs.append(float(el.get("x")))
+                ys.append(float(el.get("y")))
+        assert xs and ys
+        assert 0 <= min(xs) and max(xs) <= width
+        assert 0 <= min(ys) and max(ys) <= height
+
+    def test_empty_inventory_returns_empty(self) -> None:
+        assert render_chemicals_svg(build_chemical_inventory(_no_compound_graph())) == ""
 
 
 def _exposure_state() -> CrateState:


### PR DESCRIPTION
## Summary

SVG/Mermaid provenance-graph rendering and the maturity-report sections built on it, plus a no-op mutation guard in the ReAct loop. 11 files, +1999/−43.

- **`provenance_dag.py`** — Mermaid flowchart rendering with the four process discriminators; an SVG renderer with layered layout and a chemical inventory band; the edge/layer extraction behind both.
- **`maturity_report.py` + `.css`** — provenance, actionable-topology, chemicals and severity-tier sections.
- **`agent_loop.py`** — no-op mutation guard: a mutation leaving `validation_fingerprint()` byte-identical made no progress, whatever it returned. Swapped for a corrective before the loop bookkeeping, so it neither resets the guards nor escapes the loop-breaker — the shape that kept a 33-call `set_crate_metadata` loop alive.

## Two fixes needed to get CI green

**`test_mutation_resets_validation_guard`** — passes on `main`, failed here. `_install_spy` replaces `run_tool` wholesale, so a stubbed `set_crate_metadata` never touched the state and left the fingerprint identical; the new guard then *correctly* reported it wrote nothing — the opposite of what a test about mutations resetting the guard is driving. The spy now writes to state for mutation tools, as the real tools do.

I checked the guard itself is sound before touching the test: `validation_fingerprint()` hashes entities **and** metadata, so a genuine `set_crate_metadata` does move it. This was a harness artifact, not a product regression.

**`E501`** in `provenance_dag.py:1552` (102 > 100) — the `brief` dict literal is wrapped.

## Verification

`ruff` clean; 212 tests pass locally across `test_provenance_dag` / `test_maturity_report` / `test_agent_loop` / `test_path_traversal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)