### PR TITLE
feat(dashboard): show where the crate was last exported, and when

### DIFF
--- a/builder/state.py
+++ b/builder/state.py
@@ -563,6 +563,10 @@ class CrateMetadata:
     input_type: InputType = "directory"
     input_path: str | None = None
     output_path: str | None = None
+    # When the crate was last written to ``output_path`` (ISO-8601, local tz).
+    # A session that has never exported leaves this None — distinguishable from
+    # "exported but the path is unknown", which the dashboard reports differently.
+    exported_at: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"input_type": self.input_type}
@@ -584,6 +588,8 @@ class CrateMetadata:
             d["input_path"] = self.input_path
         if self.output_path is not None:
             d["output_path"] = self.output_path
+        if self.exported_at is not None:
+            d["exported_at"] = self.exported_at
         return d
 
     @classmethod
@@ -603,6 +609,7 @@ class CrateMetadata:
             input_type=data.get("input_type", "directory"),  # type: ignore[arg-type]
             input_path=data.get("input_path"),
             output_path=data.get("output_path"),
+            exported_at=data.get("exported_at"),
         )
 
 
@@ -1220,13 +1227,15 @@ class CrateState:
             self.metadata.to_dict() if hasattr(self.metadata, "to_dict") else None
         )
         if metadata is not None:
-            # ``output_path`` is WHERE the crate gets written, not anything the
-            # validator can observe — two exports of an identical crate to
-            # different directories produce the same verdict. Leaving it in made
-            # `export_crate` (which sets it) look like a content change, so the
-            # recorded verdict read as stale and `ensure_validated` re-ran a full
-            # 3-pass SHACL sweep on every export to a new path.
-            metadata = {k: v for k, v in metadata.items() if k != "output_path"}
+            # WHERE the crate was written and WHEN — neither is anything the
+            # validator can observe. Two exports of an identical crate to
+            # different directories, or at different times, produce the same
+            # verdict. Leaving them in made `export_crate` (which sets both) look
+            # like a content change, so the recorded verdict read as stale and
+            # `ensure_validated` re-ran a full 3-pass SHACL sweep on every export.
+            metadata = {
+                k: v for k, v in metadata.items() if k not in ("output_path", "exported_at")
+            }
         content = {
             "entities": self.entities.to_dict()
             if hasattr(self.entities, "to_dict")

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -428,6 +428,7 @@ def export_crate(
         # crate went, so the goodbye summary (and a later re-export) had to guess
         # the default even when the caller named a different destination.
         state.metadata.output_path = output_path
+        state.metadata.exported_at = _config.now().isoformat()
 
         logger.info("Crate exported to %s", output_path)
         out: dict[str, Any] = {"success": True, "crate_path": output_path, "error": None}

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -252,6 +252,47 @@ def format_mit_coverage(
     return f"{pct}%", color
 
 
+def _format_export_timestamp(raw: str) -> str:
+    """Render an ISO export stamp as ``YYYY-MM-DD HH:MM``.
+
+    Falls back to the raw string when it does not parse: a session file written
+    by an older build, or hand-edited, should still show SOMETHING rather than
+    make the dashboard the place where a bad timestamp first surfaces.
+    """
+    from datetime import datetime
+
+    try:
+        return datetime.fromisoformat(raw).strftime("%Y-%m-%d %H:%M")
+    except (TypeError, ValueError):
+        return raw
+
+
+def _last_export_span(metadata: dict[str, Any]) -> Any:
+    """The 'Last export' row: where the crate was written, and when.
+
+    Three states worth telling apart, because they mean different things to
+    someone deciding whether their work is safely on disk:
+
+    * never exported — nothing has been written;
+    * exported, path and time known — the normal case;
+    * a path with no timestamp — a session saved before exports were stamped.
+      Reporting that as "never" would be a lie about work that DID happen.
+    """
+    from rich.text import Text
+
+    path = (metadata or {}).get("output_path")
+    stamp = (metadata or {}).get("exported_at")
+    if not path:
+        return Text.assemble(("Last export: ", HEADER_STYLE), ("never", LABEL_STYLE))
+    when = _format_export_timestamp(stamp) if stamp else "time not recorded"
+    return Text.assemble(
+        ("Last export: ", HEADER_STYLE),
+        (str(path), OK_STYLE),
+        ("  │  ", HEADER_STYLE),
+        (when, "" if stamp else LABEL_STYLE),
+    )
+
+
 def _build_cratestate_panel(
     state: dict[str, Any] | None,
     status: str = STATUS_IDLE,
@@ -337,6 +378,11 @@ def _build_cratestate_panel(
     iteration = state.get("iteration_count", 0)
     stuck = state.get("stuck", False)
 
+    # Last export — where the crate was written and when. On its own row rather
+    # than appended to the summary line, which is already at the width a narrow
+    # terminal can show; a path is long and would push the rest off-screen.
+    export_span = _last_export_span(state.get("metadata", {}))
+
     # One-line summary — all on a single rich Text
     text = Text.assemble(
         ("Phase: ", HEADER_STYLE),
@@ -350,6 +396,8 @@ def _build_cratestate_panel(
         ("  │  Iteration: ", HEADER_STYLE),
         (f"{iteration}{' ⚠ STUCK' if stuck else ''}", ERR_STYLE if stuck else "white"),
     )
+    text.append("\n")
+    text.append_text(export_span)
 
     return Panel(text, title=title, border_style=BORDER_STYLE)
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -713,3 +713,56 @@ class TestCrateStatePanelMit:
         assert "0.0%" not in out
         assert "0%" not in out
 
+
+
+class TestLastExportRow:
+    """The CrateState panel reports where the crate was written, and when.
+
+    NOTE: CI passes ``--ignore=tests/test_dashboard.py``, so these do not gate.
+    The state-level behaviour they depend on is covered by
+    ``tests/test_state_serializer.py::TestExportStamp``, which does run.
+    """
+
+    @staticmethod
+    def _render(metadata: dict) -> str:
+        import io
+
+        from rich.console import Console
+
+        from builder.tools.dashboard import _build_cratestate_panel
+
+        buf = io.StringIO()
+        Console(file=buf, width=120, color_system=None).print(
+            _build_cratestate_panel({"metadata": metadata, "entities": {}, "validation": {}})
+        )
+        return buf.getvalue()
+
+    def test_never_exported_says_so(self) -> None:
+        out = self._render({})
+        assert "Last export: never" in out
+
+    def test_shows_path_and_formatted_time(self) -> None:
+        out = self._render(
+            {
+                "output_path": "/data/S-VHPS21-ro-crate",
+                "exported_at": "2026-08-07T11:42:31.123456+02:00",
+            }
+        )
+        assert "/data/S-VHPS21-ro-crate" in out
+        assert "2026-08-07 11:42" in out
+        assert "never" not in out
+
+    def test_path_without_a_stamp_is_not_reported_as_never(self) -> None:
+        """A session saved before exports were stamped DID export.
+
+        Calling that "never" would misreport work that happened — the whole
+        reason this row exists is to tell someone their crate is on disk.
+        """
+        out = self._render({"output_path": "/data/old-crate"})
+        assert "/data/old-crate" in out
+        assert "time not recorded" in out
+        assert "Last export: never" not in out
+
+    def test_unparseable_stamp_falls_back_to_the_raw_value(self) -> None:
+        out = self._render({"output_path": "/data/x", "exported_at": "not-a-date"})
+        assert "not-a-date" in out

--- a/tests/test_state_serializer.py
+++ b/tests/test_state_serializer.py
@@ -169,3 +169,46 @@ class TestCrateStateDelegation:
         state = _populated_state()
         restored = CrateState.from_json(state.to_json())
         assert restored.to_dict() == state.to_dict()
+
+
+class TestExportStamp:
+    """``export_crate`` records WHERE and WHEN, and neither disturbs validation."""
+
+    def test_exported_at_round_trips(self):
+        state = CrateState()
+        state.metadata.output_path = "/data/crate"
+        state.metadata.exported_at = "2026-08-07T11:42:31+02:00"
+        restored = StateSerializer.from_dict(StateSerializer.to_dict(state))
+        assert restored.metadata.exported_at == "2026-08-07T11:42:31+02:00"
+        assert restored.metadata.output_path == "/data/crate"
+
+    def test_absent_stamp_stays_absent(self):
+        """A session that never exported must not gain a spurious key.
+
+        The dashboard tells "never exported" from "exported before stamping"
+        by presence, so an empty string or a default would erase that.
+        """
+        data = StateSerializer.to_dict(CrateState())
+        assert "exported_at" not in data["metadata"]
+        assert StateSerializer.from_dict(data).metadata.exported_at is None
+
+    def test_stamp_does_not_move_the_validation_fingerprint(self):
+        """Exporting must not invalidate a recorded verdict.
+
+        ``exported_at`` lives in metadata, which the fingerprint hashes — and
+        `export_crate` sets it on every write. Left in, the recorded verdict
+        would read as stale immediately after every export and `ensure_validated`
+        would re-run a full 3-pass SHACL sweep. Same reason `output_path` is
+        excluded.
+        """
+        state = CrateState()
+        state.metadata.title = "Crate"
+        before = state.validation_fingerprint()
+
+        state.metadata.output_path = "/data/crate"
+        state.metadata.exported_at = "2026-08-07T11:42:31+02:00"
+        assert state.validation_fingerprint() == before
+
+        # Control: real metadata still moves it, so the exclusion is not blanket.
+        state.metadata.title = "Renamed"
+        assert state.validation_fingerprint() != before


### PR DESCRIPTION
## Summary

The dashboard reported everything about the crate except whether it had actually been **written anywhere** — the one thing you check before closing a session.

`export_crate` already recorded `output_path`; it now also stamps `metadata.exported_at`, and the CrateState panel gains a "Last export" row carrying both.

```
Last export: /data/S-VHPS21-ro-crate  │  2026-08-07 11:42
```

## Three states, deliberately distinguished

| State | Shown |
|---|---|
| never exported | `never` |
| exported, path + time | the path and `YYYY-MM-DD HH:MM` |
| path but no timestamp | the path and `time not recorded` |

That third case is a session saved *before* exports were stamped. Reporting it as "never" would misreport work that did happen — the opposite of what the row is for. An unparseable stamp falls back to the raw string rather than making the dashboard the place a bad timestamp first surfaces.

## The fingerprint trap

`exported_at` is excluded from `validation_fingerprint` alongside `output_path`. Both are set by `export_crate` on **every** write, and neither is anything the validator can observe. Left in, a recorded verdict would read as stale immediately after every export and `ensure_validated` would re-run a full 3-pass SHACL sweep for nothing — exactly the bug fixed for `output_path` in #441. Pinned by a test, with a control asserting real metadata changes still move the fingerprint.

## Note on test coverage

CI passes `--ignore=tests/test_dashboard.py`, so the four render tests here **do not gate**. The state-level behaviour they rest on is covered in `tests/test_state_serializer.py::TestExportStamp`, which does run.

While there I found `TestLiveRefresh::test_follows_newest_session_per_wake_when_unpinned` **already failing on `main`** — unrelated to this change, and left alone. It's a consequence of that file never running in CI.

## Verification

`ruff` clean, `ty` clean; 16 passing in `test_state_serializer`, 34 in `test_dashboard` (the 35th is the pre-existing failure above). All four display states rendered and eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)