### PR TITLE
feat(writers): follow identifier and AOP edges into the provenance graph

### DIFF
--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -364,8 +364,12 @@ def _build_cratestate_panel(
     else:
         val_color = WARN_STYLE
     val_str = " ".join(val_parts)
-    if required_count > 0:
-        val_str += f"  [{ERR_STYLE}]{required_count} REQUIRED[/{ERR_STYLE}]"
+    # Kept as a SPAN, not as markup inside the string: this goes into
+    # Text.assemble, which takes (text, style) pairs and does not parse console
+    # markup — an embedded "[red]…[/red]" rendered literally in the dashboard.
+    issue_span = (
+        (f"  {required_count} REQUIRED", ERR_STYLE) if required_count > 0 else ("", "")
+    )
 
     # MIT score — shared formatter keeps this identical to the interactive UI.
     mit = state.get("mit_assessment", {})
@@ -391,6 +395,7 @@ def _build_cratestate_panel(
         (f"{total}  ({', '.join(f'{n}={c}' for n, c in entity_counts[:3])})", ""),
         ("  │  Validation: ", HEADER_STYLE),
         (val_str, val_color),
+        issue_span,
         ("  │  MIT: ", HEADER_STYLE),
         (mit_text, mit_color),
         ("  │  Iteration: ", HEADER_STYLE),

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -741,6 +741,37 @@ _COLUMNS_KEYS = ("columns", "column", "http://www.w3.org/ns/csvw#column")
 _VALUEURL_KEYS = ("valueUrl", "http://www.w3.org/ns/csvw#valueUrl")
 _CONFORMSTO_KEYS = ("conformsTo", "http://purl.org/dc/terms/conformsTo")
 _CITATION_KEYS = ("citation", "funder", "publisher")
+# An entity's identifier PropertyValues (a compound's CAS / PubChem CID / DTXSID,
+# a person's ORCID). The compound DOES reference them — `identifier` is how the
+# link is expressed — so leaving the predicate out of the vocabulary reported 71
+# perfectly-wired nodes as orphans in a real crate. Reachability is only as
+# complete as this list.
+_IDENTIFIER_REL_KEYS = (
+    "identifier",
+    "http://schema.org/identifier",
+    "https://schema.org/identifier",
+)
+# The AOP-Wiki subgraph (profiles.context): an AdverseOutcomePathway points at its
+# KeyEvents and KeyEventRelationships, and each relationship at its upstream /
+# downstream event. Entirely invisible before — the `keyEvent`/`key_events`
+# guesses in _MENTIONS_KEYS never matched the names actually serialized.
+_AOP_KEYS = (
+    "has_key_event",
+    "has_key_event_relationship",
+    "has_molecular_initiating_event",
+    "has_adverse_outcome",
+    "upstream_event",
+    "downstream_event",
+    "https://aopwiki.org/ontology/hasKeyEvent",
+    "https://aopwiki.org/ontology/hasKeyEventRelationship",
+    "https://aopwiki.org/ontology/hasMolecularInitiatingEvent",
+    "https://aopwiki.org/ontology/hasAdverseOutcome",
+    "https://aopwiki.org/ontology/upstreamEvent",
+    "https://aopwiki.org/ontology/downstreamEvent",
+)
+# Remaining reference-bearing predicates that reach a contextual node.
+_CONTACT_KEYS = ("contactPoint", "http://schema.org/contactPoint")
+_PROPERTYURL_KEYS = ("propertyUrl", "http://www.w3.org/ns/csvw#propertyUrl")
 _MEASTECH_KEYS = ("measurementTechnique", "measurementMethod", "intendedUse")
 _PARAM_KEYS = (
     "parameter",
@@ -775,6 +806,10 @@ _SECONDARY_RELATIONS: tuple[tuple[tuple[str, ...], str, bool], ...] = (
     (_CITATION_KEYS, "citation", False),
     (_MEASTECH_KEYS, "measurementTechnique", False),
     (_PARAM_KEYS, "parameter", False),
+    (_IDENTIFIER_REL_KEYS, "identifier", False),
+    (_AOP_KEYS, "aopEvent", False),
+    (_CONTACT_KEYS, "contactPoint", False),
+    (_PROPERTYURL_KEYS, "propertyUrl", False),
 )
 
 


### PR DESCRIPTION
The graph builder missed two families of reference-bearing predicates, both **present in the crate and absent from the rendered graph**:

- an entity's identifier PropertyValues (a compound's CAS / PubChem CID / DTXSID);
- the AOP-Wiki subgraph — an `AdverseOutcomePathway` pointing at its KeyEvents and KeyEventRelationships, and each relationship at its upstream / downstream event.

Also: the dashboard's status span is assembled as a `(text, style)` pair rather than embedded console markup. `Text.assemble` does not parse markup, so an inline `[red]…[/red]` rendered literally.

`ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)