### PR TITLE
refactor(mit): one owner for the MIT checklist traversal

### DIFF
--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Literal
 
 from builder.state import CrateState, Entity
@@ -40,6 +39,8 @@ from builder.tools.field_kinds import (
 )
 from builder.tools.mit_assessment import (
     graph_nodes,
+    iter_scorable_params,
+    load_mit_yaml,
     slot_matcher,
     slot_type_present,
 )
@@ -49,8 +50,10 @@ logger = logging.getLogger(__name__)
 Tier = Literal["MUST", "SHOULD", "MAY"]
 Source = Literal["shacl", "mit", "fair"]
 
-# Path to the MIT YAML (shared with builder.tools.mit_assessment).
-MIT_YAML_PATH = Path(__file__).resolve().parent.parent.parent / "mit" / "invitro_tox.yaml"
+# The MIT checklist path, loader and parameter traversal all live in
+# builder.tools.mit_assessment (#357). This module had its own copy of each, with
+# its own dedup, and its own comment saying it "mirrors mit_assessment" — three
+# readers of one checklist, free to drift.
 
 
 @dataclass(frozen=True)
@@ -364,28 +367,6 @@ def _shacl_gaps(state: CrateState) -> tuple[list[Gap], dict[str, bool], dict[str
 # ---------------------------------------------------------------------------
 
 
-def _load_mit_yaml() -> dict[str, Any] | None:
-    """Load and parse the MIT YAML (mirrors mit_assessment._load_mit_yaml)."""
-    try:
-        import yaml
-
-        with open(MIT_YAML_PATH) as f:
-            return yaml.safe_load(f)
-    except Exception as e:  # noqa: BLE001 — best-effort, never crash the engine
-        logger.warning("gap engine: failed to load MIT YAML from %s: %s", MIT_YAML_PATH, e)
-        return None
-
-
-
-
-def _parse_crate_slots(slot_str: str) -> list[tuple[str, str]]:
-    """Parse ``"A:x;B:y"`` into ``[(A, x), (B, y)]`` (mirrors mit_assessment)."""
-    slots: list[tuple[str, str]] = []
-    for part in (p.strip() for p in slot_str.split(";")):
-        if ":" in part:
-            entity_type, field_name = part.split(":", 1)
-            slots.append((entity_type.strip(), field_name.strip()))
-    return slots
 
 
 def _mit_suggestion(param: dict[str, Any]) -> str | None:
@@ -424,7 +405,7 @@ def _mit_gaps(state: CrateState, *, graph: Any | None = None) -> tuple[list[Gap]
     ``report-only`` gap (#257, fix B) so the guidance loop never phrases it as a
     specific "this chemical / this protocol" that does not exist.
     """
-    mit_data = _load_mit_yaml()
+    mit_data = load_mit_yaml()
     if mit_data is None:
         return [], 0.0
 
@@ -436,92 +417,76 @@ def _mit_gaps(state: CrateState, *, graph: Any | None = None) -> tuple[list[Gap]
     matcher = slot_matcher(state, graph=graph)
     nodes = graph_nodes(graph) if graph is not None else None
     present_types = _present_entity_types(state)
-    modules = mit_data.get("modules", [])
     gaps: list[Gap] = []
     total_completed = 0
     total_required = 0
 
-    for module in modules:
-        all_params: list[dict[str, Any]] = []
-        for section in module.get("sections", []):
-            all_params.extend(section.get("parameters", []))
-        all_params.extend(module.get("parameters", []))
+    # ONE traversal, shared with the scorer (#357): section walk, dedup by id and
+    # the skip rule all live in `iter_scorable_params`, so "the gap engine emits a
+    # gap" and "the scorer counts the slot unfilled" range over the same
+    # parameters by construction rather than by two copies staying in step.
+    for _module, param, slots in iter_scorable_params(mit_data):
+        crate_slot = param.get("crate_slot", "")
+        total_required += 1
+        if any(matcher(et, f) for et, f in slots):
+            total_completed += 1
+            continue
 
-        # Deduplicate by parameter id (mirrors mit_assessment).
-        seen: set[str] = set()
-        unique_params: list[dict[str, Any]] = []
-        for param in all_params:
-            pid = param.get("id", "")
-            if pid and pid not in seen:
-                seen.add(pid)
-                unique_params.append(param)
-
-        for param in unique_params:
-            crate_slot = param.get("crate_slot", "")
-            if not crate_slot:
-                continue
-            slots = _parse_crate_slots(crate_slot)
-            total_required += 1
-            is_filled = any(matcher(et, f) for et, f in slots)
-            if is_filled:
-                total_completed += 1
-                continue
-
-            # Unfilled -> a gap. Tier from the `additional` flag.
-            additional = bool(param.get("additional", False))
-            tier: Tier = "MAY" if additional else "SHOULD"
-            # The first slot drives the routed property/entity_type (the canonical
-            # crate field the parameter maps to); the rest are alternatives.
-            slot_entity_type, slot_field = slots[0] if slots else (None, None)
-            param_name = param.get("name") or param.get("id") or slot_field or "parameter"
-            # (#257, fix B) Does ANY slot reference an entity type that actually has
-            # an instance? If not, the parameter is type-level only — there is no
-            # concrete entity to ask about, so phrasing it as a specific entity is
-            # exactly the bug (asking for "this chemical"'s CAS with zero chemicals).
-            has_instance = any(
-                slot_type_present(et, nodes) if nodes is not None else et in present_types
-                for et, _ in slots
-                if et
+        # Unfilled -> a gap. Tier from the `additional` flag.
+        additional = bool(param.get("additional", False))
+        tier: Tier = "MAY" if additional else "SHOULD"
+        # The first slot drives the routed property/entity_type (the canonical
+        # crate field the parameter maps to); the rest are alternatives.
+        slot_entity_type, slot_field = slots[0] if slots else (None, None)
+        param_name = param.get("name") or param.get("id") or slot_field or "parameter"
+        # (#257, fix B) Does ANY slot reference an entity type that actually has
+        # an instance? If not, the parameter is type-level only — there is no
+        # concrete entity to ask about, so phrasing it as a specific entity is
+        # exactly the bug (asking for "this chemical"'s CAS with zero chemicals).
+        has_instance = any(
+            slot_type_present(et, nodes) if nodes is not None else et in present_types
+            for et, _ in slots
+            if et
+        )
+        if not has_instance:
+            # No instance of any of the parameter's entity types: surface a
+            # creation-prompt, report-only gap (never a per-field ask on a
+            # non-existent entity).
+            message = (
+                f"No {slot_entity_type or 'matching'} recorded yet; the MIT "
+                f"profile expects '{param_name}' (crate_slot {crate_slot}). "
+                "Add one to capture it."
             )
-            if not has_instance:
-                # No instance of any of the parameter's entity types: surface a
-                # creation-prompt, report-only gap (never a per-field ask on a
-                # non-existent entity).
-                message = (
-                    f"No {slot_entity_type or 'matching'} recorded yet; the MIT "
-                    f"profile expects '{param_name}' (crate_slot {crate_slot}). "
-                    "Add one to capture it."
-                )
-                fix_hint = REPORT_ONLY
-            # MIT gaps are emitted crate-level (entity_id None). They are only
-            # committable when their field maps to a Root Data Entity slot; the
-            # rest have no deterministic settable target and are report-only, so
-            # the guidance loop surfaces them for context without burning a turn.
-            elif not _is_committable(state, None, slot_field, slot_entity_type):
-                message = (
-                    f"MIT parameter '{param_name}' is not yet captured (crate_slot {crate_slot})."
-                )
-                fix_hint = REPORT_ONLY
-            else:
-                message = (
-                    f"MIT parameter '{param_name}' is not yet captured (crate_slot {crate_slot})."
-                )
-                # MIT enrichment needs content the user provides or a drafter
-                # synthesizes; it is never a deterministic auto-fix (D5).
-                fix_hint = "ask-user" if not additional else "draft"
-            gaps.append(
-                Gap(
-                    tier=tier,
-                    source="mit",
-                    entity_id=None,
-                    entity_type=slot_entity_type,
-                    property=slot_field,
-                    message=message,
-                    suggestion=_mit_suggestion(param),
-                    fix_hint=fix_hint,
-                    auto_fixable=False,
-                )
+            fix_hint = REPORT_ONLY
+        # MIT gaps are emitted crate-level (entity_id None). They are only
+        # committable when their field maps to a Root Data Entity slot; the
+        # rest have no deterministic settable target and are report-only, so
+        # the guidance loop surfaces them for context without burning a turn.
+        elif not _is_committable(state, None, slot_field, slot_entity_type):
+            message = (
+                f"MIT parameter '{param_name}' is not yet captured (crate_slot {crate_slot})."
             )
+            fix_hint = REPORT_ONLY
+        else:
+            message = (
+                f"MIT parameter '{param_name}' is not yet captured (crate_slot {crate_slot})."
+            )
+            # MIT enrichment needs content the user provides or a drafter
+            # synthesizes; it is never a deterministic auto-fix (D5).
+            fix_hint = "ask-user" if not additional else "draft"
+        gaps.append(
+            Gap(
+                tier=tier,
+                source="mit",
+                entity_id=None,
+                entity_type=slot_entity_type,
+                property=slot_field,
+                message=message,
+                suggestion=_mit_suggestion(param),
+                fix_hint=fix_hint,
+                auto_fixable=False,
+            )
+        )
 
     overall = total_completed / total_required if total_required > 0 else 0.0
     return gaps, overall

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -16,7 +16,7 @@ is only synthesized at assembly, so the graph path is the accurate one.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -24,11 +24,13 @@ from builder.state import CrateState, MITReport
 
 logger = logging.getLogger(__name__)
 
-# Path to the MIT YAML file
+# Path to the MIT YAML file. THE one constant (#357): `gap_analysis` imports it
+# rather than deriving its own, so the two readers can never point at different
+# checklists.
 MIT_YAML_PATH = Path(__file__).resolve().parent.parent.parent / "mit" / "invitro_tox.yaml"
 
 
-def _load_mit_yaml() -> dict[str, Any] | None:
+def load_mit_yaml() -> dict[str, Any] | None:
     """Load and parse the MIT YAML file.
 
     Returns:
@@ -44,7 +46,7 @@ def _load_mit_yaml() -> dict[str, Any] | None:
         return None
 
 
-def _parse_crate_slots(slot_str: str) -> list[tuple[str, str]]:
+def parse_crate_slots(slot_str: str) -> list[tuple[str, str]]:
     """Parse a crate_slot string into a list of (EntityType, field) tuples.
 
     Crate slots are formatted like "Investigation:name;Study:name;Assay:name"
@@ -252,7 +254,7 @@ def _count_filled_fields(state: CrateState) -> dict[tuple[str, str], bool]:
 # ---------------------------------------------------------------------------
 # Scoring
 # ---------------------------------------------------------------------------
-def _unique_module_params(module: dict[str, Any]) -> list[dict[str, Any]]:
+def unique_module_params(module: dict[str, Any]) -> list[dict[str, Any]]:
     """The module's parameters (sections + top-level), deduplicated by id."""
     all_params: list[dict[str, Any]] = []
     for section in module.get("sections", []):
@@ -269,6 +271,33 @@ def _unique_module_params(module: dict[str, Any]) -> list[dict[str, Any]]:
     return unique
 
 
+def iter_scorable_params(
+    mit_data: dict[str, Any],
+) -> Iterator[tuple[dict[str, Any], dict[str, Any], list[tuple[str, str]]]]:
+    """Yield ``(module, param, slots)`` for every scorable MIT parameter.
+
+    THE single traversal of the checklist (#357): the walk over
+    ``sections`` + top-level parameters, the dedup by id, and the skip rule all
+    live here, so the scorer (:func:`_score_modules`) and the gap engine
+    (``gap_analysis._mit_gaps``) cannot drift into disagreeing about which
+    parameters exist or how many there are.
+
+    A parameter is *scorable* when its ``crate_slot`` parses to at least one
+    ``(EntityType, field)`` pair. A parameter with no parseable slot has nothing
+    the matcher could ever match, so counting it in the denominator would mark it
+    permanently uncoverable and silently depress every score. The two callers
+    previously disagreed on exactly this: the scorer skipped such a parameter,
+    the gap engine counted it. No parameter in the shipped checklist triggers it
+    today, which is precisely why it was worth removing before one did.
+    """
+    for module in mit_data.get("modules", []):
+        for param in unique_module_params(module):
+            slots = parse_crate_slots(param.get("crate_slot", ""))
+            if not slots:
+                continue
+            yield module, param, slots
+
+
 def _score_modules(
     mit_data: dict[str, Any],
     slot_filled: Callable[[str, str], bool],
@@ -279,26 +308,16 @@ def _score_modules(
     total_completed = 0
     total_required = 0
 
-    for module in mit_data.get("modules", []):
+    # A module with no scorable parameter never gets a row, as before: it is
+    # created on first yield, so an all-unscorable module is simply never keyed.
+    for module, _param, slots in iter_scorable_params(mit_data):
         module_name = module.get("name", module.get("id", "unknown"))
-        module_completed = 0
-        module_total = 0
-
-        for param in _unique_module_params(module):
-            slots = _parse_crate_slots(param.get("crate_slot", ""))
-            if not slots:
-                continue
-            module_total += 1
-            if any(slot_filled(et, field) for et, field in slots):
-                module_completed += 1
-
-        if module_total > 0:
-            module_scores[module_name] = {
-                "completed": module_completed,
-                "total": module_total,
-            }
-            total_completed += module_completed
-            total_required += module_total
+        bucket = module_scores.setdefault(module_name, {"completed": 0, "total": 0})
+        bucket["total"] += 1
+        total_required += 1
+        if any(slot_filled(et, field) for et, field in slots):
+            bucket["completed"] += 1
+            total_completed += 1
 
     overall_score = total_completed / total_required if total_required > 0 else 0.0
     return MITReport(module_scores=module_scores, overall_score=overall_score)
@@ -323,7 +342,7 @@ def assess_mit_coverage(
     Returns:
         An MITReport with per-module scores and an overall score.
     """
-    mit_data = _load_mit_yaml()
+    mit_data = load_mit_yaml()
     if mit_data is None:
         return MITReport(module_scores={}, overall_score=0.0)
 

--- a/tests/test_tools_gap_analysis.py
+++ b/tests/test_tools_gap_analysis.py
@@ -731,8 +731,8 @@ class TestMitGapsUseTheGraphMatcher:
         """
         from builder.tools.mit_assessment import (
             _assemble_graph,
-            _load_mit_yaml,
-            _parse_crate_slots,
+            load_mit_yaml,
+            parse_crate_slots,
             slot_matcher,
         )
 
@@ -740,7 +740,7 @@ class TestMitGapsUseTheGraphMatcher:
         matcher = slot_matcher(state, graph={"@graph": _assemble_graph(state)})
 
         scorer_unfilled: set[str] = set()
-        for module in (_load_mit_yaml() or {}).get("modules", []):
+        for module in (load_mit_yaml() or {}).get("modules", []):
             # The YAML nests most parameters under `sections`; walk both, exactly
             # as the gap engine and the scorer do.
             params = [
@@ -749,7 +749,7 @@ class TestMitGapsUseTheGraphMatcher:
             ]
             for param in params:
                 crate_slot = param.get("crate_slot", "")
-                slots = _parse_crate_slots(crate_slot)
+                slots = parse_crate_slots(crate_slot)
                 if not slots:
                     continue
                 if not any(matcher(et, f) for et, f in slots):
@@ -790,3 +790,159 @@ class TestMitGapsUseTheGraphMatcher:
         scorer = assess_mit_coverage(state, graph={"@graph": _assemble_graph(state)})
 
         assert report.mit_overall == pytest.approx(scorer.overall_score, abs=1e-6)
+
+
+class TestMitSingleOwner:
+    """The scorer and the gap engine read ONE checklist, ONE way (#357).
+
+    Module/param iteration and dedup used to be implemented twice — in
+    ``mit_assessment._score_modules`` and again inside ``gap_analysis._mit_gaps``,
+    whose own comment said it "mirrors mit_assessment" — with the checklist path
+    hardcoded in both. Three readers of the same YAML, free to drift.
+
+    These tests pin the collapse. The traversal test deliberately re-derives the
+    expected count from the raw YAML rather than from the shared helper, so it
+    still fails if the shared traversal itself is wrong.
+    """
+
+    @staticmethod
+    def _state():
+        from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+        return vhps_fixture_state("S-VHPS21")
+
+    def test_one_checklist_path_constant(self):
+        """``gap_analysis`` no longer derives its own path to the MIT YAML."""
+        from builder.tools import gap_analysis, mit_assessment
+
+        assert mit_assessment.MIT_YAML_PATH.is_file()
+        assert not hasattr(gap_analysis, "MIT_YAML_PATH"), (
+            "gap_analysis re-introduced its own MIT_YAML_PATH; import the one in "
+            "mit_assessment so the two readers cannot point at different checklists"
+        )
+
+    def test_scorer_and_gap_engine_report_the_same_score(self):
+        """THE acceptance: both assessors agree on the same state, graph or not."""
+        from builder.tools.gap_analysis import _mit_gaps
+        from builder.tools.mit_assessment import _assemble_graph, assess_mit_coverage
+
+        state = self._state()
+        for graph in (None, {"@graph": _assemble_graph(state)}):
+            scored = assess_mit_coverage(state, graph=graph).overall_score
+            _gaps, gap_score = _mit_gaps(state, graph=graph)
+            assert scored == pytest.approx(gap_score), (
+                f"scorer says {scored}, gap engine says {gap_score} "
+                f"(graph={'yes' if graph else 'no'})"
+            )
+
+    def test_every_scored_param_is_either_covered_or_a_gap(self):
+        """Gaps and covered params partition the denominator — no param is lost.
+
+        A divergence in the two traversals shows up here as a partition that does
+        not add up, which a bare score comparison could hide (both sides could
+        skip the same parameter and still agree on the ratio).
+        """
+        from builder.tools.gap_analysis import _mit_gaps
+        from builder.tools.mit_assessment import (
+            _assemble_graph,
+            assess_mit_coverage,
+            iter_scorable_params,
+            load_mit_yaml,
+        )
+
+        state = self._state()
+        graph = {"@graph": _assemble_graph(state)}
+        report = assess_mit_coverage(state, graph=graph)
+        gaps, _score = _mit_gaps(state, graph=graph)
+
+        denominator = sum(m["total"] for m in report.module_scores.values())
+        covered = sum(m["completed"] for m in report.module_scores.values())
+        assert len(gaps) + covered == denominator
+        assert denominator == len(list(iter_scorable_params(load_mit_yaml() or {})))
+
+    def test_traversal_matches_the_raw_checklist(self):
+        """The shared traversal is pinned to the YAML, not to itself.
+
+        Re-derived here straight from the file — section params plus top-level
+        params, deduplicated by id, keeping those whose ``crate_slot`` parses.
+        If ``iter_scorable_params`` silently dropped a module or stopped
+        deduplicating, every self-consistent test above would still pass.
+        """
+        import yaml
+
+        from builder.tools.mit_assessment import (
+            MIT_YAML_PATH,
+            iter_scorable_params,
+            parse_crate_slots,
+        )
+
+        data = yaml.safe_load(MIT_YAML_PATH.read_text(encoding="utf-8"))
+        expected: list[str] = []
+        for module in data.get("modules", []):
+            seen: set[str] = set()
+            for param in [
+                *(p for sec in module.get("sections", []) for p in sec.get("parameters", [])),
+                *module.get("parameters", []),
+            ]:
+                pid = param.get("id", "")
+                if not pid or pid in seen:
+                    continue
+                seen.add(pid)
+                if parse_crate_slots(param.get("crate_slot", "")):
+                    expected.append(pid)
+
+        actual = [p.get("id", "") for _m, p, _s in iter_scorable_params(data)]
+        assert actual == expected
+        assert len(actual) == len(set(actual)), "traversal yielded a duplicate id"
+
+    def test_a_param_with_an_unparseable_slot_is_skipped_not_counted(self):
+        """The one rule the two copies disagreed on, now settled in one place.
+
+        The scorer skipped a parameter whose ``crate_slot`` is non-empty but
+        parses to no ``(EntityType, field)`` pair; the gap engine counted it in
+        its denominator, marking it permanently uncoverable. No parameter in the
+        shipped checklist triggers this — which is exactly why it needed pinning
+        before one did.
+        """
+        from builder.tools.mit_assessment import iter_scorable_params
+
+        data = {
+            "modules": [
+                {
+                    "name": "M",
+                    "parameters": [
+                        {"id": "good", "crate_slot": "Investigation:name"},
+                        {"id": "unparseable", "crate_slot": "no-colon-here"},
+                        {"id": "empty", "crate_slot": ""},
+                    ],
+                }
+            ]
+        }
+        assert [p.get("id") for _m, p, _s in iter_scorable_params(data)] == ["good"]
+
+    def test_a_param_repeated_across_sections_is_yielded_once(self):
+        """Dedup by id is pinned on synthetic data, not on the shipped checklist.
+
+        The shipped YAML currently contains **zero** duplicate ids, so a test that
+        re-derives from the real file cannot tell whether dedup still happens —
+        verified by mutation: deleting the dedup left every checklist-derived
+        assertion green. Hand-built data is the only thing that holds this rule.
+        """
+        from builder.tools.mit_assessment import iter_scorable_params
+
+        data = {
+            "modules": [
+                {
+                    "name": "M",
+                    "sections": [
+                        {"parameters": [{"id": "dup", "crate_slot": "Investigation:name"}]},
+                        {"parameters": [{"id": "dup", "crate_slot": "Study:name"}]},
+                    ],
+                    "parameters": [{"id": "dup", "crate_slot": "Assay:name"}],
+                }
+            ]
+        }
+        yielded = list(iter_scorable_params(data))
+        assert [p.get("id") for _m, p, _s in yielded] == ["dup"]
+        # First occurrence wins, so the denominator counts it once.
+        assert yielded[0][2] == [("Investigation", "name")]


### PR DESCRIPTION
Closes #357.

The MIT checklist had **three readers with parallel logic**:

- `mit_assessment` owned `_score_modules` / `_unique_module_params`;
- `gap_analysis` re-implemented the same walk **inline** inside `_mit_gaps`, with its own dedup and a comment admitting it *"mirrors mit_assessment"*;
- the YAML path was hardcoded in both modules.

`mit_assessment` is now the single owner. `iter_scorable_params(mit_data)` holds the section walk, the dedup by id, and the skip rule; both the scorer and the gap engine iterate it. `gap_analysis`'s `MIT_YAML_PATH`, `_load_mit_yaml` and `_parse_crate_slots` are deleted in favour of imports, and the three helpers are promoted to public names — matching the public `graph_nodes` / `slot_matcher` / `slot_type_present` the module already exports.

## The drift was already there

The two copies **disagreed on one rule**. For a parameter whose `crate_slot` is non-empty but parses to no `(EntityType, field)` pair:

| | behaviour |
| --- | --- |
| scorer | skips it |
| gap engine | counts it in the denominator |

That marks such a parameter permanently uncoverable and silently depresses every score. Settled on the scorer's rule: nothing the matcher can ever match does not belong in the denominator.

**No parameter in the shipped checklist triggers it, so no number changes today.** Verified identical before and after — `0.147727` with a graph, `0.0` without, denominator `176`, and scorer/gap-engine agreement in both modes.

## Tests

Six new, in `TestMitSingleOwner`, including the two from the issue's acceptance (score agreement; one checklist-path constant).

`test_traversal_matches_the_raw_checklist` re-derives its expectation **from the raw YAML rather than from the shared helper**, so it still fails if the shared traversal is itself wrong.

Two rules are pinned on **synthetic** data because the shipped checklist cannot exercise them:

- the unparseable-slot skip (no such parameter ships);
- **dedup by id** — the YAML contains **zero** duplicate ids.

That second one was found by mutation: deleting the dedup left every checklist-derived assertion green. A hand-built fixture is the only thing that can hold the rule, and with it, removing the dedup fails.

## Verification

- `44 passed` in `test_tools_gap_analysis` (one pre-existing test updated for the renames — it imported the now-public names).
- `85 passed` across `test_tools_mit_assessment` + `test_maturity_report`.
- Mutation-checked both directions.

Not in scope: #313 (retiring the local YAML path for the `tox-maturity-indicators` package loader) becomes a one-line change now that the path has a single owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)