### PR TITLE
test: give every export-heavy module the timeout headroom #446 made necessary

### DIFF
--- a/tests/test_build_output_payload.py
+++ b/tests/test_build_output_payload.py
@@ -13,9 +13,21 @@ import json
 import warnings
 from pathlib import Path
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools.builder import build_crate
 
+
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
 
 def _state_with_output(tmp_path: Path) -> CrateState:
     state = CrateState()

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -11,9 +11,21 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools.builder import build_crate
 
+
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
 
 def _ent(entity_id, type_, **fields):
     return Entity(

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -22,6 +22,16 @@ from builder.tools.data_content import (
     validate_table,
 )
 
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
+
 # The committed per-well fixture the pipeline actually meets in the corpus. Anchored
 # to this file, not the CWD — a test below deliberately chdirs. The fixture is owned
 # by the eval corpus, so ``test_the_corpus_fixture_still_requires_aliasing`` guards

--- a/tests/test_crate_mapping_namespace.py
+++ b/tests/test_crate_mapping_namespace.py
@@ -11,9 +11,21 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools.builder import build_crate
 
+
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
 
 def _entity(entity_id: str, entity_type: str, **fields) -> Entity:
     return Entity(

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -6,11 +6,23 @@ import json
 from typing import Any
 from pathlib import Path
 
+import pytest
+
 from builder.state import CrateState, ValidationReport
 from builder.tools.builder import build_crate, export_crate
 from builder.writers.maturity_report import REPORT_FILENAME, build_maturity_html
 from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
+
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
 
 def _body(page: str) -> str:
     """The rendered markup without the inlined stylesheet.

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -10,9 +10,21 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools.builder import build_crate
 
+
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
 
 def _state(tmp_path: Path) -> CrateState:
     state = CrateState()

--- a/tests/test_tools_aop_subgraph.py
+++ b/tests/test_tools_aop_subgraph.py
@@ -26,6 +26,16 @@ from builder.tools.drafters import draft_investigation, draft_study
 from builder.tools.validation import build_and_validate
 from lookups import _http, aopwiki
 
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
+
 FIXTURES = Path(__file__).parent / "fixtures"
 
 

--- a/tests/test_tools_builder.py
+++ b/tests/test_tools_builder.py
@@ -6,9 +6,21 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from builder.state import CrateState, Entity, EntityProvenance, FileClassification
 from builder.tools.builder import assemble_crate, build_crate, export_crate
 
+
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
 
 def _ent(entity_id, type_, **fields):
     return Entity(

--- a/tests/test_tools_management.py
+++ b/tests/test_tools_management.py
@@ -19,6 +19,16 @@ from builder.tools.management import (
 )
 
 
+
+# Every test here exports a crate, and each export now runs the uncached,
+# owlrl-heavy validator over all three profiles at the full severity gate (#446)
+# — ~10s per export locally, and the 2-vCPU CI runner is ~2-3x slower, which puts
+# the whole module against the CI-wide `--timeout=30`. Same headroom, for the
+# same reason, that the other export-heavy modules already take
+# (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
+# Headroom, not a licence to grow: no test in this module is changed.
+pytestmark = pytest.mark.timeout(120)
+
 def _ent(entity_id, type_, **fields):
     return Entity(
         entity_id=entity_id,


### PR DESCRIPTION
**`main` is red.** `test_tools_builder.py::TestBuildCrate::test_build_crate_path_round_trips_into_validate` timed out on shard 7 at `cccf549` (the #446 merge) — having passed 18/18 on the PR itself. It sat just under the CI-wide `--timeout=30`, and widening the export gate to the full severity sweep pushed it over.

## I already made this mistake once

I hit exactly this on #446 with `test_readers.py`, fixed that one module, and treated it as a one-off. It wasn't. So this time I measured the whole class instead of patching whichever test happened to fail:

| local | test |
| ---: | --- |
| **20.24s** | `test_tools_builder::test_build_crate_path_round_trips_into_validate` |
| 11.43s | `test_condition_table::test_multi_compound_column_drops_its_valueurl` |
| 11.42s | `test_maturity_report::test_export_embeds_provenance_from_crate_graph` |
| 11.35s | `test_condition_table::test_populated_rows_survive_the_export` |
| 11.17s | `test_maturity_report::test_export_writes_maturity_report` |
| 10.3–11.1s | ~15 more across `test_builder_domain`, `test_tools_management`, `test_crate_mapping_namespace`, `test_tools_aop_subgraph`, `test_preview`, `test_build_output_payload` |

Those are **local** numbers. The 2-vCPU runner is ~2–3× slower, which puts the entire class at 20–35s against a 30s cap.

That's the real problem: **which tests fail is decided by shard assignment and runner luck**, not by any property of the change under test. A PR goes green, the merge goes red, and the next PR inherits a failure it didn't cause — which is exactly what happened to #455 and #456, both of which fail on the shard holding this test.

## The fix

The same module-level mark the four already-marked export-heavy modules carry (`test_export_smoke`, `test_readers`, `test_path_traversal`, `test_html_xss`), applied to the nine that lacked it.

- **Additive only**: 102 insertions, 0 deletions. No test body is touched.
- The tight `--timeout=30` is **kept** for the ~1800 fast tests, where it's worth having. This does not raise the global cap.

## Worth a decision, not taken here

Every export now runs the uncached, owlrl-heavy validator over all three profiles at the full gate (#446) — ~10s each, and roughly 40 tests pay it. Timeout headroom stops the bleeding; **caching the validator across exports, or scoping the sweep, would buy back far more.** That's a design call, so I've left it to you rather than folding it into a red-CI fix.

## Verified

`52 passed` under the CI-wide `--timeout=30`, including the test that broke `main`. `ruff check` (CI's exact command) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)