### PR TITLE
fix(scanner): stop ingesting the tool's own crates, and let the #68 cap engage

### DIFF
--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -38,6 +38,19 @@ _MAX_UNCOMPRESSED_BYTES = 2 * 1024**3  # 2 GiB
 # the parity is guarded by tests/test_file_readers.py.
 _MAX_FILE_BYTES = 100 * 1024 * 1024  # 100 MB
 
+# The RO-Crate manifest. A directory holding one IS a crate, which is how the
+# scanner recognises its own prior output without maintaining a list of
+# directory names that would drift (#416).
+_CRATE_MANIFEST = "ro-crate-metadata.json"
+
+# Default ceiling on files returned by one scan (#68 / #416). The #68 cap has
+# existed since the scanner did, but every production caller left it at 0
+# ("unlimited"), so the safety valve never engaged: pointing a run at a folder
+# holding previous sessions scanned ~9.5k files and fed them to the drafter as
+# billed context. Generous enough that a real deposit is never truncated, low
+# enough to bound a runaway; a scan that hits it says so loudly.
+_DEFAULT_MAX_FILES = 5000
+
 
 class _UnsafeArchiveError(Exception):
     """An archive member would escape the destination (Zip-Slip) or blow the
@@ -480,8 +493,20 @@ def _safe_walk(root: Path) -> list[Path]:
 
     Hidden and special directories (``.git``, ``__MACOSX``, dot-prefixed)
     are pruned in-place during the walk so they are never descended.
+
+    **Nested RO-Crates are pruned too (#416).** A directory holding an
+    ``ro-crate-metadata.json`` is a crate — in practice one this tool produced,
+    under ``sessions/<id>/working_crate/`` or ``output/<name>_crate/``. Walking
+    into it makes the builder ingest its own prior output as if it were source
+    research data, so a second run over a folder is contaminated by the first.
+    Stating the invariant ("do not descend into a crate") rather than listing
+    directory names avoids a list that drifts.
+
+    The walk *root* is deliberately exempt: pointing the scanner straight at a
+    crate is an explicit request to read that crate, not self-ingestion.
     """
     results: list[Path] = []
+    root = root.resolve()
 
     def _onerror(err: OSError) -> None:
         logger.warning("Skipping unreadable directory: %s", err.filename or err)
@@ -497,6 +522,13 @@ def _safe_walk(root: Path) -> list[Path]:
             dirnames[:] = [d for d in dirnames if not _should_prune(d)]
 
             dirpath = Path(dirpath_str)
+            # Self-ingestion guard (#416): skip a nested crate entirely — its
+            # manifest, its CSVW tables and its copied payload.
+            if _CRATE_MANIFEST in filenames and dirpath.resolve() != root:
+                logger.info("Skipping nested RO-Crate (not source data): %s", dirpath)
+                dirnames[:] = []
+                continue
+
             for name in filenames:
                 results.append(dirpath / name)
     except PermissionError:
@@ -509,7 +541,7 @@ def _safe_walk(root: Path) -> list[Path]:
 def scan_files(
     path: str,
     approved_roots: set[str] | None = None,
-    max_files: int = 0,
+    max_files: int = _DEFAULT_MAX_FILES,
     max_line_length: int = 0,
 ) -> list[FileClassification]:
     """Scan a directory or zip archive and return a file inventory.
@@ -535,8 +567,11 @@ def scan_files(
         approved_roots: Set of resolved absolute directory paths that are
             allowed for scanning. ``None`` or an empty set means *nothing is
             approved* and the scan is refused.
-        max_files: Maximum number of files to return. 0 means unlimited.
-            When exceeded, the list is truncated and a warning is logged.
+        max_files: Maximum number of files to return; 0 means unlimited.
+            Defaults to :data:`_DEFAULT_MAX_FILES` rather than 0 so the #68 cap
+            actually engages on the production path, which passed nothing and
+            therefore never capped anything. When exceeded, the list is
+            truncated and a warning is logged.
         max_line_length: Maximum length for each ``first_rows`` line.
             0 means unlimited. Longer lines are truncated.
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1041,3 +1041,132 @@ class TestScientificMimeRegistry:
         p = tmp_path / "notes.unknownext"
         p.write_bytes(b"just some plain readable text\n")
         assert _detect_mime_type(p) == "text/plain"
+
+
+class TestSelfIngestionGuard:
+    """A scan never ingests the tool's own prior output (#416).
+
+    Pointing a run at a folder that holds previous sessions used to scan ~9.5k
+    files, including every prior session's payload, and feed them to the drafter
+    as billed context. That is not merely slow — it is circular: the builder
+    ingests crates it produced as if they were source research data, so a second
+    run over a folder is contaminated by the first.
+    """
+
+    def _crate(self, directory: Path) -> None:
+        """Write a minimal but real crate marker plus some payload."""
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "ro-crate-metadata.json").write_text('{"@graph": []}', encoding="utf-8")
+        (directory / "ro-crate-preview.html").write_text("<html></html>", encoding="utf-8")
+        payload = directory / "data"
+        payload.mkdir(exist_ok=True)
+        (payload / "copied_measurements.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+
+    def test_nested_session_crate_is_not_scanned(self, tmp_path):
+        """Nothing under sessions/<id>/working_crate/ reaches the inventory."""
+        (tmp_path / "real_data.csv").write_text("x,y\n1,2\n", encoding="utf-8")
+        self._crate(tmp_path / "sessions" / "20260721_115953" / "working_crate")
+
+        names = {r.path for r in _scan(str(tmp_path))}
+
+        assert any(n.endswith("real_data.csv") for n in names), (
+            "the genuine source file must still be scanned"
+        )
+        assert not [n for n in names if "working_crate" in n], (
+            f"prior session output was ingested: {sorted(names)}"
+        )
+
+    def test_nested_output_crate_is_not_scanned(self, tmp_path):
+        """Same for an export sitting under output/<name>_crate/."""
+        (tmp_path / "protocol.txt").write_text("method\n", encoding="utf-8")
+        self._crate(tmp_path / "output" / "vhps_crate")
+
+        names = {r.path for r in _scan(str(tmp_path))}
+
+        assert any(n.endswith("protocol.txt") for n in names)
+        assert not [n for n in names if "vhps_crate" in n]
+
+    def test_scanning_a_crate_directly_still_works(self, tmp_path):
+        """The walk root is exempt — pointing at a crate is an explicit request.
+
+        Without this exemption the guard would break reading an existing crate
+        back in, which is a supported entry point, not self-ingestion.
+        """
+        crate = tmp_path / "some_crate"
+        self._crate(crate)
+
+        names = {r.path for r in _scan(str(crate))}
+
+        assert any(n.endswith("ro-crate-metadata.json") for n in names), (
+            "scanning a crate root directly must still see the manifest"
+        )
+        assert any(n.endswith("copied_measurements.csv") for n in names)
+
+    def test_a_filename_mentioning_output_is_unaffected(self, tmp_path):
+        """The guard keys on the manifest, not on directory or file names.
+
+        A name list (`sessions`, `output`, …) would drift and would also punish
+        legitimate input that happens to use those words.
+        """
+        data = tmp_path / "output_from_instrument"
+        data.mkdir()
+        (data / "sessions_summary_output.csv").write_text("a\n1\n", encoding="utf-8")
+
+        names = {r.path for r in _scan(str(tmp_path))}
+
+        assert any(n.endswith("sessions_summary_output.csv") for n in names), (
+            f"legitimate input was pruned by name: {sorted(names)}"
+        )
+
+
+class TestDefaultFileCap:
+    """The #68 cap actually engages on the production path (#416)."""
+
+    def test_cap_has_a_non_zero_default(self, tmp_path):
+        """Every production caller passed nothing, so the valve never engaged."""
+        import inspect
+
+        from builder.tools.scanner import _DEFAULT_MAX_FILES
+
+        default = inspect.signature(scan_files).parameters["max_files"].default
+        assert default == _DEFAULT_MAX_FILES
+        assert default > 0, "a 0 default is what let ~9.5k files through"
+
+    def test_default_cap_truncates_and_says_so(self, tmp_path, caplog):
+        """A truncated scan is loud — a silent one reads as a complete inventory."""
+        import logging
+
+        from builder.tools import scanner
+
+        for i in range(12):
+            (tmp_path / f"f{i}.csv").write_text("a\n1\n", encoding="utf-8")
+
+        with mock.patch.object(scanner, "_DEFAULT_MAX_FILES", 5):
+            # Re-read the module default through an explicit pass, mirroring what
+            # the production caller now gets implicitly.
+            with caplog.at_level(logging.WARNING):
+                result = scan_files(
+                    str(tmp_path), approved_roots={str(tmp_path.resolve())}, max_files=5
+                )
+
+        assert len(result) == 5
+        assert any("max_files" in r.getMessage() for r in caplog.records), (
+            "truncation must be logged"
+        )
+
+    def test_engine_initialize_inherits_the_cap(self):
+        """The engine passes no max_files, so it must inherit the default.
+
+        This is the gap #68 left open: the cap was plumbed and enforced, but the
+        only production call site left it at 'unlimited'.
+        """
+        import inspect
+
+        from builder import engine as engine_mod
+
+        src = inspect.getsource(engine_mod)
+        assert "scan_files(" in src
+        assert "max_files" not in src.split("scan_files(")[1].split(")")[0], (
+            "engine now passes max_files explicitly — update this test to assert "
+            "the value it passes instead of the inherited default"
+        )


### PR DESCRIPTION
Closes #416.

Pointing a run at a directory that holds previous runs scanned **9,492 files**, including every prior session's payload, then fed them to the drafter — real billed tokens spent on the tool's own output. Two independent gaps, both fixed here.

## 1. Self-ingestion — the serious one

`_safe_walk._should_prune` pruned only dot-directories, so `.venv`/`.git` were excluded *incidentally* while `sessions/`, `output/`, `eval_reports/` and `ab_comparison/` were all descended.

That is not merely slow, it is **circular**. `sessions/<id>/working_crate/` and `output/<name>_crate/` hold crates this tool *produced* — the manifest, the CSVW condition tables, the copied payload. Re-scanning them means the builder ingests its own prior output as if it were source research data, so a second run over a folder is contaminated by the first. It also inflates the fail-closed `approved_scan_roots` surface and the drafter's context budget with material that is by definition already modelled.

**Fixed by stating the invariant rather than listing names:** a directory holding an `ro-crate-metadata.json` *is* a crate, and the walk does not descend into it.

The issue offered a name list as the simpler option; I took the invariant because a name list drifts, and because it would punish legitimate input that happens to use those words — there's a test for exactly that (`output_from_instrument/sessions_summary_output.csv` survives).

**The walk root is deliberately exempt.** Pointing the scanner straight at a crate is an explicit request to read that crate, not self-ingestion, and that's a supported entry point. Without the exemption this fix would break reading an existing crate back in.

## 2. The cap was plumbed but permanently open

`scan_files(..., max_files: int = 0)` documented *"0 means unlimited"* and has enforced the cap since #68 — but the only production caller passed nothing:

```python
# builder/engine.py:236
self.state.scanned_files = scan_files(input_path, approved_roots=scan_roots)
```

So the #68 safety valve never engaged on the real path. `max_files` now defaults to `_DEFAULT_MAX_FILES = 5000`: generous enough that a real deposit is never truncated, low enough to bound a runaway. Truncation already logged loudly; a test now pins that it does.

The issue offered either "a non-zero default" or "have `engine.initialize()` pass one". I took the former — it fixes every call site at once and **keeps the change to a single module**, which matters because `builder/engine.py` currently has uncommitted work in it.

## Tests

Seven new tests in `tests/test_scanner.py`:

- nested session crate is not scanned; nested output crate is not scanned
- scanning a crate directly still works (the root exemption)
- a folder named `output_from_instrument` holding `sessions_summary_output.csv` is unaffected — the guard keys on the manifest, not on names
- the default is non-zero; truncation is logged; `engine.initialize()` inherits the cap (asserted against the real call site, and the assertion message tells the next person what to do if the engine starts passing one explicitly)

**Verified to bite:** reverting the guard turns the two nested-crate tests red.

`81 passed` in `tests/test_scanner.py`; `65 passed` across `test_scan_loop_fix`, `test_path_traversal` and `test_engine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)