### PR TITLE
test: make the two timing assertions deterministic instead of load-sensitive

### DIFF
--- a/tests/test_http_rate_limit.py
+++ b/tests/test_http_rate_limit.py
@@ -16,6 +16,30 @@ import pytest
 from lookups import _http
 
 
+class _FrozenClock:
+    """A stand-in for the ``time`` module with a clock that never advances.
+
+    ``_HostRateLimiter`` reads ``time.monotonic()`` and calls ``time.sleep()``,
+    both through the module object, so swapping the module out captures the
+    limiter's decisions exactly. Freezing rather than advancing is deliberate:
+    the reservation arithmetic is what the cap *is*, and it is computed under
+    the lock, so a frozen clock exercises it fully while removing every
+    scheduler-dependent quantity from the assertions.
+    """
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+        self.sleeps: list[float] = []
+        self._lock = threading.Lock()
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        with self._lock:
+            self.sleeps.append(seconds)
+
+
 @pytest.fixture(autouse=True)
 def _reset_throttle():
     """Reset the per-host throttle state before and after each test."""
@@ -28,7 +52,14 @@ class TestHostRateLimiter:
     """`_HostRateLimiter.wait` spaces requests to the same host."""
 
     def test_sequential_calls_to_same_host_are_spaced(self):
-        """Two back-to-back acquisitions for one host are >= min_interval apart."""
+        """Two back-to-back acquisitions for one host are >= min_interval apart.
+
+        Deliberately kept on the real clock: the sibling tests freeze it, so
+        without this one nothing would check that the limiter actually sleeps.
+        A *lower* bound on elapsed time is safe under load — a starved scheduler
+        can only make this wait longer, never shorter — which is exactly what
+        the load-sensitive assertions removed in #406 could not say.
+        """
         limiter = _http._HostRateLimiter(min_interval=0.1)
         start = time.monotonic()
         limiter.wait("aopwiki.org")
@@ -36,30 +67,49 @@ class TestHostRateLimiter:
         elapsed = time.monotonic() - start
         assert elapsed >= 0.1, f"second call should wait, elapsed={elapsed:.3f}s"
 
-    def test_different_hosts_are_independent(self):
-        """A request to a different host is not delayed by another host."""
+    def test_different_hosts_are_independent(self, monkeypatch):
+        """A request to a different host is not delayed by another host.
+
+        Asserted on the *slot the limiter reserves*, not on elapsed wall-clock.
+        An upper bound on elapsed time is load-sensitive by construction: a
+        starved scheduler makes a correct limiter look slow, so the test fails
+        for a reason that has nothing to do with the property under test.
+        """
+        clock = _FrozenClock()
+        monkeypatch.setattr(_http, "time", clock)
         limiter = _http._HostRateLimiter(min_interval=0.5)
-        start = time.monotonic()
+
         limiter.wait("aopwiki.org")
         limiter.wait("pubchem.ncbi.nlm.nih.gov")
-        elapsed = time.monotonic() - start
-        # Two different hosts: neither blocks the other, so well under one
-        # min_interval of total wait.
-        assert elapsed < 0.5, f"distinct hosts must not block each other, elapsed={elapsed:.3f}s"
 
-    def test_concurrent_calls_do_not_exceed_rate_cap(self):
-        """N concurrent acquisitions for one host serialize to >= (N-1)*interval."""
-        limiter = _http._HostRateLimiter(min_interval=0.05)
+        # Neither host blocked the other: both were granted immediately, so
+        # neither call slept at all.
+        assert clock.sleeps == [], f"distinct hosts blocked each other: {clock.sleeps}"
+
+    def test_concurrent_calls_do_not_exceed_rate_cap(self, monkeypatch):
+        """N concurrent acquisitions for one host reserve N spaced-out slots.
+
+        The rate cap lives entirely in the slot reservation, which happens under
+        the limiter's lock and is therefore scheduler-independent. The previous
+        version measured wall-clock *after* ``wait`` returned, which is a
+        different quantity: a thread descheduled between the grant and the
+        timestamp bunches two grants together and fails a correct limiter. That
+        is what made this flaky under ``-n auto`` (#406).
+
+        Freezing the clock removes wall-clock from the assertion entirely and
+        makes the check exact rather than a tolerance-padded lower bound, so it
+        is also strictly stronger than what it replaces.
+        """
+        clock = _FrozenClock()
+        monkeypatch.setattr(_http, "time", clock)
+        interval = 0.05
+        limiter = _http._HostRateLimiter(min_interval=interval)
         n = 6
         barrier = threading.Barrier(n)
-        timestamps: list[float] = []
-        lock = threading.Lock()
 
         def worker() -> None:
             barrier.wait()  # release all threads at once
             limiter.wait("aopwiki.org")
-            with lock:
-                timestamps.append(time.monotonic())
 
         threads = [threading.Thread(target=worker) for _ in range(n)]
         for t in threads:
@@ -67,12 +117,11 @@ class TestHostRateLimiter:
         for t in threads:
             t.join()
 
-        timestamps.sort()
-        # Minimum spacing between any two consecutive grants respects the cap.
-        for earlier, later in zip(timestamps, timestamps[1:]):
-            gap = later - earlier
-            assert gap >= 0.05 - 0.01, f"consecutive grants too close: {gap:.3f}s"
-        # And the whole batch took at least (n-1) intervals — i.e. the rate cap
-        # was never exceeded by parallelism.
-        total = timestamps[-1] - timestamps[0]
-        assert total >= (n - 1) * 0.05 - 0.02, f"batch finished too fast: {total:.3f}s"
+        # The first caller is granted immediately and never sleeps; the other
+        # n-1 are queued behind it at exactly one interval each. Order across
+        # threads is arbitrary, the multiset is not.
+        expected = [round(interval * k, 6) for k in range(1, n)]
+        assert sorted(round(s, 6) for s in clock.sleeps) == expected
+        # And the host's next free slot is n intervals out — the cap was never
+        # exceeded by parallelism.
+        assert limiter._next_allowed["aopwiki.org"] == pytest.approx(clock.now + n * interval)

--- a/tests/test_verification_concurrency.py
+++ b/tests/test_verification_concurrency.py
@@ -12,7 +12,6 @@ bounded ThreadPoolExecutor. This module asserts:
 from __future__ import annotations
 
 import threading
-import time
 
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools import verification
@@ -70,34 +69,66 @@ class TestVerifyAllConcurrency:
             assert _field_status(state, f"chem_{i:03d}", "identifier") == "verified"
 
     def test_verifications_run_concurrently(self, monkeypatch):
-        """The independent per-field lookups overlap in time."""
-        state = _make_state(6)
-        active = 0
+        """The independent per-field lookups genuinely overlap.
+
+        Proved by *rendezvous*, not by elapsed wall-clock (#406). A barrier of
+        ``k`` parties cannot be crossed unless ``k`` lookups are in flight at the
+        same moment, so crossing it IS the concurrency claim — and it holds no
+        matter how the scheduler treats these threads.
+
+        The old version asserted ``elapsed < 0.9`` against ``time.sleep(0.2)``
+        per lookup. That is an *upper* bound on wall-clock, which a loaded
+        machine violates while the code under test is perfectly correct; it made
+        this one of the four tests that failed under full-suite ``-n auto``.
+        Loosening the threshold would have been the tempting fix and the wrong
+        one — it weakens the test without making it deterministic.
+
+        Sizing the barrier from ``_VERIFY_WORKERS`` also strengthens the claim:
+        the old assertion settled for ``max_active >= 2``, this one pins the
+        full configured pool width, and it self-adjusts if that width changes.
+        """
+        n = 6
+        state = _make_state(n)
+        parties = min(verification._VERIFY_WORKERS, n)
+        # Guard the guard: sizing the barrier from the value under test would go
+        # vacuous if that value ever became 1 — a one-party barrier is crossed by
+        # serial code. Verified by mutation: without this line, setting
+        # _VERIFY_WORKERS = 1 makes a serial pool pass this test.
+        assert parties >= 2, (
+            f"_VERIFY_WORKERS={verification._VERIFY_WORKERS} configures a serial "
+            f"pool, so verify_all_identifiers cannot be concurrent at all"
+        )
+        # A generous timeout: it is never waited out on success (the barrier
+        # releases the instant the last party arrives), and on failure it is a
+        # definite BrokenBarrierError rather than a flaky threshold.
+        barrier = threading.Barrier(parties, timeout=20)
         max_active = 0
+        active = 0
         lock = threading.Lock()
 
-        def slow_lookup(query):
+        def rendezvous_lookup(query):
             nonlocal active, max_active
             with lock:
                 active += 1
                 max_active = max(max_active, active)
             try:
-                time.sleep(0.2)
-                return {"found": True, "data": {"pubchem_cid": "712"}, "error": None}
+                barrier.wait()
+            except threading.BrokenBarrierError:  # pragma: no cover - failure path
+                raise AssertionError(
+                    f"only {max_active} lookup(s) ever ran at once; "
+                    f"{parties} must overlap for the pool to be concurrent"
+                ) from None
             finally:
                 with lock:
                     active -= 1
+            return {"found": True, "data": {"pubchem_cid": "712"}, "error": None}
 
-        monkeypatch.setattr(verification, "lookup_compound", slow_lookup)
+        monkeypatch.setattr(verification, "lookup_compound", rendezvous_lookup)
 
-        start = time.monotonic()
         results = verification.verify_all_identifiers(state)
-        elapsed = time.monotonic() - start
 
-        assert len(results) == 6
-        # Serial would be 6 * 0.2 = 1.2s; concurrent must be well under that.
-        assert elapsed < 0.9, f"verifications not concurrent, elapsed={elapsed:.3f}s"
-        assert max_active >= 2, f"expected overlapping lookups, max_active={max_active}"
+        assert len(results) == n
+        assert max_active >= parties, f"expected {parties} overlapping lookups, saw {max_active}"
 
     def test_matches_serial_outcome_for_mixed_results(self, monkeypatch):
         """A mix of verified/cleared fields matches what the serial path would do."""


### PR DESCRIPTION
Addresses the two concurrency/timing cases in #406.

Both asserted on **observed wall-clock**, which is non-deterministic by construction: under full-suite `-n auto` a starved scheduler fails them while the code under test is perfectly correct. That is the failure mode the issue describes — *"two consecutive runs of identical code produced different failing sets"*.

The issue is explicit that loosening the thresholds is the tempting fix and the wrong one — *"it weakens the test without making it deterministic"*. Both are now asserted on instrumented records instead, and both came out **stronger** than what they replace.

## `test_concurrent_calls_do_not_exceed_rate_cap`

The rate cap lives entirely in the **slot reservation**, computed under the limiter's lock and therefore scheduler-independent:

```python
self._next_allowed[host] = start + interval   # under self._lock
```

The old test measured wall-clock *after* `wait()` returned — a different quantity. A thread descheduled between the grant and its `timestamps.append(...)` bunches two grants together and fails a correct limiter.

A frozen clock now stands in for the `time` module, so the assertion is the **exact multiset of sleeps** the limiter requested — `[i, 2i, …, (n-1)i]` — plus the host's final reserved slot. That is exact rather than a tolerance-padded lower bound.

`test_different_hosts_are_independent` got the same treatment. It was **not** in the reported four, but it asserted `elapsed < 0.5` — an *upper* bound on wall-clock, i.e. the same latent defect, waiting to surface.

`test_sequential_calls_to_same_host_are_spaced` deliberately keeps the real clock: its bound is a *lower* one, which load can only satisfy harder, and without it nothing would check that the limiter actually sleeps.

## `test_verifications_run_concurrently`

Concurrency is now proved by **rendezvous**: a barrier of `k` parties cannot be crossed unless `k` lookups are in flight at the same moment — whatever the scheduler does. Crossing it *is* the concurrency claim.

`elapsed < 0.9` against `time.sleep(0.2)` per lookup is gone, along with the sleeps: the module runs in **0.23s instead of ~1.5s**. Sizing the barrier from `_VERIFY_WORKERS` also raises the claim from `max_active >= 2` to the full configured pool width.

## Verified to bite

| Mutation | Result |
| --- | --- |
| limiter reserves from `now` instead of `start` (breaks the cap) | cap test fails |
| `_VERIFY_WORKERS = 1` (serial pool) | concurrency test fails |

The second one **initially passed vacuously** — `min(1, 6)` sized the barrier to one party, and a one-party barrier is crossed by serial code. The test now asserts `parties >= 2` before building it, with that mutation recorded in a comment so the trap isn't re-set later.

## Not covered — #406 stays open

The two `tests/test_agents_guidance.py` cases are untouched. The issue calls for identifying shared state under a reliable reproduction (*"confirm first whether they fail under `-n auto` alone or only alongside the rest of the suite"*), which needs repeated local full-suite runs.

`6 passed in 0.23s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)