### PR TITLE
fix(ci): give the export smoke test the timeout its workload needs

### DIFF
--- a/tests/test_export_smoke.py
+++ b/tests/test_export_smoke.py
@@ -13,10 +13,20 @@ from __future__ import annotations
 import warnings
 from pathlib import Path
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools.builder import build_crate
 from profiles.validator import validate_crate
 from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+# This module writes a real crate to disk and runs the uncached, owlrl-heavy
+# on-disk validator over all three passes — ~23s locally, and the 2-vCPU CI
+# runner is slower still, so it sat just under the CI-wide `--timeout=30` and
+# eventually tipped over it. Same headroom every other SHACL/export-heavy module
+# already takes (test_pipeline_e2e, test_e2e_agent_eval, test_csvw_payload, …).
+# The budget is headroom, not a licence to grow: the test is unchanged.
+pytestmark = pytest.mark.timeout(120)
 
 
 class TestGoldenCrateExport:


### PR DESCRIPTION
## `main` is red — this fixes it

`main` failed at `f8e898c` on a **timeout**, not an assertion: `test_exports_metadata_preview_and_validates_clean` exceeded the CI-wide `--timeout=30`.

## Not a regression from that merge

| Commit | Duration | CI |
|---|---|---|
| `b66f9b9` (last green) | 22.83s | pass |
| `f8e898c` (red) | 22.56s | **timeout** |

Same cost either side. The test writes a real crate to disk and runs the uncached, owlrl-heavy on-disk validator across all three passes — it has been sitting just under the cap for a while, and the 2-vCPU runner is slower than local, so it was one bad scheduling beat from failing regardless of what merged.

## The fix

`tests/test_export_smoke.py` was the only module of its weight without a timeout override. `test_pipeline_e2e`, `test_e2e_agent_eval`, `test_csvw_payload`, `test_tools_resolve_compound` and others all set `pytest.mark.timeout(120)`; this one was missed.

**The test itself is unchanged** — the budget is headroom, not permission to grow.

## Verification

Passes under an explicit `--timeout=30` run (32.05s wall, proving the module override applies). `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)