### PR TITLE
chore(types): clear every ty diagnostic and make the check gate CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,12 @@ jobs:
         run: uvx ruff check
 
       - name: Type check (ty)
+        # Enforcing as of the ty-clean sweep: the tree reports zero diagnostics,
+        # so this now gates. It ran with continue-on-error for a long time and
+        # quietly accumulated 36 findings that nothing was ever going to force
+        # anyone to fix — including a genuinely wrong `_format_document_context`
+        # signature and an LSP-violating callback override.
         run: uv run ty check
-        continue-on-error: true  # ty is a Rust-based type checker still evolving
 
   test:
     runs-on: ubuntu-latest

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -13,7 +13,7 @@ import traceback
 from contextvars import ContextVar
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Sequence, cast
+from typing import TYPE_CHECKING, Any, Literal, Sequence, cast, overload
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langgraph.errors import GraphRecursionError
@@ -161,7 +161,16 @@ class _ToolSpinnerCallback(BaseCallbackHandler):
         # never shows text from the step before.
         self.spinner.set_preview(None)
 
-    on_chat_model_start = on_llm_start
+    def on_chat_model_start(
+        self, serialized: dict[str, Any], messages: list[list[Any]], **kwargs: Any
+    ) -> None:
+        # Same reset as on_llm_start, but declared separately rather than aliased.
+        # The base signature takes `messages`, not `prompts`, so `on_chat_model_start
+        # = on_llm_start` was an LSP violation: a caller passing `messages=` by
+        # keyword would have hit an unexpected-argument TypeError. Both bodies
+        # ignore their payload, so this only ever mattered to a keyword caller —
+        # but the alias made the class type-incorrect for every checker.
+        self.spinner.set_preview(None)
 
     def on_llm_new_token(self, token: Any, **kwargs: Any) -> None:
         # Only fires when the model was built with streaming. The spinner keeps
@@ -649,6 +658,28 @@ def _reply_is_empty_completion(reply: str | None) -> bool:
     if not reply:
         return True
     return not reply.strip()
+
+
+@overload
+def _invoke_with_timeout(
+    app: Any,
+    payload: dict[str, Any],
+    config: Any,
+    *,
+    timeout: float,
+    include_error: Literal[False] = False,
+) -> tuple[dict[str, Any] | None, str]: ...
+
+
+@overload
+def _invoke_with_timeout(
+    app: Any,
+    payload: dict[str, Any],
+    config: Any,
+    *,
+    timeout: float,
+    include_error: Literal[True],
+) -> tuple[dict[str, Any] | None, str, dict[str, str] | None]: ...
 
 
 def _invoke_with_timeout(
@@ -1715,7 +1746,7 @@ def _format_document_evidence(engine: AgentEngine, *, limit: int = 12000) -> str
     return "".join(parts)
 
 
-def _format_document_context(documents: list[dict[str, Any]]) -> str:
+def _format_document_context(documents: list[dict[str, Any]] | None) -> str:
     """Format the ranked document discovery results as a bounded context string.
 
     Produces one line per candidate::
@@ -2431,7 +2462,7 @@ def run_interactive_agent(
         else:
             _print_fresh_fallback()
         if verbose and outcome == "error" and greeting_diagnostic:
-            diagnostic_record = {
+            diagnostic_record: dict[str, Any] = {
                 "event": "model_error",
                 "exception_type": greeting_diagnostic["exception_type"],
                 "message": greeting_diagnostic["message"],
@@ -2557,7 +2588,7 @@ def run_interactive_agent(
             console.print()
         elif outcome == "error":
             if verbose and diagnostic:
-                diagnostic_record = {
+                diagnostic_record: dict[str, Any] = {
                     "event": "model_error",
                     "exception_type": diagnostic["exception_type"],
                     "message": diagnostic["message"],

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -33,7 +33,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from time import monotonic
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from rich.console import Console, Group, RenderableType
 from rich.markdown import Markdown
@@ -46,6 +46,11 @@ if TYPE_CHECKING:
     from builder.engine import AgentEngine
 
 logger = logging.getLogger(__name__)
+
+# rich's ``Console.color_system`` property widens to ``str | None`` on the way
+# out, but ``Console.__init__`` only accepts this literal set on the way back in
+# — so round-tripping one console's colour system into another needs a cast.
+ColorSystem = Literal["auto", "standard", "256", "truecolor", "windows"]
 
 # Marker glyphs shared across the chrome (green ● = active/pass, ○ = pending).
 _PASS_DOT = "[green]●[/green]"
@@ -829,7 +834,7 @@ class PinnedFooter:
                 file=buffer,
                 width=width,
                 force_terminal=True,
-                color_system=self._console.color_system,  # type: ignore[arg-type]
+                color_system=cast("ColorSystem | None", self._console.color_system),
                 highlight=False,
                 soft_wrap=True,
                 legacy_windows=False,

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -10,7 +10,7 @@ import os
 
 import pytest
 
-from builder.state import Entity
+from builder.state import Entity, EntityType
 
 
 class TestDetectProvider:
@@ -599,9 +599,13 @@ class TestToolSpinnerCallback:
 
         spinner = _FakeSpinner()
         long_input = "x" * 200
-        _ToolSpinnerCallback(spinner).on_tool_start(
+        # _FakeSpinner implements only the handful of methods the callback calls,
+        # so it is a stand-in rather than a ProgressSpinner. The ignore has to sit
+        # on the CONSTRUCTOR line — it was previously parked on the closing paren,
+        # where it silenced nothing and registered as unused.
+        _ToolSpinnerCallback(spinner).on_tool_start(  # ty: ignore[invalid-argument-type]
             {"name": "read_file"}, long_input
-        )  # ty: ignore[invalid-argument-type]
+        )
 
         assert spinner.tools == ["read_file(" + ("x" * 77) + "...)"]
 
@@ -2167,7 +2171,7 @@ class TestExportOnCompletedBuild:
     crate to disk (no quit needed), surfaces the absolute path, stamps the
     _EXPORTED_FLAG, and leaves the finish backstop a no-op afterward."""
 
-    def _engine_with_entities(self, *types: str):
+    def _engine_with_entities(self, *types: EntityType):
         from builder.engine import AgentEngine
 
         engine = AgentEngine()

--- a/tests/test_build_mode.py
+++ b/tests/test_build_mode.py
@@ -36,9 +36,13 @@ class TestBuildModeFromCli:
 
         parser = build_arg_parser()
         arch = next(a for a in parser._actions if "--arch" in a.option_strings)
-        assert set(arch.choices) == {m.value for m in BuildMode}
+        # argparse types `choices` as optional; a `--arch` with no choices at all
+        # would silently pass both assertions below, so pin it here.
+        choices = arch.choices
+        assert choices is not None, "--arch must constrain its choices"
+        assert set(choices) == {m.value for m in BuildMode}
         # Every CLI choice round-trips through the shared enum.
-        for choice in arch.choices:
+        for choice in choices:
             assert BuildMode(choice).value == choice
 
 
@@ -56,7 +60,7 @@ class TestRunBuildDispatch:
 
         monkeypatch.setattr(build_mod, "run_interactive_build", _fake_build)
 
-        result = run_build(BuildMode.PIPELINE, object(), output=print)
+        result = run_build(BuildMode.PIPELINE, cast("AgentEngine", object()), output=print)
 
         assert captured["kw"].get("output") is print
         assert result == {"pipeline": {}, "guidance": None}
@@ -72,7 +76,13 @@ class TestRunBuildDispatch:
 
         monkeypatch.setattr(agent_loop, "run_interactive_agent", _fake_agent)
 
-        result = run_build(BuildMode.REACT, object(), provider="openai", model="m", base_url="u")
+        result = run_build(
+            BuildMode.REACT,
+            cast("AgentEngine", object()),
+            provider="openai",
+            model="m",
+            base_url="u",
+        )
 
         # ReAct-only kwargs are forwarded; the loop mutates state in place, so
         # run_build returns None rather than a structured pipeline result.
@@ -101,7 +111,7 @@ class TestRunBuildDispatch:
             captured.update(kw)
 
         monkeypatch.setattr(agent_loop, "run_interactive_agent", _fake_agent)
-        run_build(BuildMode.REACT, object(), resumed=True)
+        run_build(BuildMode.REACT, cast("AgentEngine", object()), resumed=True)
 
         assert captured["resumed"] is True
 
@@ -117,7 +127,7 @@ class TestRunBuildDispatch:
             captured.update(kw)
 
         monkeypatch.setattr(agent_loop, "run_interactive_agent", _fake_agent)
-        run_build(BuildMode.REACT, object(), initial_prompt="build the crate")
+        run_build(BuildMode.REACT, cast("AgentEngine", object()), initial_prompt="build the crate")
 
         assert captured["initial_prompt"] == "build the crate"
 
@@ -129,7 +139,7 @@ class TestRunBuildDispatch:
             agent_loop, "run_interactive_agent", lambda engine, **kw: captured.update(kw)
         )
 
-        run_build(BuildMode.REACT, object(), verbose=True)
+        run_build(BuildMode.REACT, cast("AgentEngine", object()), verbose=True)
 
         assert captured["verbose"] is True
 
@@ -146,7 +156,7 @@ class TestRunBuildDispatch:
             return {}
 
         monkeypatch.setattr(build_mod, "run_interactive_build", _fake_build)
-        run_build(BuildMode.PIPELINE, object(), initial_prompt="ignored here")
+        run_build(BuildMode.PIPELINE, cast("AgentEngine", object()), initial_prompt="ignored here")
 
         assert "initial_prompt" not in captured
 
@@ -163,7 +173,7 @@ class TestRunBuildDispatch:
             return {}
 
         monkeypatch.setattr(build_mod, "run_interactive_build", _fake_build)
-        run_build(BuildMode.PIPELINE, object(), resumed=True)
+        run_build(BuildMode.PIPELINE, cast("AgentEngine", object()), resumed=True)
 
         assert captured["resumed"] is True
 

--- a/tests/test_fair_indicators_source.py
+++ b/tests/test_fair_indicators_source.py
@@ -24,8 +24,10 @@ GEN = REPO / "scripts" / "gen_fair_indicators.py"
 
 def _load_generator():
     spec = importlib.util.spec_from_file_location("gen_fair_indicators", GEN)
-    mod = importlib.util.module_from_spec(spec)
+    # Checked BEFORE module_from_spec, which cannot take None — the assert used
+    # to sit after the call it was meant to guard.
     assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
 

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 from pathlib import Path
 
 from builder.state import CrateState, ValidationReport
@@ -434,10 +435,10 @@ class TestSeverityTiers:
     unevaluated tier as a green zero would be a false pass.
     """
 
-    def _passed(self, **overrides: object) -> ValidationReport:
-        base = {"base_passed": True, "isa_passed": True, "tox_passed": True}
+    def _passed(self, **overrides: Any) -> ValidationReport:
+        base: dict[str, Any] = {"base_passed": True, "isa_passed": True, "tox_passed": True}
         base.update(overrides)
-        return ValidationReport(**base)  # type: ignore[arg-type]
+        return ValidationReport(**base)
 
     def test_reports_all_three_severity_tiers(self) -> None:
         state = vhps_fixture_state("S-VHPS21")

--- a/tests/test_provenance_dag.py
+++ b/tests/test_provenance_dag.py
@@ -530,20 +530,31 @@ class TestRenderChemicalsSvg:
         # viewBox would simply be invisible.
         import xml.etree.ElementTree as ET
 
+        def attr(el: ET.Element, name: str) -> str:
+            """A geometry attribute the renderer must always emit.
+
+            ``Element.get`` is optional-typed, and a missing coordinate here
+            would otherwise crash with a bare ``AttributeError: 'NoneType'``
+            instead of naming the element that lost it.
+            """
+            value = el.get(name)
+            assert value is not None, f"<{el.tag}> is missing {name!r}"
+            return value
+
         svg = render_chemicals_svg(build_chemical_inventory(_chemicals_graph()))
         root = ET.fromstring(svg)  # also asserts well-formedness
-        _, _, width, height = (float(v) for v in root.get("viewBox").split())
+        _, _, width, height = (float(v) for v in attr(root, "viewBox").split())
         xs: list[float] = []
         ys: list[float] = []
         for el in root.iter():
             if el.tag == "polygon" and el.get("class", "").startswith("n "):
-                for point in el.get("points").split():
+                for point in attr(el, "points").split():
                     px, py = point.split(",")
                     xs.append(float(px))
                     ys.append(float(py))
             elif el.tag == "text":
-                xs.append(float(el.get("x")))
-                ys.append(float(el.get("y")))
+                xs.append(float(attr(el, "x")))
+                ys.append(float(attr(el, "y")))
         assert xs and ys
         assert 0 <= min(xs) and max(xs) <= width
         assert 0 <= min(ys) and max(ys) <= height


### PR DESCRIPTION
## Summary

`ty check` ran with `continue-on-error: true`, so its findings never reddened CI and quietly accumulated to **36**. This clears all of them and drops the flag, so ty gates from here.

## Three were real defects, not noise

| | |
|---|---|
| `_format_document_context` | Annotated `list[dict[str, Any]]`, but the body opens `if not documents:` and its own test asserts `(None) == ""`. The signature did not describe the function. |
| `on_chat_model_start = on_llm_start` | Aliased a method taking `prompts: list[str]` onto a base taking `messages: list[list[BaseMessage]]`. Positional calls work and both bodies ignore the payload, but a **keyword** caller would hit an unexpected-argument `TypeError`. |
| `test_fair_indicators_source` | Asserted `spec and spec.loader` *after* passing `spec` to `module_from_spec`, which cannot take `None` — the guard sat below the call it was meant to protect. |

## The rest are precision

- **`_invoke_with_timeout`** returns a 2- or 3-tuple depending on `include_error`, unnarrowable from a plain `bool` → split into two `@overload`s so the three-way unpacks type correctly.
- **`diagnostic_record`** inferred as `dict[str, str]`, making `log_event(**record)` look like it might pass a `str` to `iteration: int | None` → `dict[str, Any]`.
- **`Console.color_system`** widens to `str | None` on read but only accepts a `Literal` set on write; the existing `# type: ignore[arg-type]` was mypy-style and ty doesn't consume it → `ColorSystem` alias + cast.
- **Tests** — `cast("AgentEngine", object())` on the seven `run_build` dispatch calls (matching the idiom already at the eighth), `EntityType` for entity-type varargs, an `attr()` helper for required SVG geometry, `dict[str, Any]` for `ValidationReport` kwargs, and a `ty: ignore` moved onto the constructor line it was meant to cover — it had been parked on the closing paren, silencing nothing and registering as unused.

## Verification

`ty check`: 36 → **0**. `ruff check`: clean. **331 tests pass** locally across the 11 touched/adjacent suites.

Note the `lint` job will now fail on any new ty diagnostic — that's the point, but it does mean the next PR that trips one gets blocked rather than warned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)