### PR TITLE
feat: generator provenance, crate attribution, and recorded user answers

### DIFF
--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -183,6 +183,13 @@ def _make_usage_logger(engine: AgentEngine, totals: dict[str, int]) -> UsageSink
         out_t = _as_int(output_tokens)
         totals["input_tokens"] += in_t
         totals["output_tokens"] += out_t
+        # Also accumulate onto the crate's generator record so the exported crate
+        # carries what the run cost. Independent of the profiler below: cost
+        # accounting must not depend on instrumentation being enabled.
+        try:
+            engine.state.record_llm_usage({"input_tokens": in_t, "output_tokens": out_t})
+        except Exception:  # noqa: BLE001 — accounting never breaks a leaf call
+            logger.debug("Could not record leaf LLM usage", exc_info=True)
         profiler = getattr(engine, "profiler", None)
         if profiler is not None:
             profiler.log_event(

--- a/builder/agents/progress_spinner.py
+++ b/builder/agents/progress_spinner.py
@@ -52,6 +52,10 @@ _DELEGATED_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 # terminal; the footer truncates anything wider anyway.
 _PREVIEW_WIDTH = 40
 
+# Never shrink the tail below this, however narrow the row: a handful of
+# characters would flicker without being readable.
+_PREVIEW_MIN_WIDTH = 24
+
 # Minimum seconds an op stays on the line before a newer one may replace it.
 # Most tools return in milliseconds, so without this the line was a stream of
 # unreadable flashes; long enough to read a tool name, short enough that the
@@ -126,6 +130,7 @@ class ProgressSpinner:
         *,
         tick_interval: float = 0.5,
         activity_sink: Callable[[str | None], None] | None = None,
+        width_provider: Callable[[], int] | None = None,
     ) -> None:
         """Build a spinner.
 
@@ -170,6 +175,7 @@ class ProgressSpinner:
         self._preview_buffer = ""
         self._tick_interval = tick_interval
         self._sink = activity_sink
+        self._width_provider = width_provider
         self._frame = 0
         self._start = monotonic()
         self._stop = threading.Event()
@@ -218,12 +224,46 @@ class ProgressSpinner:
             style = "grey62" if self._item_done else "cyan"
             if self._item_kind == "writing":
                 label = "[dim]wrote:[/dim] " if self._item_done else "[dim]writing:[/dim] "
-                line += f'  [dim]·[/dim] {label}[{style}]"{self._item_text}"[/{style}]'
+                tail = self._preview_tail(
+                    plain_prefix_len=len(f"{self._phrase}… ({elapsed}s)  · ")
+                    + len("wrote: " if self._item_done else "writing: ")
+                )
+                if tail:
+                    line += f'  [dim]·[/dim] {label}[{style}]"{tail}"[/{style}]'
             else:
                 line += f"  [dim]·[/dim] [{style}]{self._item_text}[/{style}]"
                 if self._shown_skipped:
                     line += f" [dim](+{self._shown_skipped} more)[/dim]"
         return line
+
+    def _preview_tail(self, *, plain_prefix_len: int) -> str:
+        """The streamed reply tail, sized to the row it will be painted on.
+
+        The window follows the END of the text (that is what makes it read as
+        live), so it must be cut to fit BEFORE painting: the footer truncates
+        an over-long line from the right, which would leave the stale head of
+        the reply on screen and never advance. Falls back to a fixed width when
+        no row width is available (no footer, or a non-terminal).
+        """
+        text = (self._preview_buffer or self._item_text or "").replace("\n", " ")
+        width = 0
+        if self._width_provider is not None:
+            try:
+                width = int(self._width_provider())
+            except Exception:  # noqa: BLE001 — sizing is advisory
+                width = 0
+        if not width:
+            return text[-_PREVIEW_WIDTH:].lstrip()
+        # 2 for the spinner glyph + space, 2 for the surrounding quotes, 1 spare
+        # so the write can never reach the final column and wrap the row.
+        available = width - plain_prefix_len - 5
+        if available < _PREVIEW_MIN_WIDTH:
+            # A narrow row cannot show a useful amount of text. Drop the tail
+            # rather than overflow: the phrase and the running tool matter more,
+            # and an over-long line would be cut from the right — taking the
+            # newest characters, which are the ones worth seeing.
+            return ""
+        return text[-available:].lstrip()
 
     def _render_delegated(self) -> str:
         """The delegated line — the animation frame Rich would otherwise draw.
@@ -272,7 +312,11 @@ class ProgressSpinner:
     def _offer(self, text: str, kind: str) -> None:
         """Display *text* now, or hold it until the current item has had its dwell."""
         now = monotonic()
-        if self._item_text is None or (now - self._item_at) >= _MIN_DWELL:
+        # "thinking…" is a placeholder for text that has not arrived yet, so the
+        # first token replaces it immediately — the dwell exists to let the user
+        # READ something, and there is nothing to read here.
+        placeholder = self._item_kind == "thinking"
+        if placeholder or self._item_text is None or (now - self._item_at) >= _MIN_DWELL:
             self._item_text, self._item_kind, self._item_done = text, kind, False
             self._item_at = now
             self._pending = None

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -375,7 +375,10 @@ def _run_validation_escalation(
         prefs[tier] = response.get("action") == "approved"
         return prefs[tier]
 
-    if not approved("recommended", "Required validation passed. Run recommended checks?"):
+    if not approved(
+        "recommended",
+        "Required validation passed. Shall we now also work on the recommended checks?",
+    ):
         setattr(engine, _VALIDATION_ESCALATION_FP_FLAG, fingerprint)
         return {
             "recommended": {"status": "declined_by_user"},
@@ -426,7 +429,9 @@ def _run_validation_escalation(
         summary["optional"] = {"status": "blocked_by_recommended_findings"}
     elif approved(
         "optional",
-        "Recommended validation completed (" + recommended_status + "). Run optional checks?",
+        "Recommended checks completed ("
+        + recommended_status
+        + "). Shall we now also work on the optional checks?",
     ):
         # As above, this call is synchronous and completes before the escalation
         # fingerprint is recorded or control returns to the model loop.
@@ -675,6 +680,32 @@ def _crate_is_complete(engine: AgentEngine) -> bool:
         return False
 
 
+# Longest a reply can be and still count as running commentary rather than
+# content. "Let me fix the two issues: the supplier key in the JSON-LD context,
+# and the missing additionalProperty on the DataAnalysis process" is 137.
+_COMMENTARY_MAX_CHARS = 240
+
+
+def _reply_is_running_commentary(reply: str | None) -> bool:
+    """Whether *reply* is a throwaway "here is what I'll do next" line.
+
+    Only these are printed transiently, because only these are worthless once
+    the next step starts. The bar is deliberately high: a reply with any
+    structure — more than one line, a heading, a bullet list, a table — is an
+    ANSWER (the issue list the user just asked for, a summary of what was
+    built), and erasing it to make room for the next "Let me…" would destroy
+    the thing the user is reading.
+    """
+    text = (reply or "").strip()
+    if not text or len(text) > _COMMENTARY_MAX_CHARS:
+        return False
+    if "\n" in text:
+        return False  # multi-line means structure, which means content
+    if text.lstrip()[:1] in {"#", "-", "*", "|", ">", "`"}:
+        return False
+    return not _reply_is_question(text)
+
+
 def _reply_is_empty_completion(reply: str | None) -> bool:
     """Return True when a turn produced no meaningful text (the stall symptom).
 
@@ -771,12 +802,42 @@ def _invoke_with_timeout(
         if isinstance(outcome["error"], _InvocationCancelled) and not cancel_event.is_set():
             logger.info("Model invoke stopped by a loop guard: %s", outcome["error"])
             return (None, "stopped", None) if include_error else (None, "stopped")
+        if _is_timeout_error(outcome["error"]):
+            # The provider's own request timeout is wired to the SAME duration as
+            # the wall-clock guard above, so in practice it raises first and the
+            # guard never sees a live worker. Reporting that as a generic error
+            # told the user something broke when the run simply ran out of time.
+            logger.info("Model invoke timed out: %s", outcome["error"])
+            return (None, "timeout", None) if include_error else (None, "timeout")
         logger.warning("Model invoke raised: %s", outcome["error"])
         if include_error:
             error = outcome["error"]
             return None, "error", _error_diagnostic(error, outcome["traceback"])
         return None, "error"
     return (outcome["result"], "ok", None) if include_error else (outcome["result"], "ok")
+
+
+def _is_timeout_error(exc: BaseException | None) -> bool:
+    """Whether *exc* is a request/connection timeout rather than a real failure.
+
+    Every provider SDK spells this differently (``APITimeoutError``,
+    ``ReadTimeout``, ``TimeoutException``, …) and importing them all here would
+    couple the loop to each vendor, so the class name and its module are matched
+    instead. ``TimeoutError`` is caught outright.
+    """
+    if exc is None:
+        return False
+    if isinstance(exc, TimeoutError):
+        return True
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        name = type(current).__name__.casefold()
+        if "timeout" in name or "timedout" in name:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def _unreadable_file_message(path: str, tool_name: str = "read_file_sample") -> str:
@@ -943,6 +1004,70 @@ def _no_op_mutation_message(tool_name: str, kwargs: dict[str, Any], engine: Agen
         "missing entities, wire the process chain, then build_and_validate)."
     )
     return "\n".join(lines)
+
+
+# Recent post-mutation state fingerprints, newest last. A mutation landing on
+# one of these has undone itself — the crate is back somewhere it just was.
+_MUTATION_HISTORY_FLAG = "_mutation_fingerprint_history"
+_MUTATION_CYCLE_COUNT_FLAG = "_mutation_cycle_count"
+
+# How far back a revisit still counts as a cycle, and how many cycles end the
+# turn. A model rewriting one field in alternating encodings produces a tight
+# A-B-A-B, so a short window catches it while leaving honest edit-and-revert
+# sequences (which a user drives, spaced by their own turns) alone.
+_MUTATION_HISTORY_WINDOW = 8
+_MUTATION_CYCLE_ABORT = 3
+
+
+def _record_mutation_cycle(
+    engine: AgentEngine, tool_name: str, kwargs: dict[str, Any]
+) -> str | None:
+    """Detect a mutation that returned the crate to a recent state.
+
+    The no-op guard catches "this call changed nothing". It cannot catch
+    "this call changed something back": writing ``hasPart`` as a string, then as
+    a list, then as a string again alters the stored value every time, so every
+    write looks like progress while the crate oscillates between two states.
+
+    Returns a corrective to hand the model instead of the result, or ``None``
+    when the mutation is genuinely new. Raises :class:`_InvocationCancelled`
+    once the cycling has continued past :data:`_MUTATION_CYCLE_ABORT`, ending
+    the turn — the same escalation the validation guard uses, for the same
+    reason: only handing control back reliably stops it.
+    """
+    try:
+        fingerprint = engine.state.validation_fingerprint()
+    except Exception:  # noqa: BLE001 — best-effort bookkeeping
+        return None
+    history: list[str] = list(getattr(engine, _MUTATION_HISTORY_FLAG, None) or [])
+    revisited = fingerprint in history
+    history.append(fingerprint)
+    setattr(engine, _MUTATION_HISTORY_FLAG, history[-_MUTATION_HISTORY_WINDOW:])
+    if not revisited:
+        setattr(engine, _MUTATION_CYCLE_COUNT_FLAG, 0)
+        return None
+
+    cycles = int(getattr(engine, _MUTATION_CYCLE_COUNT_FLAG, 0)) + 1
+    setattr(engine, _MUTATION_CYCLE_COUNT_FLAG, cycles)
+    logger.warning(
+        "Mutation cycle detected: %s returned the crate to a recent state (cycle %d/%d)",
+        tool_name,
+        cycles,
+        _MUTATION_CYCLE_ABORT,
+    )
+    _log_suppressed(engine, tool_name, f"mutation_cycle_{cycles}", kwargs)
+    if cycles >= _MUTATION_CYCLE_ABORT:
+        raise _InvocationCancelled("mutation cycle with no progress")
+    return (
+        f"{tool_name} put the crate back into a state it was in a moment ago — you are "
+        "cycling, not progressing. This usually means the same fact is being rewritten "
+        "in different encodings (a bare id, then a list, then an {'@id': …} object). "
+        "All of those are accepted and stored identically, so rewriting it a third way "
+        "changes nothing.\n\n"
+        "If a validation issue persists after you set a field, the field is not the "
+        "problem — re-read the issue and fix what it actually names, or ask the user. "
+        "Do NOT write this field again."
+    )
 
 
 def _log_suppressed(
@@ -1178,6 +1303,13 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     kwargs = {
                         k: v for k, v in kwargs.items() if k not in ("args", "kwargs")
                     }
+                # An explicit null is the model saying "not specified", but it
+                # reaches the tool as a real None and overwrites the parameter's
+                # default: `list_scanned_files(offset=None)` raised
+                # "'>' not supported between NoneType and int". Weak models fill
+                # in EVERY optional parameter this way, so drop the nulls and let
+                # the defaults apply — omitted and null mean the same thing here.
+                kwargs = {k: v for k, v in kwargs.items() if v is not None}
                 _raise_if_invocation_cancelled()
                 # Loop-breaker (#287 Fix B): if this is the Nth consecutive
                 # IDENTICAL call that has been returning a non-progress result
@@ -1204,11 +1336,31 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     evidence = getattr(engine.state, "document_evidence", {})
                     path = _reader_evidence_key(engine, str(kwargs.get("path", "")))
                     read_args = {k: v for k, v in kwargs.items() if k != "path"}
-                    if path and any(
-                        item.get("path") == path and item.get("args", {}) == read_args
-                        for item in evidence.values()
-                    ):
+                    cached = next(
+                        (
+                            item
+                            for item in evidence.values()
+                            if item.get("path") == path and item.get("args", {}) == read_args
+                        ),
+                        None,
+                    )
+                    if path and cached is not None:
                         _log_suppressed(engine, tool_name, "already_in_evidence", kwargs)
+                        # HAND BACK THE CONTENT, do not just refuse. The evidence
+                        # block in the state brief is capped, so a second document
+                        # is silently replaced by "[omitted for context budget]" —
+                        # and telling the model "it is already in your context"
+                        # when it demonstrably is not sent one session round this
+                        # loop 90 times (47 read_docx + 43 read_excel, ~1M input
+                        # tokens) asking for a file we were holding all along.
+                        # Serving the stored copy is cheaper than the re-read it
+                        # replaces and is the honest answer to the question asked.
+                        content = str(cached.get("content", "")).strip()
+                        if content:
+                            return (
+                                f"[Serving the copy of {path} already loaded this session "
+                                "— identical to re-reading it.]\n\n" + content
+                            )
                         return (
                             "Already loaded this document into bounded session evidence. "
                             "Use the loaded evidence in the state context; request a specific "
@@ -1397,6 +1549,10 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                     if unchanged:
                         logger.info("No-op mutation suppressed: %s(%s)", tool_name, signature)
                         result = _no_op_mutation_message(tool_name, kwargs, engine)
+                    else:
+                        cycle = _record_mutation_cycle(engine, tool_name, kwargs)
+                        if cycle is not None:
+                            result = cycle
 
                 # Track repeated list queries independently: this never stores or
                 # reuses their result, and mutations always reset the streak.
@@ -1588,6 +1744,51 @@ def _wrap_tools_node(tool_node: Any, profiler: Any, iteration_getter: Any) -> An
     return timed_tools_node
 
 
+# Entity types that are meaningless unless something points at them. A compound
+# nobody exposed, a cell line nobody cultured, a file nobody produced: each is
+# extraction that never became structure. Deliberately excludes the backbone
+# (Investigation/Study/Assay) and processes, which are wired by the mapper from
+# their parent links rather than by an inbound reference.
+_MUST_BE_LINKED_TYPES: frozenset[str] = frozenset(
+    {"MolecularEntity", "CellLineSample", "Sample", "File", "Person", "Organization"}
+)
+
+
+def _unreferenced_entities(state: CrateState) -> dict[str, list[str]]:
+    """Entities of a linkable type that nothing in the crate points at.
+
+    One pass: collect every id mentioned by any reference field, then report the
+    linkable entities missing from that set. Extraction is the easy half — a
+    session resolved 22 compounds and wired NONE of them, and the crate still
+    reported itself "complete" because counting entities cannot see that.
+
+    Returns ``{entity type: [ids]}``, empty when everything is connected.
+    """
+    from builder.tools._crate_mapping import _REF_FIELDS
+
+    referenced: set[str] = set()
+    for ent in state.list_entities():
+        for field in _REF_FIELDS:
+            value = ent.fields.get(field)
+            if value is None:
+                continue
+            items = value if isinstance(value, (list, tuple)) else [value]
+            for item in items:
+                key = item.get("@id") if isinstance(item, dict) else item
+                if isinstance(key, str) and key.strip():
+                    referenced.add(key.strip().lstrip("./").lstrip("#"))
+
+    orphans: dict[str, list[str]] = {}
+    for ent in state.list_entities():
+        etype = getattr(ent, "type", "")
+        if etype not in _MUST_BE_LINKED_TYPES:
+            continue
+        if ent.entity_id in referenced:
+            continue
+        orphans.setdefault(etype, []).append(ent.entity_id)
+    return orphans
+
+
 def _completeness_nudge(state: CrateState) -> str:
     """Compute a short deterministic present/missing/next-action steering line.
 
@@ -1617,12 +1818,20 @@ def _completeness_nudge(state: CrateState) -> str:
     n_cells = counts.get("CellLineSample", 0)
     has_process = any(counts.get(t) for t in ("LabProcess", "LabProtocol"))
     has_files = bool(counts.get("File"))
+    # Crate-level attribution: who is responsible for the DATASET. Tracked here
+    # because nothing else ever prompts for it — a crate can otherwise reach
+    # "complete" naming six publication authors and no owner at all.
+    meta = state.metadata
+    has_attribution = bool(meta.publisher or meta.creator or meta.contact)
+    orphans = _unreferenced_entities(state)
 
     present: list[str] = []
     if has_backbone:
         present.append("backbone ✓")
     if has_person:
         present.append("person ✓")
+    if has_attribution:
+        present.append("crate owner ✓")
     if n_compounds:
         present.append(f"{n_compounds} compounds ✓")
     if n_cells:
@@ -1639,6 +1848,11 @@ def _completeness_nudge(state: CrateState) -> str:
         missing.append("process chain")
     if not has_files:
         missing.append("file attachments")
+    if not has_attribution:
+        missing.append("crate owner (publisher/creator/contact)")
+    if orphans:
+        detail = ", ".join(f"{len(ids)} {t}" for t, ids in sorted(orphans.items()))
+        missing.append(f"links for {detail}")
     # Validation + export are always the closing steps until the crate lands.
     missing.append("validation")
     missing.append("export")
@@ -1655,6 +1869,26 @@ def _completeness_nudge(state: CrateState) -> str:
         next_action = "draft_process_chain"
     elif not has_files:
         next_action = "attach_files"
+    elif orphans:
+        # Extraction outran wiring. Name the actual ids so the next step is a
+        # concrete link call, and say plainly that guessing is not the fallback:
+        # an unresolvable connection is a question for the user, not a fifth
+        # encoding of the same failed write.
+        first_type, first_ids = sorted(orphans.items())[0]
+        sample = ", ".join(first_ids[:3]) + ("…" if len(first_ids) > 3 else "")
+        next_action = (
+            f"link the unconnected {first_type}(s) ({sample}) into the chain — "
+            "attach_files / link / populate_condition_table. Try it yourself "
+            "FIRST; if which entity it belongs to is genuinely ambiguous, ask the "
+            "user with present_to_human instead of guessing or re-writing the "
+            "same field another way"
+        )
+    elif not has_attribution:
+        next_action = (
+            "set_crate_metadata(publisher=…/creator=…/contact=…) — take the "
+            "corresponding person/affiliation from the assay metadata and CONFIRM "
+            "with the user; never invent it"
+        )
     else:
         # The crate looks complete — close it out.
         next_action = "build_and_validate then export_crate"
@@ -2128,6 +2362,17 @@ def _build_agent_graph(
         model = llm.bind_tools(active_tools) if active_tools else llm
         _raise_if_invocation_cancelled()
         response = model.invoke(model_messages)
+        # Accumulate this call's token usage onto the crate's generator record so
+        # the exported crate carries what the run cost. Done HERE rather than in
+        # the profiler wrapper because that wrapper is skipped entirely when
+        # profiling is off — cost accounting must not depend on instrumentation.
+        try:
+            call_in, call_out = _extract_token_usage(response)
+            engine.state.record_llm_usage(
+                {"input_tokens": call_in or 0, "output_tokens": call_out or 0}
+            )
+        except Exception:  # noqa: BLE001 — accounting never breaks the loop
+            logger.debug("Could not record LLM usage for this call", exc_info=True)
         # Return only the new response; the add_messages reducer appends it
         return {"messages": [response]}
 
@@ -2380,7 +2625,13 @@ def run_interactive_agent(
         checkpoint_thread_id = (
             f"{engine.state.session_id}:recovered-{checkpoint_generation}"
         )
-        logger.warning(
+        # INFO, not WARNING: rotating is the designed response to a turn that
+        # did not finish cleanly, and most non-ok outcomes are themselves
+        # deliberate (a loop guard stopping the turn, a time or step limit). The
+        # severity belongs to the CAUSE, which is already logged at its own
+        # level by whatever produced it — warning here too made routine
+        # housekeeping look like something had gone wrong.
+        logger.info(
             "Rotated LangGraph checkpoint after %s; continuing with fresh thread %s",
             outcome,
             checkpoint_thread_id,
@@ -2405,11 +2656,20 @@ def run_interactive_agent(
                     return ui.flatten_message_content(msg.content)
         return ""
 
-    def _print_reply(content: str) -> None:
-        """Print an agent reply through the shared renderer (empty → skip)."""
-        if not content:
+    replies = ui.TransientReplies(console)
+
+    def _print_reply(content: str, *, transient: bool = False) -> None:
+        """Print an agent reply through the shared renderer (empty → skip).
+
+        Running commentary from an autonomous run is printed *transient*: the
+        next one overwrites it, because "Let me build and validate" is obsolete
+        the moment the next step starts and scrolling twenty of them buries the
+        output that matters. A question or a final answer is printed normally
+        and stays.
+        """
+        if not content or not content.strip():
             return
-        console.print(ui.render_reply(content))
+        replies.print(content, transient=transient)
 
     # ── Session banner + greeting ───────────────────────────────────────
     # `resumed` is the caller's fact (--resume), never a guess from how populated
@@ -2471,27 +2731,42 @@ def run_interactive_agent(
     else:
         greeting_prompt = "Greet the user and tell them what you can help build."
 
-    def _print_resume_fallback() -> None:
-        """Print a resume fallback with next-step suggestions."""
-        suggestions = (
-            "Try asking to:\n"
-            "  • [cyan]list entities[/cyan] — see all drafted items\n"
-            "  • [cyan]run validation[/cyan] — check for missing fields\n"
-            "  • [cyan]assess MIT[/cyan] — check Minimum Information coverage\n"
-            "  • [cyan]draft[/cyan] <entity type> — add more entities\n"
-            "  • [cyan]build crate[/cyan] — assemble the RO-Crate"
-        )
+    def _print_resume_panel() -> None:
+        """Print the resume welcome: where the crate stands and what to do next.
+
+        Shown on EVERY resume, not only when the model fails to greet. The
+        suggestions are derived from the crate's actual state — blocking issues
+        first, then the next unmet step of the BASE -> ISA -> TOX climb, then
+        export — so they are correct regardless of what the model says, and they
+        are still there when it says nothing at all (a reasoning-heavy model
+        answering "welcome them back" with 18 tokens of thought and no text).
+        """
+        lines: list[str] = []
         if val.required_issues:
-            suggestions = (
-                f"There are [red]{len(val.required_issues)} REQUIRED validation issues[/red].\n"
-                "Try asking to [cyan]validate[/cyan] to see them."
+            blocking = f"[red]{len(val.required_issues)} REQUIRED issue(s)[/red]"
+            lines.append(
+                f"  • [cyan]what is still missing?[/cyan] — {blocking} block conformance"
             )
+            lines.append("  • [cyan]fix the required issues[/cyan] — I'll work through them")
+        elif not (val.base_passed and val.isa_passed and val.tox_passed):
+            nxt = (
+                "base" if not val.base_passed else "ISA" if not val.isa_passed else "ISA-Tox"
+            )
+            lines.append(f"  • [cyan]validate[/cyan] — {nxt} does not pass yet")
+        else:
+            lines.append("  • [cyan]export the crate[/cyan] — all three profiles pass")
+        if not any(e.type == "File" for e in engine.state.list_entities()) and file_count:
+            lines.append(
+                f"  • [cyan]attach the data files[/cyan] — {file_count} scanned, none placed yet"
+            )
+        lines.append("  • [cyan]list entities[/cyan] — see everything drafted so far")
+
         console.print(
             Panel(
-                f"[bold]Welcome back![/bold]\n"
-                f"You have [bold cyan]{entity_count}[/bold cyan] entities drafted "
-                f"across {len(counts)} types.\n"
-                f"[dim]{suggestions}[/dim]",
+                f"[bold]Welcome back![/bold] "
+                f"[bold cyan]{entity_count}[/bold cyan] entities across "
+                f"{len(counts)} types, {file_count} scanned files.\n"
+                "[dim]Where to pick up:[/dim]\n" + "\n".join(lines),
                 border_style="green",
             )
         )
@@ -2532,11 +2807,22 @@ def run_interactive_agent(
             )
         root_logger.setLevel(old_root_level)
         _rotate_checkpoint(outcome)
-        reply = _extract_reply(result) if (outcome == "ok" and result) else ""
-        if reply:
+        # .strip(): a greeting of pure whitespace (a model that spent its turn on
+        # reasoning blocks and emitted a bare newline) is NOT a greeting. Left
+        # untrimmed it was truthy, so the user got an empty green bullet and the
+        # fallback panel — the thing that actually says what to do next — was
+        # skipped precisely when it was needed most.
+        reply = (_extract_reply(result) or "").strip() if (outcome == "ok" and result) else ""
+        if resumed:
+            # ALWAYS on a resume: where the crate stands and what to do next is
+            # derived from state, so it is correct whatever the model says (or
+            # fails to say). Any greeting it does produce prints underneath as
+            # commentary, not as the only orientation the user gets.
+            _print_resume_panel()
+            if reply:
+                _print_reply(reply)
+        elif reply:
             _print_reply(reply)
-        elif resumed:
-            _print_resume_fallback()
         else:
             _print_fresh_fallback()
         if verbose and outcome == "error" and greeting_diagnostic:
@@ -2570,7 +2856,7 @@ def run_interactive_agent(
             )
         )
         if resumed:
-            _print_resume_fallback()
+            _print_resume_panel()
         else:
             _print_fresh_fallback()
 
@@ -2584,8 +2870,32 @@ def run_interactive_agent(
         ALWAYS lands when the session ends with un-exported entities. It is
         idempotent (never double-exports) and never raises (the goodbye must
         always print).
+
+        Runs under the same spinner the rest of the session uses: the build here
+        is a full SHACL pass plus a disk write — tens of seconds on a real crate
+        — and a bare "Finalizing…" line with nothing moving reads as a hang at
+        the exact moment the user is waiting to leave.
         """
-        _finish_backstop(engine, emit=console.print)
+        delegated = footer.active
+        spinner = ProgressSpinner(
+            console,
+            "finalizing the crate",
+            tick_interval=0.12 if delegated else 0.5,
+            activity_sink=footer.set_activity if delegated else None,
+            width_provider=footer.line_width if delegated else None,
+        )
+        # The backstop drives tools through engine.run_tool (not the LangChain
+        # callbacks the turn spinner listens to), so name the running step from
+        # the engine's own event hook.
+        prior_tool_event = engine.on_tool_event
+        engine.on_tool_event = lambda tool, phase, args_str: (
+            spinner.set_current(tool) if phase == "start" else spinner.set_current(None)
+        )
+        try:
+            with spinner:
+                _finish_backstop(engine, emit=console.print)
+        finally:
+            engine.on_tool_event = prior_tool_event
 
     def _run_turn(message_content: str) -> tuple[str, str]:
         """Run ONE model invocation and return ``(reply, outcome)`` (#263).
@@ -2611,6 +2921,9 @@ def run_interactive_agent(
             console,
             tick_interval=0.12 if delegated else 0.5,
             activity_sink=footer.set_activity if delegated else None,
+            # Lets the streamed reply tail fill the footer row exactly rather
+            # than sitting at a fixed width and being cut from the wrong end.
+            width_provider=footer.line_width if delegated else None,
         )
         main_config = {
             **_thread_config(),
@@ -2640,21 +2953,33 @@ def run_interactive_agent(
         # Flush any in-loop auto-export status lines buffered during the invoke
         # (#287 Fix A) now the spinner's Live region is gone, so "Crate written
         # to: <abs path>" lands cleanly in the transcript.
+        if auto_export_lines:
+            replies.invalidate()  # this output must not be erased with the reply
         while auto_export_lines:
             console.print(auto_export_lines.pop(0))
 
         if outcome == "ok" and result:
             reply = _extract_reply(result)
             if reply:
-                _print_reply(reply)
+                # Only throwaway commentary is transient. Anything with
+                # structure — the issue list just asked for, a summary — is the
+                # turn's result and must survive the next step.
+                _print_reply(reply, transient=_reply_is_running_commentary(reply))
         elif outcome == "timeout":
+            # Not a failure: a built-in limit was reached and the turn is being
+            # handed back. Saying "error" here sent people hunting for a bug
+            # that did not exist.
             console.print(
-                "[yellow]A tool timed out[/yellow] and I ended this step "
-                "to avoid hanging. Your work so far is saved."
+                f"[dim]Over to you — that step passed the {request_timeout:.0f}s time "
+                "limit, so I stopped it. Nothing is lost; the session is saved. "
+                "Say [/dim][bold]continue[/bold][dim] to pick it back up.[/dim]"
             )
+            console.print()
+        elif outcome == "stopped":
             console.print(
-                "  [dim]You can continue by typing[/dim] "
-                "[bold]continue[/bold]"
+                "[dim]Over to you — I was repeating the same step without getting "
+                "anywhere, so I stopped rather than keep spending on it. The session "
+                "is saved.[/dim]"
             )
             console.print()
         elif outcome == "stopped":
@@ -2669,9 +2994,10 @@ def run_interactive_agent(
             console.print()
         elif outcome == "recursion":
             console.print(
-                "[yellow]I reached the step limit for this request[/yellow] and "
-                "stopped to avoid an endless loop. Your session is saved — try a "
-                "smaller or more specific request, or ask me to continue."
+                "[dim]Over to you — this request hit its step limit "
+                f"([bold]{max_iterations}[/bold] tool iterations), so I stopped. The "
+                "session is saved; a smaller or more specific request usually gets "
+                "further.[/dim]"
             )
             console.print()
         elif outcome == "error":
@@ -2694,9 +3020,12 @@ def run_interactive_agent(
                     console.print(f"[dim]Traceback tail: {diagnostic['traceback_tail']}[/dim]")
                 console.print("Your work so far is saved.")
             else:
+                # Reserved for a GENUINE failure now that timeouts, loop guards
+                # and the step limit each report themselves.
                 console.print(
-                    "[yellow]I hit an error on that step[/yellow] and stopped. Your "
-                    "work so far is saved."
+                    "[yellow]Something actually went wrong on that step[/yellow] and I "
+                    "stopped. The session is saved. Re-run with [bold]-v[/bold] to see "
+                    "the underlying error."
                 )
             console.print()
 
@@ -2727,6 +3056,10 @@ def run_interactive_agent(
     try:
         while True:
             try:
+                # Back at the prompt: whatever narration is on screen is now the
+                # last thing the agent said, so it stays. Anything printed from
+                # here on must not be erased by the next turn's reply.
+                replies.invalidate()
                 # Status before each prompt: a repaint of the pinned footer when
                 # it owns the bottom rows, otherwise the scrolling header (counts
                 # live there, so the prompt line stays clean).

--- a/builder/agents/react/system_prompt.py
+++ b/builder/agents/react/system_prompt.py
@@ -174,7 +174,7 @@ as soon as the backbone exists — do **not** leave it to the end:
 
 The publication's authors are NOT this. They describe the paper; publisher /
 creator / contact describe the dataset. A crate can list six authors and still
-have no owner. `license` belongs here too — ask for it, never assume one.
+have no owner. The license belongs here too — ask for it, never assume one.
 
 ### Once BASE Passes
 - Add the ISA structural layer: LabProcesses, Samples, data Files linked to Assays. Wire the derivation chain explicitly — create data files with `draft_file`, connect each process to what it consumes and produces with `link` (e.g. `link(process, 'result', file)`), and run `check_provenance` to confirm no process output dangles and no file is orphaned (Sample → CellCulture → Exposure → EndpointReadout → DataAnalysis).

--- a/builder/agents/react/system_prompt.py
+++ b/builder/agents/react/system_prompt.py
@@ -128,6 +128,54 @@ A `build_and_validate` result may carry an **escalation** field: the user was as
 - At least one Assay (linked to Study)
 - Optionally: a Person, Organization, or File — but the Investigation+Study+Assay backbone is the quickest path to a passing crate
 
+### Connecting Entities: Try Yourself, Then Ask
+
+Extracting entities is the easy half. A crate with 22 compounds and no links
+between them is a list, not a graph — and it is the half that goes wrong. So:
+
+1. **Always attempt the connection yourself first.** Use the evidence you have:
+   the assay workbook names which chemicals were dosed in which exposure, the
+   SOP names the instrument, the file names carry plate/timepoint. Wire with
+   `link`, `attach_files`, `populate_condition_table`, `draft_process_chain`.
+2. **If a write does not take effect, STOP and re-read the error.** Do not
+   rewrite the same field in another encoding — a bare id, a list, an
+   `{"@id": …}` object and a `./#Type_id` are all accepted and stored
+   identically, so a second spelling changes nothing. If validation still
+   complains after a successful write, the field was not the problem.
+3. **When it is genuinely ambiguous, ASK.** Which of three assays a data file
+   belongs to; whether a compound is the test item or the reference; whether a
+   person is an author or the crate's publisher — these are not inferable from
+   the file names, and a wrong link is worse than an absent one because it
+   validates. Use `present_to_human` with the specific options you are choosing
+   between, and say what evidence you have for each.
+
+The bar for asking: you have tried, and the evidence genuinely does not decide
+it. Do not ask before trying; do not guess after failing.
+
+### Establish Who Owns the Crate (early, once)
+
+A crate that does not say who is responsible for it credits nobody. Settle this
+as soon as the backbone exists — do **not** leave it to the end:
+
+1. **Look first.** The assay metadata workbook usually names it outright:
+   `Corresponding person`, `Corresponding person_ORCID`,
+   `Corresponding person_Affiliation`, `Funding Agency`, `Grant_id`. Read those
+   fields before asking.
+2. **Draft and verify.** `draft_person` / `draft_organization` (or
+   `lookup_orcid` / `lookup_ror`) so the value is a resolvable identifier.
+3. **Record it** with `set_crate_metadata(publisher=…, creator=…, contact=…)`.
+   These take an entity id or a verified ORCID/ROR IRI and are REJECTED if they
+   do not resolve — a bare name is not attribution.
+4. **Confirm with the user.** State what you found and ask them to confirm or
+   correct it: "The metadata names Dr. X (ORCID …, Universiteit Utrecht) as the
+   corresponding person — should they be the crate's contact and publisher?"
+   The corresponding person of an assay is evidence, not proof, of who publishes
+   the dataset. If nothing names them, ASK rather than guess.
+
+The publication's authors are NOT this. They describe the paper; publisher /
+creator / contact describe the dataset. A crate can list six authors and still
+have no owner. `license` belongs here too — ask for it, never assume one.
+
 ### Once BASE Passes
 - Add the ISA structural layer: LabProcesses, Samples, data Files linked to Assays. Wire the derivation chain explicitly — create data files with `draft_file`, connect each process to what it consumes and produces with `link` (e.g. `link(process, 'result', file)`), and run `check_provenance` to confirm no process output dangles and no file is orphaned (Sample → CellCulture → Exposure → EndpointReadout → DataAnalysis).
 - Then the TOX domain layer: MolecularEntity lookups, Cellosaurus queries, AOP refs, BAO terms

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -395,7 +395,7 @@ TOOL_SPECS = [
     },
     {
         "name": "set_crate_metadata",
-        "description": "WRITE-ONLY setter for top-level crate metadata on the Root Data Entity (./): title/description/accession plus the root dates release_date (schema:releaseDate) and date_modified (schema:dateModified). You MUST pass at least one value to write — a call with all fields null writes nothing, is REJECTED with an error, and does not read anything back; use get_status to READ the current crate metadata. Pass ISO-8601 strings for the dates, e.g. release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z'. Only the fields you pass are written — never fabricate a date. datePublished is auto-set at build time and is not controlled here. Example: set_crate_metadata(accession='S-VHPS21', release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z').",
+        "description": "WRITE-ONLY setter for top-level crate metadata on the Root Data Entity (./): title/description/accession, the root dates release_date/date_modified, and crate-level ATTRIBUTION (publisher/creator/contact/license) — who is responsible for this dataset, which is NOT the same as the publication's authors. You MUST pass at least one value to write — a call with all fields null writes nothing, is REJECTED with an error, and does not read anything back; use get_status to READ the current crate metadata. Pass ISO-8601 strings for the dates, e.g. release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z'. Only the fields you pass are written — never fabricate a date. datePublished is auto-set at build time and is not controlled here. Example: set_crate_metadata(accession='S-VHPS21', release_date='2025-11-10', date_modified='2026-06-14T19:37:30Z').",
         "parameters": {
             "type": "object",
             "properties": {
@@ -418,6 +418,39 @@ TOOL_SPECS = [
                 "date_modified": {
                     "type": "string",
                     "description": "ISO-8601 date/datetime for schema:dateModified, e.g. '2026-06-14T19:37:30Z'.",
+                },
+                "publisher": {
+                    "type": "string",
+                    "description": "WHO PUBLISHES this dataset: an entity id of a drafted Person/Organization, or a verified ORCID/ROR IRI. Rejected if it does not resolve — a bare name is not attribution.",
+                },
+                "creator": {
+                    "type": "string",
+                    "description": "WHO MADE this dataset (entity id or verified ORCID/ROR IRI). Distinct from the publication's authors, which describe the paper.",
+                },
+                "contact": {
+                    "type": "string",
+                    "description": "WHO TO CONTACT about this dataset (entity id or verified ORCID IRI) — typically the corresponding person named in the assay metadata.",
+                },
+                "license": {
+                    "type": "string",
+                    "description": "Licence for the dataset, ideally a URL (e.g. 'https://creativecommons.org/licenses/by/4.0/'). Ask the user; never guess.",
+                },
+            },
+        },
+    },
+    {
+        "name": "set_validation_preference",
+        "description": "Record whether the user wants the broader RECOMMENDED / OPTIONAL validation tiers run from now on. The loop asks about each tier ONCE and then honours the answer silently — call this only when the user changes their mind mid-session, e.g. 'stop running the recommended checks' (recommended=false) or 'let's look at the optional findings too' (optional=true). The tiers are a hierarchy: turning recommended off turns optional off with it, and turning optional on turns recommended on. Never call this to re-ask a question the user has already answered.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "recommended": {
+                    "type": "boolean",
+                    "description": "Run the RECOMMENDED (SHOULD) tier from now on. Omit to leave unchanged.",
+                },
+                "optional": {
+                    "type": "boolean",
+                    "description": "Run the OPTIONAL (MAY) tier from now on. Omit to leave unchanged.",
                 },
             },
         },

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -456,23 +456,6 @@ TOOL_SPECS = [
         },
     },
     {
-        "name": "set_validation_preference",
-        "description": "Record whether the user wants the broader RECOMMENDED / OPTIONAL validation tiers run from now on. The loop asks about each tier ONCE and then honours the answer silently — call this only when the user changes their mind mid-session, e.g. 'stop running the recommended checks' (recommended=false) or 'let's look at the optional findings too' (optional=true). The tiers are a hierarchy: turning recommended off turns optional off with it, and turning optional on turns recommended on. Never call this to re-ask a question the user has already answered.",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "recommended": {
-                    "type": "boolean",
-                    "description": "Run the RECOMMENDED (SHOULD) tier from now on. Omit to leave unchanged.",
-                },
-                "optional": {
-                    "type": "boolean",
-                    "description": "Run the OPTIONAL (MAY) tier from now on. Omit to leave unchanged.",
-                },
-            },
-        },
-    },
-    {
         "name": "remove_entity",
         "description": "Remove an entity by id. Refuses (with an error naming the referrers) if other entities still reference it, so no dangling reference is left behind. Pass cascade=true to clear those references and remove anyway.",
         "parameters": {

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -147,6 +147,17 @@ class UiSnapshot:
     # context bloat, which the session total (a sum over every re-send) hides.
     turn_tokens_in: int = 0
     turn_tokens_out: int = 0
+    # The model actually answering. Read from the session profile once a reply
+    # has come back, else the configured model — so a fresh session still names
+    # what it is about to run.
+    model: str = ""
+    # Where the crate was written, and what is still open on it. Both belong in
+    # the goodbye summary: "where did my crate go" and "is it finished" are the
+    # two questions a user has when the session ends.
+    crate_path: str = ""
+    should_issue_count: int = 0
+    may_issue_count: int = 0
+    assessed_tiers: tuple[str, ...] = ()
 
 
 @dataclass
@@ -267,6 +278,14 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
 
     tokens_in, tokens_out, last_model = _read_token_totals(state.session_id)
     turn_in, turn_out = _read_turn_tokens(state.session_id)
+    model_name = last_model
+    if not model_name:
+        try:
+            from builder.config import get_active_model
+
+            model_name = get_active_model() or ""
+        except Exception:  # noqa: BLE001 — naming the model is advisory
+            logger.debug("active model unavailable", exc_info=True)
     cost_usd: float | None = None
     if tokens_in + tokens_out > 0:
         try:
@@ -296,6 +315,11 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
         cost_usd=cost_usd,
         turn_tokens_in=turn_in,
         turn_tokens_out=turn_out,
+        model=model_name,
+        crate_path=getattr(state.metadata, "output_path", "") or "",
+        should_issue_count=len(val.should_issues),
+        may_issue_count=len(val.may_issues),
+        assessed_tiers=tuple(sorted(getattr(val, "assessed_tiers", ()) or ())),
     )
 
 
@@ -306,6 +330,21 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
 
 def _dot(ok: bool) -> str:
     return _PASS_DOT if ok else _PENDING_DOT
+
+
+def _compact_model(name: str) -> str:
+    """A model name short enough for the pinned line, still recognisable.
+
+    Drops a provider prefix and a trailing release date — ``claude-sonnet-4``
+    identifies the model as well as ``anthropic/claude-sonnet-4-20250514`` and
+    leaves room for the counts that share the row. The header panel shows the
+    full name, so nothing is lost.
+    """
+    short = (name or "").rsplit("/", 1)[-1]
+    parts = short.split("-")
+    if len(parts) > 1 and parts[-1].isdigit() and len(parts[-1]) == 8:
+        short = "-".join(parts[:-1])
+    return short
 
 
 def _compact_tokens(count: int) -> str:
@@ -353,7 +392,12 @@ def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None =
         # rather than showing a misleading pair of zeros.
         turn_in = snap.turn_tokens_in or snap.tokens_in
         turn_out = snap.turn_tokens_out or snap.tokens_out
-        token_str = "  " + _SEP + "  " + field(
+        # The model sits at the head of the spend segment: it is what the tokens
+        # and the cost are being spent ON, so the three read as one fact.
+        model_prefix = (
+            f"{field('model', _compact_model(snap.model))}  {_SEP}  " if snap.model else ""
+        )
+        token_str = "  " + _SEP + "  " + model_prefix + field(
             "tokens",
             f"↑{_compact_tokens(turn_in)} ↓{_compact_tokens(turn_out)}"
             f"  {_compact_tokens(total)} tok{cost_str}",
@@ -374,6 +418,7 @@ def status_field_values(snap: UiSnapshot) -> dict[str, Any]:
     """The comparable value behind each status field, keyed as in *highlight*."""
     return {
         "session": snap.session_id,
+        "model": snap.model,
         "entities": snap.entity_count,
         "files": snap.file_count,
         "base": snap.base_passed,
@@ -521,6 +566,8 @@ def render_resume_summary(snap: UiSnapshot, *, resumed: bool) -> RenderableType:
     summary.add_column(style="white")
 
     summary.add_row("Session:", f"[cyan]{snap.session_id}[/cyan]")
+    if snap.model:
+        summary.add_row("Model:", f"[cyan]{snap.model}[/cyan]")
     summary.add_row("Entities:", f"[green]{snap.entity_count}[/green]")
     summary.add_row("Files:", f"[green]{snap.file_count}[/green]")
 
@@ -551,15 +598,26 @@ def render_resume_summary(snap: UiSnapshot, *, resumed: bool) -> RenderableType:
 
 
 def render_goodbye(
-    session_id: str, entity_counts: dict[str, int], *, resumable: bool
+    session_id: str,
+    entity_counts: dict[str, int],
+    *,
+    resumable: bool,
+    snap: UiSnapshot | None = None,
 ) -> RenderableType:
-    """The goodbye panel — session id, entity breakdown, and a resume hint.
+    """The goodbye panel — what was built, where it went, and what it cost.
+
+    A session ends with three unanswered questions: where is my crate, is it
+    finished, and what did that cost me? The entity breakdown alone answers
+    none of them. When *snap* is supplied, the panel adds the export path, the
+    outstanding issues per assessed tier, and the run's token spend.
 
     Args:
         session_id: The session identifier to echo.
         entity_counts: Per-type entity counts (``{}`` renders "0").
         resumable: When true, include the ``--resume`` command line (the
             caller decides this, e.g. only when a ``sessions/`` dir exists).
+        snap: Optional session snapshot supplying crate path, issues and cost.
+            Omitted (the default) renders the original three-row panel.
     """
     t = Table.grid(padding=(0, 1))
     t.add_column(style="yellow bold", width=14)
@@ -571,6 +629,43 @@ def render_goodbye(
         t.add_row("Entities:", parts)
     else:
         t.add_row("Entities:", "0")
+
+    if snap is not None:
+        t.add_row(
+            "Crate:",
+            f"[cyan]{snap.crate_path}[/cyan]"
+            if snap.crate_path
+            else "[yellow]not exported[/yellow] [dim]— ask me to export next time[/dim]",
+        )
+
+        # Only report a tier that actually ran: "0 recommended issues" would
+        # otherwise claim a clean bill of health for checks nobody performed.
+        conformance = "  ".join(
+            f"[{'green' if ok else 'red'}]{label}[/{'green' if ok else 'red'}]"
+            for label, ok in (
+                ("base", snap.base_passed),
+                ("ISA", snap.isa_passed),
+                ("Tox", snap.tox_passed),
+            )
+        )
+        open_counts: list[str] = [
+            f"[red]{snap.required_issue_count} required[/red]"
+            if snap.required_issue_count
+            else "[green]0 required[/green]"
+        ]
+        if "recommended" in snap.assessed_tiers:
+            open_counts.append(f"{snap.should_issue_count} recommended")
+        if "optional" in snap.assessed_tiers:
+            open_counts.append(f"{snap.may_issue_count} optional")
+        t.add_row("Validation:", f"{conformance}  [dim]·[/dim]  " + ", ".join(open_counts))
+
+        if snap.tokens_in + snap.tokens_out:
+            from builder.pricing import format_cost
+
+            total = _compact_tokens(snap.tokens_in + snap.tokens_out)
+            cost = format_cost(snap.cost_usd) if snap.cost_usd is not None else "cost unknown"
+            model = f" [dim]on {_compact_model(snap.model)}[/dim]" if snap.model else ""
+            t.add_row("This run:", f"[cyan]{cost}[/cyan] [dim]({total} tokens)[/dim]{model}")
 
     if resumable:
         t.add_row(
@@ -791,6 +886,18 @@ class PinnedFooter:
             f"[grey35]─[/grey35]"
         )
 
+    def line_width(self) -> int:
+        """Columns a footer row can paint into (0 when the footer is inactive).
+
+        Handed to the spinner so a streamed reply tail can fill the row exactly
+        — the footer truncates the HEAD of an over-long line, which for a
+        moving tail would show the wrong end of the text.
+        """
+        if not self._active:
+            return 0
+        width, _height = self._terminal_size()
+        return max(0, width - 1)
+
     def set_activity(self, markup: str | None) -> None:
         """Show (``None`` clears) the working line on the footer's middle row.
 
@@ -894,6 +1001,57 @@ class PinnedFooter:
                 self.refresh()
 
 
+class TransientReplies:
+    """Prints agent replies so that running commentary overwrites itself.
+
+    An autonomous run narrates every step — "Let me fix the two issues", "Let me
+    build and validate" — and each line is superseded by the next one seconds
+    later. Scrolled into the transcript they bury the output that matters; kept
+    transient, the newest one simply replaces the last.
+
+    A transient reply is erased only when it is still the last thing on screen.
+    Anything else printing in between (an export path, a tool result, the user's
+    own line) calls :meth:`invalidate`, and the reply then stays put rather than
+    having its lines cut out from under whatever followed it.
+
+    Off a terminal this is a plain passthrough, so piped output and CI logs keep
+    the full transcript.
+    """
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+        self._height = 0
+
+    def invalidate(self) -> None:
+        """Forget the last reply — something else has been printed since."""
+        self._height = 0
+
+    def print(self, content: Any, *, transient: bool = False) -> None:
+        """Print *content* as an agent reply, optionally as overwritable narration."""
+        if not content:
+            return
+        renderable = render_reply(content)
+        erasable = bool(getattr(self._console, "is_terminal", False))
+        if erasable and self._height:
+            # Walk up over the previous reply, clearing each line. Deliberately
+            # NOT "erase to end of screen": that would also wipe the pinned
+            # footer on the bottom rows.
+            try:
+                self._console.file.write("\x1b[1A\x1b[2K" * self._height)
+                self._console.file.flush()
+            except Exception:  # noqa: BLE001 — chrome must never break a turn
+                logger.debug("transient reply erase failed", exc_info=True)
+        self._height = 0
+        self._console.print(renderable)
+        if erasable and transient:
+            try:
+                self._height = len(
+                    self._console.render_lines(renderable, pad=False)
+                )
+            except Exception:  # noqa: BLE001 — fall back to leaving it on screen
+                logger.debug("transient reply height failed", exc_info=True)
+
+
 def make_status_footer(engine: AgentEngine, console: Console | None = None) -> PinnedFooter:
     """A :class:`PinnedFooter` showing *engine*'s live status line (both arms).
 
@@ -952,9 +1110,17 @@ def print_resume_summary(engine: AgentEngine, *, resumed: bool) -> None:
     fresh ``--input`` run a resume.
     """
     snap = snapshot_from_engine(engine)
+    console = get_console()
     if snap.entity_count or snap.file_count:
-        console = get_console()
         console.print(render_resume_summary(snap, resumed=resumed))
+        console.print()
+    elif snap.model:
+        # Nothing built yet, so the panel would be an empty box — but the model
+        # about to spend the user's money is still worth stating up front.
+        console.print(
+            f"[dim]session[/dim] [cyan]{snap.session_id}[/cyan]  {_SEP}  "
+            f"[dim]model[/dim] [cyan]{snap.model}[/cyan]"
+        )
         console.print()
 
 
@@ -972,7 +1138,9 @@ def print_goodbye(engine: AgentEngine, *, resumable: bool | None = None) -> None
     snap = snapshot_from_engine(engine)
     console = get_console()
     console.print()
-    console.print(render_goodbye(snap.session_id, snap.entity_counts, resumable=resumable))
+    console.print(
+        render_goodbye(snap.session_id, snap.entity_counts, resumable=resumable, snap=snap)
+    )
     console.print()
 
 

--- a/builder/config.py
+++ b/builder/config.py
@@ -315,6 +315,33 @@ def get_model_provider() -> str | None:
     return None
 
 
+def get_active_model() -> str | None:
+    """Return the primary (orchestrator) model name that a turn would use.
+
+    Mirrors the resolution in :func:`builder.agents.llm._build_chat_model` so
+    the UI can name the model BEFORE the first call — the session profile only
+    learns it once a response comes back, and "which model am I about to spend
+    money with?" is a question worth answering up front.
+
+    Returns *None* when no API family is configured.
+    """
+    load_config()  # env vars are populated from the config file here
+    family = get_provider()
+    if family == "openai":
+        return (
+            os.environ.get("VITRO_OPENAI_MODEL")
+            or os.environ.get("OPENAI_MODEL")
+            or "gpt-4o"
+        )
+    if family == "anthropic":
+        return (
+            os.environ.get("VITRO_ANTHROPIC_MODEL")
+            or os.environ.get("ANTHROPIC_MODEL")
+            or "claude-sonnet-4-20250514"
+        )
+    return None
+
+
 def get_drafter_model() -> str | None:
     """Return the configured *drafter* model name, or ``None`` if unset.
 

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -478,10 +478,29 @@ class AgentEngine:
 
         if not isinstance(path, str) or not path.strip():
             return None
-        name = Path(path).name
-        # Only a BARE name is resolved. A path with directories in it was a real
-        # (wrong) location, not a filename the model read off the inventory.
-        if not name or name != path.strip():
+        raw = path.strip()
+        name = Path(raw).name
+        if not name:
+            return None
+
+        # A path RELATIVE to the input root ("Assay_OATP1C1/Assay-metadata.xlsx")
+        # is the other shape a model naturally emits: it is how the file appears
+        # in the crate and in the inventory's relative listings. Resolved against
+        # the CWD it lands outside every approved root and was refused — one
+        # weak-model session lost 11 of 20 failed tool calls this way, retrying
+        # the same workbook six times. Joining it to an approved root can only
+        # reach files the sandbox already allows, and containment is re-checked.
+        if name != raw and not Path(raw).is_absolute():
+            for root in self.state.approved_scan_roots:
+                try:
+                    candidate = Path(root) / raw
+                    if not candidate.is_file():
+                        continue
+                    resolved = str(candidate.resolve())
+                except (OSError, RuntimeError, ValueError):
+                    continue
+                if _contain(resolved, self.state.approved_scan_roots) is not None:
+                    return resolved
             return None
 
         matches: list[str] = []
@@ -840,12 +859,21 @@ class AgentEngine:
             if self.profiler is not None:
                 self.profiler.log_event(event="hitl_wait", tool=tool_name)
             result = self.human_interface.present(kwargs.get("context", ""), kwargs.get("options"))
+            # Persist the answer: it is otherwise only a tool result inside the
+            # graph checkpoint, which a rotated thread discards (#user_answers).
+            if isinstance(result, dict):
+                spoken = result.get("comments") or result.get("action") or ""
+                self.state.record_user_answer(kwargs.get("context", ""), str(spoken))
         elif tool_name == "request_input":
             if self.profiler is not None:
                 self.profiler.log_event(event="hitl_wait", tool=tool_name)
             result = self.human_interface.request_input(
                 kwargs.get("prompt", ""), kwargs.get("field_type", "text")
             )
+            if isinstance(result, dict) and not result.get("skipped"):
+                self.state.record_user_answer(
+                    kwargs.get("prompt", ""), str(result.get("value") or "")
+                )
         elif tool_name in scanner_tools:
             tool_fn = scanner_tools[tool_name]
             # Prompt-once, children-only approval for a user-submitted folder

--- a/builder/state.py
+++ b/builder/state.py
@@ -1206,13 +1206,22 @@ class CrateState:
         validator could observe busts the cache, while a change to a pure output
         (a verdict, a score) does not.
         """
+        metadata = (
+            self.metadata.to_dict() if hasattr(self.metadata, "to_dict") else None
+        )
+        if metadata is not None:
+            # ``output_path`` is WHERE the crate gets written, not anything the
+            # validator can observe — two exports of an identical crate to
+            # different directories produce the same verdict. Leaving it in made
+            # `export_crate` (which sets it) look like a content change, so the
+            # recorded verdict read as stale and `ensure_validated` re-ran a full
+            # 3-pass SHACL sweep on every export to a new path.
+            metadata = {k: v for k, v in metadata.items() if k != "output_path"}
         content = {
             "entities": self.entities.to_dict()
             if hasattr(self.entities, "to_dict")
             else str(self.entities),
-            "metadata": self.metadata.to_dict()
-            if hasattr(self.metadata, "to_dict")
-            else str(self.metadata),
+            "metadata": metadata if metadata is not None else str(self.metadata),
         }
         return hashlib.sha256(
             json.dumps(content, sort_keys=True, default=str).encode("utf-8")

--- a/builder/state.py
+++ b/builder/state.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import builder.config as _config
 
@@ -338,6 +339,190 @@ class ArchivePreview:
 # ---------------------------------------------------------------------------
 
 
+def _app_version() -> str:
+    """The running vitro-crate version, for the crate's generator record.
+
+    A default rather than something only ``capture()`` fills in: the version is
+    a constant of the running program, and leaving it empty until export made
+    ``build_and_validate`` validate a DIFFERENT crate from the one written —
+    one whose ``SoftwareApplication`` had no ``version``, which trips a BASE
+    check the agent then cannot fix, because the value only ever appears after
+    the export it is trying to reach.
+
+    Prefers the installed distribution metadata so a wheel reports its real
+    version, falling back to the source ``__version__``.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("vitro-crate")
+        except PackageNotFoundError:
+            pass
+    except Exception:  # pragma: no cover - metadata is optional, never fatal
+        logger.debug("distribution version unavailable", exc_info=True)
+    try:
+        from builder import __version__
+
+        return str(__version__)
+    except Exception:  # pragma: no cover - version is cosmetic, never fatal
+        return ""
+
+
+@dataclass
+class GeneratorInfo:
+    """What produced this crate: the application, and the model(s) it drove.
+
+    A receiving lab cannot judge LLM-assisted metadata without knowing what
+    assisted it. This records the tool, its version, and the model behind it so
+    the crate says how it was made rather than presenting itself as hand-curated.
+
+    **Secrets never enter this record.** Only the allowlisted fields below are
+    captured — never an API key, never a raw ``base_url`` (which can carry a
+    token in its path or query), never arbitrary environment. ``api_host`` keeps
+    the hostname alone, which is what identifies a deployment; anything else is
+    dropped. The crate is a shareable artifact, so a leak here is a leak to
+    everyone the crate reaches.
+
+    Attributes:
+        name: Application name.
+        version: Application version.
+        url: Application homepage / source repository.
+        provider: The API family driving the run ("openai" / "anthropic" / …).
+        model: Effective orchestrator model name.
+        drafter_model: Effective drafter model, when it differs.
+        api_host: HOSTNAME of a custom API base, or None for the vendor default.
+        architecture: Which build path ran ("react" / "pipeline").
+        settings: Extra allowlisted, stringified run settings.
+    """
+
+    name: str = "vitro-crate"
+    version: str = field(default_factory=lambda: _app_version())
+    url: str = "https://github.com/johannehouweling/vitro-crate"
+    provider: str | None = None
+    model: str | None = None
+    drafter_model: str | None = None
+    api_host: str | None = None
+    architecture: str | None = None
+    settings: dict[str, str] = field(default_factory=dict)
+    # Run cost/effort. Baked into every export so a crate carries the price and
+    # wall-clock of producing it — the numbers to optimise against, and the ones
+    # nobody can reconstruct after the session is gone.
+    started_at: str = ""
+    ended_at: str = ""
+    duration_seconds: float | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    llm_calls: int = 0
+    cost_usd: float | None = None
+
+    # Run settings safe to publish. Anything not named here is dropped rather
+    # than filtered by pattern — an allowlist cannot be defeated by a new secret
+    # whose name nobody thought to blocklist.
+    ALLOWED_SETTINGS: ClassVar[frozenset[str]] = frozenset(
+        {"temperature", "max_iterations", "seed", "reasoning_effort", "max_history_tokens"}
+    )
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        architecture: str | None = None,
+        settings: dict[str, Any] | None = None,
+    ) -> GeneratorInfo:
+        """Snapshot the running application and its resolved model configuration."""
+        import builder.config as _cfg
+
+        # `str(...)` rather than importing straight into the name: `__version__`
+        # is a string LITERAL, so binding the fallback "" to the same name is a
+        # type error against its narrowed type.
+        app_version: str
+        try:
+            from builder import __version__
+
+            app_version = str(__version__)
+        except Exception:  # pragma: no cover - version is cosmetic, never fatal
+            app_version = ""
+
+        def _host(raw: str | None) -> str | None:
+            if not raw:
+                return None
+            host = str(raw).split("://", 1)[-1].split("/", 1)[0]
+            return host or None
+
+        safe: dict[str, str] = {}
+        for key, value in (settings or {}).items():
+            if key in cls.ALLOWED_SETTINGS and value is not None:
+                safe[key] = str(value)
+
+        def _quiet(fn: Any) -> Any:
+            try:
+                return fn()
+            except Exception:  # pragma: no cover - config must never fail an export
+                return None
+
+        model = _quiet(_cfg.get_active_model)
+        drafter = _quiet(_cfg.get_drafter_model)
+        return cls(
+            version=str(app_version or ""),
+            provider=_quiet(_cfg.get_provider),
+            model=model,
+            drafter_model=drafter if drafter and drafter != model else None,
+            api_host=_host(os.environ.get("VITRO_OPENAI_API_BASE")
+                           or os.environ.get("OPENAI_API_BASE")),
+            architecture=architecture,
+            settings=safe,
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"name": self.name, "version": self.version, "url": self.url}
+        for key in (
+            "provider", "model", "drafter_model", "api_host", "architecture",
+            "started_at", "ended_at",
+        ):
+            value = getattr(self, key)
+            if value:
+                d[key] = value
+        for key in ("input_tokens", "output_tokens", "llm_calls"):
+            if getattr(self, key):
+                d[key] = getattr(self, key)
+        if self.duration_seconds is not None:
+            d["duration_seconds"] = self.duration_seconds
+        if self.cost_usd is not None:
+            d["cost_usd"] = self.cost_usd
+        if self.settings:
+            d["settings"] = dict(self.settings)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GeneratorInfo:
+        return cls(
+            name=data.get("name", "vitro-crate"),
+            # A session saved before the version was recorded (or by an older
+            # build) restores as empty; fill it from the running app rather than
+            # resuming into a crate that fails BASE for a value we know.
+            version=data.get("version") or _app_version(),
+            url=data.get("url", "https://github.com/johannehouweling/vitro-crate"),
+            provider=data.get("provider"),
+            model=data.get("model"),
+            drafter_model=data.get("drafter_model"),
+            api_host=data.get("api_host"),
+            architecture=data.get("architecture"),
+            settings={k: str(v) for k, v in (data.get("settings") or {}).items()},
+            started_at=data.get("started_at", ""),
+            ended_at=data.get("ended_at", ""),
+            duration_seconds=data.get("duration_seconds"),
+            input_tokens=int(data.get("input_tokens") or 0),
+            output_tokens=int(data.get("output_tokens") or 0),
+            llm_calls=int(data.get("llm_calls") or 0),
+            cost_usd=data.get("cost_usd"),
+        )
+
+
 @dataclass
 class CrateMetadata:
     """Top-level metadata describing the RO-Crate itself.
@@ -361,6 +546,14 @@ class CrateMetadata:
     accession: str | None = None
     release_date: str | None = None
     date_modified: str | None = None
+    # Crate-level attribution. Distinct from the publication's authors, which
+    # describe the PAPER: these say who is responsible for this dataset. Each
+    # holds an entity id (a drafted Person/Organization) or a resolvable IRI
+    # (ORCID / ROR). Without them a crate credits nobody a registry can resolve.
+    publisher: str | None = None
+    creator: str | None = None
+    contact: str | None = None
+    license: str | None = None
     input_type: InputType = "directory"
     input_path: str | None = None
     output_path: str | None = None
@@ -377,6 +570,10 @@ class CrateMetadata:
             d["release_date"] = self.release_date
         if self.date_modified is not None:
             d["date_modified"] = self.date_modified
+        for key in ("publisher", "creator", "contact", "license"):
+            value = getattr(self, key)
+            if value is not None:
+                d[key] = value
         if self.input_path is not None:
             d["input_path"] = self.input_path
         if self.output_path is not None:
@@ -393,6 +590,10 @@ class CrateMetadata:
             accession=data.get("accession"),
             release_date=data.get("release_date"),
             date_modified=data.get("date_modified"),
+            publisher=data.get("publisher"),
+            creator=data.get("creator"),
+            contact=data.get("contact"),
+            license=data.get("license"),
             input_type=data.get("input_type", "directory"),  # type: ignore[arg-type]
             input_path=data.get("input_path"),
             output_path=data.get("output_path"),
@@ -817,6 +1018,7 @@ class CrateState:
     created_at: str = ""
     updated_at: str = ""
     metadata: CrateMetadata = field(default_factory=CrateMetadata)
+    generator: GeneratorInfo = field(default_factory=GeneratorInfo)
     entities: EntityStore = field(default_factory=EntityStore)
 
     scanned_files: list[FileClassification] = field(default_factory=list)
@@ -843,6 +1045,14 @@ class CrateState:
     # Persisted deliberately: an answer given before a --resume is still the
     # user's answer afterwards.
     validation_preferences: dict[str, bool] = field(default_factory=dict)
+
+    # What the user has already told us, in order. A HITL answer arrives as a
+    # tool result and therefore lives ONLY in the graph checkpoint — so a turn
+    # that ends mid-flight (a loop guard, a timeout) rotates the thread and the
+    # answer is gone, and the agent asks the same question again. One session
+    # asked who owns the dataset three times and was answered twice. State is
+    # the durable half of the session, so answers belong here.
+    user_answers: list[dict[str, str]] = field(default_factory=list)
 
     # ------------------------------------------------------------------
     # Entity management
@@ -888,6 +1098,102 @@ class CrateState:
     # ------------------------------------------------------------------
     # Content fingerprints (change detection for caching / export gating)
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Generator provenance & run cost
+    # ------------------------------------------------------------------
+
+    def record_llm_usage(
+        self,
+        usage: dict[str, Any] | None,
+        *,
+        calls: int = 1,
+    ) -> None:
+        """Accumulate one LLM call's token usage onto the generator record.
+
+        Accepts either naming convention the codebase sees
+        (``input_tokens``/``output_tokens`` or ``prompt_tokens``/``completion_tokens``).
+        A missing or unparseable usage dict is ignored rather than raising — cost
+        accounting must never take down a build.
+        """
+        if not usage:
+            return
+        try:
+            inp = int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0)
+            out = int(usage.get("output_tokens") or usage.get("completion_tokens") or 0)
+        except (TypeError, ValueError):
+            return
+        if not (inp or out):
+            return
+        self.generator.input_tokens += inp
+        self.generator.output_tokens += out
+        self.generator.llm_calls += calls
+
+    def record_user_answer(self, question: str, answer: str, *, limit: int = 20) -> None:
+        """Remember something the user told us, durably and in order.
+
+        Bounded to the most recent *limit* exchanges: this is fed back into the
+        model's context every turn, so it must stay small, and the recent
+        answers are the ones still in play. A repeated question overwrites its
+        earlier entry rather than accumulating, so re-asking (which happens) does
+        not push the other answers out.
+        """
+        q = " ".join(str(question).split())[:300]
+        a = " ".join(str(answer).split())[:300]
+        if not q or not a:
+            return
+        self.user_answers = [item for item in self.user_answers if item.get("question") != q]
+        self.user_answers.append({"question": q, "answer": a})
+        del self.user_answers[:-limit]
+
+    def stamp_generator(self, *, architecture: str | None = None) -> GeneratorInfo:
+        """Finalise the generator record for export: identity, timing, cost.
+
+        Called by ``export_crate`` so every written crate carries how it was made.
+        Preserves already-recorded token counts (the accumulator above) and fills
+        in what can only be known at the end: the end time, the elapsed wall-clock
+        since ``created_at``, and the money the run cost.
+
+        Never raises: a pricing lookup needs network on first use, and a crate
+        must still export when it is unavailable.
+        """
+        prior = self.generator
+        info = GeneratorInfo.capture(
+            architecture=architecture or prior.architecture,
+            settings={"max_iterations": self.max_iterations}
+            if getattr(self, "max_iterations", None)
+            else None,
+        )
+        info.input_tokens = prior.input_tokens
+        info.output_tokens = prior.output_tokens
+        info.llm_calls = prior.llm_calls
+        info.started_at = prior.started_at or self.created_at or ""
+        info.ended_at = _config.now().isoformat()
+        if info.started_at:
+            try:
+                from datetime import datetime
+
+                start = datetime.fromisoformat(info.started_at)
+                end = datetime.fromisoformat(info.ended_at)
+                info.duration_seconds = round((end - start).total_seconds(), 3)
+            except (TypeError, ValueError):
+                info.duration_seconds = None
+        if info.input_tokens or info.output_tokens:
+            try:
+                from builder.pricing import compute_cost
+
+                priced = compute_cost(
+                    info.input_tokens,
+                    info.output_tokens,
+                    info.model or "",
+                    info.provider,
+                )
+                total = priced.get("total_cost")
+                info.cost_usd = round(float(total), 6) if total is not None else None
+            except Exception:  # noqa: BLE001 - pricing is best effort, never fatal
+                info.cost_usd = None
+        self.generator = info
+        return info
 
     def validation_fingerprint(self) -> str:
         """Hash of what ``build_and_validate`` consumes: entities + metadata.
@@ -1057,6 +1363,7 @@ class StateSerializer:
             "created_at": state.created_at,
             "updated_at": state.updated_at,
             "metadata": cls._encode(state.metadata),
+            "generator": cls._encode(state.generator),
             "entities": cls._encode(state.entities),
             "approved_scan_roots": list(state.approved_scan_roots),
             "scanned_files": [cls._encode(f) for f in state.scanned_files],
@@ -1067,6 +1374,7 @@ class StateSerializer:
             "fair_assessment": cls._encode(state.fair_assessment),
             "checkpoint": cls._encode(state.checkpoint),
             "validation_preferences": dict(state.validation_preferences),
+            "user_answers": [dict(a) for a in state.user_answers],
             "iteration_count": state.iteration_count,
             "max_iterations": state.max_iterations,
             "stuck": state.stuck,
@@ -1102,6 +1410,7 @@ class StateSerializer:
             created_at=data.get("created_at", ""),
             updated_at=data.get("updated_at", ""),
             metadata=CrateMetadata.from_dict(data.get("metadata", {})),
+            generator=GeneratorInfo.from_dict(data.get("generator", {})),
             entities=EntityStore.from_dict(data.get("entities", {})),
             approved_scan_roots=set(data.get("approved_scan_roots", [])),
             scanned_files=[FileClassification.from_dict(f) for f in data.get("scanned_files", [])],
@@ -1119,6 +1428,11 @@ class StateSerializer:
                 str(k): bool(v)
                 for k, v in (data.get("validation_preferences") or {}).items()
             },
+            user_answers=[
+                {"question": str(a.get("question", "")), "answer": str(a.get("answer", ""))}
+                for a in (data.get("user_answers") or [])
+                if isinstance(a, dict)
+            ],
         )
 
     @classmethod

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -380,6 +380,10 @@ _STRUCT_FIELDS = frozenset(
         "dest_path",
         "path",
         "contentUrl",
+        # Provisional-placeholder markers (#438) — consumed to materialise a
+        # minimal typed table, never emitted as stray literals on the File node.
+        "provisional",
+        "table_kind",
         # LabProcess kwargs threaded into the typed subtype constructors (#143)
         # rather than emitted as stray literals on the process node.
         "units",
@@ -433,11 +437,16 @@ def populate_crate(
         state,
         crate,
         idx,
+        output_dir,
         materialize_payload=materialize_payload,
         include_all_scanned=include_all_scanned,
     )
     _add_structural(state, crate, idx)
     _add_processes(state, crate, idx, output_dir, materialize_payload=materialize_payload)
+    # After the index is complete, so publisher/creator/contact can point at any
+    # Person or Organization in the crate (or at a bare ORCID/ROR IRI).
+    _wire_root_attribution(state, crate, idx)
+    _add_generator_provenance(state, crate)
     _wire_mentions(state, idx)
     _wire_dataset_aliases(state, crate, idx)
 
@@ -797,9 +806,11 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
     if m.date_modified:
         crate.root_dataset["dateModified"] = m.date_modified
     crate.root_dataset["additionalType"] = "Investigation"
-    # Base RO-Crate MUST: the Root Data Entity has a license. The ISA-Tox shape
-    # endorses this exact placeholder when none is available.
-    if not crate.root_dataset.get("license"):
+    # Base RO-Crate MUST: the Root Data Entity has a license. A license the user
+    # gave wins; the ISA-Tox shape endorses this placeholder when none is known.
+    if m.license:
+        crate.root_dataset["license"] = m.license
+    elif not crate.root_dataset.get("license"):
         crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
 
     # Conformance placement follows RO-Crate 1.2 (ro-crate-1.2.0.md §Profiles,
@@ -918,6 +929,7 @@ def _add_leaves(
     state: CrateState,
     crate: ROCrate,
     idx: dict[str, Any],
+    output_dir: Path | None = None,
     *,
     materialize_payload: bool = True,
     include_all_scanned: bool = True,
@@ -1036,6 +1048,15 @@ def _add_leaves(
         # payload at write() time (#128). Skip on the in-memory build_and_validate
         # path (materialize_payload=False) — nothing is written there.
         source = _file_source(fe, state.metadata.input_path) if materialize_payload else None
+        # A synthesized placeholder has no file on disk, so `_file_source`
+        # correctly returns None and the crate would claim a file it does not
+        # contain (#438). Materialise a minimal typed table for it instead.
+        provisional_rel: str | None = None
+        if source is None and materialize_payload and fe.fields.get("provisional"):
+            provisional_rel = _file_dest(fe)
+            source = _materialize_provisional_table(fe, output_dir, provisional_rel)
+            if source is None:
+                provisional_rel = None
         # Co-type a source-code (or otherwise extra-typed) File as a @type list,
         # e.g. ["File", "SoftwareSourceCode"] for an analysis script (#180, gold
         # plot.py). A plain File keeps its scalar @type. additional_types is
@@ -1049,18 +1070,28 @@ def _add_leaves(
                 if t and t not in seen:
                     seen.add(t)
                     file_type.append(t)
+        # A materialised provisional table is co-typed csvw:Table and carries an
+        # explicit note that it holds no rows, so a consumer can never mistake
+        # the template for data.
+        props: dict[str, Any] = {"@type": file_type, **_scalar_props(fe)}
+        if provisional_rel is not None:
+            types = file_type if isinstance(file_type, list) else [file_type]
+            props["@type"] = [*types, "csvw:Table"]
+            props["description"] = _PROVISIONAL_NOTE
         _idx_add(
             idx,
             fe,
-            crate.add(
+            node := crate.add(
                 File(
                     crate,
                     source,
                     dest_path=_file_dest(fe),
-                    properties={"@type": file_type, **_scalar_props(fe)},
+                    properties=props,
                 )
             ),
         )
+        if provisional_rel is not None:
+            _attach_provisional_schema(crate, node, fe)
 
     for proto in state.list_entities("LabProtocol"):
         _idx_add(
@@ -1437,6 +1468,216 @@ _RAW_MEASUREMENTS_COLUMNS: tuple[dict[str, str], ...] = (
 )
 
 _RAW_MEASUREMENTS_HEADER = ",".join(c["titles"] for c in _RAW_MEASUREMENTS_COLUMNS) + "\n"
+
+
+# --- provisional placeholder tables (#438) ---------------------------------
+# `draft_process_chain` synthesizes a result File for an EndpointReadout /
+# DataAnalysis that has no explicit output, because a missing result fires a tox
+# REQUIRED Violation. Those entities used to be metadata only: the exported crate
+# listed a file in `hasPart` that no byte of the payload contained, and ro-crate-py
+# warned "No source for …" on every export.
+#
+# They are now materialised the same way the condition and raw-measurements
+# tables already are — a header-only CSV with a typed CSVW schema — so the
+# reference resolves and the column contract tells a human exactly what to fill
+# in. No measurement row is ever fabricated (D5): the file ships EMPTY below its
+# header, and the node says so in `description` so a consumer cannot mistake a
+# template for data.
+_ANALYSIS_RESULT_COLUMNS: tuple[dict[str, str], ...] = (
+    {
+        "titles": "group",
+        "datatype": "string",
+        "propertyUrl": iri("NCIT:C43359"),
+    },
+    {
+        "titles": "endpoint",
+        "datatype": "string",
+        "propertyUrl": iri("IAO:0000109"),
+    },
+    {
+        "titles": "value",
+        "datatype": "double",
+        "propertyUrl": iri("IAO:0000109"),
+    },
+    {
+        "titles": "unit",
+        "datatype": "string",
+        "propertyUrl": iri("IAO:0000039"),
+    },
+)
+
+_PROVISIONAL_TABLES: dict[str, tuple[str, tuple[dict[str, str], ...]]] = {
+    "measurements": ("Provisional measurements", _RAW_MEASUREMENTS_COLUMNS),
+    "analysis": ("Provisional analysis results", _ANALYSIS_RESULT_COLUMNS),
+}
+
+_PROVISIONAL_NOTE = (
+    "Provisional template generated to keep the derivation chain complete: the "
+    "column headers below are a suggested minimal shape and the table contains NO "
+    "rows. Replace it with the real output of this step, or fill in the rows."
+)
+
+
+def _materialize_provisional_table(
+    fe: Entity, output_dir: Path | None, rel: str
+) -> str | None:
+    """Write a provisional placeholder's header-only CSV and return its path.
+
+    Returns ``None`` when there is nothing to write (not a provisional entity, or
+    the in-memory validate path where no payload is materialised), leaving the
+    caller's existing source resolution untouched.
+    """
+    if not fe.fields.get("provisional") or output_dir is None:
+        return None
+    kind = str(fe.fields.get("table_kind") or "measurements")
+    spec = _PROVISIONAL_TABLES.get(kind)
+    if spec is None:
+        return None
+    _name, columns = spec
+    dest = output_dir / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not dest.exists():
+        dest.write_text(",".join(c["titles"] for c in columns) + "\n", encoding="utf-8")
+    return str(dest)
+
+
+def _attach_provisional_schema(crate: ROCrate, node: Any, fe: Entity) -> None:
+    """Give a materialised provisional table the same typed CSVW schema the
+    condition / raw-measurements tables carry, so its columns are machine-readable
+    rather than a bare header line."""
+    kind = str(fe.fields.get("table_kind") or "measurements")
+    spec = _PROVISIONAL_TABLES.get(kind)
+    if spec is None:
+        return
+    name, columns = spec
+    slug = _slug(fe.entity_id)
+    schema = _build_csvw_schema(
+        crate,
+        schema_id=f"#{slug}_schema",
+        schema_name=f"{name} schema",
+        id_prefix=f"#{slug}",
+        columns=columns,
+    )
+    node["tableSchema"] = {"@id": schema.id}
+    node.append_to("conformsTo", schema)
+
+
+# --- generator provenance -------------------------------------------------
+# Every export records what produced the crate: the application and version, the
+# model that drove it, and what the run cost in tokens, money and wall-clock.
+# LLM-assisted metadata cannot be judged without knowing what assisted it, and
+# the cost/time figures are the ones nobody can reconstruct once the session is
+# gone — so they travel with the crate rather than living only in a log.
+#
+# Modelled the RO-Crate way: a `SoftwareApplication` for the tool, a second one
+# for the model, and a `CreateAction` whose `instrument` is the tool, whose
+# `result` is the Root Data Entity, and whose run metrics hang off it as
+# `PropertyValue`s. The root `mentions` the action so it is reachable.
+_GENERATOR_METRICS: tuple[tuple[str, str, str | None], ...] = (
+    ("input_tokens", "Input tokens", None),
+    ("output_tokens", "Output tokens", None),
+    ("llm_calls", "LLM calls", None),
+    ("duration_seconds", "Run duration", "s"),
+    ("cost_usd", "Estimated cost", "USD"),
+)
+
+
+def _wire_root_attribution(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+    """Put crate-level attribution on the Root Data Entity.
+
+    ``author`` on the root is populated from every drafted ``Person``, which
+    answers "who is named in this crate" — not "who is responsible for this
+    dataset". ``publisher`` / ``creator`` / ``contactPoint`` answer the second
+    question, and a crate without them credits nobody a registry can resolve.
+
+    Each value is an entity id or a resolvable IRI (ORCID / ROR), wired through
+    the shared resolver so a bare identifier still emits a proper reference.
+    """
+    m = state.metadata
+    for prop, value in (
+        ("publisher", m.publisher),
+        ("creator", m.creator),
+        ("contactPoint", m.contact),
+    ):
+        if value:
+            _wire_reference(crate.root_dataset, prop, value, idx)
+
+
+def _add_generator_provenance(state: CrateState, crate: ROCrate) -> None:
+    """Record the generating application, model and run cost on the crate."""
+    gen = state.generator
+    if not gen or not gen.name:
+        return
+
+    app = crate.add(
+        ContextEntity(
+            crate,
+            gen.url or f"#{_slug(gen.name)}",
+            properties={
+                "@type": "SoftwareApplication",
+                "name": gen.name,
+                **({"version": gen.version} if gen.version else {}),
+                **({"url": gen.url} if gen.url else {}),
+            },
+        )
+    )
+
+    action_props: dict[str, Any] = {
+        "@type": "CreateAction",
+        "name": f"{gen.name} build",
+    }
+    if gen.started_at:
+        action_props["startTime"] = gen.started_at
+    if gen.ended_at:
+        action_props["endTime"] = gen.ended_at
+    action = crate.add(
+        ContextEntity(crate, f"#{_slug(gen.name)}_run", properties=action_props)
+    )
+    action.append_to("instrument", app)
+    action["result"] = {"@id": "./"}
+
+    # The model is an instrument of the run too — naming it is the point of the
+    # record, and its settings ride along as PropertyValues.
+    if gen.model:
+        model_props: dict[str, Any] = {"@type": "SoftwareApplication", "name": gen.model}
+        if gen.provider:
+            model_props["provider"] = gen.provider
+        model_node = crate.add(
+            ContextEntity(crate, f"#model_{_slug(gen.model)}", properties=model_props)
+        )
+        action.append_to("instrument", model_node)
+
+    for key, label, unit in _GENERATOR_METRICS:
+        value = getattr(gen, key, None)
+        if not value:
+            continue
+        pv_props: dict[str, Any] = {
+            "@type": "PropertyValue",
+            "name": label,
+            "value": str(value),
+        }
+        if unit:
+            pv_props["unitText"] = unit
+        action.append_to(
+            "additionalProperty",
+            crate.add(ContextEntity(crate, param_id(label, str(value)), properties=pv_props)),
+        )
+    for key, value in (gen.settings or {}).items():
+        action.append_to(
+            "additionalProperty",
+            crate.add(
+                ContextEntity(
+                    crate,
+                    param_id(key, str(value)),
+                    properties={
+                        "@type": "PropertyValue",
+                        "name": key,
+                        "value": str(value),
+                    },
+                )
+            ),
+        )
+    crate.root_dataset.append_to("mentions", action)
 
 
 def _condition_table_rel(exp_pid: str) -> str:

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -19,7 +19,7 @@ from rocrate.rocrate import ROCrate
 
 import builder.config as _config
 from builder.state import CrateState
-from builder.tools._crate_mapping import populate_crate
+from builder.tools._crate_mapping import _file_dest, populate_crate
 from profiles.context import ISA_TOX_CONTEXT
 
 logger = logging.getLogger(__name__)
@@ -367,6 +367,14 @@ def export_crate(
                     validation_info["error"],
                 )
 
+        # Stamp what produced this crate — application, version, model, and the
+        # run's tokens/cost/wall-clock — immediately before assembly, so the
+        # figures cover the whole session up to this write (#generator).
+        try:
+            state.stamp_generator()
+        except Exception as gen_err:  # noqa: BLE001 — provenance never fails an export
+            logger.warning("Could not record generator provenance: %s", gen_err)
+
         crate = assemble_crate(state, output_dir, materialize_payload=True)
         # Embed the standard ro-crate-py preview (ro-crate-preview.html, a
         # CreativeWork about ./) so the written crate is browsable without
@@ -393,10 +401,25 @@ def export_crate(
 
         crate.write(str(output_dir))
 
+        # Remember where it landed: without this the state cannot say where the
+        # crate went, so the goodbye summary (and a later re-export) had to guess
+        # the default even when the caller named a different destination.
+        state.metadata.output_path = output_path
+
         logger.info("Crate exported to %s", output_path)
         out: dict[str, Any] = {"success": True, "crate_path": output_path, "error": None}
         if validation_info is not None:
             out["validation"] = validation_info
+        # Empty templates written to keep the derivation chain complete (#438).
+        # Returned so the caller can ask the user to confirm or replace them —
+        # they are the one part of the payload that carries no real data.
+        provisional = sorted(
+            _file_dest(fe)
+            for fe in state.list_entities("File")
+            if fe.fields.get("provisional")
+        )
+        if provisional:
+            out["provisional_tables"] = provisional
         return out
 
     except OSError as e:

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -392,6 +392,16 @@ def draft_process_chain(
     return result
 
 
+# Which minimal table a synthesized placeholder should carry (#438). An
+# EndpointReadout emits per-well measurements; a DataAnalysis emits summarised
+# results. The columns themselves live in ``_crate_mapping`` next to the existing
+# CSVW table contracts, so every table the crate ships is typed the same way.
+_PROVISIONAL_TABLE_KIND: dict[str, str] = {
+    "EndpointReadout": "measurements",
+    "DataAnalysis": "analysis",
+}
+
+
 def _synthesize_output(
     state: CrateState,
     proc: Entity,
@@ -416,18 +426,23 @@ def _synthesize_output(
         if upstream is not None:
             sample_hints["derives_from"] = upstream
         return draft_sample_fn(state, sample_hints)
-    # Data producer: a placeholder result File.
+    # Data producer: a placeholder result File. It is marked PROVISIONAL so the
+    # build materialises a minimal typed table for it (#438) — an entity alone
+    # left the exported crate claiming a file that was never written.
     name = f"{proc.entity_id}_result.csv"
     file_id = f"file_{_slug(name)}"
     existing = state.get_entity(file_id)
     if existing is not None:
         return existing
-    return draft_file_fn(
+    placeholder = draft_file_fn(
         state,
         name=name,
         path=f"data/{name}",
         role="processed_data",
     )
+    placeholder.fields["provisional"] = True
+    placeholder.fields["table_kind"] = _PROVISIONAL_TABLE_KIND.get(ptype, "measurements")
+    return placeholder
 
 
 def _synthesize_input(state: CrateState, proc: Entity, draft_file_fn: Any) -> Entity:
@@ -441,7 +456,12 @@ def _synthesize_input(state: CrateState, proc: Entity, draft_file_fn: Any) -> En
     existing = state.get_entity(file_id)
     if existing is not None:
         return existing
-    return draft_file_fn(state, name=name, path=f"data/{name}", role="raw_data")
+    placeholder = draft_file_fn(state, name=name, path=f"data/{name}", role="raw_data")
+    # A DataAnalysis consumes measurements, so its provisional input carries the
+    # per-well measurement shape rather than the analysis-result shape.
+    placeholder.fields["provisional"] = True
+    placeholder.fields["table_kind"] = "measurements"
+    return placeholder
 
 
 def _input_ref(proc: Entity) -> Any:

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -21,6 +21,105 @@ from builder.tools.field_kinds import is_reference_field, is_resolvable_referenc
 logger = logging.getLogger(__name__)
 
 
+# Reference properties the build resolves as COLLECTIONS (via ``_resolve_many`` /
+# ``_wire_references``). For these a bare value and a one-item list say the same
+# thing, so both are stored as a list — otherwise "assay_y" and ["assay_y"] are
+# two different states and a model alternating between them looks like progress
+# forever (observed: a string/list flip every ~6s for a full minute).
+#
+# Deliberately an allow-list: the single-valued references (``labprotocol``,
+# ``cell_line``, ``study_id``, ``measurementMethod``, …) go through
+# ``_wire_reference``, which resolves ONE value — wrapping those in a list would
+# silently break them. An unrecognised reference field keeps its shape.
+_COLLECTION_REF_FIELDS: frozenset[str] = frozenset(
+    {
+        "hasPart",
+        "has_part",
+        "studies",
+        "assays",
+        "resources",
+        "dataFiles",
+        "author",
+        "mentions",
+        "chemicals",
+        "cell_lines",
+        "biological_models",
+        "biologicalModels",
+        "samples",
+        "result",
+        "output",
+        "input",
+        "object",
+        "about",
+        "funder",
+        "additionalProperty",
+    }
+)
+
+
+def _normalize_reference_one(state: CrateState, value: Any) -> str | None:
+    """One reference value reduced to its bare entity id (or a kept-verbatim IRI).
+
+    Accepts every encoding a caller might reach for — ``"assay_x"``,
+    ``{"@id": "assay_x"}``, ``"#assay_x"``, ``"./#Assay_assay_x"`` — because the
+    build resolves all of them. An external IRI is kept as-is; an unrecognised
+    string is kept verbatim rather than dropped, so nothing is silently lost.
+    """
+    key = value.get("@id") if isinstance(value, dict) else value
+    if not isinstance(key, str):
+        return None
+    key = key.strip()
+    if not key:
+        return None
+    if "://" in key:
+        return key  # external identifier — already canonical
+    bare = key.lstrip("./").lstrip("#")
+    if state.get_entity(bare) is not None:
+        return bare
+    # Crate-style type-qualified id, e.g. "Assay_assay_x" -> "assay_x".
+    if "_" in bare:
+        candidate = bare.split("_", 1)[1]
+        if state.get_entity(candidate) is not None:
+            return candidate
+    return key
+
+
+def _normalize_reference_value(
+    state: CrateState, entity_id: str, value: Any, field: str = ""
+) -> Any:
+    """Canonicalise a reference-valued field before it is stored.
+
+    The same fact can be written six ways — bare id, ``{"@id": …}``, a
+    ``./#Type_id`` crate id, each of those alone or in a list — and every one of
+    them used to be stored verbatim. A model that cannot tell which encoding the
+    validator wants then cycles through them, and because each write genuinely
+    changes the stored value, nothing downstream recognises it as going in
+    circles: one observed session wrote the same Study→Assay link 29 times in
+    six encodings, ~1.7M input tokens.
+
+    Collapsing to one canonical form makes the second write of the same fact a
+    true no-op, which the loop's no-op guard already catches. Self-references
+    and duplicates are dropped — a Study listing itself under ``hasPart`` is
+    never meaningful. List-ness is preserved: some reference properties are
+    single-valued in the build and wrapping them in a list would break them.
+    """
+    if value is None or value == "":
+        return value
+    is_list = isinstance(value, (list, tuple))
+    items = list(value) if is_list else [value]
+    out: list[str] = []
+    for item in items:
+        norm = _normalize_reference_one(state, item)
+        if norm is None or norm == entity_id or norm in out:
+            continue
+        out.append(norm)
+    if field in _COLLECTION_REF_FIELDS:
+        return out  # a collection property is always stored as a list
+    if is_list:
+        return out
+    return out[0] if out else None
+
+
 def set_fields(
     state: CrateState,
     entity_id: str,
@@ -49,6 +148,12 @@ def set_fields(
     entity = state.get_entity(entity_id)
     if entity is None:
         raise ValueError(f"Entity not found: {entity_id}")
+
+    fields = {
+        name: (_normalize_reference_value(state, entity_id, value, name)
+               if is_reference_field(name) else value)
+        for name, value in fields.items()
+    }
 
     for field, value in fields.items():
         # (#375) A reference-only property whose value is not a resolvable
@@ -267,6 +372,10 @@ def set_crate_metadata(
     accession: str | None = None,
     release_date: str | None = None,
     date_modified: str | None = None,
+    publisher: str | None = None,
+    creator: str | None = None,
+    contact: str | None = None,
+    license: str | None = None,
 ) -> dict[str, Any]:
     """Set top-level crate metadata on ``state.metadata`` (the Root Data Entity).
 
@@ -303,7 +412,10 @@ def set_crate_metadata(
     tokens) without anything stopping it. Use ``get_status`` to read the current
     metadata.
     """
-    supplied = (title, description, accession, release_date, date_modified)
+    supplied = (
+        title, description, accession, release_date, date_modified,
+        publisher, creator, contact, license,
+    )
     if all(value in (None, "") for value in supplied):
         return {
             "error": (
@@ -326,12 +438,35 @@ def set_crate_metadata(
         m.release_date = release_date
     if date_modified not in (None, ""):
         m.date_modified = date_modified
+    # Attribution: an entity id or a resolvable IRI, never free text — a name
+    # string credits nobody a registry can resolve (D5).
+    for attr, value in (
+        ("publisher", publisher), ("creator", creator), ("contact", contact)
+    ):
+        if value in (None, ""):
+            continue
+        if not is_resolvable_reference(state, value):
+            return {
+                "error": (
+                    f"{attr}={value!r} does not resolve to anyone. Draft the Person or "
+                    "Organization first (draft_person / draft_organization), or pass a "
+                    "verified ORCID/ROR IRI. A bare name is not attribution."
+                ),
+                "tool": "set_crate_metadata",
+            }
+        setattr(m, attr, value)
+    if license not in (None, ""):
+        m.license = license
     return {
         "title": m.title,
         "description": m.description,
         "accession": m.accession,
         "release_date": m.release_date,
         "date_modified": m.date_modified,
+        "publisher": m.publisher,
+        "creator": m.creator,
+        "contact": m.contact,
+        "license": m.license,
     }
 
 
@@ -377,8 +512,6 @@ def set_validation_preference(
         "tiers_that_will_run": ["required"]
         + [tier for tier in ("recommended", "optional") if prefs.get(tier)],
     }
-
-
 # ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -74,7 +74,11 @@ def _reproducibility_checks(state: CrateState) -> list[tuple[str, bool, str]]:
         processes,
         ("detection_instrument", "instrument_manufacturer", "software", "data_processing"),
     )
-    data_ok = bool(state.list_entities("File"))
+    # A provisional placeholder now materialises as a real (header-only) file so
+    # the crate stops claiming files it does not contain (#438) — but it holds no
+    # measurements, so counting it here would turn "data files included" green for
+    # a crate whose data is still entirely absent.
+    data_ok = any(not f.fields.get("provisional") for f in state.list_entities("File"))
     investigations = state.list_entities("Investigation")
     attribution_ok = (
         bool(state.metadata.title)
@@ -101,7 +105,8 @@ def _reproducibility_checks(state: CrateState) -> list[tuple[str, bool, str]]:
         (
             "Data files included",
             data_ok,
-            "Attach the raw/processed data files referenced by the assays.",
+            "Attach the raw/processed data files referenced by the assays — the "
+            "synthesized placeholder tables are empty templates, not data.",
         ),
         (
             "Attribution & identity",

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -730,6 +730,10 @@ _AFFILIATION_KEYS = (
     "https://schema.org/affiliation",
 )
 _PROTOCOL_KEYS = ("executesLabProtocol", "https://bioschemas.org/executesLabProtocol")
+# A CreateAction's tool/model. Nothing else references the generator's
+# SoftwareApplication nodes, so omitting this would report the crate's own
+# provenance record as orphaned.
+_INSTRUMENT_KEYS = ("instrument", "http://schema.org/instrument")
 _ABOUT_GRAPH_KEYS = _ABOUT_KEYS + ("labProcesses",)
 _SAMPLETYPE_KEYS = ("sampleType",)
 _TABLESCHEMA_KEYS = ("tableSchema", "http://www.w3.org/ns/csvw#tableSchema")
@@ -760,6 +764,7 @@ _PRIMARY_RELATIONS: tuple[tuple[tuple[str, ...], str, bool], ...] = (
     (_CONTRIBUTOR_KEYS, "contributor", False),
     (_AFFILIATION_KEYS, "affiliation", False),
     (_PROTOCOL_KEYS, "executes", False),
+    (_INSTRUMENT_KEYS, "instrument", False),
     (_SAMPLETYPE_KEYS, "sampleType", False),
 )
 _SECONDARY_RELATIONS: tuple[tuple[tuple[str, ...], str, bool], ...] = (

--- a/eval/metrics.py
+++ b/eval/metrics.py
@@ -31,6 +31,64 @@ logger = logging.getLogger(__name__)
 _VOLATILE_NODE_KEYS: frozenset[str] = frozenset({"datePublished", "dateModified"})
 
 
+def _drop_run_provenance(graph: list[Any]) -> list[Any]:
+    """Remove the generator's run record from a ``@graph`` before hashing.
+
+    ``_add_generator_provenance`` records HOW a crate was produced — a
+    ``CreateAction`` carrying start/end times plus ``PropertyValue`` nodes for the
+    run's tokens and cost, whose ``@id``s embed the values themselves. Every one
+    of those differs between two runs by construction, so leaving them in makes
+    each build hash uniquely: the determinism signal would report even the
+    deterministic pipeline arm as stochastic, and the scoring memoisation keyed on
+    this hash would never hit again (3x the SHACL cost at ``--repeats 3``).
+
+    This is the same reasoning that already strips ``datePublished`` — provenance
+    about the run is not content of the crate. The record still ships in every
+    exported crate; it just does not participate in the fingerprint. The
+    SoftwareApplication / model nodes are KEPT: they are stable for a given
+    configuration and describe what built the crate, not when.
+    """
+    actions = {
+        node.get("@id")
+        for node in graph
+        if isinstance(node, dict) and "CreateAction" in str(node.get("@type", ""))
+    }
+    if not actions:
+        return graph
+
+    # The volatile PropertyValues hang off the action's additionalProperty.
+    volatile_ids: set[Any] = set(actions)
+    for node in graph:
+        if not isinstance(node, dict) or node.get("@id") not in actions:
+            continue
+        prop = node.get("additionalProperty")
+        for ref in prop if isinstance(prop, list) else [prop]:
+            if isinstance(ref, dict) and ref.get("@id"):
+                volatile_ids.add(ref["@id"])
+
+    cleaned: list[Any] = []
+    for node in graph:
+        if not isinstance(node, dict):
+            cleaned.append(node)
+            continue
+        if node.get("@id") in volatile_ids:
+            continue
+        # Drop the root's `mentions` back-reference to the dropped action, or the
+        # root itself would still carry a pointer to a node that is no longer here.
+        mentions = node.get("mentions")
+        if mentions is not None:
+            kept = [
+                ref
+                for ref in (mentions if isinstance(mentions, list) else [mentions])
+                if not (isinstance(ref, dict) and ref.get("@id") in volatile_ids)
+            ]
+            node = {k: v for k, v in node.items() if k != "mentions"}
+            if kept:
+                node["mentions"] = kept
+        cleaned.append(node)
+    return cleaned
+
+
 @dataclass(frozen=True)
 class ProfileMetrics:
     """Token / iteration / tool-call counts mined from ``profile.ndjson``.
@@ -204,13 +262,14 @@ def crate_graph_hash(state: CrateState) -> str:
         metadata_doc = crate.metadata.generate()
         graph = metadata_doc.get("@graph", metadata_doc)
         if isinstance(graph, list):
-            # Drop volatile build-time stamps, then sort nodes by @id so neither
-            # the build clock nor insertion order can perturb the hash.
+            # Drop volatile build-time stamps and the generator's run record,
+            # then sort nodes by @id so neither the build clock, the run's cost,
+            # nor insertion order can perturb the hash.
             scrubbed = [
                 {k: v for k, v in node.items() if k not in _VOLATILE_NODE_KEYS}
                 if isinstance(node, dict)
                 else node
-                for node in graph
+                for node in _drop_run_provenance(graph)
             ]
             canonical: Any = sorted(
                 scrubbed,

--- a/eval/tests/test_metrics.py
+++ b/eval/tests/test_metrics.py
@@ -129,6 +129,38 @@ class TestCrateGraphHash:
         b = crate_graph_hash(_state_with("Stable"))
         assert a == b
 
+    def test_hash_ignores_the_generator_run_record(self) -> None:
+        """Two runs differing ONLY in run cost/timing must hash identically.
+
+        ``stamp_generator`` records how the crate was produced — start/end times
+        and PropertyValues whose ``@id``s embed the token counts and cost. Those
+        differ on every run by construction, so without scrubbing them the
+        determinism signal calls even the deterministic pipeline arm stochastic
+        and the scoring memoisation keyed on this hash never hits again.
+        """
+        a = _state_with("Stable")
+        a.stamp_generator()
+        a.generator.model = "gpt-5.6"
+        a.generator.input_tokens = 1000
+        a.generator.output_tokens = 200
+        a.generator.cost_usd = 0.25
+        a.generator.started_at = "2029-01-01T00:00:00Z"
+        a.generator.ended_at = "2029-01-01T00:01:00Z"
+
+        b = _state_with("Stable")
+        b.stamp_generator()
+        b.generator.model = "gpt-5.6"
+        # Same crate, genuinely different run: more tokens, more cost, later.
+        b.generator.input_tokens = 5321
+        b.generator.output_tokens = 999
+        b.generator.cost_usd = 1.50
+        b.generator.started_at = "2030-06-01T12:00:00Z"
+        b.generator.ended_at = "2030-06-01T12:07:00Z"
+
+        assert crate_graph_hash(a) == crate_graph_hash(b)
+        # Control: real content still moves the hash, so the scrub is not blanket.
+        assert crate_graph_hash(a) != crate_graph_hash(_state_with("Different"))
+
     def test_hash_is_a_hex_string(self) -> None:
         h = crate_graph_hash(_state_with("X"))
         assert isinstance(h, str)

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1074,8 +1074,12 @@ class TestCompletenessNudge:
             "File",
         )
         nudge = _completeness_nudge(state)
-        assert "export_crate" in nudge or "export" in nudge.lower()
-        assert "build_and_validate" in nudge or "validate" in nudge.lower()
+        low = nudge.lower()
+        assert "export_crate" in nudge or "export" in low
+        # "validation" as well as "validate": the nudge names the missing STEP
+        # ("… validation, export"), not the tool, so matching only the verb form
+        # made this assertion sensitive to wording rather than to behaviour.
+        assert "build_and_validate" in nudge or "validat" in low, nudge
 
     def test_empty_state_nudge_does_not_crash(self):
         """An empty crate still yields a (short, non-crashing) nudge."""

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -247,10 +247,15 @@ class TestReaderEvidenceSuppressesRereads:
         read_file = {t.name: t for t in _build_langchain_tools(engine)}["read_file"]
 
         assert read_file.invoke({"path": "notes.txt"}) == "REAL CONTENT"
-        # Both spellings must normalise to the stored key, or the guard misses
-        # and the model re-reads the same document indefinitely.
+        # Both spellings must normalise to the SAME stored key, or the guard
+        # misses and the model re-reads the same document indefinitely. The
+        # repeat is served from the loaded copy — the content still comes back,
+        # flagged as already-loaded, so the model is not left without it.
         for spelling in ("notes.txt", str(target)):
-            assert "Already loaded" in str(read_file.invoke({"path": spelling}))
+            served = str(read_file.invoke({"path": spelling}))
+            assert "already loaded this session" in served, served
+            assert "nested/notes.txt" in served, served
+            assert "REAL CONTENT" in served, served
 
 
 class TestSymlinkEscapeRefused:

--- a/tests/test_state_serializer.py
+++ b/tests/test_state_serializer.py
@@ -60,6 +60,8 @@ class TestStateSerializerOutput:
             "fair_assessment",
             "checkpoint",
             "validation_preferences",
+            "user_answers",
+            "generator",
             "iteration_count",
             "max_iterations",
             "stuck",


### PR DESCRIPTION
## Summary

16 files, ~+1550. Records **how** a crate was produced and **who** is responsible for it.

- **`stamp_generator`** — application, model, and the run's tokens/cost/wall-clock, baked into the export. Figures nobody can reconstruct once the session is gone.
- **`set_crate_metadata`** gains crate-level attribution (publisher / creator / contact / license) — who is responsible for the dataset, which is *not* the publication's author list.
- **`state.user_answers`** — HITL answers kept in order. They arrived as tool results and lived only in the graph checkpoint, so a turn that didn't consult it could re-ask something already answered.
- **`_resolve_within_roots`** now also resolves a path *relative to the input root* (`Assay_OATP1C1/metadata.xlsx`) — the other shape a model naturally emits, since that's how files appear in the inventory. One weak-model session lost 11 of 20 failed tool calls to this, retrying the same workbook six times. Containment is still re-checked, so it can only reach files the sandbox already allowed.
- **Reader de-duplication** now *serves* the loaded copy with a note instead of refusing, so the model still gets the content it asked for.
- **Footer/spinner** — width-aware preview tail, model name on the spend line.

## The graph-hash scrub

`stamp_generator` writes its `CreateAction` (start/end times) and `PropertyValue` nodes **whose `@id`s embed the token counts and cost** into the assembled graph. `eval/metrics.crate_graph_hash` hashes that graph, and it drives two things:

1. the harness's **determinism signal** (N repeats per case, hashes compared), and
2. **scoring memoisation** — `reaches_isa_tox_conformance` is a full 3-pass SHACL run, scored once per distinct hash.

Left alone, every build hashes uniquely: the deterministic pipeline arm would report as stochastic, and memoisation would never hit again (3× SHACL at `--repeats 3`). So the run record is scrubbed before hashing — the same reasoning that already strips `datePublished`. **The provenance still ships in every exported crate**; it just stops being part of the fingerprint. Covered by a new regression that varies only cost/timing, with a control asserting real content still moves the hash.

## Two merge artefacts fixed

- A duplicated `set_validation_preference` (byte-identical) that the 3-way merge produced.
- `app_version = ""` clashing with `__version__`'s `Literal["0.1.0"]` type.

## Verification

`ruff` clean, `ty` clean, 72 passing across `test_agents_build` / `test_state_serializer` / `test_path_traversal`, plus `eval/tests/test_metrics.py` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)