### PR TITLE
test(reachability): guard that every registered tool is reachable from the pipeline arm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1774,6 +1774,12 @@ not a validity blocker, since `datePublished` is auto-set by ro-crate-py).
 > a schema advertising a tool the engine cannot run, fails fast in either direction, so
 > the A/B always compares the *same* toolbox. A genuinely engine-routed tool (present
 > to the LLM but not in the registry) is declared once, in `_LLM_TOOLS_OUTSIDE_REGISTRY`.
+> That parity assert is also ReAct's *reachability* guard — an advertised tool is one the
+> model can always reach. The pipeline half is `PIPELINE_UNREACHED` +
+> `assert_pipeline_reachability()` in `builder/tools/reachability.py`, checked in CI by
+> `tests/test_tool_reachability.py` (#386): a registered tool with no call site reachable
+> from the deterministic arm fails unless it carries a waiver stating why, and a waiver
+> naming a tool that has since been wired fails too.
 
 ### 14.5 The pipeline spine (`builder/agents/pipeline/pipeline.py`)
 

--- a/builder/tools/reachability.py
+++ b/builder/tools/reachability.py
@@ -1,0 +1,444 @@
+"""Static reachability of registered tools from the deterministic arm (#386).
+
+``builder/agents/react/tools_spec.py`` enforces ``TOOL_REGISTRY ⇄ TOOL_SPECS``:
+every registered tool is advertised to the LLM, so on the ReAct arm the parity
+assert *is* a reachability guard — the model can always reach the whole toolbox.
+
+The deterministic pipeline arm had no analogue. A capability could sit in the
+shared toolbox, be registered, be unit-tested, work — and have no call site on
+the arm that is now the ``--interactive`` default. Nothing went red. The gap
+surfaced only in a live run, as a crate missing something the toolbox can
+produce. This module supplies the missing invariant.
+
+It is arm-agnostic on purpose (#98's MCP front-end is a plausible third caller),
+and it deliberately does **not** register anything: a ``TOOL_REGISTRY`` entry
+with no ``TOOL_SPECS`` schema would trip ``assert_tool_spec_parity()``.
+
+Two deliberate divergences from the ReAct precedent it otherwise mirrors:
+
+* **The waiver is a ``Mapping[str, str]``, not a ``frozenset``.** A reason is
+  structurally mandatory, so the waiver cannot decay into a mute allowlist.
+* **``assert_pipeline_reachability()`` is called from the test only, never at
+  runtime.** Parsing the tree on every build would be pure waste, and this
+  guard must not change either arm's behaviour.
+
+How the graph is built
+----------------------
+An AST call graph over first-party source that **resolves import bindings**.
+Three cheaper designs were considered and each is provably wrong here:
+
+* *Instrumenting* ``engine.run_tool`` at runtime sees only the ~15 literals the
+  spine dispatches. ``builder/tools/`` contains zero ``run_tool(`` call sites —
+  composites call their peers as plain Python — so every composite-internal tool
+  would be a false failure.
+* *Grepping* for ``"<tool_name>"`` under the pipeline package cannot tell a call
+  from prose. ``populate_condition_table`` is named in a docstring inside the
+  toolbox itself, so a grep guard would declare the motivating bug reachable.
+* *Bare attribute-name matching* cannot tell a tool from a same-named method:
+  ``state.list_entities()`` appears in ~20 places and would mask the registered
+  ``management.list_entities``. Only a receiver bound by an import resolves here,
+  which is exactly what removes that false positive.
+
+The analysis **over-approximates on purpose**: it can call a branch reachable
+that cannot in fact fire, so it never produces a false failure. It fails only
+when no call site exists anywhere on the arm — precisely the recurring class.
+A guard that cries wolf is worse than no guard.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+from builder.agents.react.tools_spec import _TOOL_REGISTRY_MODULES
+
+# Repository root: builder/tools/reachability.py -> builder/tools -> builder -> root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# First-party trees the graph spans. `builder/agents/react/` is excluded (see
+# _EXCLUDED_PREFIXES) so an edge into the ReAct arm terminates and the question
+# stays "reachable on the *default* arm".
+_SOURCE_ROOTS: tuple[str, ...] = ("builder", "lookups", "profiles")
+_SOURCE_FILES: tuple[str, ...] = ("main.py",)
+
+_EXCLUDED_PREFIXES: tuple[str, ...] = ("builder.agents.react.",)
+
+# Entry points of the deterministic arm. `main.py` must be here: `list_sessions`
+# and `load_session` are reached from the CLI resume path and are arm-agnostic,
+# so a pipeline-package-only seed set reports both as false failures.
+PIPELINE_SEEDS: frozenset[str] = frozenset(
+    {
+        "main",
+        "builder.agents.build",
+        "builder.agents.pipeline",
+        "builder.agents.pipeline.pipeline",
+        "builder.agents.pipeline.guidance",
+        "builder.agents.pipeline.leaves",
+    }
+)
+
+
+class ToolReachabilityError(RuntimeError):
+    """A registered tool has no call site on the deterministic arm (#386)."""
+
+
+# Registered tools with no call site on the deterministic arm, each with the
+# reason that makes the waiver an answer rather than an allowlist. Two kinds sit
+# here and the reason says which: a tool that SHOULD be wired (with the lane that
+# owns it), and a tool that is honestly ReAct-only or superseded.
+#
+# This mapping is self-cleaning by construction: `assert_pipeline_reachability`
+# fails on a waiver naming a now-reachable tool, so wiring one forces its row out.
+PIPELINE_UNREACHED: Mapping[str, str] = {
+    # --- should be wired; each names the lane that owns it -------------------
+    "lookup_cell_line_by_name": (
+        "Owned by #372 — the only name->Cellosaurus resolver, while the arm "
+        "materialises cell lines through draft_cell_line_sample, which does no "
+        "lookup; default-arm CellLineSamples therefore carry no accession."
+    ),
+    "validate_table": (
+        "The Frictionless payload layer (#409) is documented REQUIRED but never "
+        "runs on the default arm, so populated tables are never validated."
+    ),
+    "lookup_ror": (
+        "No caller. composites._find_or_draft_organization sets `ror` only when "
+        "a caller supplies one, and nothing on the arm does, so default-arm "
+        "Organizations ship with no verified ROR. Needs its own lane: network "
+        "cost plus name ambiguity."
+    ),
+    "verify_all_identifiers": (
+        "No caller. The arm verifies compound identifiers only, and only inside "
+        "resolve_compound. Needs a decision on where a D5 sweep report surfaces."
+    ),
+    "check_provenance": (
+        "No caller, though it is report-only and offline — the cheapest genuine "
+        "win here, one call after the fix loop."
+    ),
+    "lookup_unit": (
+        "No deterministic unit resolution yet; tied to the placeholder "
+        "ParameterValue lane, which is exactly where units are needed."
+    ),
+    # --- honestly ReAct-only or superseded ------------------------------------
+    "lookup_ontology_term": (
+        "Generic OLS escape hatch across EFO/OBI/NCIT/UBERON. No deterministic "
+        "field needs an arbitrary ontology term; this is LLM-discretionary."
+    ),
+    "remove_entity": (
+        "Repair-only escape hatch. repair.fix_required_issues repairs by setting "
+        "fields, never by deleting entities."
+    ),
+    "list_entities": (
+        "Thin wrapper over CrateState.list_entities; the arm calls the state "
+        "method directly (e.g. main.py's session summary). Introspection for an "
+        "LLM that cannot see the state object."
+    ),
+    "list_scanned_files": (
+        "Same class as list_entities — the spine already holds the scan result "
+        "in hand and has no need to ask for it."
+    ),
+    "get_status": (
+        "Introspection for an LLM. The arm's only route is AgentEngine.get_status, "
+        "called directly from main.py's summary."
+    ),
+    "get_hint": (
+        "Next-step advice for a model deciding what to do next. On the "
+        "deterministic arm the next step *is* code."
+    ),
+    "validate": (
+        "The on-disk validator. Both arms validate in memory via "
+        "build_and_validate; this stays as the on-disk entry the ReAct LLM may "
+        "reach for. Not dead code."
+    ),
+    "build_crate": (
+        "Its only production route is writers/rocrate_writer <- writers/arc_writer, "
+        "and write_arc has no production caller. Overlaps #360."
+    ),
+    "assess_mit_coverage": (
+        "The registered wrapper _assess_mit_coverage_tool has no arm call site. "
+        "The capability is not missing: writers/maturity_report calls the "
+        "underlying assess_mit_coverage directly, with the assembled graph."
+    ),
+    "set_validation_preference": (
+        "Records a mid-session change of mind about the RECOMMENDED/OPTIONAL "
+        "tiers. The deterministic arm has no dialogue in which the user changes "
+        "their mind, so there is nothing for it to do there."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Source discovery + parsing
+# ---------------------------------------------------------------------------
+
+
+def _module_name(path: Path) -> str:
+    """Return the dotted module name for a first-party source *path*."""
+    rel = path.relative_to(_REPO_ROOT).with_suffix("")
+    parts = list(rel.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _iter_source_paths() -> Iterable[Path]:
+    for name in _SOURCE_FILES:
+        candidate = _REPO_ROOT / name
+        if candidate.is_file():
+            yield candidate
+    for root in _SOURCE_ROOTS:
+        base = _REPO_ROOT / root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            yield path
+
+
+def _is_excluded(module: str) -> bool:
+    return any(module.startswith(prefix) for prefix in _EXCLUDED_PREFIXES)
+
+
+class _ModuleIndex:
+    """One parsed module: its import bindings and its module-level functions."""
+
+    def __init__(self, module: str, tree: ast.Module) -> None:
+        self.module = module
+        self.tree = tree
+        # local name -> fully-qualified target ("pkg.mod.func" or "pkg.mod")
+        self.bindings: dict[str, str] = {}
+        # local name -> module, for `import pkg.mod as m` / `import pkg.mod`
+        self.module_bindings: dict[str, str] = {}
+        # function name -> node, for module-level defs
+        self.functions: dict[str, ast.AST] = {}
+        self._index()
+
+    def _index(self) -> None:
+        # Imports are collected from the WHOLE module, not just module scope:
+        # the codebase uses function-local imports heavily to break cycles
+        # (`from builder.tools.validation import ensure_validated` inside
+        # `export_crate`), and those bind real edges.
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.level:  # relative import
+                    base = self._resolve_relative(node)
+                else:
+                    base = node.module or ""
+                if not base:
+                    continue
+                for alias in node.names:
+                    local = alias.asname or alias.name
+                    self.bindings[local] = f"{base}.{alias.name}"
+                    # `from pkg import mod` also binds a module for `mod.f` use.
+                    self.module_bindings[local] = f"{base}.{alias.name}"
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    local = alias.asname or alias.name.split(".")[0]
+                    target = alias.name if alias.asname else alias.name.split(".")[0]
+                    self.module_bindings[local] = target
+        for node in self.tree.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                self.functions[node.name] = node
+
+    def _resolve_relative(self, node: ast.ImportFrom) -> str:
+        parts = self.module.split(".")
+        # `from . import x` inside a package __init__ has one fewer level to strip.
+        drop = node.level - 1 if self.module in _PACKAGE_MODULES else node.level
+        base = parts[: len(parts) - drop] if drop else parts
+        if node.module:
+            return ".".join([*base, node.module])
+        return ".".join(base)
+
+
+_PACKAGE_MODULES: set[str] = set()
+
+
+@functools.lru_cache(maxsize=1)
+def _index_sources() -> dict[str, _ModuleIndex]:
+    """Parse every first-party module once; cached for the process."""
+    paths: list[tuple[str, Path]] = []
+    for path in _iter_source_paths():
+        module = _module_name(path)
+        if _is_excluded(module):
+            continue
+        if path.name == "__init__.py":
+            _PACKAGE_MODULES.add(module)
+        paths.append((module, path))
+
+    index: dict[str, _ModuleIndex] = {}
+    for module, path in paths:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError):  # unparseable file is simply not a node
+            continue
+        index[module] = _ModuleIndex(module, tree)
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Edge resolution
+# ---------------------------------------------------------------------------
+
+
+def _tool_targets() -> dict[str, str]:
+    """Return tool name -> ``"module.qualname"`` of its registered function."""
+    import importlib
+
+    for module in _TOOL_REGISTRY_MODULES:
+        importlib.import_module(module)
+    from builder.tools.registry import TOOL_REGISTRY
+
+    targets: dict[str, str] = {}
+    for name, spec in TOOL_REGISTRY.all().items():
+        fn = spec.fn
+        fn_module = getattr(fn, "__module__", None)
+        fn_qualname = getattr(fn, "__qualname__", None)
+        if fn_module and fn_qualname:
+            targets[name] = f"{fn_module}.{fn_qualname}"
+    return targets
+
+
+def _edges_from(idx: _ModuleIndex, node: ast.AST, tools: Mapping[str, str]) -> set[str]:
+    """Return every resolvable target referenced inside *node*'s subtree."""
+    out: set[str] = set()
+    for child in ast.walk(node):
+        # (c) `<anything>.run_tool("literal")` -> the registry entry.
+        if (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "run_tool"
+            and child.args
+            and isinstance(child.args[0], ast.Constant)
+            and isinstance(child.args[0].value, str)
+        ):
+            target = tools.get(child.args[0].value)
+            if target:
+                out.add(target)
+            continue
+        # (a) a name bound by an import, used as a call or passed as a value.
+        if isinstance(child, ast.Name):
+            bound = idx.bindings.get(child.id)
+            if bound:
+                out.add(bound)
+            # (b) a sibling function defined in the same module.
+            elif child.id in idx.functions:
+                out.add(f"{idx.module}.{child.id}")
+        # (a') `m.f` where `m` is an import-bound module. A receiver that is a
+        # local variable (`state.list_entities()`) resolves to nothing — the rule
+        # that keeps a CrateState method from masquerading as a tool.
+        elif isinstance(child, ast.Attribute) and isinstance(child.value, ast.Name):
+            mod = idx.module_bindings.get(child.value.id)
+            if mod:
+                out.add(f"{mod}.{child.attr}")
+    return out
+
+
+def _definition_key(target: str) -> tuple[str, str] | None:
+    """Split ``"pkg.mod.func"`` into ``(module, func)`` if that module exists."""
+    index = _index_sources()
+    if "." not in target:
+        return None
+    module, _, func = target.rpartition(".")
+    if module in index and func in index[module].functions:
+        return module, func
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def call_graph() -> dict[str, set[str]]:
+    """Return ``"module.func" -> {resolved targets}`` for every first-party func."""
+    index = _index_sources()
+    tools = _tool_targets()
+    graph: dict[str, set[str]] = {}
+    for module, idx in index.items():
+        for name, node in idx.functions.items():
+            graph[f"{module}.{name}"] = _edges_from(idx, node, tools)
+    return graph
+
+
+def reachable_functions(seeds: Iterable[str] = PIPELINE_SEEDS) -> set[str]:
+    """Return every ``"module.func"`` reachable from the *seeds* modules.
+
+    Every function defined in a seed module is a root, as is module-level code
+    there — the arm's entry points are files, not a single ``main()``.
+    """
+    index = _index_sources()
+    tools = _tool_targets()
+    graph = call_graph()
+
+    frontier: set[str] = set()
+    for seed in seeds:
+        idx = index.get(seed)
+        if idx is None:
+            continue
+        for name in idx.functions:
+            frontier.add(f"{seed}.{name}")
+        # Module-level statements (CLI wiring, constants holding callables).
+        module_level = ast.Module(
+            body=[
+                stmt
+                for stmt in idx.tree.body
+                if not isinstance(stmt, ast.FunctionDef | ast.AsyncFunctionDef)
+            ],
+            type_ignores=[],
+        )
+        frontier |= _edges_from(idx, module_level, tools)
+
+    reached: set[str] = set()
+    while frontier:
+        target = frontier.pop()
+        if target in reached:
+            continue
+        reached.add(target)
+        key = _definition_key(target)
+        if key is None:
+            continue
+        module, func = key
+        frontier |= graph.get(f"{module}.{func}", set()) - reached
+    return reached
+
+
+def reachable_tools(seeds: Iterable[str] = PIPELINE_SEEDS) -> set[str]:
+    """Return the registered tool names with a call site reachable from *seeds*."""
+    reached = reachable_functions(seeds)
+    return {name for name, target in _tool_targets().items() if target in reached}
+
+
+def unreached_tools(seeds: Iterable[str] = PIPELINE_SEEDS) -> set[str]:
+    """Return the registered tool names with no call site reachable from *seeds*."""
+    return set(_tool_targets()) - reachable_tools(seeds)
+
+
+def assert_pipeline_reachability() -> None:
+    """Raise :class:`ToolReachabilityError` if the waiver has drifted (#386).
+
+    Two-sided, exactly like ``missing``/``extra`` in ``assert_tool_spec_parity``:
+    an unwaived unreached tool fails, **and** a waiver naming a now-reached tool
+    fails. That second direction is what keeps the waiver self-cleaning — when a
+    tool gets wired, its row must be deleted or CI goes red.
+    """
+    unreached = unreached_tools()
+    unwaived = unreached - set(PIPELINE_UNREACHED)
+    stale = set(PIPELINE_UNREACHED) - unreached
+    if unwaived or stale:
+        raise ToolReachabilityError(
+            "Tool reachability on the deterministic arm has drifted (#386): "
+            f"registered tools with no call site and no waiver: {sorted(unwaived)}; "
+            f"waivers naming tools that are now reachable: {sorted(stale)}."
+        )
+
+
+__all__ = [
+    "PIPELINE_SEEDS",
+    "PIPELINE_UNREACHED",
+    "ToolReachabilityError",
+    "assert_pipeline_reachability",
+    "call_graph",
+    "reachable_functions",
+    "reachable_tools",
+    "unreached_tools",
+]

--- a/tests/test_tool_reachability.py
+++ b/tests/test_tool_reachability.py
@@ -1,0 +1,182 @@
+"""Every registered tool is reachable from the deterministic arm — or waived (#386).
+
+The ReAct arm's ``TOOL_REGISTRY ⇄ TOOL_SPECS`` parity assert doubles as its
+reachability guard: every registered tool is advertised, so the model can always
+reach it. The pipeline arm had no analogue, and a capability with no call site
+there stayed green in CI and surfaced only in a live run.
+
+The first five tests are discriminators: each one **fails against a plausible
+cheaper implementation** of the guard, which is what keeps this module from
+being tautological. No test hand-builds a tool list — the expected side is always
+the real ``TOOL_REGISTRY``, the measured side is always computed from the real
+source tree.
+
+Pure AST parse plus a registry import: no network, no LLM, no SHACL, no crate
+build. Measured at ~0.4 s, so no timeout mark is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.tools.reachability import (
+    PIPELINE_SEEDS,
+    PIPELINE_UNREACHED,
+    ToolReachabilityError,
+    assert_pipeline_reachability,
+    call_graph,
+    reachable_functions,
+    reachable_tools,
+    unreached_tools,
+)
+from builder.tools.registry import TOOL_REGISTRY
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestCallGraphDiscriminators:
+    """Each test here is red against a cheaper guard that would ship the bug."""
+
+    def test_call_graph_finds_a_transitive_composite_edge(self) -> None:
+        """A tool reached only as a plain Python call, two modules away, counts.
+
+        ``draft_process``'s route to the arm is
+        ``pipeline.run_tool("draft_process_chain")`` -> ``composites.draft_process_chain``
+        -> ``drafters.draft_process``. Only the first hop is a ``run_tool``
+        literal; ``builder/tools/`` contains no ``run_tool`` call sites at all.
+
+        Discriminates against: a run_tool-literal-only implementation, which
+        would see 15 names and call ~45 tools unreachable.
+        """
+        assert "draft_process" in reachable_tools()
+        assert "builder.tools.composites.draft_process_chain" in reachable_functions()
+
+    def test_direct_import_counts_as_reachable(self) -> None:
+        """Six tools reach the arm by direct import, never through ``run_tool``.
+
+        Discriminates against: anything that only follows ``engine.run_tool``.
+        (This set is also the standing counter-example to AGENTS.md's claim that
+        the spine routes every step through ``engine.run_tool(...)``.)
+        """
+        by_import = {
+            "save_session",
+            "export_crate",
+            "read_file",
+            "extract_pdf_text",
+            "lookup_orcid",
+            "build_and_validate",
+        }
+        assert by_import <= reachable_tools()
+
+    def test_state_method_name_is_not_reachability(self) -> None:
+        """``engine.state.list_entities()`` is not the ``list_entities`` tool.
+
+        Honesty control. The premise is asserted before the conclusion: the name
+        appears in ``main.py`` — a *seed* module — as an attribute call, and the
+        registered tool is still correctly unreached, because the receiver is a
+        local object rather than an import binding.
+
+        Discriminates against: bare attribute-name matching, and against a grep
+        over the seed modules. Both would call this tool reachable.
+        """
+        main_src = (_REPO_ROOT / "main.py").read_text(encoding="utf-8")
+        assert "state.list_entities()" in main_src, (
+            "premise gone: main.py no longer calls the CrateState method, so "
+            "this test no longer discriminates against name matching"
+        )
+        assert "list_entities" not in reachable_tools()
+
+    def test_string_literal_mention_is_not_reachability(self) -> None:
+        """A tool named in a string literal is not thereby called.
+
+        Honesty control. ``check_provenance`` appears verbatim as a dict key in
+        the profiler's icon map in ``builder/tools/dashboard.py``, and has no
+        call site on the arm.
+
+        Discriminates against: a grep implementation — i.e. this proves the guard
+        would have caught the class of bug that motivated it.
+        """
+        dashboard_src = (_REPO_ROOT / "builder" / "tools" / "dashboard.py").read_text(
+            encoding="utf-8"
+        )
+        assert '"check_provenance"' in dashboard_src, (
+            "premise gone: the icon map no longer names check_provenance, so "
+            "this test no longer discriminates against a grep guard"
+        )
+        assert "check_provenance" not in reachable_tools()
+
+    def test_react_modules_are_not_graph_nodes(self) -> None:
+        """Traversal terminates at the ReAct arm, so ``main.py`` is a safe seed.
+
+        Without this, ``main.py`` (which wires both arms) would drag the entire
+        ReAct arm in and every tool would look reachable — the guard would be
+        vacuous rather than wrong, which is harder to notice.
+        """
+        react_nodes = [k for k in call_graph() if k.startswith("builder.agents.react.")]
+        assert react_nodes == []
+
+
+class TestTheGuard:
+    """The invariant itself, and the waiver that records its exceptions."""
+
+    def test_every_registered_tool_is_reachable_or_waived(self) -> None:
+        unreached = unreached_tools()
+        unwaived = unreached - set(PIPELINE_UNREACHED)
+        stale = set(PIPELINE_UNREACHED) - unreached
+        assert not unwaived, (
+            f"registered tools with no call site on the deterministic arm and no "
+            f"waiver in PIPELINE_UNREACHED: {sorted(unwaived)}"
+        )
+        assert not stale, (
+            f"PIPELINE_UNREACHED names tools that are now reachable — delete "
+            f"these rows: {sorted(stale)}"
+        )
+
+    def test_dropping_the_main_seed_loses_exactly_the_cli_resume_tools(self) -> None:
+        """Mutation control: the verdict is computed, not a constant.
+
+        ``main.py`` is the only seed whose removal changes the answer, and it
+        changes it by exactly the two tools the CLI resume path owns. This is
+        also the standing evidence for *why* ``main.py`` is a seed: without it
+        both tools are reported as false failures.
+        """
+        full = reachable_tools()
+        without_main = reachable_tools(PIPELINE_SEEDS - {"main"})
+        assert full - without_main == {"list_sessions", "load_session"}
+
+    def test_waiver_entries_carry_a_reason(self) -> None:
+        for name, reason in PIPELINE_UNREACHED.items():
+            assert isinstance(reason, str) and len(reason) >= 20, (
+                f"waiver for {name!r} must state why, in a sentence"
+            )
+
+    def test_assert_pipeline_reachability_passes_on_the_current_tree(self) -> None:
+        assert_pipeline_reachability()
+
+
+class TestAssertBitesBothWays:
+    """The two failure directions, mirroring tests/test_tools_spec.py."""
+
+    def test_flags_an_unwaived_tool(self) -> None:
+        snapshot = TOOL_REGISTRY.all()
+        try:
+            TOOL_REGISTRY.register("zz_unwired_probe", lambda **_: None)
+            with pytest.raises(ToolReachabilityError) as excinfo:
+                assert_pipeline_reachability()
+            assert "zz_unwired_probe" in str(excinfo.value)
+        finally:
+            # ToolRegistry has no unregister; restore the snapshot wholesale.
+            TOOL_REGISTRY._tools = dict(snapshot)  # noqa: SLF001
+        assert_pipeline_reachability()
+
+    def test_flags_a_stale_waiver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A waiver naming a reachable tool fails — what keeps it self-cleaning."""
+        import builder.tools.reachability as reach
+
+        stale = {**PIPELINE_UNREACHED, "resolve_compound": "wired, so this is stale"}
+        monkeypatch.setattr(reach, "PIPELINE_UNREACHED", stale)
+        with pytest.raises(ToolReachabilityError) as excinfo:
+            reach.assert_pipeline_reachability()
+        assert "resolve_compound" in str(excinfo.value)


### PR DESCRIPTION
Closes #386.

The ReAct arm's `TOOL_REGISTRY ⇄ TOOL_SPECS` parity assert doubles as its **reachability** guard: every registered tool is advertised to the LLM, so the model can always reach it. The deterministic pipeline arm — now the `--interactive` default — had no analogue.

A capability could be registered, unit-tested, working, and have **no call site on that arm**. Nothing went red. It surfaced only in a live run, as a crate missing something the toolbox can produce. #372 and #338 are two instances of the same class.

**Measured on this tree: 16 of 60 registered tools have no reachable call site on the default arm.**

## Why a static call graph, and not something cheaper

Three cheaper designs are each provably wrong here. The module docstring records why, so the next person doesn't re-propose them:

| Rejected | Why it fails *here* |
| --- | --- |
| Instrument `engine.run_tool` at runtime | `builder/tools/` has **zero** `run_tool` call sites — composites call peers as plain Python. The recorder would see ~15 names and report ~45 tools unreached. |
| Grep for `"<tool_name>"` | Cannot tell a call from prose. |
| Bare attribute-name matching | Cannot tell a tool from a same-named method: `main.py`'s `engine.state.list_entities()` would mask the registered `list_entities`. |

The chosen analysis resolves **import bindings**, so a receiver that is a local variable resolves to nothing. It **over-approximates on purpose** — it can call an unfireable branch reachable, so it never produces a false failure, and fails only when no call site exists anywhere. A guard that cries wolf is worse than no guard.

## Shape

`builder/tools/reachability.py` mirrors the `tools_spec.py` precedent one-for-one (`PIPELINE_UNREACHED` / `reachable_tools()` / `ToolReachabilityError` / `assert_pipeline_reachability()`), with two deliberate divergences stated in the docstring:

- **The waiver is a `Mapping[str, str]`, not a `frozenset`** — a reason is structurally mandatory, so it cannot decay into a mute allowlist.
- **The assert is test-only.** Parsing the tree on every build would be pure waste, and this lane must not change either arm's behaviour.

It registers nothing (a registry entry with no schema would trip `assert_tool_spec_parity()`).

The assert is **two-sided**: an unwaived unreached tool fails, **and a waiver naming a now-reachable tool fails**. That second direction is what keeps the waiver self-cleaning — wire a tool and its row must go, or CI is red.

## Verified against today's tree, not the issue's

The issue's numbers were measured in July. Re-measured here:

- **4 of its 18 have since been wired** — `populate_condition_table`, `lookup_bao_term`, `draft_defined_term`, `draft_property_value`.
- **2 tools it predates are newly unreached** — `assess_mit_coverage`, `set_validation_preference`.

Two of its proposed control tests had **lost their premise** and were replaced with stronger ones found on this tree:

- Its docstring control used `populate_condition_table`, which is now reachable. Replaced with `check_provenance`, named verbatim in the profiler's icon map.
- Its mutation control assumed dropping `guidance.py` from the seeds unreaches `set_crate_metadata`; it doesn't, because `pipeline.py` imports `guidance`. Replaced with the one seed-drop that *does* change the answer — `main.py`, which uniquely contributes `list_sessions` and `load_session`, and is therefore also the standing evidence for why `main.py` is a seed.

Every control now **asserts its own premise first**, so it fails loudly rather than silently going vacuous when the tree moves again.

## Proof it bites

Replacing the single `run_tool("resolve_compound")` call site makes the guard fail naming the whole six-tool cascade:

```
registered tools with no call site and no waiver:
['draft_molecular_entity', 'lookup_cell_line', 'lookup_compound',
 'lookup_dtxsid', 'resolve_compound', 'verify_identifier']
```

## Scope

- **No production behaviour changes. No tool is wired by this PR** — that is explicitly out of scope; each `WIRE`-verdict tool carries a waiver row naming the lane that owns it (#372, #409, and three currently unowned).
- One sentence appended to the tool-registration contract in `AGENTS.md`; `tests/test_agents_doc_toolbox.py` and `tests/test_tools_spec.py` both still pass (17 passed).
- `11 passed in 1.33s` — pure AST parse plus a registry import. No network, no LLM, no SHACL, so no timeout mark needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)