### PR TITLE
test: put the last two ignored modules back in CI

### DIFF
--- a/.github/workflows/calibrate-durations.yml
+++ b/.github/workflows/calibrate-durations.yml
@@ -43,8 +43,6 @@ jobs:
         # us upload the durations collected so far.
         run: >-
           uv run pytest
-          --ignore=tests/test_validator_wiring.py
-          --ignore=tests/test_lookups_contract.py
           --timeout=120
           --store-durations
           --durations-path .test_durations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,6 @@ jobs:
         # `test` job still fails if any shard fails (matrix default).
         run: >-
           uv run pytest
-          --ignore=tests/test_validator_wiring.py
-          --ignore=tests/test_lookups_contract.py
           --timeout=30
           --splits 16
           --group ${{ matrix.group }}

--- a/tests/test_validator_wiring.py
+++ b/tests/test_validator_wiring.py
@@ -10,9 +10,19 @@ from __future__ import annotations
 
 import warnings
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools.builder import build_crate
 from profiles.validator import SHAPES_DIR, validate_crate
+
+# This module builds a crate and runs the uncached, owlrl-heavy on-disk
+# validator over all three passes — ~22s locally, and the 2-vCPU CI runner is
+# slower still, so it does not fit the CI-wide `--timeout=30`. That, not any
+# network access, is why it was excluded from CI; the headroom brings it back.
+# Same budget every other SHACL/export-heavy module takes (test_export_smoke,
+# test_readers, test_pipeline_e2e, test_csvw_payload, …).
+pytestmark = pytest.mark.timeout(120)
 
 
 def _ent(entity_id, type_, **fields):


### PR DESCRIPTION
Follow-up to #452, and a correction to it.

#452 re-enabled `tests/test_dashboard.py` and asserted the two remaining `--ignore` entries stayed out because they *"reach the network and are a separate call"*. **That was wrong.** Neither touches the network. Having claimed it, I checked it.

## `tests/test_lookups_contract.py` — never needed excluding

It replays recorded HTTP fixtures through the `responses` library, which intercepts every request and raises on an unregistered one. It is hermetic and fast:

```
59 passed in 6.32s
```

No timeout mark needed, no network, no reason for it to have been out.

## `tests/test_validator_wiring.py` — slow, not networked

It builds a crate and runs the uncached, owlrl-heavy on-disk validator over all three SHACL passes: **~22s locally**, and the 2-vCPU runner is slower still, so it does not fit the CI-wide `--timeout=30`. Slowness is the real reason it was excluded.

It gets the same module-level timeout mark every other SHACL/export-heavy module already carries (`test_export_smoke`, `test_readers`, `test_pipeline_e2e`, `test_csvw_payload`).

**Verified the mark is what saves it, not luck:** the module still passes under `--timeout=1`, so `pytestmark` genuinely overrides the CLI cap rather than the tests merely happening to fit.

## Result

Both workflows now carry **no `--ignore` at all** — `ci.yml` and `calibrate-durations.yml`. Together with #452 that returns 96 previously-invisible tests to CI (35 dashboard + 59 lookups-contract + 2 validator-wiring).

`61 passed in 27.5s` under the CI-wide `--timeout=30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)