### PR TITLE
feat(report): expand provenance/maturity rendering and persist validation answers

### DIFF
--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -212,7 +212,9 @@ class ProgressSpinner:
         """
         elapsed = int(monotonic() - self._start)
         line = f"[green]{self._phrase}…[/green] [dim]({elapsed}s)[/dim]"
-        if self._item_text:
+        if self._item_kind == "thinking" and not self._item_done:
+            line += "  [dim]·[/dim] [cyan]thinking…[/cyan]"
+        elif self._item_text:
             style = "grey62" if self._item_done else "cyan"
             if self._item_kind == "writing":
                 label = "[dim]wrote:[/dim] " if self._item_done else "[dim]writing:[/dim] "
@@ -365,6 +367,17 @@ class ProgressSpinner:
         else:
             self._offer(window, "writing")
 
+    def begin_generation(self) -> None:
+        """Mark the model as generating before any text has arrived.
+
+        Most calls in this agent emit tool calls with no prose at all, so
+        without this the line kept showing the last finished tool for the whole
+        model call and read as "still stuck on that tool". ``thinking…`` says
+        the model has the floor; the first real token replaces it with the tail.
+        """
+        self._preview_buffer = ""
+        self._offer("", "thinking")
+
     def set_preview(self, text: str | None) -> None:
         """Seed the reply tail, or (with ``None``) end it.
 
@@ -374,7 +387,7 @@ class ProgressSpinner:
         """
         self._preview_buffer = text or ""
         if not text:
-            if self._item_kind == "writing":
+            if self._item_kind in ("writing", "thinking"):
                 self._mark_done()
             return
         window = text.replace("\n", " ")[-_PREVIEW_WIDTH:].lstrip()

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -158,9 +158,13 @@ class _ToolSpinnerCallback(BaseCallbackHandler):
 
     def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:
         # A new generation begins: drop the previous reply's tail so the line
-        # never shows text from the step before.
-        self.spinner.set_preview(None)
+        # never shows text from the step before, and say the model has the floor
+        # — most calls here emit only tool calls, so there may be no text at all.
+        self.spinner.begin_generation()
 
+    # LangChain dispatches chat models to on_chat_model_start, never
+    # on_llm_start; the positional shape is the same (serialized, then the
+    # prompt payload), so the same handler serves both.
     on_chat_model_start = on_llm_start
 
     def on_llm_new_token(self, token: Any, **kwargs: Any) -> None:
@@ -197,7 +201,15 @@ def _build_args_schema(name: str, params: dict[str, Any]) -> type[BaseModel] | N
         return None
     properties = params.get("properties", {})
     if not properties:
-        return None
+        # A zero-parameter tool still needs an EXPLICIT empty schema. Advertised
+        # with no schema at all, the model invents a placeholder payload —
+        # `get_status(args=[], kwargs=None)` — which the tool function rejects
+        # with a TypeError. That cost 33 of 36 get_status calls in one session:
+        # each one burned a model turn and returned an error the model then
+        # tried to work around.
+        from pydantic import BaseModel, create_model
+
+        return create_model(f"{name}_args", __base__=BaseModel)
 
     from pydantic import BaseModel, Field, create_model
 
@@ -266,6 +278,12 @@ _AUTO_EXPORT_EMIT_FLAG = "on_auto_export"
 _VALIDATION_ESCALATION_FP_FLAG = "_validation_escalation_fingerprint"
 _VALIDATION_ESCALATION_PURPOSE = "validation_escalation"
 
+# Attribute holding the user's standing answers: ``{"recommended": bool,
+# "optional": bool}``. Whether they want the broader tiers is a preference about
+# how they work, not a judgement about one crate state, so it is asked once and
+# then honoured silently for the rest of the session.
+_VALIDATION_ESCALATION_PREF_FLAG = "_validation_escalation_preferences"
+
 
 # How many issue strings each escalation tier contributes to the summary handed
 # back to the model. Bounded so a noisy RECOMMENDED/OPTIONAL pass cannot flood
@@ -329,15 +347,26 @@ def _run_validation_escalation(
     if getattr(engine, _VALIDATION_ESCALATION_FP_FLAG, None) == fingerprint:
         return None
 
-    def approved(context: str) -> bool:
+    # A tier is offered ONCE per session. The answer is a standing preference,
+    # not a per-state decision: keyed on the fingerprint alone, the same question
+    # came back after every mutation that re-passed REQUIRED, so a long session
+    # asked "Run recommended checks?" over and over having already been told yes.
+    prefs: dict[str, bool] = dict(getattr(engine, _VALIDATION_ESCALATION_PREF_FLAG, None) or {})
+
+    def approved(tier: str, context: str) -> bool:
+        """The user's standing answer for *tier*, asked at most once per session."""
+        if tier in prefs:
+            return prefs[tier]
         response = engine.human_interface.present(
             context,
             options=["yes", "no"],
             purpose=_VALIDATION_ESCALATION_PURPOSE,
         )
-        return response.get("action") == "approved"
+        prefs[tier] = response.get("action") == "approved"
+        setattr(engine, _VALIDATION_ESCALATION_PREF_FLAG, prefs)
+        return prefs[tier]
 
-    if not approved("Required validation passed. Run recommended checks?"):
+    if not approved("recommended", "Required validation passed. Run recommended checks?"):
         setattr(engine, _VALIDATION_ESCALATION_FP_FLAG, fingerprint)
         return {
             "recommended": {"status": "declined_by_user"},
@@ -387,9 +416,8 @@ def _run_validation_escalation(
     if has_recommended_findings:
         summary["optional"] = {"status": "blocked_by_recommended_findings"}
     elif approved(
-        "Recommended validation completed ("
-        + recommended_status
-        + "). Run optional checks?"
+        "optional",
+        "Recommended validation completed (" + recommended_status + "). Run optional checks?",
     ):
         # As above, this call is synchronous and completes before the escalation
         # fingerprint is recorded or control returns to the model loop.
@@ -438,21 +466,20 @@ _LIST_ENTITIES_COUNT_FLAG = "_list_entities_repeat_count"
 # ReAct-level guard: repeated unchanged build_and_validate calls
 # ---------------------------------------------------------------------------
 
-# Attribute name on the engine storing the last build_and_validate call
-# signature (normalised severity + profile). Used to detect when the model
-# re-issues the same validation call without any intervening mutation.
-_BUILD_VALIDATE_LAST_SIG_FLAG = "_build_validate_last_signature"
+# Attribute holding ``{(severity, profile): state fingerprint when it last ran}``.
+# Consecutive-repeat detection alone was evadable by ALTERNATING scopes: a
+# session issued 10x (required, all) and 10x (required, base) against one
+# unchanged crate, and because no two consecutive calls matched, the guard never
+# fired. Keying on the state a scope was last validated against catches any
+# order — and needs no invalidation, since a real mutation changes the
+# fingerprint and every stored entry stops matching by construction.
+_BUILD_VALIDATE_SEEN_FLAG = "_build_validate_seen_fingerprints"
 
-# Attribute name storing how many consecutive identical unchanged
-# build_and_validate calls have been observed so far. The first call is
-# allowed; subsequent identical non-mutation calls are suppressed.
-_BUILD_VALIDATE_COUNT_FLAG = "_build_validate_repeat_count"
-_BUILD_VALIDATE_FP_FLAG = "_build_validate_input_fingerprint"
-
-# How many consecutive identical build_and_validate calls are tolerated
-# before the guard kicks in. A value of 1 means the second identical call
-# (with no mutation in between) is the one that gets redirected.
-_BUILD_VALIDATE_REPEAT_THRESHOLD = 1
+# Bounces off the suppression guard (same scope, same state) that end the turn.
+# Suppression alone does not stop the loop — the model reads the corrective and
+# calls straight back, so every bounce still costs a full model turn. Two
+# warnings, then hand control to the user.
+_VALIDATE_SUPPRESS_ABORT = 3
 
 
 def _build_validate_signature(kwargs: dict[str, Any]) -> tuple[str, str]:
@@ -706,6 +733,13 @@ def _invoke_with_timeout(
         )
         return (None, "timeout", None) if include_error else (None, "timeout")
     if outcome["error"] is not None:
+        # A deliberate stop (a guard ending a non-progressing turn) is NOT an
+        # error: reporting it as one would tell the user something broke when
+        # the loop did exactly what it should. The timeout path also raises
+        # _InvocationCancelled, so the set cancel_event distinguishes them.
+        if isinstance(outcome["error"], _InvocationCancelled) and not cancel_event.is_set():
+            logger.info("Model invoke stopped by a loop guard: %s", outcome["error"])
+            return (None, "stopped", None) if include_error else (None, "stopped")
         logger.warning("Model invoke raised: %s", outcome["error"])
         if include_error:
             error = outcome["error"]
@@ -1074,7 +1108,17 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
         params: dict[str, Any] = cast(dict[str, Any], spec_dict.get("parameters", {}))
 
         def _make_tool(tool_name: str, tool_desc: str, tool_params: dict) -> BaseTool:
+            declared = set((tool_params or {}).get("properties") or {})
+
             def _run(**kwargs: Any) -> Any:
+                # Drop the generic `args`/`kwargs` placeholders some providers
+                # emit for a tool whose schema declares no such parameter. They
+                # reach the tool function as unexpected keywords and raise a
+                # TypeError, turning a harmless status query into a failed call.
+                if kwargs and not declared.intersection(kwargs):
+                    kwargs = {
+                        k: v for k, v in kwargs.items() if k not in ("args", "kwargs")
+                    }
                 _raise_if_invocation_cancelled()
                 # Loop-breaker (#287 Fix B): if this is the Nth consecutive
                 # IDENTICAL call that has been returning a non-progress result
@@ -1110,26 +1154,63 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                         )
                 if tool_name == "build_and_validate":
                     bv_sig = _build_validate_signature(kwargs)
-                    bv_last = getattr(engine, _BUILD_VALIDATE_LAST_SIG_FLAG, None)
-                    bv_count = getattr(engine, _BUILD_VALIDATE_COUNT_FLAG, 0)
                     try:
                         bv_fp = engine.state.validation_fingerprint()
                     except Exception:  # noqa: BLE001 — the guard must never block a call.
                         bv_fp = None
-                    bv_last_fp = getattr(engine, _BUILD_VALIDATE_FP_FLAG, None)
-                    if (
-                        bv_sig == bv_last
-                        and bv_fp is not None
-                        and bv_fp == bv_last_fp
-                        and bv_count >= _BUILD_VALIDATE_REPEAT_THRESHOLD
-                    ):
+                    bv_seen: dict[tuple[str, str], tuple[str, int]] = getattr(
+                        engine, _BUILD_VALIDATE_SEEN_FLAG, None
+                    ) or {}
+                    bv_entry = bv_seen.get(bv_sig)
+                    # Suppress when THIS scope has already been validated against
+                    # THIS state, whatever ran in between — alternating scopes is
+                    # otherwise a free pass through a consecutive-repeat check.
+                    if bv_fp is not None and bv_entry is not None and bv_entry[0] == bv_fp:
+                        strikes = bv_entry[1] + 1
+                        bv_seen = dict(bv_seen)
+                        bv_seen[bv_sig] = (bv_fp, strikes)
+                        setattr(engine, _BUILD_VALIDATE_SEEN_FLAG, bv_seen)
+                        logger.info(
+                            "Suppressed build_and_validate%s (strike %d/%d) — already "
+                            "validated against this unchanged state",
+                            bv_sig,
+                            strikes,
+                            _VALIDATE_SUPPRESS_ABORT,
+                        )
+                        # Suppressing the SHACL pass saves seconds but NOT tokens:
+                        # the model reads the corrective and immediately calls
+                        # again, so a bounce still costs a full model turn (~12.5k
+                        # input tokens; 17 bounces in 90s were observed). After a
+                        # couple of strikes, end the turn instead of answering —
+                        # handing control back to the user is the only thing that
+                        # reliably stops it.
+                        if strikes >= _VALIDATE_SUPPRESS_ABORT:
+                            logger.warning(
+                                "Ending turn: build_and_validate%s bounced %d times "
+                                "against unchanged state",
+                                bv_sig,
+                                strikes,
+                            )
+                            raise _InvocationCancelled(
+                                "repeated validation of an unchanged crate"
+                            )
                         issue_text = _format_validation_issues_summary(engine)
                         v = engine.state.validation
+                        opener = (
+                            f"build_and_validate({bv_sig[0]}, {bv_sig[1]}) has already run "
+                            "against this exact crate state — no state change since, and "
+                            "re-running another scope over the same state will not help "
+                            "either. The result has not changed. "
+                        )
+                        if strikes > 1:
+                            opener = (
+                                f"STOP. build_and_validate({bv_sig[0]}, {bv_sig[1]}) has now "
+                                f"been called {strikes} times against an unchanged crate — "
+                                "no state change, so no new result is possible. "
+                            )
                         corrective = (
-                            f"build_and_validate({bv_sig[0]}, {bv_sig[1]}) called "
-                            "again with no state change since the last identical call. "
-                            "The result has not changed. "
-                            f"Conformance: base={'pass' if v.base_passed else 'fail'}, "
+                            opener
+                            + f"Conformance: base={'pass' if v.base_passed else 'fail'}, "
                             f"isa={'pass' if v.isa_passed else 'fail'}, "
                             f"tox={'pass' if v.tox_passed else 'fail'}. "
                             f"{_validation_tier_counts(engine)} "
@@ -1139,12 +1220,20 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                         if issue_text:
                             corrective += f"\n\nCurrent issues:\n{issue_text}"
                         corrective += (
-                            "\n\nIf you believe the state has changed, make a mutation "
-                            "first (set_fields, link, etc.) and validation will "
-                            "re-run automatically."
+                            "\n\nYour next call MUST be a mutation (set_fields, link, "
+                            "draft_*, attach_files) or export_crate — not another "
+                            "validation. Validation re-runs automatically once the "
+                            "state actually changes."
                         )
-                        logger.info("Suppressed repeated unchanged %s", bv_sig)
                         return corrective
+                    if bv_fp is not None:
+                        # Record BEFORE running: validation never mutates entities
+                        # or metadata (the #153 write-back only touches
+                        # state.validation, which the fingerprint excludes), so
+                        # the pre-call fingerprint is the state it validated.
+                        bv_seen = dict(bv_seen)
+                        bv_seen[bv_sig] = (bv_fp, 0)
+                        setattr(engine, _BUILD_VALIDATE_SEEN_FLAG, bv_seen)
 
                 # Snapshot the state so a mutation that writes nothing can be
                 # recognised AFTER the fact. The tools reject the obvious cases
@@ -1250,11 +1339,10 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     _record_recent_mutation(engine, result)
                     setattr(engine, _LIST_ENTITIES_LAST_SIG_FLAG, None)
                     setattr(engine, _LIST_ENTITIES_COUNT_FLAG, 0)
-                    # A mutation resets the build_and_validate repeat guard so
-                    # the next (changed-state) call is allowed to run fresh.
-                    setattr(engine, _BUILD_VALIDATE_LAST_SIG_FLAG, None)
-                    setattr(engine, _BUILD_VALIDATE_COUNT_FLAG, 0)
-                    setattr(engine, _BUILD_VALIDATE_FP_FLAG, None)
+                    # The build_and_validate memo needs no clearing here: a real
+                    # mutation changes the state fingerprint, so every scope it
+                    # recorded stops matching and the next validation runs fresh.
+                    setattr(engine, _BUILD_VALIDATE_SEEN_FLAG, {})
                 elif tool_name == "list_entities":
                     list_last = getattr(engine, _LIST_ENTITIES_LAST_SIG_FLAG, None)
                     list_count = getattr(engine, _LIST_ENTITIES_COUNT_FLAG, 0)
@@ -1267,60 +1355,12 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     setattr(engine, _LIST_ENTITIES_LAST_SIG_FLAG, None)
                     setattr(engine, _LIST_ENTITIES_COUNT_FLAG, 0)
 
-                # ReAct-level guard: repeated identical build_and_validate calls
-                # with no intervening mutation.  The engine-level debounce (#155)
-                # already avoids re-running the SHACL pass, but the model still
-                # burns tokens on unnecessary tool/model iterations.  Intercept
-                # here — BEFORE the loop-breaker (which guards non-progress, not
-                # this) — and redirect to the cached result + a corrective message
-                # telling the model to work on the reported issues instead.
-                # (Issue #NNN: fix validation escalation and repeated validation
-                # loops.)
-                if tool_name == "build_and_validate":
-                    bv_sig = _build_validate_signature(kwargs)
-                    bv_last = getattr(engine, _BUILD_VALIDATE_LAST_SIG_FLAG, None)
-                    bv_count = getattr(engine, _BUILD_VALIDATE_COUNT_FLAG, 0)
-                    try:
-                        bv_fp = engine.state.validation_fingerprint()
-                    except Exception:  # noqa: BLE001 — best-effort bookkeeping.
-                        bv_fp = None
-                    setattr(engine, _BUILD_VALIDATE_FP_FLAG, bv_fp)
-                    if bv_sig == bv_last and bv_count >= _BUILD_VALIDATE_REPEAT_THRESHOLD:
-                        # Defensive fallback for callers that bypass the pre-run guard.
-                        # Suppress the redundant call — return a compact corrective result.
-                        issue_text = _format_validation_issues_summary(engine)
-                        v = engine.state.validation
-                        corrective = (
-                            f"build_and_validate({bv_sig[0]}, {bv_sig[1]}) called "
-                            f"again with no state change since the last identical call. "
-                            f"The result has not changed. "
-                            f"Conformance: base={'pass' if v.base_passed else 'fail'}, "
-                            f"isa={'pass' if v.isa_passed else 'fail'}, "
-                            f"tox={'pass' if v.tox_passed else 'fail'}. "
-                            f"{_validation_tier_counts(engine)} "
-                            f"Use the existing validation result and address the "
-                            f"reported issues instead of re-validating."
-                        )
-                        if issue_text:
-                            corrective += f"\n\nCurrent issues:\n{issue_text}"
-                        corrective += (
-                            "\n\nIf you believe the state has changed, make a mutation "
-                            "first (set_fields, link, etc.) and validation will "
-                            "re-run automatically."
-                        )
-                        # Stamp the fingerprint so the escalation guard also
-                        # recognises this as stable state.
-                        try:
-                            setattr(
-                                engine,
-                                _VALIDATION_ESCALATION_FP_FLAG,
-                                engine.state.validation_fingerprint(),
-                            )
-                        except Exception:  # noqa: BLE001 — fingerprint is best-effort.
-                            pass
-                        return corrective
-                    setattr(engine, _BUILD_VALIDATE_LAST_SIG_FLAG, bv_sig)
-                    setattr(engine, _BUILD_VALIDATE_COUNT_FLAG, bv_count + 1)
+                # The pre-run guard above is the only build_and_validate
+                # gate: it suppresses BEFORE the SHACL pass and before the
+                # tokens are spent. A second post-run copy used to sit here as
+                # a fallback, keyed on consecutive repeats — the very scheme
+                # alternating scopes walked straight through — so it could only
+                # ever fire after the work it was meant to prevent.
 
                 # Update the loop-breaker detection state AFTER post-processing so
                 # it sees the same message the model sees. A repeated identical
@@ -1419,13 +1459,17 @@ def _wrap_model_node(call_model: Any, profiler: Any, iteration_getter: Any) -> A
             last_msg = out_messages[-1]
             input_tokens, output_tokens = _extract_token_usage(last_msg)
             model_name = _extract_model_name(last_msg)
-            # Capture the model's reply text — truncate to avoid bloating profile
+            # Capture the model's reply TEXT — truncate to avoid bloating profile.
+            # str(content) would write the raw content-block repr (#341): with the
+            # Responses API that means every profile line carried reasoning-block
+            # ids and empty summaries, so `response_text` looked non-empty on all
+            # 196 calls of one session while only a handful said anything.
             content = getattr(last_msg, "content", None)
             if content:
-                text = str(content)
+                text = ui.flatten_message_content(content)
                 if len(text) > 2000:
                     text = text[:1997] + "..."
-                response_text = text
+                response_text = text or None
 
         profiler.log_event(
             event="node_end",
@@ -2546,6 +2590,16 @@ def run_interactive_agent(
             console.print(
                 "  [dim]You can continue by typing[/dim] "
                 "[bold]continue[/bold]"
+            )
+            console.print()
+        elif outcome == "stopped":
+            console.print(
+                "[yellow]I was repeating the same step without making progress[/yellow], "
+                "so I stopped. Your work so far is saved."
+            )
+            console.print(
+                "  [dim]Tell me what to do next — e.g.[/dim] [bold]export the crate[/bold] "
+                "[dim]or[/dim] [bold]what is still missing?[/bold]"
             )
             console.print()
         elif outcome == "recursion":

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -597,6 +597,12 @@ _FOOTER_MIN_HEIGHT = 10
 # rather than fighting a terminal that clearly does not want it.
 _FOOTER_MAX_FAILURES = 3
 
+# Key hint shown at the right-hand end of the footer's rule. Ctrl+C interrupts
+# the agent mid-run and hands the prompt back (the session and the crate
+# survive); Ctrl+D on an empty prompt ends the session. Both are otherwise
+# undiscoverable while the agent is working.
+_FOOTER_KEY_HINT = "ctrl+c interrupt · ctrl+d exit"
+
 
 def _truthy(value: str | None) -> bool:
     return (value or "").strip().lower() in {"1", "true", "yes", "on"}
@@ -748,7 +754,7 @@ class PinnedFooter:
             return
 
         line = self._to_ansi(markup, width - 1)
-        rule = self._to_ansi(f"[grey35]{'─' * max(0, width - 1)}[/grey35]", width - 1)
+        rule = self._to_ansi(self._rule_markup(width - 1), width - 1)
         activity = self._to_ansi(self._activity or "", width - 1)
         self._write(
             "\x1b7"
@@ -759,6 +765,25 @@ class PinnedFooter:
             + f"\x1b[{height};1H\x1b[2K"
             + line
             + "\x1b8"
+        )
+
+    def _rule_markup(self, width: int) -> str:
+        """The separator rule, carrying the key hint at its right-hand end.
+
+        The hint rides on the rule rather than taking a row of its own: the two
+        keys that matter while the agent is working are only discoverable by
+        guessing otherwise, and the rule is the one line here with space to
+        spare. Dropped when the terminal is too narrow to hold both.
+        """
+        if width <= 0:
+            return ""
+        if not _FOOTER_KEY_HINT or width < len(_FOOTER_KEY_HINT) + 12:
+            return f"[grey35]{'─' * width}[/grey35]"
+        dashes = width - len(_FOOTER_KEY_HINT) - 3
+        return (
+            f"[grey35]{'─' * dashes}[/grey35] "
+            f"[grey42]{_FOOTER_KEY_HINT}[/grey42] "
+            f"[grey35]─[/grey35]"
         )
 
     def set_activity(self, markup: str | None) -> None:

--- a/builder/state.py
+++ b/builder/state.py
@@ -819,6 +819,13 @@ class CrateState:
     fair_assessment: FAIRReport = field(default_factory=FAIRReport)
     checkpoint: ReasoningLog = field(default_factory=ReasoningLog)
 
+    # Standing answers to "run the broader validation tiers?", keyed
+    # ``"recommended"`` / ``"optional"``. Absent means "not asked yet"; a
+    # recorded bool means the user has decided and must not be asked again.
+    # Persisted deliberately: an answer given before a --resume is still the
+    # user's answer afterwards.
+    validation_preferences: dict[str, bool] = field(default_factory=dict)
+
     # ------------------------------------------------------------------
     # Entity management
     # ------------------------------------------------------------------
@@ -1041,6 +1048,7 @@ class StateSerializer:
             "mit_assessment": cls._encode(state.mit_assessment),
             "fair_assessment": cls._encode(state.fair_assessment),
             "checkpoint": cls._encode(state.checkpoint),
+            "validation_preferences": dict(state.validation_preferences),
             "iteration_count": state.iteration_count,
             "max_iterations": state.max_iterations,
             "stuck": state.stuck,
@@ -1085,6 +1093,10 @@ class StateSerializer:
             mit_assessment=MITReport.from_dict(data.get("mit_assessment", {})),
             fair_assessment=FAIRReport.from_dict(data.get("fair_assessment", {})),
             checkpoint=checkpoint,
+            # Read back, not just written: without this the standing "don't ask
+            # me again" answers reset to {} on every --resume, which is the one
+            # thing persisting them was meant to prevent.
+            validation_preferences=dict(data.get("validation_preferences") or {}),
         )
 
     @classmethod

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -7,6 +7,7 @@
   --low:#d03b3b; --low-ink:#b3261e; --na-a:#e6ebeb; --na-b:#f3f6f6; --na-ink:#7a8688;
   --cov:#0e7c86; --track:#e6ebeb;
   --cat-process:#2a78d6; --cat-material:#008300; --cat-data:#c0407a; --cat-chemical:#9a5b00;
+  --cat-agent:#7a3fc4; --cat-org:#4b5a94; --cat-container:#3f51a8;
   --edge-object:#8a9698; --edge-result:#0e7c86;
   color-scheme: light;
   background:var(--page); color:var(--ink);
@@ -179,8 +180,52 @@
 .mat .prov-legend .gl { width:1.5rem; height:0; border-top:2px solid var(--edge-result); }
 .mat .prov-legend .gl.obj { border-top:2px dashed var(--edge-object); }
 
+/* graph views — CSS-only tabs. The report is a self-contained offline artifact
+   with no script, so the tabs are radio inputs plus `:checked ~` sibling rules;
+   that keeps them keyboard-operable for free. Print expands every panel. */
+.mat .tab-in { position:absolute; width:1px; height:1px; opacity:0; margin:0; }
+.mat .tabbar { display:flex; flex-wrap:wrap; gap:.25rem; margin:0 0 1rem;
+  padding-bottom:.55rem; border-bottom:1px solid var(--hairline); }
+.mat .tabbar .tab { display:inline-flex; align-items:center; gap:.4rem; cursor:pointer;
+  font-size:.85rem; font-weight:580; color:var(--ink-2); padding:.34rem .75rem;
+  border-radius:999px; border:1px solid transparent; white-space:nowrap; }
+.mat .tabbar .tab:hover { background:var(--surface-2); color:var(--ink); }
+.mat .tabbar .tb-c { font-size:.7rem; color:var(--muted); font-variant-numeric:tabular-nums;
+  background:var(--surface-2); border-radius:999px; padding:.02rem .38rem; }
+.mat .panel { display:none; }
+.mat .panel > .panel-h { display:none; }
+.mat #mv-isa:checked ~ .tabbar .tab[for="mv-isa"],
+.mat #mv-prov:checked ~ .tabbar .tab[for="mv-prov"],
+.mat #mv-chem:checked ~ .tabbar .tab[for="mv-chem"],
+.mat #mv-cell:checked ~ .tabbar .tab[for="mv-cell"],
+.mat #mv-people:checked ~ .tabbar .tab[for="mv-people"] {
+  background:var(--accent-soft); border-color:color-mix(in srgb,var(--accent) 34%,transparent);
+  color:var(--accent); }
+.mat #mv-isa:checked ~ .tabbar .tab[for="mv-isa"] .tb-c,
+.mat #mv-prov:checked ~ .tabbar .tab[for="mv-prov"] .tb-c,
+.mat #mv-chem:checked ~ .tabbar .tab[for="mv-chem"] .tb-c,
+.mat #mv-cell:checked ~ .tabbar .tab[for="mv-cell"] .tb-c,
+.mat #mv-people:checked ~ .tabbar .tab[for="mv-people"] .tb-c {
+  background:var(--surface); color:var(--accent); }
+.mat #mv-isa:focus-visible ~ .tabbar .tab[for="mv-isa"],
+.mat #mv-prov:focus-visible ~ .tabbar .tab[for="mv-prov"],
+.mat #mv-chem:focus-visible ~ .tabbar .tab[for="mv-chem"],
+.mat #mv-cell:focus-visible ~ .tabbar .tab[for="mv-cell"],
+.mat #mv-people:focus-visible ~ .tabbar .tab[for="mv-people"] {
+  outline:2px solid var(--accent); outline-offset:2px; }
+.mat #mv-isa:checked ~ #p-isa,
+.mat #mv-prov:checked ~ #p-prov,
+.mat #mv-chem:checked ~ #p-chem,
+.mat #mv-cell:checked ~ #p-cell,
+.mat #mv-people:checked ~ #p-people { display:block; }
+
 /* chemicals — route diagram + identification matrix (#85) */
-.mat .prov.chem { min-width:34rem; }
+/* The derivation chain is wide and fixed, so it stretches and scrolls. The
+   routed views (chemicals / cell lines / people) size themselves to their
+   content — from ~210 to ~540 units — so they render at natural size and
+   only shrink when the page is narrower. Stretching them to the chain's
+   44rem floor would upscale a small diagram several times over. */
+.mat svg.prov.view { width:auto; min-width:0; max-width:100%; height:auto; }
 .mat .prov .n-chem { fill:color-mix(in srgb,var(--cat-chemical) 9%,var(--surface-2));
   stroke:var(--cat-chemical); }
 .mat .prov .tag-chem { fill:var(--cat-chemical); }
@@ -193,6 +238,28 @@
 .mat .prov .mk-link { fill:var(--edge-result); }
 .mat .prov .e-break { stroke:var(--low); stroke-dasharray:4 3; }
 .mat .prov .brk { fill:var(--low-ink); font-size:11px; font-weight:700; text-anchor:end; }
+.mat .prov .brk.start { text-anchor:start; }
+/* people & organisations */
+.mat .prov .n-agent { fill:color-mix(in srgb,var(--cat-agent) 9%,var(--surface-2));
+  stroke:var(--cat-agent); }
+.mat .prov .tag-agent { fill:var(--cat-agent); }
+.mat .prov .n-org { fill:color-mix(in srgb,var(--cat-org) 9%,var(--surface-2));
+  stroke:var(--cat-org); }
+.mat .prov .tag-org { fill:var(--cat-org); }
+.mat .prov .n-container { fill:color-mix(in srgb,var(--cat-container) 9%,var(--surface-2));
+  stroke:var(--cat-container); }
+.mat .prov .tag-container { fill:var(--cat-container); }
+.mat .prov .bars { stroke:var(--cat-container); stroke-width:1.2; fill:none; opacity:.75; }
+/* Every node shape needs its own unwired state, or an unreachable entity renders
+   identically to a correctly linked one. */
+.mat .prov .n-material.unwired, .mat .prov .n-container.unwired,
+.mat .prov .n-agent.unwired, .mat .prov .n-org.unwired {
+  fill:color-mix(in srgb,var(--low) 7%,var(--surface-2)); stroke:var(--low);
+  stroke-dasharray:5 3; }
+.mat .prov .tag-material.unwired, .mat .prov .tag-container.unwired,
+.mat .prov .tag-agent.unwired, .mat .prov .tag-org.unwired { fill:var(--low-ink); }
+.mat .chem-tbl th[scope="row"] .ty { font-size:.68rem; color:var(--muted);
+  text-transform:uppercase; letter-spacing:.05em; }
 .mat .prov .elabel { fill:var(--muted); font-size:8.5px; text-anchor:middle;
   font-weight:600; letter-spacing:.03em; }
 .mat .prov-legend .gl.brk { border-top:2px dashed var(--low); }
@@ -214,6 +281,8 @@
 .mat .chem-tbl .cn { font-weight:580; color:var(--ink); }
 .mat .chem-tbl tbody tr:last-child th, .mat .chem-tbl tbody tr:last-child td { border-bottom:none; }
 .mat .chem-tbl tr.more th { color:var(--muted); font-style:italic; font-weight:500; }
+.mat .chem-flag.muted { color:var(--muted); background:var(--surface-2);
+  border:1px solid var(--border); font-weight:600; }
 .mat .chem-flag { font-size:.66rem; text-transform:uppercase; letter-spacing:.05em;
   font-weight:650; color:var(--low-ink); background:color-mix(in srgb,var(--low) 11%,transparent);
   border-radius:999px; padding:.05rem .42rem; white-space:nowrap; }
@@ -242,4 +311,10 @@
   .mat{background:#fff;color:#000;padding:0;--surface:#fff;--surface-2:#fff;}
   .mat section,.mat .kpi{break-inside:avoid;border:1px solid #ccc;box-shadow:none;}
   .mat details{display:block;} .mat .disc[open] summary{display:none;}
+  /* Tabs are an on-screen affordance: print every view, each under its own
+     heading, so a printed report never silently loses two of the three. */
+  .mat .tabbar{display:none;}
+  .mat .panel{display:block !important; break-inside:avoid;}
+  .mat .panel + .panel{margin-top:1.2rem; padding-top:1rem; border-top:1px solid #ccc;}
+  .mat .panel > .panel-h{display:block; font-size:.95rem; font-weight:660; margin:0 0 .6rem;}
 }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -627,63 +627,275 @@ def _render_topology_strip(counts: dict[str, int]) -> str:
     return f'<div class="comp topo">{"".join(parts)}</div>'
 
 
-def _render_provenance_section(graph: dict[str, Any] | list[dict[str, Any]]) -> str:
-    """Fold the provenance chain + graph topology into the report (#85).
+def _legend(*items: str) -> str:
+    return f'<div class="prov-legend">{"".join(items)}</div>'
 
-    Draws the LabProcess derivation chain as a self-contained inline SVG (offline,
-    no script) with a shape legend, and appends the graph-topology strip. When the
-    crate records no derivation chain, the SVG is replaced by a note but the
-    topology strip still renders. Called only when a crate ``@graph`` is supplied.
+
+# Legend swatches, drawn with the same outline the diagrams use.
+_LG_PROCESS = (
+    '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
+    '<polygon points="4,1 14,1 18,7 14,13 4,13 1,7" fill="var(--accent-soft)" '
+    'stroke="var(--cat-process)" stroke-width="1.6"/></svg> Process</span>'
+)
+_LG_SAMPLE = (
+    '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+    '<rect x="1" y="2" width="20" height="10" rx="5" fill="var(--surface-2)" '
+    'stroke="var(--cat-material)" stroke-width="1.6"/></svg> Sample / material</span>'
+)
+_LG_FILE = (
+    '<span class="lg"><svg width="18" height="14" aria-hidden="true">'
+    '<rect x="1" y="1" width="15" height="12" rx="2" fill="var(--surface-2)" '
+    'stroke="var(--cat-data)" stroke-width="1.6"/></svg> File / table</span>'
+)
+_LG_COMPOUND = (
+    '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+    '<polygon points="4,1 18,1 21,4 21,10 18,13 4,13 1,10 1,4" fill="var(--surface-2)" '
+    'stroke="var(--cat-chemical)" stroke-width="1.6"/></svg> Compound</span>'
+)
+_LG_CONTAINER = (
+    '<span class="lg"><svg width="24" height="14" aria-hidden="true">'
+    '<rect x="1" y="2" width="22" height="10" rx="2" fill="var(--surface-2)" '
+    'stroke="var(--cat-container)" stroke-width="1.6"/>'
+    '<path d="M5,2 V12 M19,2 V12" stroke="var(--cat-container)" stroke-width="1.2"/>'
+    '</svg> Investigation / Study / Assay</span>'
+)
+_LG_CELLLINE = (
+    '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+    '<rect x="1" y="2" width="20" height="10" rx="5" fill="var(--surface-2)" '
+    'stroke="var(--cat-material)" stroke-width="1.6"/></svg> Cell line / sample</span>'
+)
+_LG_PERSON = (
+    '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+    '<rect x="1" y="2" width="20" height="10" rx="5" fill="var(--surface-2)" '
+    'stroke="var(--cat-agent)" stroke-width="1.6"/></svg> Person</span>'
+)
+_LG_ORG = (
+    '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
+    '<rect x="1" y="2" width="20" height="10" rx="2" fill="var(--surface-2)" '
+    'stroke="var(--cat-org)" stroke-width="1.6"/></svg> Organisation</span>'
+)
+_LG_LINK = '<span class="lg"><span class="gl"></span> links to</span>'
+_LG_BREAK = '<span class="lg"><span class="gl brk"></span> ✗ link missing</span>'
+
+
+_ISA_LEVEL_NOTE = {
+    "Investigation": "the question the crate answers",
+    "Study": "a coherent body of work toward it",
+    "Assay": "one measurement campaign",
+}
+
+
+def _render_isa_panel(inv: dict[str, Any]) -> tuple[str, str]:
+    """The ISA structure view: the Investigation / Study / Assay backbone.
+
+    ISA is the skeleton the other views hang off, and it is expressed purely as
+    ``hasPart`` between Datasets that differ only by ``additionalType`` — so it is
+    invisible in the JSON and breaks in ways that still validate: a Study nobody
+    lists as a part, an Assay with no process attached, a level with no
+    ``identifier`` (which is what makes an ISA node citable at all).
+
+    Returns:
+        ``(panel html, tab badge)`` — ``("", "")`` when the crate has no ISA nodes.
     """
-    from builder.writers.provenance_dag import build_crate_graph, render_provenance_svg
+    from builder.writers.provenance_dag import ISA_COVERAGE_FIELDS, render_isa_svg
+
+    nodes = inv["nodes"]
+    if not nodes:
+        return "", ""
+    counts = inv["counts"]
+    detached = counts["detached"]
+    pct = (
+        round(counts["fields_met"] / counts["fields_total"] * 100)
+        if counts["fields_total"]
+        else 0
+    )
+
+    svg = render_isa_svg(inv)
+    diagram = (
+        f'<div class="prov-scroll">{svg}</div>\n  '
+        + _legend(_LG_CONTAINER, _LG_LINK, _LG_BREAK)
+        if svg
+        else ""
+    )
+
+    notes = []
+    if detached:
+        loose = [n["label"] for n in nodes if n["state"] == "detached"]
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{detached} ISA container'
+            f'{"" if detached == 1 else "s"} sit outside the hierarchy</b> '
+            f'({", ".join(loose[:4])}{"&hellip;" if len(loose) > 4 else ""}). '
+            "Nothing lists them under <code>hasPart</code>, so a reader walking the "
+            "Investigation never reaches them.</span></p>"
+        )
+    hollow = [n for n in nodes if n["fields"]["Contains the next level"] is False]
+    if hollow:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{len(hollow)} container'
+            f'{"" if len(hollow) == 1 else "s"} contain nothing below them</b> '
+            f'({", ".join(n["label"] for n in hollow[:4])}). An Assay needs a '
+            "<code>LabProcess</code>, a Study an Assay, an Investigation a Study — "
+            "otherwise the level is a label with no work under it.</span></p>"
+        )
+    if not notes:
+        notes.append(
+            '<p class="good-note">The Investigation / Study / Assay hierarchy is complete.</p>'
+        )
+
+    head = "".join(
+        f'<th scope="col" title="{html.escape(full)}">{html.escape(short)}</th>'
+        for full, short in ISA_COVERAGE_FIELDS
+    )
+    rows = []
+    for n in sorted(nodes, key=lambda n: (n["state"] == "linked", n["met"], n["id"])):
+        flag = (
+            ""
+            if n["state"] == "linked"
+            else '<span class="chem-flag" title="nothing lists this container under '
+            'hasPart">detached</span>'
+        )
+        extra = (
+            f'<span class="ty">{len(n["processes"])} process'
+            f'{"" if len(n["processes"]) == 1 else "es"}</span>'
+            if n["level"] == "Assay"
+            else ""
+        )
+        cells = "".join(
+            f"<td>{_mk(_kind(n['fields'].get(full)))}</td>" for full, _short in ISA_COVERAGE_FIELDS
+        )
+        rows.append(
+            f'<tr><th scope="row">{_mk("ok" if n["state"] == "linked" else "no")}'
+            f'<span class="cn">{n["label"]}</span>'
+            f'<span class="ty" title="{html.escape(_ISA_LEVEL_NOTE[n["level"]])}">'
+            f'{n["level"]}</span>{extra}{flag}</th>{cells}</tr>'
+        )
+    matrix = (
+        '<div class="chem-tbl-scroll"><table class="chem-tbl">'
+        '<caption class="sr-only">Structural fields carried by each ISA container</caption>'
+        f'<thead><tr><th scope="col">Container</th>{head}</tr></thead>'
+        f'<tbody>{"".join(rows)}</tbody></table></div>'
+    )
+
+    panel = (
+        '<p class="prov-cap">The ISA backbone every other view hangs off — the '
+        "Investigation that states the question, the Studies under it, and the Assays "
+        f"whose processes the Provenance view traces. <b>{counts['investigations']}</b> "
+        f"investigation · <b>{counts['studies']}</b> stud"
+        f"{'y' if counts['studies'] == 1 else 'ies'} · <b>{counts['assays']}</b> assay"
+        f"{'' if counts['assays'] == 1 else 's'} · <b>{counts['processes']}</b> process"
+        f"{'' if counts['processes'] == 1 else 'es'} · <b>{pct}%</b> complete.</p>\n"
+        f"  {diagram}\n"
+        f"  {''.join(notes)}\n"
+        f"  {matrix}"
+    )
+    return panel, str(counts["total"])
+
+
+def _render_provenance_panel(graph: dict[str, Any] | list[dict[str, Any]]) -> str:
+    """The derivation-chain view: materials, processes, and the files produced."""
+    from builder.writers.provenance_dag import render_provenance_svg
 
     svg = render_provenance_svg(graph)
-    # all_edges=True so every dangling stub (incl. those referenced only via
-    # secondary relations) is present in the node list — the counts are identical
-    # either way, but this lets the actionable disclosure name each one (#310).
-    model = build_crate_graph(graph, all_edges=True)
-    counts = model.get("counts", {})
-    nodes = model.get("nodes", [])
-    if svg:
-        body = (
-            '<p class="prov-cap">The derivation chain a receiving lab follows to trace an '
-            "output back to its inputs — materials, the processes applied, and the files "
-            "each step produced.</p>\n"
-            f'  <div class="prov-scroll">{svg}</div>\n'
-            '  <div class="prov-legend">'
-            '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
-            '<polygon points="4,1 14,1 18,7 14,13 4,13 1,7" fill="var(--accent-soft)" '
-            'stroke="var(--cat-process)" stroke-width="1.6"/></svg> Process</span>'
-            '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
-            '<rect x="1" y="2" width="20" height="10" rx="5" fill="var(--surface-2)" '
-            'stroke="var(--cat-material)" stroke-width="1.6"/></svg> Sample / material</span>'
-            '<span class="lg"><svg width="18" height="14" aria-hidden="true">'
-            '<rect x="1" y="1" width="15" height="12" rx="2" fill="var(--surface-2)" '
-            'stroke="var(--cat-data)" stroke-width="1.6"/></svg> File / table</span>'
-            '<span class="lg"><span class="gl obj"></span> consumes (object)</span>'
-            '<span class="lg"><span class="gl"></span> produces (result)</span>'
-            "</div>"
-        )
-    else:
-        body = (
+    if not svg:
+        return (
             '<p class="lead">No derivation chain recorded — this crate has no LabProcess '
             "input/output edges to trace.</p>"
         )
     return (
-        "<section>\n"
-        '  <div class="sec-h"><h2>Provenance &amp; graph</h2>'
-        '<span class="sec-meta">how the result was produced</span></div>\n'
-        f"  {body}\n"
-        f"  {_render_topology_strip(counts)}\n"
-        f"  {_render_topology_detail(nodes)}\n"
-        "</section>\n"
+        '<p class="prov-cap">The derivation chain a receiving lab follows to trace an '
+        "output back to its inputs — materials, the processes applied, and the files "
+        "each step produced.</p>\n"
+        f'  <div class="prov-scroll">{svg}</div>\n  '
+        + _legend(
+            _LG_PROCESS,
+            _LG_SAMPLE,
+            _LG_FILE,
+            '<span class="lg"><span class="gl obj"></span> consumes (object)</span>',
+            '<span class="lg"><span class="gl"></span> produces (result)</span>',
+        )
     )
 
 
-# Cap the per-compound matrix so a screening crate with hundreds of compounds
-# can't blow up the page; the tail is summarised as "+N more" (never dropped
-# silently). Unwired compounds sort first — they are the actionable ones.
-_CHEM_LIST_CAP = 12
+# The graph views, in tab order: (radio id, panel id, tab label).
+_VIEWS: tuple[tuple[str, str, str], ...] = (
+    ("mv-isa", "p-isa", "ISA structure"),
+    ("mv-prov", "p-prov", "Provenance"),
+    ("mv-chem", "p-chem", "Chemicals"),
+    ("mv-cell", "p-cell", "Cell lines"),
+    ("mv-people", "p-people", "People &amp; orgs"),
+)
+
+
+def _render_graph_views_section(
+    graph: dict[str, Any] | list[dict[str, Any]], chem_inv: dict[str, Any]
+) -> str:
+    """The graph-views section: one diagram per tab, over a shared topology strip.
+
+    The three views answer different questions about the same ``@graph`` —
+    *how was the result produced* (provenance), *what was tested* (chemicals),
+    *who is credited* (people) — and a reader wants one at a time, not three
+    stacked diagrams. They are therefore tabbed.
+
+    The tabs are pure CSS (radio inputs + ``:checked ~`` sibling rules), because
+    the report is a self-contained offline artifact embedded in the crate and
+    carries no script; the radios keep them keyboard-operable, and print styles
+    expand every panel so a printed report loses nothing. A view whose diagram
+    has no content (a crate with no compounds, or one that credits nobody) drops
+    its tab entirely rather than showing an empty panel, and the first surviving
+    tab is the one selected.
+
+    Called only when a crate ``@graph`` is supplied.
+    """
+    from builder.writers.provenance_dag import (
+        build_cellline_inventory,
+        build_crate_graph,
+        build_isa_inventory,
+        build_people_inventory,
+    )
+
+    panels = {
+        "p-isa": _render_isa_panel(build_isa_inventory(graph)),
+        "p-prov": (_render_provenance_panel(graph), ""),
+        "p-chem": _render_chemicals_panel(chem_inv),
+        "p-cell": _render_celllines_panel(build_cellline_inventory(graph)),
+        "p-people": _render_people_panel(build_people_inventory(graph)),
+    }
+    live = [(rid, pid, label) for rid, pid, label in _VIEWS if panels[pid][0]]
+
+    inputs = "".join(
+        f'<input class="tab-in" type="radio" name="mat-view" id="{rid}"'
+        f'{" checked" if i == 0 else ""}>'
+        for i, (rid, _pid, _label) in enumerate(live)
+    )
+    tabs = "".join(
+        f'<label class="tab" for="{rid}"><span class="tb-n">{label}</span>'
+        + (f'<span class="tb-c">{panels[pid][1]}</span>' if panels[pid][1] else "")
+        + "</label>"
+        for rid, pid, label in live
+    )
+    bodies = "".join(
+        f'<div class="panel" id="{pid}">'
+        f'<h3 class="panel-h">{label}</h3>{panels[pid][0]}</div>'
+        for _rid, pid, label in live
+    )
+
+    # all_edges=True so every dangling stub (incl. those referenced only via
+    # secondary relations) is present in the node list — the counts are identical
+    # either way, but this lets the actionable disclosure name each one (#310).
+    model = build_crate_graph(graph, all_edges=True)
+    return (
+        "<section>\n"
+        '  <div class="sec-h"><h2>Graph views</h2>'
+        f'<span class="sec-meta">{len(live)} view{"" if len(live) == 1 else "s"} '
+        "of the same crate</span></div>\n"
+        f"  {inputs}\n"
+        f'  <div class="tabbar">{tabs}</div>\n'
+        f"  {bodies}\n"
+        f"  {_render_topology_strip(model.get('counts', {}))}\n"
+        f"  {_render_topology_detail(model.get('nodes', []))}\n"
+        "</section>\n"
+    )
+
 
 _CHEM_STATE_MARK = {"wired": "ok", "mentioned": "na", "unlinked": "no"}
 _CHEM_STATE_NOTE = {
@@ -693,8 +905,8 @@ _CHEM_STATE_NOTE = {
 }
 
 
-def _render_chemicals_section(inv: dict[str, Any]) -> str:
-    """The Chemicals section: how each compound reaches the experiment, and how
+def _render_chemicals_panel(inv: dict[str, Any]) -> tuple[str, str]:
+    """The Chemicals view: how each compound reaches the experiment, and how
     completely it is identified.
 
     Two views of the same inventory, because either alone misleads. The diagram
@@ -705,15 +917,18 @@ def _render_chemicals_section(inv: dict[str, Any]) -> str:
     score perfectly on one and fail the other, so the section never collapses them
     into a single number.
 
-    Returns ``""`` when the crate declares no compounds — an empty chemicals
-    panel on a non-chemical crate would read as a failure rather than as
-    "not applicable".
+    Returns ``("", "")`` when the crate declares no compounds — the view drops
+    its tab entirely, because an empty chemicals panel on a non-chemical crate
+    would read as a failure rather than as "not applicable".
+
+    Returns:
+        ``(panel html, tab badge)``.
     """
     from builder.writers.provenance_dag import CHEM_COVERAGE_FIELDS, render_chemicals_svg
 
     chems = inv["chemicals"]
     if not chems:
-        return ""
+        return "", ""
     counts = inv["counts"]
     total, wired = counts["total"], counts["wired"]
     id_pct = (
@@ -741,14 +956,16 @@ def _render_chemicals_section(inv: dict[str, Any]) -> str:
     # Per-compound identification matrix. Unwired first, then worst-covered, so
     # the rows that survive the cap are the ones worth acting on.
     ordered = sorted(
-        chems, key=lambda c: (c["state"] == "wired", c["met"], c["name"].casefold())
+        chems, key=lambda c: (c["state"] == "wired", c["met"], c["name"].casefold(), c["id"])
     )
     head = "".join(
         f'<th scope="col" title="{html.escape(full)}">{html.escape(short)}</th>'
         for full, short in CHEM_COVERAGE_FIELDS
     )
+    # Every compound is listed, matching the diagram: this is a metadata-checking
+    # view, and a truncated tail hides the rows worth acting on.
     rows = []
-    for c in ordered[:_CHEM_LIST_CAP]:
+    for c in ordered:
         link = " 🔗" if c["resolvable"] else ""
         flag = (
             ""
@@ -764,12 +981,6 @@ def _render_chemicals_section(inv: dict[str, Any]) -> str:
             f'<tr><th scope="row">{_mk(_CHEM_STATE_MARK[c["state"]])}'
             f'<span class="cn">{c["label"]}{link}</span>{flag}</th>{cells}</tr>'
         )
-    extra = len(ordered) - _CHEM_LIST_CAP
-    if extra > 0:
-        rows.append(
-            f'<tr class="more"><th scope="row">+{extra} more compounds</th>'
-            f'<td colspan="{len(CHEM_COVERAGE_FIELDS)}"></td></tr>'
-        )
     matrix = (
         '<div class="chem-tbl-scroll"><table class="chem-tbl">'
         f'<caption class="sr-only">Identification fields carried by each compound</caption>'
@@ -778,38 +989,245 @@ def _render_chemicals_section(inv: dict[str, Any]) -> str:
     )
 
     diagram = (
-        f'<div class="prov-scroll">{svg}</div>\n'
-        '  <div class="prov-legend">'
-        '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
-        '<polygon points="4,1 14,1 18,7 14,13 4,13 1,7" fill="var(--accent-soft)" '
-        'stroke="var(--cat-process)" stroke-width="1.6"/></svg> Process</span>'
-        '<span class="lg"><svg width="20" height="14" aria-hidden="true">'
-        '<rect x="1" y="1" width="15" height="12" rx="2" fill="var(--surface-2)" '
-        'stroke="var(--cat-data)" stroke-width="1.6"/></svg> Condition table</span>'
-        '<span class="lg"><svg width="22" height="14" aria-hidden="true">'
-        '<polygon points="4,1 18,1 21,4 21,10 18,13 4,13 1,10 1,4" '
-        'fill="var(--surface-2)" stroke="var(--cat-chemical)" stroke-width="1.6"/>'
-        "</svg> Compound</span>"
-        '<span class="lg"><span class="gl"></span> links to</span>'
-        '<span class="lg"><span class="gl brk"></span> ✗ route stops here</span>'
-        "</div>"
+        f'<div class="prov-scroll">{svg}</div>\n  '
+        + _legend(_LG_PROCESS, _LG_FILE, _LG_COMPOUND, _LG_LINK, _LG_BREAK)
         if svg
         else ""
     )
 
-    return (
-        "<section>\n"
-        '  <div class="sec-h"><h2>Chemicals</h2>'
-        f'<span class="sec-meta"><b>{total}</b> compound{"" if total == 1 else "s"} · '
-        f"<b>{wired}</b> wired · <b>{id_pct}%</b> identified</span></div>\n"
-        '  <p class="lead">The substances under test — whether each one is actually '
+    panel = (
+        '<p class="prov-cap">The substances under test — whether each one is actually '
         "connected to the experiment that used it, and whether a reader could obtain the "
-        "same material.</p>\n"
+        f"same material. <b>{total}</b> compound{'' if total == 1 else 's'} · "
+        f"<b>{wired}</b> wired · <b>{id_pct}%</b> identified.</p>\n"
         f"  {diagram}\n"
         f"  {route_note}\n"
-        f"  {matrix}\n"
-        "</section>\n"
+        f"  {matrix}"
     )
+    return panel, str(total)
+
+
+# An organisation reached through a person's affiliation is CORRECTLY linked —
+# that is the normal shape — so it reads as met, with a muted chip naming the
+# route. Only "unattached" is a defect.
+_CELL_STATE_NOTE = {
+    "wired": "consumed by a process",
+    "mentioned": "named in the crate, but consumed by no process",
+    "unlinked": "nothing in the crate references this cell line",
+}
+
+
+def _render_celllines_panel(inv: dict[str, Any]) -> tuple[str, str]:
+    """The Cell lines view: the biological test system, and whether it is pinned down.
+
+    The same two questions the compound view asks, because a cell line fails the
+    same two ways. It is *unreachable* when the ``CellCulture`` consumes a freshly
+    minted generic ``Sample`` instead of the declared ``CellLineSample`` — the
+    line is then described and used by nothing. It is *unidentified* when it
+    carries a name but no Cellosaurus RRID: "CHO-K1" names a family of divergent
+    stocks, ``CVCL_0214`` names one, and organ / tissue / passage are what let
+    another lab reproduce the culture rather than merely recognise it.
+
+    Returns:
+        ``(panel html, tab badge)`` — ``("", "")`` when the crate declares none.
+    """
+    from builder.writers.provenance_dag import CELLLINE_COVERAGE_FIELDS, render_celllines_svg
+
+    lines = inv["celllines"]
+    if not lines:
+        return "", ""
+    counts = inv["counts"]
+    total, wired = counts["total"], counts["wired"]
+    rrid_backed = sum(1 for c in lines if c["rrid"])
+    pct = (
+        round(counts["fields_met"] / counts["fields_total"] * 100)
+        if counts["fields_total"]
+        else 0
+    )
+
+    svg = render_celllines_svg(inv)
+    diagram = (
+        f'<div class="prov-scroll">{svg}</div>\n  '
+        + _legend(_LG_PROCESS, _LG_CELLLINE, _LG_FILE, _LG_LINK, _LG_BREAK)
+        if svg
+        else ""
+    )
+
+    notes = []
+    unreached = total - wired
+    if unreached:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{unreached} of {total} cell lines are '
+            "not consumed by any process.</b> The <code>CellCulture</code> should take the "
+            "declared cell line as its <code>input</code> — when it takes a freshly minted "
+            "generic <code>Sample</code> instead, the line is described in the crate and used "
+            "by nothing.</span></p>"
+        )
+    if total - rrid_backed:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{total - rrid_backed} of {total} cell '
+            "lines carry no Cellosaurus RRID.</b> A name identifies a family of divergent "
+            "stocks; <code>CVCL_…</code> identifies the one that was used.</span></p>"
+        )
+    if not notes:
+        notes.append(
+            '<p class="good-note">Every cell line is consumed by a process and RRID-backed.</p>'
+        )
+
+    ordered = sorted(
+        lines, key=lambda c: (c["state"] == "wired", c["met"], c["name"].casefold(), c["id"])
+    )
+    head = "".join(
+        f'<th scope="col" title="{html.escape(full)}">{html.escape(short)}</th>'
+        for full, short in CELLLINE_COVERAGE_FIELDS
+    )
+    rows = []
+    for c in ordered:
+        link = " 🔗" if c["resolvable"] else ""
+        rrid = f'<span class="ty">{html.escape(c["rrid"])}</span>' if c["rrid"] else ""
+        flag = (
+            ""
+            if c["state"] == "wired"
+            else f'<span class="chem-flag" title="{html.escape(_CELL_STATE_NOTE[c["state"]])}">'
+            f"{'not linked' if c['state'] == 'unlinked' else 'no process'}</span>"
+        )
+        cells = "".join(
+            f'<td>{_mk("ok" if c["fields"].get(full) else "no")}</td>'
+            for full, _short in CELLLINE_COVERAGE_FIELDS
+        )
+        rows.append(
+            f'<tr><th scope="row">{_mk(_CHEM_STATE_MARK[c["state"]])}'
+            f'<span class="cn">{c["label"]}{link}</span>{rrid}{flag}</th>{cells}</tr>'
+        )
+    matrix = (
+        '<div class="chem-tbl-scroll"><table class="chem-tbl">'
+        '<caption class="sr-only">Identification fields carried by each cell line</caption>'
+        f'<thead><tr><th scope="col">Cell line</th>{head}</tr></thead>'
+        f'<tbody>{"".join(rows)}</tbody></table></div>'
+    )
+
+    panel = (
+        '<p class="prov-cap">The biological test system — whether the declared line is the '
+        "one the culture actually consumed, and whether another lab could obtain the same "
+        f"stock. <b>{total}</b> cell line{'' if total == 1 else 's'} · <b>{wired}</b> "
+        f"consumed by a process · <b>{pct}%</b> characterised.</p>\n"
+        f"  {diagram}\n"
+        f"  {''.join(notes)}\n"
+        f"  {matrix}"
+    )
+    return panel, str(total)
+
+
+_AGENT_STATE_MARK = {"credited": "ok", "affiliated": "ok", "unattached": "no"}
+_AGENT_STATE_NOTE = {
+    "credited": "credited directly by an entity in the crate",
+    "affiliated": "linked through a person's affiliation",
+    "unattached": "nothing in the crate references this agent",
+}
+_AGENT_STATE_CHIP = {"affiliated": ("muted", "via affiliation"), "unattached": ("", "unattached")}
+def _render_people_panel(inv: dict[str, Any]) -> tuple[str, str]:
+    """The People & organisations view: who the crate credits, how resolvably.
+
+    Attribution is where a crate quietly stops being machine-actionable. A bare
+    ``name`` satisfies every profile while crediting nobody a registry can
+    resolve, and the diagram makes the two failure shapes visible: a person with
+    no ``affiliation`` (the institution behind the work is unrecorded) and an
+    agent nothing references at all — which is what a duplicated institution
+    looks like, one copy ROR-backed and carrying edges, the other locally minted
+    and carrying none.
+
+    Returns ``("", "")`` when the crate names no people or organisations.
+
+    Returns:
+        ``(panel html, tab badge)``.
+    """
+    from builder.writers.provenance_dag import AGENT_COVERAGE_FIELDS, render_people_svg
+
+    agents = inv["agents"]
+    if not agents:
+        return "", ""
+    counts = inv["counts"]
+    total, pid_backed, unattached = counts["total"], counts["pid_backed"], counts["unattached"]
+
+    svg = render_people_svg(inv)
+    diagram = (
+        f'<div class="prov-scroll">{svg}</div>\n  '
+        + _legend(_LG_PERSON, _LG_ORG, _LG_LINK, _LG_BREAK)
+        if svg
+        else ""
+    )
+
+    notes = []
+    if unattached:
+        loose = [a["label"] for a in agents if a["state"] == "unattached"]
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{unattached} of {total} agents are '
+            "referenced by nothing in the crate</b> "
+            f"({', '.join(loose[:4])}{'…' if len(loose) > 4 else ''}). An agent no entity "
+            "credits is usually a duplicate of one that is — the same institution minted "
+            "twice, once with its ROR and once locally. Point the crediting entity at the "
+            "identifier-backed copy and drop the other.</span></p>"
+        )
+    missing_pid = total - pid_backed
+    if missing_pid:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{missing_pid} of {total} agents carry '
+            "no persistent identifier.</b> Give each person an ORCID and each organisation a "
+            "ROR — a name string credits nobody a machine can resolve.</span></p>"
+        )
+    if not notes:
+        notes.append(
+            '<p class="good-note">Every agent is credited and identifier-backed.</p>'
+        )
+
+    ordered = sorted(
+        agents, key=lambda a: (a["state"] == "credited", a["met"], a["name"].casefold(), a["id"])
+    )
+    head = "".join(
+        f'<th scope="col" title="{html.escape(full)}">{html.escape(short)}</th>'
+        for full, short in AGENT_COVERAGE_FIELDS
+    )
+    # Every agent is listed — no cap. This view exists so a person can CHECK the
+    # attribution entity by entity, and a truncated tail is exactly where a
+    # duplicated institution or a missing-ORCID author would hide.
+    rows = []
+    for a in ordered:
+        link = " 🔗" if a["resolvable"] else ""
+        chip = _AGENT_STATE_CHIP.get(a["state"])
+        flag = (
+            ""
+            if chip is None
+            else f'<span class="chem-flag{" " + chip[0] if chip[0] else ""}" '
+            f'title="{html.escape(_AGENT_STATE_NOTE[a["state"]])}">{chip[1]}</span>'
+        )
+        kind = "Person" if a["kind"] == "person" else "Organisation"
+        cells = "".join(
+            f"<td>{_mk(_kind(a['fields'].get(full)))}</td>"
+            for full, _short in AGENT_COVERAGE_FIELDS
+        )
+        rows.append(
+            f'<tr><th scope="row">{_mk(_AGENT_STATE_MARK[a["state"]])}'
+            f'<span class="cn">{a["label"]}{link}</span>'
+            f'<span class="ty">{kind}</span>{flag}</th>{cells}</tr>'
+        )
+    matrix = (
+        '<div class="chem-tbl-scroll"><table class="chem-tbl">'
+        '<caption class="sr-only">Attribution fields carried by each agent</caption>'
+        f'<thead><tr><th scope="col">Agent</th>{head}</tr></thead>'
+        f'<tbody>{"".join(rows)}</tbody></table></div>'
+    )
+
+    panel = (
+        '<p class="prov-cap">Who the crate credits, and whether that credit resolves — '
+        f"an ORCID for a person, a ROR for an institution. <b>{counts['people']}</b> "
+        f"{'person' if counts['people'] == 1 else 'people'} · <b>{counts['orgs']}</b> "
+        f"organisation{'' if counts['orgs'] == 1 else 's'} · <b>{pid_backed}</b> "
+        "identifier-backed.</p>\n"
+        f"  {diagram}\n"
+        f"  {''.join(notes)}\n"
+        f"  {matrix}"
+    )
+    return panel, str(total)
 
 
 def build_maturity_html(
@@ -862,17 +1280,23 @@ def build_maturity_html(
     repro_ready = sum(1 for _, ok, _ in checks if ok)
 
     header = _render_header(title, accession, tiers)
+    # The chemicals inventory is shared: it feeds the KPI tile and the Chemicals
+    # graph view, and is a single cheap pass over the graph — build it once.
+    chem_inv: dict[str, Any] | None = None
+    views_section = ""
     if graph is not None:
         from builder.writers.provenance_dag import build_chemical_inventory
 
         chem_inv = build_chemical_inventory(graph)
-        chem_section = _render_chemicals_section(chem_inv)
-    else:
-        chem_inv, chem_section = None, ""
+        views_section = _render_graph_views_section(graph, chem_inv)
     kpis = _render_kpis(
-        tiers, fair, mit, repro_ready, len(checks), chem_inv if chem_section else None
+        tiers,
+        fair,
+        mit,
+        repro_ready,
+        len(checks),
+        chem_inv if chem_inv and chem_inv["chemicals"] else None,
     )
-    prov_section = _render_provenance_section(graph) if graph is not None else ""
     prof_section = _render_profile_section(val, tiers)
     fair_section = _render_fair_section(fair)
     mit_section = _render_mit_section(mit)
@@ -885,8 +1309,7 @@ def build_maturity_html(
     body = (
         header
         + kpis
-        + prov_section
-        + chem_section
+        + views_section
         + prof_section
         + fair_section
         + mit_section

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -358,10 +358,7 @@ def render_provenance_mermaid(
     Returns:
         The Mermaid source as a string.
     """
-    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
-    nodes: dict[str, dict[str, Any]] = {
-        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
-    }
+    nodes = _graph_nodes(metadata)
 
     # Collect derivation edges first; the set of touched ids defines the
     # provenance subgraph we actually draw (everything else is excluded).
@@ -474,6 +471,7 @@ _SVG_CLASS = {
     "chem": ("n-chem", "tag-chem"),
     "agent": ("n-agent", "tag-agent"),
     "org": ("n-org", "tag-org"),
+    "container": ("n-container", "tag-container"),
 }
 
 
@@ -512,6 +510,13 @@ def _svg_node_shape(cls: str, x: int, y: int, variant: str = "") -> str:
         )
         fold = f"M{x + w - f},{y} V{y + f} H{x + w} Z"
         return f'<path class="n n-data{extra}" d="{body}"/><path class="fold" d="{fold}"/>'
+    if cls == "container":  # barred block — an ISA container (Investigation/Study/Assay)
+        bar = 7
+        return (
+            f'<rect class="n n-container{extra}" x="{x}" y="{y}" width="{w}" '
+            f'height="{h}" rx="3" ry="3"/>'
+            f'<path class="bars" d="M{x + bar},{y} V{y + h} M{x + w - bar},{y} V{y + h}"/>'
+        )
     if cls == "agent":  # pill — a person (no materials share this view)
         return (
             f'<rect class="n n-agent{extra}" x="{x}" y="{y}" width="{w}" height="{h}" '
@@ -560,10 +565,7 @@ def render_provenance_svg(
         The ``<svg>…</svg>`` markup, or ``""`` when the crate records no
         derivation chain (no in-crate process input/output edges to draw).
     """
-    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
-    nodes: dict[str, dict[str, Any]] = {
-        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
-    }
+    nodes = _graph_nodes(metadata)
 
     # Directed derivation edges, both pointing "downstream": material --object-->
     # process, process --result--> data. Only edges whose endpoints are both
@@ -711,6 +713,22 @@ _AUTHOR_KEYS = (
     "http://schema.org/author",
     "http://schema.org/creator",
 )
+_CONTRIBUTOR_KEYS = (
+    "contributor",
+    "maintainer",
+    "http://schema.org/contributor",
+    "http://schema.org/maintainer",
+)
+# A Person's institution. This is the ONLY edge that reaches an affiliation-only
+# Organization: nothing else in the crate references it, so leaving it out of the
+# relation sets below reports every ROR-backed institution as an orphan while the
+# crate is in fact correct.
+_AFFILIATION_KEYS = (
+    "affiliation",
+    "memberOf",
+    "http://schema.org/affiliation",
+    "https://schema.org/affiliation",
+)
 _PROTOCOL_KEYS = ("executesLabProtocol", "https://bioschemas.org/executesLabProtocol")
 _ABOUT_GRAPH_KEYS = _ABOUT_KEYS + ("labProcesses",)
 _SAMPLETYPE_KEYS = ("sampleType",)
@@ -739,6 +757,8 @@ _PRIMARY_RELATIONS: tuple[tuple[tuple[str, ...], str, bool], ...] = (
     (_ABOUT_GRAPH_KEYS, "about", False),
     (_MENTIONS_KEYS, "mentions", False),
     (_AUTHOR_KEYS, "author", False),
+    (_CONTRIBUTOR_KEYS, "contributor", False),
+    (_AFFILIATION_KEYS, "affiliation", False),
     (_PROTOCOL_KEYS, "executes", False),
     (_SAMPLETYPE_KEYS, "sampleType", False),
 )
@@ -901,7 +921,7 @@ def build_crate_graph(
         identifier_backed, orphan}``.
     """
     graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
-    raw = {n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n}
+    raw = _graph_nodes(graph)
     root_id = _find_root_id(raw, list(graph))
 
     # In-crate nodes = everything except plumbing descriptors.
@@ -1052,10 +1072,27 @@ _CAS_RE = re.compile(r"\d{2,7}-\d{2}-\d")
 # its ``propertyID`` *and* against the compound's own ``@id``, so a crate whose
 # @id is the PubChem/CompTox page still counts as carrying that identifier even
 # when it never spells the scheme out as a PropertyValue.
-_CHEM_ID_SCHEMES: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...] = (
-    ("CAS", "CAS", ("cas", "casrn", "cas rn", "cas number", "cas registry number"), ()),
-    ("PubChem CID", "CID", ("pubchem cid", "pubchem", "cid"), ("pubchem.ncbi.nlm.nih.gov",)),
-    ("DTXSID", "DTXSID", ("dtxsid", "dsstox", "dsstox substance id"), ("comptox.epa.gov",)),
+# ``pattern`` guards the URL fallback below: a host match alone would turn ANY
+# PubChem page (a /bioassay/, a /patent/) into a "CID", inflating the
+# identification score with a value that identifies nothing.
+_CHEM_ID_SCHEMES: tuple[
+    tuple[str, str, tuple[str, ...], tuple[str, ...], "re.Pattern[str] | None"], ...
+] = (
+    ("CAS", "CAS", ("cas", "casrn", "cas rn", "cas number", "cas registry number"), (), _CAS_RE),
+    (
+        "PubChem CID",
+        "CID",
+        ("pubchem cid", "pubchem", "cid"),
+        ("pubchem.ncbi.nlm.nih.gov/compound",),
+        re.compile(r"\d+"),
+    ),
+    (
+        "DTXSID",
+        "DTXSID",
+        ("dtxsid", "dsstox", "dsstox substance id"),
+        ("comptox.epa.gov/dashboard/chemical",),
+        re.compile(r"DTXSID\w+", re.IGNORECASE),
+    ),
 )
 
 # Structure/characterisation fields carried directly on the compound. The
@@ -1092,8 +1129,21 @@ _CHEM_STRUCTURE_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
 # The coverage matrix columns: (full name, column header). Registry identifiers
 # first (they are what makes a compound orderable), then structure.
 CHEM_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = tuple(
-    (scheme, short) for scheme, short, _a, _h in _CHEM_ID_SCHEMES
+    (scheme, short) for scheme, short, *_rest in _CHEM_ID_SCHEMES
 ) + tuple((label, label) for label, _keys in _CHEM_STRUCTURE_FIELDS)
+
+# The less canonical ways an entity can still be referenced. They are scanned
+# last (a canonical route is preferred when both exist) but they MUST be scanned:
+# the panel states outright that "nothing in the crate references this compound",
+# and the topology strip a few lines below it reaches the same node over the
+# fuller `_PRIMARY_RELATIONS`/`_SECONDARY_RELATIONS` vocabulary. Omitting them
+# let the two halves of one section contradict each other.
+_EXTRA_LINK_RELATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (_OUTPUT_KEYS, "result"),
+    (_LINEAGE_KEYS, "derivesFrom"),
+    (_HASPART_KEYS, "hasPart"),
+    (_PARAM_KEYS, "parameter"),
+)
 
 # Relations by which some other entity can point AT a compound, most canonical
 # first — the order decides which route is drawn when a compound is reachable
@@ -1106,13 +1156,31 @@ _CHEM_LINK_RELATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
     (_VALUEURL_KEYS, "valueUrl"),
     (_MENTIONS_KEYS, "mentions"),
     (_INPUT_KEYS, "input"),
-    (_PARAM_KEYS, "parameter"),
-)
+) + _EXTRA_LINK_RELATIONS
 # Containment relations walked *upward* from a referrer to the entity a process
 # actually produced: a `compound` column is owned by a csvw:Schema, which is the
 # tableSchema of the condition table, which is the Exposure's result.
 _CHEM_CONTAINMENT_KEYS: tuple[tuple[str, ...], ...] = (_TABLESCHEMA_KEYS, _COLUMNS_KEYS)
 _CHEM_ANCHOR_HOPS = 3
+
+
+def _graph_nodes(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Index a serialized document by ``@id``, skipping malformed entries.
+
+    ``@id`` MUST be a string, but a hand-edited or machine-mangled crate can
+    carry a number or an object there. Indexing on it unguarded raises
+    ``TypeError`` out of the report writer, and because the report is built
+    inside ``export_crate`` that costs the crate its entire maturity report over
+    one bad node. Skipping the node degrades one row instead.
+    """
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    return {
+        n["@id"]: n
+        for n in graph
+        if isinstance(n, dict) and isinstance(n.get("@id"), str)
+    }
 
 
 def _is_chemical(node: dict[str, Any]) -> bool:
@@ -1135,7 +1203,7 @@ def _literal(node: dict[str, Any], keys: tuple[str, ...]) -> str | None:
 def _registry_identifiers(
     node: dict[str, Any],
     nodes: dict[str, Any],
-    schemes: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...],
+    schemes: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...], Any], ...],
 ) -> dict[str, str]:
     """Persistent identifiers an entity carries, as ``{scheme: value}``.
 
@@ -1150,18 +1218,35 @@ def _registry_identifiers(
 
     def _scheme_of(name: str | None, url: str | None) -> str | None:
         key = (name or "").strip().casefold().replace("_", " ")
-        for scheme, _short, aliases, hosts in schemes:
+        for scheme, _short, aliases, hosts, _pat in schemes:
             if key and key in aliases:
                 return scheme
             if url and any(host in url for host in hosts):
                 return scheme
         return None
 
+    def _from_url(url: str) -> tuple[str, str] | None:
+        """``(scheme, value)`` when *url* is a registry URL whose tail actually
+        looks like that registry's identifier."""
+        for scheme, _short, _aliases, hosts, pattern in schemes:
+            if not hosts or not any(host in url for host in hosts):
+                continue
+            tail = url.rstrip("/").rsplit("/", 1)[-1]
+            if not tail:
+                return None
+            if pattern is None:
+                return (scheme, tail)
+            match = pattern.fullmatch(tail)
+            # A host match alone is not an identifier: /bioassay/1234 lives on the
+            # PubChem host and identifies no compound.
+            return (scheme, match.group(0)) if match else None
+        return None
+
     for key in _IDENTIFIER_KEYS:
         for item in _as_list(node.get(key)):
             if not isinstance(item, dict):
                 continue
-            pv = nodes.get(item["@id"], item) if "@id" in item else item
+            pv = nodes.get(item["@id"], item) if isinstance(item.get("@id"), str) else item
             prop_id = _first(pv, _PROPERTYID_KEYS)
             if isinstance(prop_id, dict):
                 prop_id = prop_id.get("@id")
@@ -1171,15 +1256,19 @@ def _registry_identifiers(
             value = _literal(pv, _VALUE_KEYS)
             if scheme and value and scheme not in found:
                 found[scheme] = value
+                continue
+            # The identifier node may BE the registry URL (an ORCID or a ROR
+            # given as {"@id": "https://orcid.org/…"}) with no separate value.
+            own = pv.get("@id")
+            if isinstance(own, str) and (hit := _from_url(own)) and hit[0] not in found:
+                found[hit[0]] = hit[1]
 
-    nid = str(node.get("@id", ""))
-    for scheme, _short, _aliases, hosts in schemes:
-        if scheme in found or not hosts:
+    for candidate in (_literal(node, _URL_KEYS), node.get("@id")):
+        if not isinstance(candidate, str):
             continue
-        if any(host in nid for host in hosts):
-            tail = nid.rstrip("/").rsplit("/", 1)[-1]
-            if tail:
-                found[scheme] = tail
+        hit = _from_url(candidate)
+        if hit and hit[0] not in found:
+            found[hit[0]] = hit[1]
     return found
 
 
@@ -1200,27 +1289,155 @@ def _chem_identifiers(node: dict[str, Any], nodes: dict[str, Any]) -> dict[str, 
     return found
 
 
-def _chem_referrers(
-    nodes: dict[str, Any], chem_ids: set[str]
+def _referrers_to(
+    nodes: dict[str, Any],
+    member_ids: set[str],
+    relations: tuple[tuple[tuple[str, ...], str], ...],
 ) -> dict[str, list[tuple[str, str]]]:
-    """``chemical id -> [(referrer id, relation label)]``, deterministically ordered.
+    """``member id -> [(referrer id, relation label)]``, deterministically ordered.
 
-    Compound→compound references are ignored: they are not a route into the
+    References *between* members are ignored: they are not a route into the
     experiment, and counting them would let a cluster of mutually-referencing
-    compounds mask the fact that none of them reaches a process.
+    entities mask the fact that none of them reaches a process.
     """
-    order = {label: i for i, (_keys, label) in enumerate(_CHEM_LINK_RELATIONS)}
+    order = {label: i for i, (_keys, label) in enumerate(relations)}
     out: dict[str, set[tuple[str, str]]] = {}
     for nid, node in nodes.items():
-        if nid in chem_ids or str(nid).rsplit("/", 1)[-1] in _EXCLUDED_IDS:
+        if nid in member_ids or str(nid).rsplit("/", 1)[-1] in _EXCLUDED_IDS:
             continue
-        for keys, label in _CHEM_LINK_RELATIONS:
+        for keys, label in relations:
             for ref in _refs(node, keys):
-                if ref in chem_ids:
+                if ref in member_ids:
                     out.setdefault(ref, set()).add((nid, label))
+    return {mid: sorted(pairs, key=lambda p: (order[p[1]], p[0])) for mid, pairs in out.items()}
+
+
+def _route_resolver(
+    nodes: dict[str, Any],
+    member_ids: set[str],
+    relations: tuple[tuple[tuple[str, ...], str], ...],
+) -> Any:
+    """Build ``resolve(member_id) -> route | None`` for a routed inventory.
+
+    A *route* is how a reader gets from a ``LabProcess`` to the entity:
+    ``{process, via, link, edge}``. Some referrers are not themselves produced by
+    a process — a CSVW column is owned by a schema which is the ``tableSchema`` of
+    the table a process actually produced — so the referrer is walked up the
+    containment chain to the nearest process-produced ancestor before giving up.
+
+    ``process`` is ``None`` when the entity is referenced in-crate but by nothing
+    a process produced; the whole route is ``None`` when nothing references it.
+    """
+    referrers = _referrers_to(nodes, member_ids, relations)
+
+    producers: dict[str, list[str]] = {}
+    parents: dict[str, list[str]] = {}
+    for nid, node in nodes.items():
+        if _is_process(node):
+            for dst in _refs(node, _OUTPUT_KEYS):
+                producers.setdefault(dst, []).append(nid)
+        for keys in _CHEM_CONTAINMENT_KEYS:
+            for ref in _refs(node, keys):
+                parents.setdefault(ref, []).append(nid)
+
+    def _anchor_of(ref_id: str) -> str | None:
+        """Nearest ancestor of *ref_id* (itself included) that a process produced."""
+        seen: set[str] = set()
+        frontier = [ref_id]
+        for _ in range(_CHEM_ANCHOR_HOPS + 1):
+            nxt: list[str] = []
+            for cur in frontier:
+                if cur in seen:
+                    continue
+                seen.add(cur)
+                if cur in producers:
+                    return cur
+                nxt.extend(parents.get(cur, ()))
+            if not nxt:
+                break
+            frontier = sorted(nxt)
+        return None
+
+    def _resolve(mid: str) -> dict[str, Any] | None:
+        fallback: dict[str, Any] | None = None
+        for rid, label in referrers.get(mid, []):
+            if _is_process(nodes[rid]):
+                return {"process": rid, "via": rid, "link": rid, "edge": label}
+            anchor = _anchor_of(rid)
+            if anchor is not None:
+                return {
+                    "process": sorted(producers[anchor])[0],
+                    "via": anchor,
+                    "link": rid,
+                    "edge": label,
+                }
+            if fallback is None:
+                fallback = {"process": None, "via": rid, "link": rid, "edge": label}
+        return fallback
+
+    return _resolve
+
+
+_ROUTE_STATE_ORDER = {"wired": 0, "mentioned": 1, "unlinked": 2}
+
+
+def _route_state(route: dict[str, Any] | None) -> str:
+    if route is None:
+        return "unlinked"
+    return "wired" if route["process"] else "mentioned"
+
+
+def _route_bands(
+    members: list[dict[str, Any]], nodes: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Group routed members into the diagram's bands.
+
+    Members sharing a ``(process, via)`` pair travel together — the relation is
+    *not* part of the key, so a table that reaches some of its members by
+    ``about`` and others by the column's ``valueUrl`` still draws one band; the
+    band's edge label then names both mechanisms rather than the diagram
+    repeating the same process and table twice.
+    """
+    banded: dict[tuple[str, str | None, str | None], list[dict[str, Any]]] = {}
+    for member in members:
+        route = member["route"] or {}
+        banded.setdefault(
+            (member["state"], route.get("process"), route.get("via")), []
+        ).append(member)
+    return [
+        {
+            "state": state,
+            "edge": " · ".join(sorted({m["route"]["edge"] for m in group if m["route"]})),
+            "process": _chem_node_brief(proc, nodes[proc]) if proc else None,
+            "via": _chem_node_brief(via, nodes[via]) if via else None,
+            "members": group,
+        }
+        for (state, proc, via), group in sorted(
+            banded.items(),
+            key=lambda kv: (_ROUTE_STATE_ORDER[kv[0][0]], kv[0][1] or "", kv[0][2] or ""),
+        )
+    ]
+
+
+def _route_counts(members: list[dict[str, Any]]) -> dict[str, int]:
     return {
-        cid: sorted(pairs, key=lambda p: (order[p[1]], p[0])) for cid, pairs in out.items()
+        "total": len(members),
+        "wired": sum(1 for m in members if m["state"] == "wired"),
+        "mentioned": sum(1 for m in members if m["state"] == "mentioned"),
+        "unlinked": sum(1 for m in members if m["state"] == "unlinked"),
+        "fields_met": sum(m["met"] for m in members),
+        "fields_total": sum(m["total"] for m in members),
     }
+
+
+_EMPTY_ROUTE_COUNTS = {
+    "total": 0,
+    "wired": 0,
+    "mentioned": 0,
+    "unlinked": 0,
+    "fields_met": 0,
+    "fields_total": 0,
+}
 
 
 def _chem_node_brief(nid: str, node: dict[str, Any]) -> dict[str, str]:
@@ -1267,84 +1484,24 @@ def build_chemical_inventory(
         carries ``total`` / ``wired`` / ``mentioned`` / ``unlinked`` plus
         ``fields_met`` / ``fields_total`` for the identification coverage.
     """
-    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
-    nodes: dict[str, dict[str, Any]] = {
-        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
-    }
+    nodes = _graph_nodes(metadata)
     chem_ids = {nid for nid, n in nodes.items() if _is_chemical(n)}
-    empty_counts = {
-        "total": 0,
-        "wired": 0,
-        "mentioned": 0,
-        "unlinked": 0,
-        "fields_met": 0,
-        "fields_total": 0,
-    }
     if not chem_ids:
-        return {"chemicals": [], "groups": [], "counts": empty_counts}
+        return {"chemicals": [], "groups": [], "counts": dict(_EMPTY_ROUTE_COUNTS)}
 
-    referrers = _chem_referrers(nodes, chem_ids)
-
-    # Which process produced a given entity, and the CSVW containment chain used
-    # to walk a referrer up to such an entity.
-    producers: dict[str, list[str]] = {}
-    parents: dict[str, list[str]] = {}
-    for nid, node in nodes.items():
-        if _is_process(node):
-            for dst in _refs(node, _OUTPUT_KEYS):
-                producers.setdefault(dst, []).append(nid)
-        for keys in _CHEM_CONTAINMENT_KEYS:
-            for ref in _refs(node, keys):
-                parents.setdefault(ref, []).append(nid)
-
-    def _anchor_of(ref_id: str) -> str | None:
-        """Nearest ancestor of *ref_id* (itself included) that a process produced."""
-        seen: set[str] = set()
-        frontier = [ref_id]
-        for _ in range(_CHEM_ANCHOR_HOPS + 1):
-            nxt: list[str] = []
-            for cur in frontier:
-                if cur in seen:
-                    continue
-                seen.add(cur)
-                if cur in producers:
-                    return cur
-                nxt.extend(parents.get(cur, ()))
-            if not nxt:
-                break
-            frontier = sorted(nxt)
-        return None
-
-    def _route_of(cid: str) -> dict[str, Any] | None:
-        """The best route into *cid*: process-backed if one exists, else the first
-        in-crate referrer (a compound that is named but produced by nothing)."""
-        fallback: dict[str, Any] | None = None
-        for rid, label in referrers.get(cid, []):
-            if _is_process(nodes[rid]):
-                return {"process": rid, "via": rid, "link": rid, "edge": label}
-            anchor = _anchor_of(rid)
-            if anchor is not None:
-                return {
-                    "process": sorted(producers[anchor])[0],
-                    "via": anchor,
-                    "link": rid,
-                    "edge": label,
-                }
-            if fallback is None:
-                fallback = {"process": None, "via": rid, "link": rid, "edge": label}
-        return fallback
+    resolve = _route_resolver(nodes, chem_ids, _CHEM_LINK_RELATIONS)
 
     chemicals: list[dict[str, Any]] = []
     for cid in sorted(chem_ids, key=lambda c: (_name(nodes[c]).casefold(), c)):
         node = nodes[cid]
         ids = _chem_identifiers(node, nodes)
-        structure = {
-            label: _literal(node, keys) is not None for label, keys in _CHEM_STRUCTURE_FIELDS
+        fields: dict[str, bool] = {
+            scheme: scheme in ids for scheme, *_rest in _CHEM_ID_SCHEMES
         }
-        fields = {scheme: scheme in ids for scheme, _s, _a, _h in _CHEM_ID_SCHEMES}
-        fields.update(structure)
-        route = _route_of(cid)
-        state = "unlinked" if route is None else ("wired" if route["process"] else "mentioned")
+        fields.update(
+            {label: _literal(node, keys) is not None for label, keys in _CHEM_STRUCTURE_FIELDS}
+        )
+        route = resolve(cid)
         chemicals.append(
             {
                 **_chem_node_brief(cid, node),
@@ -1353,47 +1510,196 @@ def build_chemical_inventory(
                 "fields": fields,
                 "met": sum(1 for ok in fields.values() if ok),
                 "total": len(fields),
-                "state": state,
+                "state": _route_state(route),
                 "route": route,
             }
         )
 
-    # Diagram bands: compounds sharing a (process, via) pair travel together —
-    # the relation is *not* part of the key, so a table that reaches some of its
-    # compounds by `about` and others by the column's `valueUrl` still draws one
-    # band; the band's edge label then names both mechanisms rather than the
-    # diagram repeating the same process and table twice.
-    order = {"wired": 0, "mentioned": 1, "unlinked": 2}
-    banded: dict[tuple[str, str | None, str | None], list[dict[str, Any]]] = {}
-    for chem in chemicals:
-        route = chem["route"] or {}
-        banded.setdefault(
-            (chem["state"], route.get("process"), route.get("via")), []
-        ).append(chem)
-    groups = [
-        {
-            "state": state,
-            "edge": " · ".join(
-                sorted({c["route"]["edge"] for c in members if c["route"]})
-            ),
-            "process": _chem_node_brief(proc, nodes[proc]) if proc else None,
-            "via": _chem_node_brief(via, nodes[via]) if via else None,
-            "chemicals": members,
-        }
-        for (state, proc, via), members in sorted(
-            banded.items(), key=lambda kv: (order[kv[0][0]], kv[0][1] or "", kv[0][2] or "")
-        )
-    ]
-
-    counts = {
-        "total": len(chemicals),
-        "wired": sum(1 for c in chemicals if c["state"] == "wired"),
-        "mentioned": sum(1 for c in chemicals if c["state"] == "mentioned"),
-        "unlinked": sum(1 for c in chemicals if c["state"] == "unlinked"),
-        "fields_met": sum(c["met"] for c in chemicals),
-        "fields_total": sum(c["total"] for c in chemicals),
+    return {
+        "chemicals": chemicals,
+        "groups": _route_bands(chemicals, nodes),
+        "counts": _route_counts(chemicals),
     }
-    return {"chemicals": chemicals, "groups": groups, "counts": counts}
+
+
+# ---------------------------------------------------------------------------
+# Cell lines (#85) — the biological test system, and whether it is pinned down.
+#
+# A cell line is the other half of "what was tested", and it fails the same two
+# ways a compound does. It is *unreachable* when the CellCulture consumes a
+# freshly minted generic Sample instead of the declared CellLineSample — the line
+# is then described in the crate and used by nothing, exactly the shape the
+# compound view exposes. And it is *unidentified* when it carries a name but no
+# Cellosaurus RRID: "CHO-K1" names a family of divergent stocks, RRID CVCL_0214
+# names one, and passage/organ/tissue are what let another lab reproduce the
+# culture rather than merely recognise it.
+# ---------------------------------------------------------------------------
+
+_CELLLINE_TYPES = frozenset({"CellLine", "CellLineSample"})
+_CELL_LINE_TERM_HINT = "cell line"
+
+# Cellosaurus accessions, with or without the RRID: prefix (RRID:CVCL_0214).
+_RRID_RE = re.compile(r"(?:RRID[:\s]*)?CVCL[_:][A-Z0-9]+", re.IGNORECASE)
+
+_ADDPROP_KEYS: tuple[str, ...] = (
+    "additionalProperty",
+    "http://schema.org/additionalProperty",
+    "https://schema.org/additionalProperty",
+)
+_URL_KEYS: tuple[str, ...] = ("url", "http://schema.org/url", "https://schema.org/url")
+
+# ISA Sample Characteristics that make a culture reproducible, matched
+# case-folded against each additionalProperty PropertyValue's ``name`` (the
+# shape ``_crate_mapping._CELL_LINE_CHARACTERISTICS`` mints).
+_CELLLINE_CHARACTERISTICS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Organ", ("organ",)),
+    ("Tissue", ("tissue",)),
+    ("Passage", ("passage", "passage number")),
+)
+
+CELLLINE_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Cellosaurus RRID", "RRID"),
+    ("Typed as a cell line", "Type"),
+) + tuple((label, label) for label, _keys in _CELLLINE_CHARACTERISTICS)
+
+# How something can point at a cell line. ``input`` is canonical and first: the
+# CellCulture consumes the line (``_INPUT_KEYS`` already covers the ``cell_line``
+# alias). ``derivesFrom`` catches the cultured Sample that descends from it, and
+# ``mentions`` the Study-level ``cell_lines``/``biologicalModels`` alias.
+_CELLLINE_LINK_RELATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (_INPUT_KEYS, "input"),
+    (_ABOUT_KEYS, "about"),
+    (_VALUEURL_KEYS, "valueUrl"),
+    (_MENTIONS_KEYS, "mentions"),
+) + _EXTRA_LINK_RELATIONS
+
+
+def _is_cellline(node: dict[str, Any], nodes: dict[str, Any]) -> bool:
+    """True for a cell-line entity.
+
+    Accepts the canonical ISA-Tox shape (a ``Sample`` with
+    ``additionalType: CellLine``), a bare ``CellLine`` type, and a ``Sample``
+    whose ``sampleType`` resolves to the shared "cell line" ``DefinedTerm`` —
+    the last so a crate that types its line only by term still appears.
+    """
+    if _types(node) & _CELLLINE_TYPES or _additional_type(node) in _CELLLINE_TYPES:
+        return True
+    if "Sample" not in _types(node):
+        return False
+    return any(
+        _CELL_LINE_TERM_HINT in (_literal(nodes[ref], _NAME_KEYS) or "").casefold()
+        for ref in _refs(node, _SAMPLETYPE_KEYS)
+        if ref in nodes
+    )
+
+
+def _cellline_rrid(node: dict[str, Any], nodes: dict[str, Any]) -> str | None:
+    """The Cellosaurus accession, from an ``identifier``, a ``url`` or the ``@id``."""
+    candidates: list[str] = []
+    for key in _IDENTIFIER_KEYS:
+        for item in _as_list(node.get(key)):
+            if isinstance(item, str):
+                candidates.append(item)
+            elif isinstance(item, dict):
+                pv = nodes.get(item["@id"], item) if "@id" in item else item
+                candidates.extend(
+                    v for v in (_literal(pv, _VALUE_KEYS), pv.get("@id")) if isinstance(v, str)
+                )
+    candidates.extend(
+        v for v in (_literal(node, _URL_KEYS), node.get("@id")) if isinstance(v, str)
+    )
+    for cand in candidates:
+        match = _RRID_RE.search(cand)
+        if match:
+            return match.group(0)
+    return None
+
+
+def _cellline_characteristics(node: dict[str, Any], nodes: dict[str, Any]) -> dict[str, bool]:
+    """Which reproducibility characteristics (organ / tissue / passage) are recorded.
+
+    Read from the ISA ``additionalProperty`` PropertyValues the builder mints,
+    falling back to a bare literal on the entity so an externally-authored crate
+    that never promoted them still scores.
+    """
+    present: set[str] = set()
+    for key in _ADDPROP_KEYS:
+        for item in _as_list(node.get(key)):
+            if not isinstance(item, dict):
+                continue
+            pv = nodes.get(item["@id"], item) if "@id" in item else item
+            if not isinstance(pv, dict) or _literal(pv, _VALUE_KEYS) is None:
+                continue
+            name = (_literal(pv, _NAME_KEYS) or "").strip().casefold()
+            for label, aliases in _CELLLINE_CHARACTERISTICS:
+                if name in aliases:
+                    present.add(label)
+    for label, aliases in _CELLLINE_CHARACTERISTICS:
+        if label not in present and _literal(node, aliases) is not None:
+            present.add(label)
+    return {label: label in present for label, _aliases in _CELLLINE_CHARACTERISTICS}
+
+
+def build_cellline_inventory(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Model the crate's cell lines: their route into the experiment + their identity.
+
+    Resolves, for every cell-line entity, how it is reachable from a
+    ``LabProcess`` — canonically the ``CellCulture`` that consumes it as
+    ``input``/``cell_line``, or the cultured ``Sample`` that ``derivesFrom`` it —
+    and whether it carries a Cellosaurus RRID, an ontology-backed ``sampleType``,
+    and the organ / tissue / passage characteristics another lab needs to
+    reproduce the culture.
+
+    Pure and cheap: one pass over the serialized ``@graph``, no validation and no
+    network. Crate-controlled text is HTML-escaped in ``label`` (#169).
+
+    Returns:
+        ``{"celllines": [...], "groups": [...], "counts": {...}}``, shaped exactly
+        like :func:`build_chemical_inventory` so both feed the same renderer —
+        ``state`` is ``"wired"`` / ``"mentioned"`` / ``"unlinked"``.
+    """
+    nodes = _graph_nodes(metadata)
+    line_ids = {nid for nid, n in nodes.items() if _is_cellline(n, nodes)}
+    if not line_ids:
+        return {"celllines": [], "groups": [], "counts": dict(_EMPTY_ROUTE_COUNTS)}
+
+    resolve = _route_resolver(nodes, line_ids, _CELLLINE_LINK_RELATIONS)
+
+    lines: list[dict[str, Any]] = []
+    for lid in sorted(line_ids, key=lambda c: (_name(nodes[c]).casefold(), c)):
+        node = nodes[lid]
+        rrid = _cellline_rrid(node, nodes)
+        typed = bool(
+            _additional_type(node) in _CELLLINE_TYPES
+            or _types(node) & _CELLLINE_TYPES
+            or any(ref in nodes for ref in _refs(node, _SAMPLETYPE_KEYS))
+        )
+        fields: dict[str, bool] = {
+            "Cellosaurus RRID": rrid is not None,
+            "Typed as a cell line": typed,
+        }
+        fields.update(_cellline_characteristics(node, nodes))
+        route = resolve(lid)
+        lines.append(
+            {
+                **_chem_node_brief(lid, node),
+                "resolvable": _is_uri(lid),
+                "rrid": rrid,
+                "fields": fields,
+                "met": sum(1 for ok in fields.values() if ok),
+                "total": len(fields),
+                "state": _route_state(route),
+                "route": route,
+            }
+        )
+
+    return {
+        "celllines": lines,
+        "groups": _route_bands(lines, nodes),
+        "counts": _route_counts(lines),
+    }
 
 
 # --- chemicals diagram -----------------------------------------------------
@@ -1410,20 +1716,30 @@ _CHEM_BAND_GAP = 26
 # inter-column gap (_CHEM_COL_DX - _SVG_NODE_W = 44px), or a stub drawn next to a
 # populated column lands on top of that column's node.
 _CHEM_BREAK_DX = 30
-# Named compounds drawn per band before the tail is folded into one aggregate
-# node. A band of exactly _CHEM_MAX_NODES is drawn in full — aggregating a single
-# compound into "1 more" would cost a row and tell the reader less.
-_CHEM_MAX_NAMED = 3
-_CHEM_MAX_NODES = 4
+# Every compound in a band is drawn by name (see _band_nodes). The former
+# 3-named-plus-aggregate cap is gone: it hid exactly the detail the band exists
+# to show.
+
+# Arrowhead element ids — one per diagram (see _svg_link).
+_CHEM_MARKER = "chem-ar-link"
+_CELLLINE_MARKER = "cell-ar-link"
+_ISA_MARKER = "isa-ar-link"
+_PEOPLE_MARKER = "people-ar-link"
 
 
 def _band_nodes(members: list[dict[str, Any]]) -> list[dict[str, Any] | None]:
-    """The entries drawn for one band: each member, or a named head then ``None``
-    standing for "and N more" — the diagram answers *how do these connect*, and a
-    long verbatim list is the matrix's job, not the picture's."""
-    if len(members) <= _CHEM_MAX_NODES:
-        return list(members)
-    return [*members[:_CHEM_MAX_NAMED], None]
+    """The entries drawn for one band: **every** member, named.
+
+    This used to draw a head of :data:`_CHEM_MAX_NAMED` and fold the tail into a
+    single "and N more" node, on the reasoning that the diagram answers *how do
+    these connect* and a verbatim list is the matrix's job. In practice the
+    aggregate hid the thing the picture is for: a crate with 22 compounds
+    rendered as "3 named + 19 more", so which compounds were unwired — all of
+    them, as it turned out — could not be read off the diagram at all. The band
+    grows a row per compound; the SVG canvas is sized from the accumulated band
+    height, so it scales with the list.
+    """
+    return list(members)
 
 
 def _svg_place(
@@ -1448,12 +1764,21 @@ def _svg_place(
     )
 
 
-def _svg_link(out: list[str], x1: int, y1: int, x2: int, y2: int, label: str = "") -> None:
-    """Append a labelled bezier edge between two node edges."""
+def _svg_link(
+    out: list[str], x1: int, y1: int, x2: int, y2: int, label: str = "", *, marker: str
+) -> None:
+    """Append a labelled bezier edge between two node edges.
+
+    ``marker`` is the arrowhead's element id, which every diagram must namespace
+    for itself: several of these SVGs share one HTML document, ``url(#…)``
+    resolves to the first matching id in that document, and the panels that hold
+    them are ``display:none`` until their tab is selected — so a shared id points
+    the arrowheads of one diagram at a marker inside a hidden subtree.
+    """
     dx = (x2 - x1) // 2 if y1 == y2 else max((x2 - x1) // 2, 30)
     out.append(
         f'<path class="e e-link" d="M{x1},{y1} C{x1 + dx},{y1} {x2 - dx},{y2} {x2},{y2}" '
-        'marker-end="url(#view-ar-link)"/>'
+        f'marker-end="url(#{marker})"/>'
     )
     if label:
         out.append(
@@ -1481,20 +1806,23 @@ def _svg_break(out: list[str], x_end: int, y: int, *, leading: bool = True) -> N
         )
 
 
-_VIEW_MARKER = (
-    '<marker id="view-ar-link" viewBox="0 0 10 10" refX="9" refY="5" '
-    'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
-    '<path d="M0,0 L10,5 L0,10 z" class="mk-link"/></marker>'
-)
-
-
-def _svg_document(body_edges: list[str], body_nodes: list[str], w: int, h: int, aria: str) -> str:
+def _svg_document(
+    body_edges: list[str],
+    body_nodes: list[str],
+    w: int,
+    h: int,
+    aria: str,
+    *,
+    marker: str,
+) -> str:
     """Wrap drawn edges/nodes in the finished, self-contained ``<svg>`` element."""
     return (
         f'<svg viewBox="0 0 {w} {h}" width="{w}" height="{h}" '
         f'role="img" aria-label="{_escape(aria)}" class="prov view">'
         f"<title>{_escape(aria)}</title>"
-        f"<defs>{_VIEW_MARKER}</defs>"
+        f'<defs><marker id="{marker}" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+        '<path d="M0,0 L10,5 L0,10 z" class="mk-link"/></marker></defs>'
         f'<g class="edges">{"".join(body_edges)}</g>'
         f'<g class="nodes">{"".join(body_nodes)}</g></svg>'
     )
@@ -1521,16 +1849,80 @@ def render_chemicals_svg(inventory: dict[str, Any]) -> str:
         The ``<svg>…</svg>`` markup, or ``""`` when the crate declares no
         compounds.
     """
+    return _render_routed_svg(
+        inventory,
+        node_cls="chem",
+        more_tag="MolecularEntity",
+        noun="compounds",
+        marker=_CHEM_MARKER,
+    )
+
+
+def render_celllines_svg(inventory: dict[str, Any]) -> str:
+    """Draw the cell-line routes as a self-contained inline ``<svg>``.
+
+    Same bands as the compound view, because the failure is the same: the
+    canonical route is ``CellCulture --input--> cell line`` (or the cultured
+    ``Sample --derivesFrom--> cell line``), and when the culture consumes a
+    freshly minted generic Sample instead, the declared line is left with no
+    inbound edge at all.
+
+    Args:
+        inventory: The result of :func:`build_cellline_inventory`.
+
+    Returns:
+        The ``<svg>…</svg>`` markup, or ``""`` when the crate declares no lines.
+    """
+    return _render_routed_svg(
+        inventory,
+        # A cell line IS a Sample, so it reuses the derivation chain's material
+        # stadium — the same entity keeps the same shape across every view.
+        node_cls="mat",
+        more_tag="Sample · CellLine",
+        noun="cell lines",
+        marker=_CELLLINE_MARKER,
+    )
+
+
+def _render_routed_svg(
+    inventory: dict[str, Any],
+    *,
+    node_cls: str,
+    more_tag: str,
+    noun: str,
+    marker: str,
+) -> str:
+    """Draw a routed inventory's bands: ``process → via → members``.
+
+    Shared by the compound and cell-line views — both answer "can a reader get
+    from a process to this entity", and drawing them identically is the point:
+    a break in one reads exactly like a break in the other.
+    """
     groups = inventory.get("groups") or []
     if not groups:
         return ""
 
-    # Drop the leading columns no band uses, so a crate whose compounds are all
+    def _hops(group: dict[str, Any]) -> list[dict[str, str]]:
+        """The band's left-hand nodes, rightmost last.
+
+        Two hops for the indirect route a compound takes
+        (``process --result--> table --about--> compound``); one when a process
+        references the member itself (a ``CellCulture`` consuming its cell line)
+        — drawing that process in both columns with a ``result`` edge between
+        them would depict a step the crate does not contain.
+        """
+        process, via = group["process"], group["via"]
+        if via is None:
+            return []
+        if process is not None and process["id"] != via["id"]:
+            return [process, via]
+        return [via]
+
+    # Drop the leading columns no band uses, so a crate whose members are all
     # unlinked doesn't render a diagram that is mostly empty gutter. The reserved
     # pad keeps room for the dashed ✗ stub once a left column is gone.
-    has_proc = any(g["process"] for g in groups)
-    has_via = any(g["via"] for g in groups)
-    first_col = 0 if has_proc else (1 if has_via else 2)
+    widest = max((len(_hops(g)) for g in groups), default=0)
+    first_col = 2 - widest
     x0 = _CHEM_X0 + (_CHEM_BREAK_DX + 10 if first_col else 0)
     col_x = [x0 + (i - first_col) * _CHEM_COL_DX for i in range(3)]
 
@@ -1540,24 +1932,23 @@ def render_chemicals_svg(inventory: dict[str, Any]) -> str:
     band_y = _CHEM_Y0
 
     for group in groups:
-        members = group["chemicals"]
+        members = group["members"]
         drawn = _band_nodes(members)
         span = (len(drawn) - 1) * _CHEM_ROW_DY
         centre_y = band_y + span // 2
         variant = "" if group["state"] == "wired" else "unwired"
 
-        for i, chem in enumerate(drawn):
+        for i, member in enumerate(drawn):
             y = band_y + i * _CHEM_ROW_DY
+            # ``None`` (the old "and N more" aggregate) is no longer produced by
+            # _band_nodes; the branch stays so a caller that reintroduces a cap
+            # still renders rather than crashing on a missing key.
             brief = (
-                {
-                    "id": "",
-                    "name": f"{len(members) - _CHEM_MAX_NAMED} more",
-                    "tag": "MolecularEntity",
-                }
-                if chem is None
-                else {"id": chem["id"], "name": chem["name"], "tag": chem["tag"]}
+                {"id": "", "name": "more", "tag": more_tag}
+                if member is None
+                else {"id": member["id"], "name": member["name"], "tag": member["tag"]}
             )
-            _svg_place(nodes_svg, brief, "chem", col_x[2], y, variant)
+            _svg_place(nodes_svg, brief, node_cls, col_x[2], y, variant)
             if group["via"] is not None:
                 _svg_link(
                     edges,
@@ -1566,22 +1957,23 @@ def render_chemicals_svg(inventory: dict[str, Any]) -> str:
                     col_x[2],
                     y + mid,
                     group["edge"] if i == 0 else "",
+                    marker=marker,
                 )
-            else:  # nothing in the crate points at these compounds at all
+            else:  # nothing in the crate points at these entities at all
                 _svg_break(edges, col_x[2], y + mid)
 
-        if group["via"] is not None:
-            _svg_place(
-                nodes_svg, group["via"], _node_class_for_brief(group["via"]), col_x[1], centre_y
-            )
-            if group["process"] is not None:
+        hops = _hops(group)
+        for offset, hop in enumerate(reversed(hops)):  # rightmost hop first
+            col = 1 - offset
+            _svg_place(nodes_svg, hop, _node_class_for_brief(hop), col_x[col], centre_y)
+            if offset:  # link this hop to the one on its right
                 _svg_link(
-                    edges, col_x[0] + _SVG_NODE_W, centre_y + mid, col_x[1], centre_y + mid,
-                    "result",
+                    edges, col_x[col] + _SVG_NODE_W, centre_y + mid, col_x[col + 1],
+                    centre_y + mid, "result", marker=marker,
                 )
-                _svg_place(nodes_svg, group["process"], "proc", col_x[0], centre_y)
-            else:  # named in the crate, but produced by no process
-                _svg_break(edges, col_x[1], centre_y + mid)
+        if hops and group["process"] is None:
+            # Named in the crate, but produced by no process.
+            _svg_break(edges, col_x[2 - len(hops)], centre_y + mid)
 
         band_y += span + _SVG_NODE_H + _CHEM_BAND_GAP
 
@@ -1591,8 +1983,9 @@ def render_chemicals_svg(inventory: dict[str, Any]) -> str:
         nodes_svg,
         col_x[2] + _SVG_NODE_W + 16,
         band_y - _CHEM_BAND_GAP + 18,
-        f"Compound routes: {counts.get('wired', 0)} of {counts.get('total', 0)} "
-        "compounds reachable from a process",
+        f"Routes: {counts.get('wired', 0)} of {counts.get('total', 0)} {noun} "
+        "reachable from a process",
+        marker=marker,
     )
 
 
@@ -1628,20 +2021,21 @@ _ORG_TYPES = frozenset(
     }
 )
 
-_AFFILIATION_KEYS: tuple[str, ...] = (
-    "affiliation",
-    "memberOf",
-    "http://schema.org/affiliation",
-    "https://schema.org/affiliation",
-)
-
 # Persistent-identifier schemes for agents, resolved the same way compounds are
 # (PropertyValue name / propertyID host / the entity's own @id).
-_AGENT_ID_SCHEMES: tuple[tuple[str, str, tuple[str, ...], tuple[str, ...]], ...] = (
-    ("ORCID", "ORCID", ("orcid", "orcid id", "orcid.org"), ("orcid.org",)),
-    ("ROR", "ROR", ("ror", "ror id"), ("ror.org",)),
-    ("ISNI", "ISNI", ("isni",), ("isni.org",)),
-    ("GRID", "GRID", ("grid", "grid id"), ("grid.ac",)),
+_AGENT_ID_SCHEMES: tuple[
+    tuple[str, str, tuple[str, ...], tuple[str, ...], "re.Pattern[str] | None"], ...
+] = (
+    (
+        "ORCID",
+        "ORCID",
+        ("orcid", "orcid id", "orcid.org"),
+        ("orcid.org/",),
+        re.compile(r"\d{4}-\d{4}-\d{4}-\d{3}[\dXx]"),
+    ),
+    ("ROR", "ROR", ("ror", "ror id"), ("ror.org/",), re.compile(r"0[0-9a-z]{6}[0-9]{2}")),
+    ("ISNI", "ISNI", ("isni",), ("isni.org/isni/",), re.compile(r"[\d ]{15,20}[\dXx]")),
+    ("GRID", "GRID", ("grid", "grid id"), ("grid.ac/institutes/",), re.compile(r"grid\.\d+\.\w+")),
 )
 # Which of those count as "identified" for each kind, most preferred first.
 _PID_FOR_KIND: dict[str, tuple[str, ...]] = {
@@ -1672,7 +2066,10 @@ AGENT_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = (
     ("Persistent identifier", "PID"),
     ("Name", "Name"),
     ("Affiliation", "Affiliation"),
-    ("Credited in crate", "Credited"),
+    # "Linked", not "Credited": an organisation is normally reached through a
+    # person's affiliation rather than credited directly, and that is a correct
+    # crate — the column asks whether anything connects the agent at all.
+    ("Linked in crate", "Linked"),
 )
 
 
@@ -1710,7 +2107,7 @@ def build_people_inventory(
         ``{"agents": [...], "groups": [...], "counts": {...}}``.
 
         Each agent: ``{id, name, label, tag, kind, pid, pid_scheme, resolvable,
-        affiliation, fields, met, total, state}`` where ``state`` is
+        affiliations, fields, met, total, state}`` where ``state`` is
         ``"credited"`` (something in the crate credits it), ``"affiliated"`` (an
         organisation reached only through a person's affiliation) or
         ``"unattached"`` (nothing references it — the duplicate-institution
@@ -1720,9 +2117,7 @@ def build_people_inventory(
         credits, and those people's organisations.
     """
     graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
-    nodes: dict[str, dict[str, Any]] = {
-        n["@id"]: n for n in graph if isinstance(n, dict) and "@id" in n
-    }
+    nodes = _graph_nodes(metadata)
     kinds = {nid: _agent_kind(n) for nid, n in nodes.items()}
     agent_ids = {nid for nid, kind in kinds.items() if kind}
     empty_counts = {
@@ -1738,7 +2133,7 @@ def build_people_inventory(
     if not agent_ids:
         return {"agents": [], "groups": [], "counts": empty_counts}
 
-    root_id = _find_root_id(nodes, list(graph))
+    root_id = _find_root_id(nodes, [n for n in graph if isinstance(n, dict)])
 
     # Who credits whom. An agent crediting another agent (a ScholarlyArticle's
     # author list is fine, but Person --author--> Person is not attribution)
@@ -1753,17 +2148,20 @@ def build_people_inventory(
                 if ref in agent_ids and ref != nid:
                     credits.setdefault(ref, set()).add((nid, label))
 
-    # Person → organisation, and its inverse over the drawn subgraph.
-    affiliation: dict[str, str] = {}
+    # Person → organisation(s), and the inverse. EVERY affiliation is recorded,
+    # not just the first: a co-affiliated researcher is ordinary, and stopping at
+    # one leaves the second institution referenced by nothing — which this view
+    # then reports as an unattached duplicate and advises the reader to delete.
+    affiliation: dict[str, list[str]] = {}
     affiliates: dict[str, list[str]] = {}
     for nid in sorted(agent_ids):
         if kinds[nid] != "person":
             continue
-        for ref in _refs(nodes[nid], _AFFILIATION_KEYS):
-            if kinds.get(ref) == "org":
-                affiliation[nid] = ref
+        orgs = [ref for ref in _refs(nodes[nid], _AFFILIATION_KEYS) if kinds.get(ref) == "org"]
+        if orgs:
+            affiliation[nid] = orgs
+            for ref in orgs:
                 affiliates.setdefault(ref, []).append(nid)
-                break
 
     def _credit_source(aid: str) -> tuple[str, str] | None:
         """Best credit source: the crate root when it credits this agent (that is
@@ -1774,8 +2172,15 @@ def build_people_inventory(
         rooted = [p for p in found if p[0] == root_id]
         return sorted(rooted or found, key=lambda p: (rel_order[p[1]], p[0]))[0]
 
+    # The @id tiebreak is load-bearing: `agent_ids` is a SET, so two agents with
+    # the same display name would otherwise be ordered by the per-process string
+    # hash seed — and same-named agents are exactly the duplicate-entity case
+    # this view exists to surface. The embedded artifact must be byte-stable.
+    def _agent_order(aid: str) -> tuple[bool, str, str]:
+        return (kinds[aid] != "person", _name(nodes[aid]).casefold(), aid)
+
     agents: list[dict[str, Any]] = []
-    for aid in sorted(agent_ids, key=lambda a: (kinds[a] != "person", _name(nodes[a]).casefold())):
+    for aid in sorted(agent_ids, key=_agent_order):
         node = nodes[aid]
         kind = kinds[aid]
         assert kind is not None
@@ -1793,7 +2198,7 @@ def build_people_inventory(
             "Name": _literal(node, _NAME_KEYS) is not None,
             # An organisation has no affiliation of its own — n/a, not a miss.
             "Affiliation": (aid in affiliation) if kind == "person" else None,
-            "Credited in crate": state != "unattached",
+            "Linked in crate": state != "unattached",
         }
         agents.append(
             {
@@ -1803,7 +2208,7 @@ def build_people_inventory(
                 "pid_scheme": pid_scheme,
                 "identifiers": ids,
                 "resolvable": _is_uri(aid),
-                "affiliation": affiliation.get(aid),
+                "affiliations": affiliation.get(aid, []),
                 "fields": fields,
                 "met": sum(1 for ok in fields.values() if ok),
                 "total": sum(1 for ok in fields.values() if ok is not None),
@@ -1832,10 +2237,10 @@ def build_people_inventory(
     for key, band in banded.items():
         seen = {o["id"] for o in band["orgs"]}
         for person in band["persons"]:
-            org_id = person["affiliation"]
-            if org_id and org_id not in seen and org_id in by_id:
-                seen.add(org_id)
-                band["orgs"].append(by_id[org_id])
+            for org_id in person["affiliations"]:
+                if org_id not in seen and org_id in by_id:
+                    seen.add(org_id)
+                    band["orgs"].append(by_id[org_id])
 
     groups = [
         {
@@ -1849,7 +2254,12 @@ def build_people_inventory(
             banded.items(), key=lambda kv: (kv[0][0] != root_id, kv[0][0] or "", kv[0][1])
         )
     ]
-    loose = [a for a in agents if a["state"] == "unattached"]
+    # Anything no band picked up — the unattached, plus an organisation whose only
+    # affiliate is itself unattached (counted and listed, but previously drawn
+    # nowhere). The trailing band mixes states, so the diagram marks each node
+    # from its OWN state rather than the band's.
+    placed = {a["id"] for band in banded.values() for a in band["persons"] + band["orgs"]}
+    loose = [a for a in agents if a["id"] not in placed]
     if loose:
         groups.append(
             {
@@ -1907,33 +2317,28 @@ def render_people_svg(inventory: dict[str, Any]) -> str:
     def _row_y(row: int) -> int:
         return band_y + row * _CHEM_ROW_DY
 
-    def _more(count: int, tag: str) -> dict[str, str]:
-        return {"id": "", "name": f"{count - _CHEM_MAX_NAMED} more", "tag": tag}
-
     for group in groups:
-        persons, orgs = group["persons"], group["orgs"]
-        drawn_people = _band_nodes(persons)
-        drawn_orgs = _band_nodes(orgs)
+        # Every agent is drawn — no "+N more" aggregate. This view exists so a
+        # person can CHECK the attribution metadata entity by entity, and an
+        # elided tail is exactly where a duplicated institution or a
+        # missing-ORCID author would hide.
+        drawn_people = group["persons"]
+        drawn_orgs = group["orgs"]
         unattached = group["state"] == "unattached"
-        variant = "unwired" if unattached else ""
-        person_rows = {p["id"]: i for i, p in enumerate(drawn_people) if p is not None}
+        person_rows = {p["id"]: i for i, p in enumerate(drawn_people)}
 
-        # An organisation takes the row of its first drawn affiliate so the
-        # affiliation edge stays horizontal; collisions step down to the next
-        # free row. The aggregate ("+N more") is placed the same way.
+        # An organisation takes the row of its first affiliate so the affiliation
+        # edge stays horizontal; collisions step down to the next free row.
         org_rows: dict[str, int] = {}
         used: set[int] = set()
         for org in drawn_orgs:
-            oid = org["id"] if org is not None else ""
             wanted = [
-                person_rows[p["id"]]
-                for p in drawn_people
-                if p is not None and org is not None and p["affiliation"] == org["id"]
+                person_rows[p["id"]] for p in drawn_people if org["id"] in p["affiliations"]
             ]
             row = min(wanted) if wanted else 0
             while row in used:
                 row += 1
-            org_rows[oid] = row
+            org_rows[org["id"]] = row
             used.add(row)
 
         rows = max(len(drawn_people), max(used, default=-1) + 1, 1)
@@ -1950,12 +2355,11 @@ def render_people_svg(inventory: dict[str, Any]) -> str:
 
         for i, person in enumerate(drawn_people):
             y = _row_y(i)
-            brief = (
-                _more(len(persons), "Person")
-                if person is None
-                else {"id": person["id"], "name": person["name"], "tag": person["tag"]}
+            brief = {"id": person["id"], "name": person["name"], "tag": person["tag"]}
+            loose_person = person["state"] == "unattached"
+            _svg_place(
+                nodes_svg, brief, "agent", col_x[1], y, "unwired" if loose_person else ""
             )
-            _svg_place(nodes_svg, brief, "agent", col_x[1], y, variant)
             if group["source"] is not None:
                 _svg_link(
                     edges,
@@ -1964,43 +2368,41 @@ def render_people_svg(inventory: dict[str, Any]) -> str:
                     col_x[1],
                     y + mid,
                     group["edge"] if i == 0 else "",
+                    marker=_PEOPLE_MARKER,
                 )
-            elif unattached:
+            elif loose_person:
                 _svg_break(edges, col_x[1], y + mid)
-            if person is None:
-                continue
-            if person["affiliation"] in org_rows:
+            linked = [o for o in person["affiliations"] if o in org_rows]
+            for j, org_id in enumerate(linked):
                 _svg_link(
                     edges,
                     col_x[1] + _SVG_NODE_W,
                     y + mid,
                     col_x[2],
-                    _row_y(org_rows[person["affiliation"]]) + mid,
-                    "affiliation" if i == 0 else "",
+                    _row_y(org_rows[org_id]) + mid,
+                    "affiliation" if i == 0 and j == 0 else "",
+                    marker=_PEOPLE_MARKER,
                 )
-            elif not unattached:
+            if not linked and not loose_person:
                 # Credited, but the institution behind the person is missing.
                 _svg_break(edges, col_x[1] + _SVG_NODE_W, y + mid, leading=False)
 
         for org in drawn_orgs:
-            oid = org["id"] if org is not None else ""
-            y = _row_y(org_rows[oid])
-            brief = (
-                _more(len(orgs), "Organization")
-                if org is None
-                else {"id": org["id"], "name": org["name"], "tag": org["tag"]}
-            )
-            _svg_place(nodes_svg, brief, "org", col_x[2], y, variant)
-            if unattached:
+            y = _row_y(org_rows[org["id"]])
+            brief = {"id": org["id"], "name": org["name"], "tag": org["tag"]}
+            loose_org = org["state"] == "unattached"
+            _svg_place(nodes_svg, brief, "org", col_x[2], y, "unwired" if loose_org else "")
+            if loose_org:
                 _svg_break(edges, col_x[2], y + mid)
-            elif (
-                org is not None
-                and group["source"] is not None
-                and not any(p is not None and p["affiliation"] == org["id"] for p in drawn_people)
+            elif not unattached and group["source"] is not None and not any(
+                org["id"] in p["affiliations"] for p in drawn_people
             ):
                 # Credited straight from the source (a publisher or a funder),
                 # with no person in between.
-                _svg_link(edges, col_x[0] + _SVG_NODE_W, centre + mid, col_x[2], y + mid, "")
+                _svg_link(
+                    edges, col_x[0] + _SVG_NODE_W, centre + mid, col_x[2], y + mid,
+                    group["edge"], marker=_PEOPLE_MARKER,
+                )
 
         band_y += (rows - 1) * _CHEM_ROW_DY + _SVG_NODE_H + _CHEM_BAND_GAP
 
@@ -2012,6 +2414,257 @@ def render_people_svg(inventory: dict[str, Any]) -> str:
         band_y - _CHEM_BAND_GAP + 18,
         f"Attribution: {counts.get('pid_backed', 0)} of {counts.get('total', 0)} agents "
         "carry a persistent identifier",
+        marker=_PEOPLE_MARKER,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ISA structure (#85) — the Investigation / Study / Assay backbone.
+#
+# ISA is the skeleton every other view hangs off: the Investigation states what
+# was asked, each Study a coherent set of work toward it, each Assay one
+# measurement campaign whose LabProcesses the other views trace. The skeleton is
+# expressed purely as ``hasPart`` between Datasets that differ only by
+# ``additionalType`` — so it is invisible in the JSON and easy to break in ways
+# that still validate: a Study nobody lists as a part (present in the crate,
+# outside the hierarchy), an Assay with no process attached to it, or a level
+# with no ``identifier``, which is what makes an ISA node citable at all.
+# ---------------------------------------------------------------------------
+
+_ISA_LEVELS: tuple[str, ...] = ("Investigation", "Study", "Assay")
+_ISA_CHILD_LEVEL = {"Investigation": "Study", "Study": "Assay"}
+_DESCRIPTION_KEYS: tuple[str, ...] = (
+    "description",
+    "http://schema.org/description",
+    "https://schema.org/description",
+)
+
+ISA_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Identifier", "Identifier"),
+    ("Description", "Description"),
+    ("Listed by its parent", "In parent"),
+    ("Contains the next level", "Contains"),
+)
+
+
+def _isa_level(node: dict[str, Any], is_root: bool) -> str | None:
+    """``Investigation`` / ``Study`` / ``Assay`` for an ISA container, else None.
+
+    The Root Data Entity is the Investigation whether or not it says so — a crate
+    whose root omits ``additionalType`` is still an investigation-level record,
+    and reporting it as "not an ISA node" would hide the whole hierarchy.
+    """
+    add = _additional_type(node)
+    if add in _ISA_LEVELS:
+        return add
+    return "Investigation" if is_root and "Dataset" in _types(node) else None
+
+
+def build_isa_inventory(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Model the crate's ISA backbone: Investigation → Study → Assay.
+
+    Resolves each container's level, the parent that lists it under ``hasPart``,
+    the children it lists in turn, and — for an Assay — the ``LabProcess``es it is
+    ``about``. Reports per node whether it carries an ``identifier`` and a
+    ``description``, whether a parent lists it, and whether it contains the level
+    below (an Assay's "level below" is its processes).
+
+    Pure and cheap: one pass over the serialized ``@graph``, no validation and no
+    network. Crate-controlled text is HTML-escaped in ``label`` (#169).
+
+    Returns:
+        ``{"nodes": [...], "counts": {...}}``. Each node carries ``level``,
+        ``parent``, ``children``, ``processes``, ``fields``, ``met``, ``total``
+        and ``state`` — ``"linked"`` when a parent lists it (or it is the
+        Investigation), ``"detached"`` when nothing does.
+    """
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    nodes = _graph_nodes(metadata)
+    root_id = _find_root_id(nodes, [n for n in graph if isinstance(n, dict)])
+    levels = {
+        nid: lvl
+        for nid, n in nodes.items()
+        if (lvl := _isa_level(n, nid == root_id)) is not None
+    }
+    if not levels:
+        return {
+            "nodes": [],
+            "counts": {
+                "total": 0,
+                "investigations": 0,
+                "studies": 0,
+                "assays": 0,
+                "processes": 0,
+                "detached": 0,
+                "fields_met": 0,
+                "fields_total": 0,
+            },
+        }
+
+    # hasPart, restricted to ISA containers — the parent/child skeleton. A file
+    # part is not a structural child and must not make an Assay look populated.
+    children: dict[str, list[str]] = {}
+    parent: dict[str, str] = {}
+    for nid in sorted(levels):
+        kids = [ref for ref in _refs(nodes[nid], _HASPART_KEYS) if ref in levels]
+        if kids:
+            children[nid] = kids
+        for kid in kids:
+            parent.setdefault(kid, nid)
+
+    processes: dict[str, list[str]] = {}
+    for nid in sorted(levels):
+        if levels[nid] != "Assay":
+            continue
+        procs = [
+            ref
+            for ref in _refs(nodes[nid], _ABOUT_GRAPH_KEYS)
+            if ref in nodes and _is_process(nodes[ref])
+        ]
+        if procs:
+            processes[nid] = procs
+
+    def _order(nid: str) -> tuple[int, str, str]:
+        return (_ISA_LEVELS.index(levels[nid]), _name(nodes[nid]).casefold(), nid)
+
+    out: list[dict[str, Any]] = []
+    for nid in sorted(levels, key=_order):
+        node = nodes[nid]
+        level = levels[nid]
+        is_root = nid == root_id
+        kids = children.get(nid, [])
+        procs = processes.get(nid, [])
+        contains = bool(procs) if level == "Assay" else bool(kids)
+        fields: dict[str, bool | None] = {
+            "Identifier": _literal(node, _IDENTIFIER_KEYS) is not None
+            or bool(_refs(node, _IDENTIFIER_KEYS))
+            or _is_uri(nid),
+            "Description": _literal(node, _DESCRIPTION_KEYS) is not None,
+            # The Investigation is the top of the hierarchy — it has no parent to
+            # be listed by, which is not a defect.
+            "Listed by its parent": None if level == "Investigation" else nid in parent,
+            "Contains the next level": contains,
+        }
+        out.append(
+            {
+                **_chem_node_brief(nid, node),
+                "level": level,
+                "parent": parent.get(nid),
+                "children": kids,
+                "processes": procs,
+                "fields": fields,
+                "met": sum(1 for ok in fields.values() if ok),
+                "total": sum(1 for ok in fields.values() if ok is not None),
+                "state": "linked" if (is_root or nid in parent) else "detached",
+            }
+        )
+
+    counts = {
+        "total": len(out),
+        "investigations": sum(1 for n in out if n["level"] == "Investigation"),
+        "studies": sum(1 for n in out if n["level"] == "Study"),
+        "assays": sum(1 for n in out if n["level"] == "Assay"),
+        "processes": len({p for n in out for p in n["processes"]}),
+        "detached": sum(1 for n in out if n["state"] == "detached"),
+        "fields_met": sum(n["met"] for n in out),
+        "fields_total": sum(n["total"] for n in out),
+    }
+    return {"nodes": out, "counts": counts}
+
+
+def render_isa_svg(inventory: dict[str, Any]) -> str:
+    """Draw the ISA backbone as a self-contained inline ``<svg>``.
+
+    One column per level (Investigation → Study → Assay), each node on its own
+    row so nothing is elided, with ``hasPart`` edges between them. A container no
+    parent lists gets the dashed ✗ stub on its left — present in the crate but
+    outside the hierarchy, the failure that still validates.
+
+    An Assay's LabProcess count rides in its type tag rather than as a fourth
+    column: the processes themselves are what the Provenance view draws, and
+    repeating them here would make the skeleton unreadable.
+
+    Args:
+        inventory: The result of :func:`build_isa_inventory`.
+
+    Returns:
+        The ``<svg>…</svg>`` markup, or ``""`` when the crate has no ISA nodes.
+    """
+    nodes = inventory.get("nodes") or []
+    if not nodes:
+        return ""
+    by_id = {n["id"]: n for n in nodes}
+
+    # Rows: depth-first over the hierarchy so a parent sits with its children,
+    # then anything detached, so no node is ever dropped for lack of a parent.
+    row_of: dict[str, int] = {}
+    order: list[str] = []
+
+    def _walk(nid: str) -> None:
+        if nid in row_of:
+            return
+        row_of[nid] = len(order)
+        order.append(nid)
+        for kid in by_id[nid]["children"]:
+            if kid in by_id:
+                _walk(kid)
+
+    for n in nodes:
+        if n["level"] == "Investigation":
+            _walk(n["id"])
+    for n in nodes:
+        _walk(n["id"])
+
+    x0 = _CHEM_X0 + _CHEM_BREAK_DX + 10
+    col_x = [x0 + i * _CHEM_COL_DX for i in range(3)]
+    mid = _SVG_NODE_H // 2
+    edges: list[str] = []
+    nodes_svg: list[str] = []
+
+    def _y(nid: str) -> int:
+        return _CHEM_Y0 + row_of[nid] * _CHEM_ROW_DY
+
+    for n in nodes:
+        col = _ISA_LEVELS.index(n["level"])
+        y = _y(n["id"])
+        variant = "unwired" if n["state"] == "detached" else ""
+        tag = n["tag"]
+        if n["level"] == "Assay":
+            tag = f"{tag} · {len(n['processes'])} proc"
+        _svg_place(
+            nodes_svg,
+            {"id": n["id"], "name": n["name"], "tag": tag},
+            "container",
+            col_x[col],
+            y,
+            variant,
+        )
+        if n["state"] == "detached":
+            _svg_break(edges, col_x[col], y + mid)
+        for j, kid in enumerate(n["children"]):
+            if kid not in by_id:
+                continue
+            _svg_link(
+                edges,
+                col_x[col] + _SVG_NODE_W,
+                y + mid,
+                col_x[_ISA_LEVELS.index(by_id[kid]["level"])],
+                _y(kid) + mid,
+                "hasPart" if col == 0 and j == 0 else "",
+                marker=_ISA_MARKER,
+            )
+
+    counts = inventory.get("counts", {})
+    return _svg_document(
+        edges,
+        nodes_svg,
+        col_x[2] + _SVG_NODE_W + 16,
+        _CHEM_Y0 + (len(order) - 1) * _CHEM_ROW_DY + _SVG_NODE_H + 18,
+        f"ISA structure: {counts.get('investigations', 0)} investigation, "
+        f"{counts.get('studies', 0)} studies, {counts.get('assays', 0)} assays",
+        marker=_ISA_MARKER,
     )
 
 
@@ -2024,6 +2677,15 @@ def _node_class_for_brief(brief: dict[str, str]) -> str:
     """
     tag = brief.get("tag", "")
     head = tag.split(" · ", 1)[0]
+    if head in _PROCESS_DISCRIMINATORS or head == "LabProcess":
+        return "proc"
+    # An agent can also be a credit source (a ScholarlyArticle's authors, an
+    # organisation that funds another). Keep its own shape, or the same entity
+    # renders with two different outlines in one diagram.
+    if head == "Person":
+        return "agent"
+    if head in _ORG_TYPES:
+        return "org"
     if head in ("Table", "File", "MediaObject"):
         return "data"
     if head == "Sample":

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -11,6 +11,16 @@ from builder.writers.maturity_report import REPORT_FILENAME, build_maturity_html
 from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
 
+def _body(page: str) -> str:
+    """The rendered markup without the inlined stylesheet.
+
+    The report embeds its whole CSS in a ``<style>`` block, and that block names
+    every tab id it styles — so an "``id=…`` is absent" assertion against the raw
+    page would match the stylesheet and pass for the wrong reason.
+    """
+    return page.split("</style>", 1)[-1]
+
+
 class TestReportFilename:
     """The report filename shares the crate's ``ro-crate-metadata`` stem."""
 
@@ -335,7 +345,7 @@ class TestChemicalsSection:
 
     def test_section_renders_diagram_and_matrix(self) -> None:
         page = self._page()
-        assert "<h2>Chemicals</h2>" in page
+        assert '<div class="panel" id="p-chem">' in page
         assert 'class="prov view"' in page  # the inline route diagram
         assert 'class="chem-tbl"' in page  # the identification matrix
         assert "Aflatoxin B1" in page
@@ -384,22 +394,28 @@ class TestChemicalsSection:
                 {"@id": "#f", "@type": "File", "name": "result.csv"},
             ]
         }
-        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
-        assert "<h2>Chemicals</h2>" not in page
-        assert '<span class="eyebrow">Chemicals</span>' not in page
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph))
+        assert 'id="p-chem"' not in body
+        assert 'for="mv-chem"' not in body
+        assert '<span class="eyebrow">Chemicals</span>' not in body
 
     def test_no_graph_omits_the_section(self) -> None:
-        page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
-        assert "<h2>Chemicals</h2>" not in page
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21")))
+        assert 'id="p-chem"' not in body
+        assert "Graph views" not in body
 
-    def test_matrix_is_bounded_with_more_marker(self) -> None:
+    def test_matrix_lists_every_compound(self) -> None:
+        # Uncapped, matching the diagram: this is a metadata-checking view, and a
+        # truncated tail hides exactly the rows worth acting on.
         graph = {"@graph": [{"@id": "./", "@type": "Dataset"}]}
         for i in range(15):
             graph["@graph"].append(
                 {"@id": f"#c{i}", "@type": "MolecularEntity", "name": f"Compound {i:02d}"}
             )
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
-        assert "+3 more compounds" in page
+        for i in range(15):
+            assert f"Compound {i:02d}" in page, f"compound {i} missing from the matrix"
+        assert "more compounds" not in page
 
     def test_escapes_compound_names(self) -> None:
         graph = {
@@ -419,9 +435,396 @@ class TestChemicalsSection:
         # The report is offline/no-script; the chemicals diagram must not break
         # that (it is finished SVG, like the derivation chain).
         page = self._page()
-        section = page.split("<h2>Chemicals</h2>", 1)[1].split("</section>", 1)[0]
-        assert "<script" not in section.lower()
-        assert "src=" not in section and "@import" not in section
+        panel = page.split('<div class="panel" id="p-chem">', 1)[1].split("</div>", 1)[0]
+        assert "<script" not in panel.lower()
+        assert "src=" not in panel and "@import" not in panel
+
+
+class TestGraphViewTabs:
+    """The three diagrams share one tabbed section (#85).
+
+    The report is a self-contained offline artifact embedded in the crate, so the
+    tabs must work with no script: radio inputs plus ``:checked ~`` sibling CSS.
+    That constrains the markup — the inputs must PRECEDE both the tab bar and the
+    panels as siblings, or the sibling combinator never matches and every panel
+    stays hidden.
+    """
+
+    def _graph(self) -> dict:
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Crate",
+                    "hasPart": [{"@id": "#table"}],
+                    "author": [{"@id": "https://orcid.org/0000-0002-1825-0097"}],
+                },
+                {"@id": "#cells", "@type": "Sample", "name": "Cultured cells"},
+                {
+                    "@id": "#line",
+                    "@type": "Sample",
+                    "additionalType": "CellLine",
+                    "name": "CHO-K1",
+                    "identifier": "CVCL_0214",
+                },
+                {
+                    "@id": "#culture",
+                    "@type": "LabProcess",
+                    "additionalType": "CellCulture",
+                    "name": "Cell culture",
+                    "input": {"@id": "#line"},
+                    "output": {"@id": "#cells"},
+                },
+                {
+                    "@id": "#exposure",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "name": "Exposure step",
+                    "object": {"@id": "#cells"},
+                    "result": {"@id": "#table"},
+                },
+                {
+                    "@id": "#table",
+                    "@type": ["File", "csvw:Table"],
+                    "name": "Condition table",
+                    "about": [{"@id": "#compound"}],
+                },
+                {"@id": "#compound", "@type": "MolecularEntity", "name": "Aflatoxin B1"},
+                {
+                    "@id": "https://orcid.org/0000-0002-1825-0097",
+                    "@type": "Person",
+                    "name": "Josiah Carberry",
+                    "affiliation": {"@id": "https://ror.org/05gq02987"},
+                },
+                {
+                    "@id": "https://ror.org/05gq02987",
+                    "@type": "Organization",
+                    "name": "Brown University",
+                },
+            ]
+        }
+
+    def test_all_three_views_are_tabbed(self) -> None:
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
+        assert "<h2>Graph views</h2>" in page
+        for label in ("ISA structure", "Provenance", "Chemicals", "Cell lines",
+                      "People &amp; orgs"):
+            assert f'<span class="tb-n">{label}</span>' in page, f"missing tab: {label}"
+        for pid in ("p-isa", "p-prov", "p-chem", "p-cell", "p-people"):
+            assert f'<div class="panel" id="{pid}">' in page, f"missing panel: {pid}"
+
+    def test_inputs_precede_the_tabbar_and_panels(self) -> None:
+        # The CSS-only mechanism is `input:checked ~ .panel`; a panel emitted
+        # before its radio can never be revealed.
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
+        last_input = page.rindex('<input class="tab-in"')
+        assert last_input < page.index('<div class="tabbar">')
+        assert last_input < page.index('<div class="panel"')
+
+    def test_exactly_one_tab_starts_selected(self) -> None:
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph()))
+        assert body.count('name="mat-view"') == 5
+        assert body.count(" checked>") == 1
+        # ISA is first: the structural backbone every other view hangs off.
+        assert 'id="mv-isa" checked>' in body
+
+    def test_tabs_carry_no_script(self) -> None:
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
+        assert "<script" not in page.lower()
+        assert "onclick" not in page.lower()
+
+    def test_absent_views_drop_their_tab_and_first_survivor_is_selected(self) -> None:
+        # No compounds, no cell lines and nobody credited. The root Dataset is
+        # still an Investigation, so ISA survives alongside Provenance — and the
+        # first surviving tab must be the selected one, never a dead tab bar.
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#d"}]},
+                {"@id": "#s", "@type": "Sample", "name": "Input"},
+                {
+                    "@id": "#p",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "object": {"@id": "#s"},
+                    "result": {"@id": "#d"},
+                },
+                {"@id": "#d", "@type": "File", "name": "result.csv"},
+            ]
+        }
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph))
+        for absent in ("mv-chem", "p-chem", "mv-cell", "p-cell", "mv-people", "p-people"):
+            assert f'"{absent}"' not in body, f"{absent} should have been dropped"
+        assert 'id="mv-isa" checked>' in body
+        assert body.count(" checked>") == 1
+
+    def test_every_element_id_in_the_page_is_unique(self) -> None:
+        # Several SVGs now share one document. `url(#…)` resolves to the FIRST
+        # matching id in the document, and the panels holding them are
+        # display:none until selected — so a duplicated marker id points one
+        # diagram's arrowheads at a marker inside a hidden subtree.
+        import re
+
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph()))
+        ids = re.findall(r' id="([^"]+)"', body)
+        assert sorted(ids) == sorted(set(ids)), "duplicate element id in the report"
+
+    def test_each_diagram_references_only_its_own_marker(self) -> None:
+        import re
+
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph()))
+        for svg in re.findall(r"<svg .*?</svg>", body, re.S):
+            defined = set(re.findall(r'<marker id="([^"]+)"', svg))
+            used = set(re.findall(r"url\(#([^)]+)\)", svg))
+            assert used <= defined, f"marker referenced across SVGs: {used - defined}"
+
+    def test_routed_views_are_not_stretched_to_the_chain_width(self) -> None:
+        # `.mat svg.prov` forces width:100%/min-width:44rem for the wide, fixed
+        # derivation chain. The routed views size themselves to their content
+        # (~210-540 units); inheriting that floor upscales a small diagram
+        # several times over, so they must carry their own sizing rule.
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
+        css = page.split("<style>", 1)[1].split("</style>", 1)[0]
+        assert ".mat svg.prov.view {" in css, "routed views have no sizing rule"
+        assert "min-width:0" in css.split(".mat svg.prov.view {", 1)[1].split("}", 1)[0]
+        # …and the rule must actually match the class the renderer emits.
+        assert 'class="prov view"' in _body(page)
+
+    def test_print_styles_expand_every_panel(self) -> None:
+        # Tabs are a screen affordance; a printed report must not silently lose
+        # two of the three views.
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
+        assert ".mat .panel{display:block !important;" in page.replace("\n", "")
+        assert ".mat .panel > .panel-h{display:block;" in page.replace("\n", "")
+
+    def test_topology_strip_stays_below_the_tabs(self) -> None:
+        # The strip describes the whole graph, not one view — it must not be
+        # trapped inside a panel that a reader has to select to see.
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
+        assert page.index('<div class="panel" id="p-people">') < page.index("Graph topology")
+
+
+class TestCellLinesPanel:
+    """The Cell lines view (#85): the biological test system, and whether it is
+    pinned down.
+
+    A cell line fails the same two ways a compound does — unreachable when the
+    ``CellCulture`` consumes a freshly minted generic ``Sample`` instead of the
+    declared line, and unidentified when it carries a name but no Cellosaurus
+    RRID ("CHO-K1" names a family of divergent stocks; CVCL_0214 names one).
+    """
+
+    def _graph(self, *, wire: bool = True, rrid: bool = True) -> dict:
+        line: dict = {
+            "@id": "#cho",
+            "@type": "Sample",
+            "additionalType": "CellLine",
+            "name": "CHO-K1",
+            "sampleType": {"@id": "#term"},
+        }
+        if rrid:
+            line["identifier"] = "CVCL_0214"
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#cultured"}]},
+                {"@id": "#generic", "@type": "Sample", "name": "Input sample"},
+                {
+                    "@id": "#culture",
+                    "@type": "LabProcess",
+                    "additionalType": "CellCulture",
+                    "name": "CHO-K1 culture",
+                    "input": {"@id": "#cho" if wire else "#generic"},
+                    "output": {"@id": "#cultured"},
+                },
+                {"@id": "#cultured", "@type": "Sample", "name": "Cultured cells"},
+                line,
+                {"@id": "#term", "@type": "DefinedTerm", "name": "cell line"},
+            ]
+        }
+
+    def _page(self, **kw: bool) -> str:
+        return build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph(**kw))
+
+    def test_renders_diagram_and_matrix(self) -> None:
+        page = self._page()
+        assert '<div class="panel" id="p-cell">' in page
+        assert '<span class="tb-n">Cell lines</span>' in page
+        assert "CHO-K1" in page
+        assert "CVCL_0214" in page
+        for column in ("RRID", "Type", "Organ", "Tissue", "Passage"):
+            assert f">{column}</th>" in page, f"missing cell-line column: {column}"
+
+    def test_unconsumed_line_is_called_out_with_the_fix(self) -> None:
+        page = self._page(wire=False)
+        assert "1 of 1 cell lines are not consumed by any process." in page
+        assert "<code>CellCulture</code>" in page
+        assert "<code>input</code>" in page
+
+    def test_consumed_line_reports_a_clean_route(self) -> None:
+        page = self._page(wire=True, rrid=True)
+        assert "not consumed by any process" not in page
+
+    def test_missing_rrid_is_called_out_separately_from_wiring(self) -> None:
+        # Correctly consumed but unidentified: the two defects are independent
+        # and collapsing them would hide whichever the crate actually has.
+        page = self._page(wire=True, rrid=False)
+        assert "not consumed by any process" not in page
+        assert "1 of 1 cell lines carry no Cellosaurus RRID." in page
+
+    def test_crate_without_cell_lines_omits_the_view(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#f"}]},
+                {"@id": "#f", "@type": "File", "name": "result.csv"},
+            ]
+        }
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph))
+        assert 'id="p-cell"' not in body
+        assert 'for="mv-cell"' not in body
+
+    def test_escapes_cell_line_names(self) -> None:
+        graph = self._graph()
+        graph["@graph"][5]["name"] = "<script>alert(1)</script>"
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "<script>alert(1)</script>" not in page
+        assert "&lt;script&gt;" in page
+
+
+class TestPeoplePanel:
+    """The People & organisations view (#85): who the crate credits, how resolvably.
+
+    Attribution passes every profile with a bare ``name`` while crediting nobody a
+    registry can resolve, and the classic defect — one institution minted twice,
+    once ROR-backed and once locally — is invisible in a list and obvious in a
+    graph where one copy has edges and the other has none.
+    """
+
+    def _graph(self, *, duplicate_org: bool = True) -> dict:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Crate",
+                    "author": [
+                        {"@id": "https://orcid.org/0000-0002-1825-0097"},
+                        {"@id": "#Person_no_orcid"},
+                    ],
+                },
+                {
+                    "@id": "https://orcid.org/0000-0002-1825-0097",
+                    "@type": "Person",
+                    "name": "Josiah Carberry",
+                    "affiliation": {"@id": "https://ror.org/05gq02987"},
+                },
+                # Credited, but neither ORCID-backed nor affiliated.
+                {"@id": "#Person_no_orcid", "@type": "Person", "name": "Jane Doe"},
+                {
+                    "@id": "https://ror.org/05gq02987",
+                    "@type": "Organization",
+                    "name": "Brown University",
+                },
+            ]
+        }
+        if duplicate_org:
+            # The same institution, minted locally and referenced by nobody.
+            graph["@graph"].append(
+                {"@id": "#Organization_brown", "@type": "Organization", "name": "Brown Univ."}
+            )
+        return graph
+
+    def _page(self, **kw: bool) -> str:
+        return build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph(**kw))
+
+    def test_renders_diagram_and_matrix(self) -> None:
+        page = self._page()
+        assert '<div class="panel" id="p-people">' in page
+        assert "Josiah Carberry" in page
+        assert "Brown University" in page
+        for column in ("PID", "Name", "Affiliation", "Linked"):
+            assert f">{column}</th>" in page, f"missing attribution column: {column}"
+
+    def test_flags_the_unattached_duplicate_institution(self) -> None:
+        page = self._page(duplicate_org=True)
+        assert "1 of 4 agents are referenced by nothing in the crate" in page
+        assert "Brown Univ." in page
+        assert "duplicate" in page  # the callout names the likely cause
+        # The unattached duplicate is flagged as a defect; the correctly
+        # affiliation-linked institution gets only the muted route chip.
+        assert ">unattached</span>" in page
+        assert 'class="chem-flag muted"' in page
+        assert 'class="chem-flag"' in page
+
+    def test_flags_agents_without_a_persistent_identifier(self) -> None:
+        page = self._page(duplicate_org=False)
+        # Jane Doe has no ORCID; Brown University has a ROR; Carberry an ORCID.
+        assert "1 of 3 agents carry no persistent identifier" in page
+        assert "ORCID" in page and "ROR" in page
+
+    def test_clean_attribution_reports_no_defect(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Crate",
+                    "author": [{"@id": "https://orcid.org/0000-0002-1825-0097"}],
+                },
+                {
+                    "@id": "https://orcid.org/0000-0002-1825-0097",
+                    "@type": "Person",
+                    "name": "Josiah Carberry",
+                    "affiliation": {"@id": "https://ror.org/05gq02987"},
+                },
+                {
+                    "@id": "https://ror.org/05gq02987",
+                    "@type": "Organization",
+                    "name": "Brown University",
+                },
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "Every agent is credited and identifier-backed." in page
+        assert "referenced by nothing" not in page
+
+    def test_organisation_affiliation_column_is_not_a_miss(self) -> None:
+        # An Organization has no affiliation of its own; scoring that as a miss
+        # would penalise every crate for a field that cannot apply.
+        from builder.writers.provenance_dag import build_people_inventory
+
+        inv = build_people_inventory(self._graph(duplicate_org=False))
+        org = next(a for a in inv["agents"] if a["kind"] == "org")
+        assert org["fields"]["Affiliation"] is None
+        assert org["total"] == 3  # PID + Name + Credited — Affiliation excluded
+
+    def test_crate_without_agents_omits_the_view(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#f"}]},
+                {"@id": "#f", "@type": "File", "name": "result.csv"},
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert 'id="p-people"' not in page
+
+    def test_escapes_agent_names(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "author": [{"@id": "#p"}]},
+                {"@id": "#p", "@type": "Person", "name": "<script>alert(1)</script>"},
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "<script>alert(1)</script>" not in page
+        assert "&lt;script&gt;" in page
 
 
 class TestSeverityTiers:

--- a/tests/test_provenance_dag.py
+++ b/tests/test_provenance_dag.py
@@ -8,14 +8,24 @@ only, generated from real data rather than hand-drawn.
 
 from __future__ import annotations
 
+import json
+import os
+
 from rocrate.rocrate import ROCrate
 
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools._crate_mapping import populate_crate
 from builder.writers.provenance_dag import (
+    build_cellline_inventory,
     build_chemical_inventory,
+    build_crate_graph,
+    build_isa_inventory,
+    build_people_inventory,
+    render_celllines_svg,
     render_chemicals_svg,
+    render_isa_svg,
     render_mermaid_html,
+    render_people_svg,
     render_provenance_mermaid,
     render_provenance_svg,
 )
@@ -494,17 +504,18 @@ class TestRenderChemicalsSvg:
         assert svg.count('class="n n-process"') == 1
         assert "about · valueUrl" in svg
 
-    def test_large_group_folds_its_tail_into_an_aggregate(self) -> None:
+    def test_every_member_of_a_large_band_is_named(self) -> None:
+        # No "+N more" aggregate: the picture exists so a reader can see WHICH
+        # compounds are unwired, and an elided tail hides exactly that.
         graph = {"@graph": [{"@id": "./", "@type": "Dataset"}]}
         for i in range(9):
             graph["@graph"].append(
                 {"@id": f"#c{i}", "@type": "MolecularEntity", "name": f"Compound {i}"}
             )
         svg = render_chemicals_svg(build_chemical_inventory(graph))
-        # 3 named + an aggregate naming the remainder — nothing silently dropped.
-        assert "Compound 0" in svg and "Compound 2" in svg
-        assert "Compound 8" not in svg
-        assert "6 more" in svg
+        for i in range(9):
+            assert f"Compound {i}" in svg, f"compound {i} elided from the diagram"
+        assert "more" not in svg
 
     def test_escapes_crate_controlled_names(self) -> None:
         graph = {
@@ -552,6 +563,393 @@ class TestRenderChemicalsSvg:
         assert render_chemicals_svg(build_chemical_inventory(_no_compound_graph())) == ""
 
 
+def _cellline_graph(*, wire: bool = True) -> dict:
+    """A crate with a CellLineSample and a CellCulture that may or may not use it.
+
+    The defect this view exists to catch: the culture consumes a freshly minted
+    generic ``Sample`` (``#generic``) instead of the declared line, leaving the
+    line described in the crate and consumed by nothing.
+    """
+    culture_input = "#cho" if wire else "#generic"
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#cultured"}]},
+            {"@id": "#generic", "@type": "Sample", "name": "Input sample"},
+            {
+                "@id": "#culture",
+                "@type": "LabProcess",
+                "additionalType": "CellCulture",
+                "name": "CHO-K1 culture",
+                "input": {"@id": culture_input},
+                "output": {"@id": "#cultured"},
+            },
+            {"@id": "#cultured", "@type": "Sample", "name": "Cultured cells"},
+            {
+                "@id": "#cho",
+                "@type": "Sample",
+                "additionalType": "CellLine",
+                "name": "CHO-K1",
+                "identifier": "CVCL_0214",
+                "sampleType": {"@id": "#term"},
+                "additionalProperty": [{"@id": "#organ"}, {"@id": "#passage"}],
+            },
+            {"@id": "#term", "@type": "DefinedTerm", "name": "cell line"},
+            {"@id": "#organ", "@type": "PropertyValue", "name": "Organ", "value": "ovary"},
+            {"@id": "#passage", "@type": "PropertyValue", "name": "passage", "value": "12"},
+        ]
+    }
+
+
+class TestBuildCellLineInventory:
+    """``build_cellline_inventory`` resolves each cell line's route into the
+    experiment and how completely the culture is characterised."""
+
+    def test_cellline_consumed_by_the_culture_is_wired(self) -> None:
+        inv = build_cellline_inventory(_cellline_graph(wire=True))
+        assert [c["name"] for c in inv["celllines"]] == ["CHO-K1"]
+        line = inv["celllines"][0]
+        assert line["state"] == "wired"
+        # The process references the line directly — it is both process and via.
+        assert line["route"]["process"] == "#culture"
+        assert line["route"]["edge"] == "input"
+
+    def test_cellline_the_culture_skipped_is_unlinked(self) -> None:
+        # The exact defect: a generic Sample was minted and consumed instead.
+        inv = build_cellline_inventory(_cellline_graph(wire=False))
+        assert inv["celllines"][0]["state"] == "unlinked"
+        assert inv["counts"]["wired"] == 0
+
+    def test_cultured_sample_lineage_counts_as_a_route(self) -> None:
+        graph = _cellline_graph(wire=False)
+        for node in graph["@graph"]:
+            if node["@id"] == "#cultured":
+                node["derivesFrom"] = {"@id": "#cho"}
+        inv = build_cellline_inventory(graph)
+        line = inv["celllines"][0]
+        assert line["state"] == "wired"
+        assert line["route"]["edge"] == "derivesFrom"
+        assert line["route"]["via"] == "#cultured"
+
+    def test_rrid_and_characteristics_are_scored(self) -> None:
+        line = build_cellline_inventory(_cellline_graph())["celllines"][0]
+        assert line["rrid"] == "CVCL_0214"
+        assert line["fields"] == {
+            "Cellosaurus RRID": True,
+            "Typed as a cell line": True,
+            "Organ": True,
+            "Tissue": False,  # never recorded by this crate
+            "Passage": True,
+        }
+        assert (line["met"], line["total"]) == (4, 5)
+
+    def test_rrid_read_from_a_cellosaurus_url(self) -> None:
+        graph = {
+            "@graph": [
+                {
+                    "@id": "https://www.cellosaurus.org/CVCL_0031",
+                    "@type": "Sample",
+                    "additionalType": "CellLine",
+                    "name": "HepG2",
+                }
+            ]
+        }
+        assert build_cellline_inventory(graph)["celllines"][0]["rrid"] == "CVCL_0031"
+
+    def test_sample_typed_only_by_term_is_recognised(self) -> None:
+        # No additionalType — the line is identified solely by its sampleType
+        # DefinedTerm, which an externally-authored crate may well do.
+        graph = {
+            "@graph": [
+                {
+                    "@id": "#line",
+                    "@type": "Sample",
+                    "name": "MDCK",
+                    "sampleType": {"@id": "#t"},
+                },
+                {"@id": "#t", "@type": "DefinedTerm", "name": "cell line"},
+            ]
+        }
+        assert len(build_cellline_inventory(graph)["celllines"]) == 1
+
+    def test_plain_sample_is_not_a_cell_line(self) -> None:
+        graph = {"@graph": [{"@id": "#s", "@type": "Sample", "name": "Cultured cells"}]}
+        assert build_cellline_inventory(graph)["celllines"] == []
+
+    def test_crate_without_cell_lines_is_empty(self) -> None:
+        inv = build_cellline_inventory(_no_compound_graph())
+        assert inv["celllines"] == []
+        assert inv["counts"]["total"] == 0
+
+
+class TestRenderCellLinesSvg:
+    """The cell-line diagram reuses the compound view's bands — a break reads the
+    same in both — and the material stadium, because a cell line IS a Sample."""
+
+    def test_direct_process_route_draws_the_process_once(self) -> None:
+        # `input` makes the process itself the referrer; drawing it in two
+        # columns joined by a `result` edge would depict a step that does not
+        # exist in the crate.
+        svg = render_celllines_svg(build_cellline_inventory(_cellline_graph(wire=True)))
+        assert svg.count('class="n n-process"') == 1
+        assert '"result"' not in svg and ">result<" not in svg
+        assert "CHO-K1" in svg
+
+    def test_cell_line_uses_the_material_shape(self) -> None:
+        svg = render_celllines_svg(build_cellline_inventory(_cellline_graph()))
+        assert "n-material" in svg
+
+    def test_unlinked_line_gets_a_break_marker(self) -> None:
+        svg = render_celllines_svg(build_cellline_inventory(_cellline_graph(wire=False)))
+        assert "e-break" in svg and "✗" in svg and "unwired" in svg
+
+    def test_empty_inventory_returns_empty(self) -> None:
+        assert render_celllines_svg(build_cellline_inventory(_no_compound_graph())) == ""
+
+    def test_escapes_crate_controlled_names(self) -> None:
+        graph = {
+            "@graph": [
+                {
+                    "@id": "#l",
+                    "@type": "Sample",
+                    "additionalType": "CellLine",
+                    "name": "<script>alert(1)</script>",
+                }
+            ]
+        }
+        svg = render_celllines_svg(build_cellline_inventory(graph))
+        assert "<script>alert(1)</script>" not in svg
+        assert "&lt;script&gt;" in svg
+
+
+class TestAffiliationReachability:
+    """``affiliation`` is an edge of the crate graph (#85).
+
+    Nothing else in a crate references an affiliation-only Organization, so
+    omitting the relation reported every ROR-backed institution as an orphan
+    while the crate was in fact correct — and the People view showed the very
+    same institution as connected. The two must agree.
+    """
+
+    def _graph(self) -> dict:
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Crate",
+                    "author": [{"@id": "https://orcid.org/0000-0002-1825-0097"}],
+                },
+                {
+                    "@id": "https://orcid.org/0000-0002-1825-0097",
+                    "@type": "Person",
+                    "name": "Josiah Carberry",
+                    "affiliation": {"@id": "https://ror.org/05gq02987"},
+                },
+                {
+                    "@id": "https://ror.org/05gq02987",
+                    "@type": "Organization",
+                    "name": "Brown University",
+                },
+            ]
+        }
+
+    def test_affiliated_organisation_is_not_an_orphan(self) -> None:
+        model = build_crate_graph(self._graph(), all_edges=True)
+        org = next(n for n in model["nodes"] if n["id"] == "https://ror.org/05gq02987")
+        assert org["orphan"] is False
+        assert model["counts"]["orphan"] == 0
+
+    def test_topology_and_people_view_agree(self) -> None:
+        graph = self._graph()
+        orphans = {
+            n["id"] for n in build_crate_graph(graph, all_edges=True)["nodes"] if n["orphan"]
+        }
+        unattached = {
+            a["id"] for a in build_people_inventory(graph)["agents"] if a["state"] == "unattached"
+        }
+        assert orphans == unattached == set()
+
+    def test_contributor_only_person_is_not_an_orphan(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "contributor": [{"@id": "#p"}]},
+                {"@id": "#p", "@type": "Person", "name": "Jane Doe"},
+            ]
+        }
+        model = build_crate_graph(graph, all_edges=True)
+        assert model["counts"]["orphan"] == 0
+
+
+class TestRouteClaimsMatchTopology:
+    """"Nothing in the crate references this" must be TRUE when the panel says it.
+
+    The routed views and the graph-topology strip render inside the same section.
+    When the views scanned a narrower relation vocabulary than
+    ``build_crate_graph``, an entity reached only by ``result`` / ``derivesFrom``
+    / ``hasPart`` was reported as referenced by nothing a few lines above a strip
+    that counted it as reachable.
+    """
+
+    def _graph(self, relation: str) -> dict:
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#holder"}]},
+                {"@id": "#holder", "@type": "File", "name": "holder.csv", relation: {"@id": "#c"}},
+                {"@id": "#c", "@type": "MolecularEntity", "name": "Aflatoxin B1"},
+            ]
+        }
+
+    def test_secondary_relations_are_not_reported_as_unreferenced(self) -> None:
+        for relation in ("result", "derivesFrom", "hasPart"):
+            state = build_chemical_inventory(self._graph(relation))["chemicals"][0]["state"]
+            assert state != "unlinked", f"{relation} edge reported as no reference at all"
+
+    def test_unlinked_agrees_with_the_topology_orphan_flag(self) -> None:
+        for relation in ("result", "derivesFrom", "hasPart", "about", "mentions"):
+            graph = self._graph(relation)
+            unlinked = {
+                c["id"]
+                for c in build_chemical_inventory(graph)["chemicals"]
+                if c["state"] == "unlinked"
+            }
+            orphans = {
+                n["id"] for n in build_crate_graph(graph, all_edges=True)["nodes"] if n["orphan"]
+            }
+            assert unlinked <= orphans, (
+                f"{relation}: view claims unreferenced, topology says reachable"
+            )
+
+    def test_canonical_route_still_wins_over_a_secondary_one(self) -> None:
+        # A compound reachable both canonically and loosely must report the
+        # canonical route — the added relations are a fallback, not a reordering.
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#c"}, {"@id": "#t"}]},
+                {"@id": "#s", "@type": "Sample", "name": "cells"},
+                {
+                    "@id": "#p",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "name": "Exposure",
+                    "object": {"@id": "#s"},
+                    "result": {"@id": "#t"},
+                },
+                {
+                    "@id": "#t",
+                    "@type": ["File", "csvw:Table"],
+                    "name": "Condition table",
+                    "about": [{"@id": "#c"}],
+                },
+                {"@id": "#c", "@type": "MolecularEntity", "name": "Aflatoxin B1"},
+            ]
+        }
+        route = build_chemical_inventory(graph)["chemicals"][0]["route"]
+        assert route["edge"] == "about"
+        assert route["process"] == "#p"
+
+
+class TestCoAffiliation:
+    """Every ``affiliation`` a person declares is modelled, not just the first.
+
+    Taking only the first left a co-affiliated researcher's second institution
+    referenced by nothing — which this view reports as an unattached duplicate
+    and advises the reader to delete. Wrong, and destructively so.
+    """
+
+    def _graph(self) -> dict:
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "name": "Crate", "author": [{"@id": "#p"}]},
+                {
+                    "@id": "#p",
+                    "@type": "Person",
+                    "name": "Jointly Affiliated",
+                    "affiliation": [{"@id": "#org_a"}, {"@id": "#org_b"}],
+                },
+                {"@id": "#org_a", "@type": "Organization", "name": "Institute A"},
+                {"@id": "#org_b", "@type": "Organization", "name": "Institute B"},
+            ]
+        }
+
+    def test_second_affiliation_is_not_reported_unattached(self) -> None:
+        agents = {a["name"]: a for a in build_people_inventory(self._graph())["agents"]}
+        assert agents["Institute A"]["state"] == "affiliated"
+        assert agents["Institute B"]["state"] == "affiliated"
+        assert agents["Jointly Affiliated"]["affiliations"] == ["#org_a", "#org_b"]
+
+    def test_both_affiliations_are_drawn(self) -> None:
+        svg = render_people_svg(build_people_inventory(self._graph()))
+        assert "Institute A" in svg and "Institute B" in svg
+        # Two affiliation edges out of the one person, and no "link missing" stub.
+        assert svg.count('class="e e-link"') == 3  # author + two affiliations
+        assert "e-break" not in svg
+
+    def test_topology_agrees_that_both_are_reachable(self) -> None:
+        model = build_crate_graph(self._graph(), all_edges=True)
+        assert model["counts"]["orphan"] == 0
+
+
+class TestRenderPeopleSvgCompleteness:
+    """The people diagram draws EVERY agent — no "+N more" aggregate.
+
+    This view exists so a person can check the attribution entity by entity, and
+    an elided tail is exactly where a duplicated institution or a missing-ORCID
+    author would hide.
+    """
+
+    def _many(self, n: int) -> dict:
+        graph: dict = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "name": "Crate", "author": []},
+            ]
+        }
+        for i in range(n):
+            graph["@graph"][1]["author"].append({"@id": f"#p{i}"})
+            graph["@graph"].append(
+                {
+                    "@id": f"#p{i}",
+                    "@type": "Person",
+                    "name": f"Author {i:02d}",
+                    "affiliation": {"@id": f"#org{i}"},
+                }
+            )
+            graph["@graph"].append(
+                {"@id": f"#org{i}", "@type": "Organization", "name": f"Institute {i:02d}"}
+            )
+        return graph
+
+    def test_every_person_and_organisation_is_drawn(self) -> None:
+        svg = render_people_svg(build_people_inventory(self._many(9)))
+        assert "more" not in svg
+        for i in range(9):
+            assert f"Author {i:02d}" in svg, f"person {i} elided"
+            assert f"Institute {i:02d}" in svg, f"organisation {i} elided"
+
+    def test_band_height_covers_every_drawn_row(self) -> None:
+        # With one organisation per person the rows cannot collide, but the band
+        # must still be tall enough that nothing escapes the viewBox.
+        import xml.etree.ElementTree as ET
+
+        root = ET.fromstring(render_people_svg(build_people_inventory(self._many(9))))
+        _, _, width, height = (float(v) for v in root.get("viewBox").split())
+        ys: list[float] = []
+        xs: list[float] = []
+        for el in root.iter():
+            if el.tag == "rect" and (el.get("class") or "").startswith("n "):
+                x, y = float(el.get("x")), float(el.get("y"))
+                xs += [x, x + float(el.get("width"))]
+                ys += [y, y + float(el.get("height"))]
+        assert ys and 0 <= min(ys) and max(ys) <= height
+        assert 0 <= min(xs) and max(xs) <= width
+
+
 def _exposure_state() -> CrateState:
     state = CrateState()
     state.metadata.title = "Exposure crate"
@@ -579,3 +977,274 @@ def test_renders_from_real_assembled_crate(tmp_path) -> None:
     assert "Exposure" in out
     assert "Condition table" in out
     assert "result" in out
+
+
+def _isa_graph(*, detach_study: bool = False, empty_assay: bool = False) -> dict:
+    """An Investigation → Study → Assay hierarchy, optionally broken.
+
+    ``detach_study`` drops the Study from the Investigation's ``hasPart`` (present
+    in the crate, outside the hierarchy — a break that still validates);
+    ``empty_assay`` removes the Assay's processes.
+    """
+    inv_parts = [] if detach_study else [{"@id": "#study"}]
+    assay: dict = {
+        "@id": "#assay",
+        "@type": "Dataset",
+        "additionalType": "Assay",
+        "name": "Transport assay",
+        "identifier": "inv/study/assay",
+        "description": "One measurement campaign.",
+    }
+    if not empty_assay:
+        assay["about"] = [{"@id": "#p"}]
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                "name": "OATP1C1 investigation",
+                "identifier": "inv",
+                "description": "The question.",
+                "hasPart": inv_parts,
+            },
+            {
+                "@id": "#study",
+                "@type": "Dataset",
+                "additionalType": "Study",
+                "name": "Time-course study",
+                "identifier": "inv/study",
+                "description": "A body of work.",
+                "hasPart": [{"@id": "#assay"}],
+            },
+            assay,
+            {
+                "@id": "#p",
+                "@type": "LabProcess",
+                "additionalType": "Exposure",
+                "name": "Exposure",
+            },
+        ]
+    }
+
+
+class TestBuildIsaInventory:
+    """``build_isa_inventory`` models the Investigation / Study / Assay backbone.
+
+    The hierarchy is expressed only as ``hasPart`` between Datasets that differ by
+    ``additionalType``, so it is invisible in the JSON and breaks in ways that
+    still validate.
+    """
+
+    def _by_level(self, graph: dict) -> dict:
+        return {n["level"]: n for n in build_isa_inventory(graph)["nodes"]}
+
+    def test_resolves_the_three_levels_and_their_links(self) -> None:
+        nodes = self._by_level(_isa_graph())
+        assert set(nodes) == {"Investigation", "Study", "Assay"}
+        assert nodes["Study"]["parent"] == "./"
+        assert nodes["Assay"]["parent"] == "#study"
+        assert nodes["Assay"]["processes"] == ["#p"]
+        assert all(n["state"] == "linked" for n in nodes.values())
+
+    def test_root_is_the_investigation_even_without_additional_type(self) -> None:
+        graph = _isa_graph()
+        del graph["@graph"][1]["additionalType"]
+        assert self._by_level(graph)["Investigation"]["id"] == "./"
+
+    def test_container_no_parent_lists_is_detached(self) -> None:
+        nodes = self._by_level(_isa_graph(detach_study=True))
+        assert nodes["Study"]["state"] == "detached"
+        assert nodes["Study"]["fields"]["Listed by its parent"] is False
+        # The Investigation has no parent to be listed by — n/a, not a miss.
+        assert nodes["Investigation"]["fields"]["Listed by its parent"] is None
+
+    def test_assay_with_no_process_does_not_count_as_populated(self) -> None:
+        nodes = self._by_level(_isa_graph(empty_assay=True))
+        assert nodes["Assay"]["fields"]["Contains the next level"] is False
+        assert nodes["Study"]["fields"]["Contains the next level"] is True
+
+    def test_file_parts_are_not_structural_children(self) -> None:
+        # An Assay listing only data files still contains no ISA level below it.
+        graph = _isa_graph(empty_assay=True)
+        graph["@graph"][3]["hasPart"] = [{"@id": "#f"}]
+        graph["@graph"].append({"@id": "#f", "@type": "File", "name": "raw.csv"})
+        assert self._by_level(graph)["Assay"]["fields"]["Contains the next level"] is False
+
+    def test_counts_summarise_the_hierarchy(self) -> None:
+        counts = build_isa_inventory(_isa_graph())["counts"]
+        assert counts["investigations"] == 1
+        assert counts["studies"] == 1
+        assert counts["assays"] == 1
+        assert counts["processes"] == 1
+        assert counts["detached"] == 0
+
+    def test_crate_without_isa_containers_is_empty(self) -> None:
+        assert build_isa_inventory({"@graph": [{"@id": "#f", "@type": "File"}]})["nodes"] == []
+
+
+class TestRenderIsaSvg:
+    """The ISA diagram: one column per level, one row per container, nothing elided."""
+
+    def test_draws_every_container_with_haspart_edges(self) -> None:
+        svg = render_isa_svg(build_isa_inventory(_isa_graph()))
+        for label in ("OATP1C1 investigation", "Time-course study", "Transport assay"):
+            assert label in svg, f"{label} missing from the ISA diagram"
+        assert "hasPart" in svg
+        assert svg.count('class="n n-container"') == 3
+
+    def test_assay_tag_carries_its_process_count(self) -> None:
+        svg = render_isa_svg(build_isa_inventory(_isa_graph()))
+        assert "1 PROC" in svg.upper()
+
+    def test_detached_container_is_marked_and_still_drawn(self) -> None:
+        svg = render_isa_svg(build_isa_inventory(_isa_graph(detach_study=True)))
+        assert "Time-course study" in svg  # never dropped for lack of a parent
+        assert "e-break" in svg and "unwired" in svg
+
+    def test_empty_inventory_returns_empty(self) -> None:
+        assert render_isa_svg(build_isa_inventory({"@graph": []})) == ""
+
+    def test_escapes_crate_controlled_names(self) -> None:
+        graph = _isa_graph()
+        graph["@graph"][2]["name"] = "<script>alert(1)</script>"
+        svg = render_isa_svg(build_isa_inventory(graph))
+        assert "<script>alert(1)</script>" not in svg
+        assert "&lt;script&gt;" in svg
+
+
+class TestIdentifierFallbackIsNotFabricated:
+    """The registry-URL fallback must identify, not merely match a hostname."""
+
+    def _chem(self, nid: str) -> dict:
+        inv = build_chemical_inventory(
+            {"@graph": [{"@id": nid, "@type": "MolecularEntity", "name": "X"}]}
+        )
+        return inv["chemicals"][0]["identifiers"]
+
+    def test_registry_resource_url_yields_the_identifier(self) -> None:
+        assert self._chem("https://pubchem.ncbi.nlm.nih.gov/compound/6623") == {
+            "PubChem CID": "6623"
+        }
+
+    def test_other_paths_on_the_registry_host_yield_nothing(self) -> None:
+        # /bioassay/1234 lives on the PubChem host and identifies no compound;
+        # counting it would inflate the identification score with a wrong value.
+        assert self._chem("https://pubchem.ncbi.nlm.nih.gov/bioassay/1234") == {}
+
+    def test_tail_that_is_not_shaped_like_the_identifier_is_rejected(self) -> None:
+        assert self._chem("https://pubchem.ncbi.nlm.nih.gov/compound/not-a-cid") == {}
+
+    def test_identifier_node_that_is_itself_a_registry_url_is_read(self) -> None:
+        graph = {
+            "@graph": [
+                {
+                    "@id": "#p",
+                    "@type": "Person",
+                    "name": "Josiah Carberry",
+                    "identifier": [{"@id": "https://orcid.org/0000-0002-1825-0097"}],
+                }
+            ]
+        }
+        agent = build_people_inventory(graph)["agents"][0]
+        assert agent["identifiers"] == {"ORCID": "0000-0002-1825-0097"}
+        assert agent["pid_scheme"] == "ORCID"
+
+
+class TestMalformedGraphDegradesGracefully:
+    """A single bad node must cost one row, not the whole report.
+
+    ``build_maturity_html`` runs inside ``export_crate``, so an exception here
+    loses the crate its entire maturity report.
+    """
+
+    def test_non_string_id_is_skipped_not_fatal(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": 5, "@type": "Person", "name": "Numeric id"},
+                {"@id": {"nested": 1}, "@type": "MolecularEntity", "name": "Object id"},
+                {"@id": "#ok", "@type": "Person", "name": "Fine"},
+                {"@id": "#c", "@type": "MolecularEntity", "name": "Aflatoxin B1"},
+            ]
+        }
+        assert [a["name"] for a in build_people_inventory(graph)["agents"]] == ["Fine"]
+        assert [c["name"] for c in build_chemical_inventory(graph)["chemicals"]] == [
+            "Aflatoxin B1"
+        ]
+        assert build_cellline_inventory(graph)["celllines"] == []
+        assert build_isa_inventory(graph)["nodes"] == []
+        # …and the topology model the report renders beside them survives too.
+        assert build_crate_graph(graph, all_edges=True)["counts"]["layer1"] >= 1
+
+    def test_whole_report_still_renders(self) -> None:
+        from builder.writers.maturity_report import build_maturity_html
+        from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "name": "Crate"},
+                {"@id": 5, "@type": "Person", "name": "Numeric id"},
+                {"@id": "#c", "@type": "MolecularEntity", "name": "Aflatoxin B1"},
+            ]
+        }
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "Graph views" in page
+
+
+class TestDeterministicOrdering:
+    """The embedded artifact must be byte-stable for a given ``@graph``.
+
+    Sorting a set-derived list on a key that can tie leaves the order to the
+    per-process string hash seed — and same-named agents are exactly the
+    duplicate-entity case these views exist to surface.
+    """
+
+    def _graph(self) -> dict:
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Crate",
+                    "author": [{"@id": f"#p{i}"} for i in range(6)],
+                },
+                *[
+                    {"@id": f"#p{i}", "@type": "Person", "name": "Same Name"}
+                    for i in range(6)
+                ],
+                *[
+                    {"@id": f"#c{i}", "@type": "MolecularEntity", "name": "Same Compound"}
+                    for i in range(6)
+                ],
+            ]
+        }
+
+    def test_agent_and_compound_order_is_stable_across_hash_seeds(self) -> None:
+        import subprocess
+        import sys
+
+        script = (
+            "import json,sys;"
+            "from builder.writers.provenance_dag import "
+            "build_people_inventory, build_chemical_inventory;"
+            "g=json.load(sys.stdin);"
+            "print([a['id'] for a in build_people_inventory(g)['agents']],"
+            "[c['id'] for c in build_chemical_inventory(g)['chemicals']])"
+        )
+        payload = json.dumps(self._graph())
+        outputs = set()
+        for seed in ("0", "1", "12345"):
+            env = {**os.environ, "PYTHONHASHSEED": seed}
+            res = subprocess.run(
+                [sys.executable, "-c", script],
+                input=payload,
+                capture_output=True,
+                text=True,
+                env=env,
+                check=True,
+            )
+            outputs.add(res.stdout.strip())
+        assert len(outputs) == 1, f"ordering varies with the hash seed: {outputs}"

--- a/tests/test_state_serializer.py
+++ b/tests/test_state_serializer.py
@@ -59,6 +59,7 @@ class TestStateSerializerOutput:
             "mit_assessment",
             "fair_assessment",
             "checkpoint",
+            "validation_preferences",
             "iteration_count",
             "max_iterations",
             "stuck",
@@ -102,6 +103,19 @@ class TestStateSerializerRoundTrip:
     def test_to_json_is_valid_json(self):
         text = StateSerializer.to_json(_populated_state())
         assert json.loads(text)["session_id"] == "sess-1"
+
+    def test_validation_preferences_round_trip(self):
+        """The standing "don't ask me again" answers survive a save/resume.
+
+        The existing round-trips compare ``to_dict`` output on states that leave
+        this dict empty, so ``{} == {}`` held even while ``from_dict`` dropped
+        the field entirely — the answers silently reset on every resume, which
+        is precisely what persisting them exists to prevent.
+        """
+        state = CrateState()
+        state.validation_preferences = {"recommended": True, "optional": False}
+        restored = StateSerializer.from_dict(StateSerializer.to_dict(state))
+        assert restored.validation_preferences == {"recommended": True, "optional": False}
 
     def test_partial_state_round_trips(self):
         state = CrateState(session_id="only-id")


### PR DESCRIPTION
## Summary

Next batch of in-progress work. 10 files, +2806/−474.

- **`provenance_dag.py` / `maturity_report.py` / `.css`** — broader SVG rendering, chemical-inventory grouping refactored behind a shared brief helper, and the report sections built on them.
- **`agent_loop.py` / `ui.py` / `progress_spinner.py`** — surrounding interactive changes.
- **`state.py`** — adds `validation_preferences`: standing answers to "run the broader validation tiers?", so a user who has already decided isn't re-asked across a `--resume`.

## A real bug found on the way in

`validation_preferences` was written by `to_dict` but **never read by `from_dict`** — so it reset to `{}` on every resume, defeating the only reason to persist it.

It slipped through because the existing round-trip tests compare `to_dict` output on states that leave the dict empty, so `{} == {}` held while the field was being silently dropped. Added the read, plus a round-trip regression that actually sets the field.

Also added the new key to `test_to_dict_has_expected_top_level_keys`, which pins an exhaustive set.

## One restore

`tests/test_agent_loop.py` is reset to its committed version. The working copy predated the `_install_spy` fix from #436 and would have reverted it, re-breaking `test_mutation_resets_validation_guard`. That revert was the file's *only* pending change, so nothing intentional was lost.

## Verification

`ruff` clean; **326 tests pass** locally across `test_provenance_dag` / `test_maturity_report` / `test_agent_loop` / `test_state_serializer` / `test_engine` / `test_path_traversal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)