### PR TITLE
fix(llm): apply VITRO_TEMPERATURE on both providers, not just OpenAI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,6 +567,16 @@ deterministic `temperature=0` (override via `VITRO_TEMPERATURE`).
 reasoning-token spend); the explicit value `none` disables reasoning and opts
 back to the standard `temperature=0` path.
 
+`VITRO_TEMPERATURE` applies to **both** providers, resolved once in
+`_resolve_temperature()` (#402). It previously read on the OpenAI path only while
+the Anthropic branch hard-coded `temperature: 0`, so a temperature sweep on
+Anthropic silently did nothing — and an A/B asked to compare two architectures at
+one temperature was comparing two temperatures. Blank/whitespace reads as unset
+(matching `VITRO_OPENAI_REASONING_EFFORT`); a non-numeric value raises rather than
+resolving to 0, because a silently-ignored control is the defect this fixed. A
+Responses-API reasoning model still receives no temperature at all — "no opinion"
+must be absence, since the API 400s on any explicit value.
+
 **Decision gate (future work):** upgrading the *orchestrator* to a stronger
 model is a separate, profiling-gated decision. Instrument `profile.ndjson` for
 iterations-per-task, recursion-limit hits, and REQUIRED-issue fix success;
@@ -1100,6 +1110,26 @@ profile}`), with `profile == "data"` so this layer stays cleanly distinct from
 the SHACL layers — SHACL = metadata, Frictionless = payload, never entangled. It
 never raises into the agent loop: setup errors (missing file, malformed schema)
 return `{"ok": False, "issues": [], "error": ...}`.
+
+**Invocation (Issue #409).** The layer cannot be reached through
+`build_and_validate`: that call takes `profile="all"`, `profiles/validator.py`
+accepts only `all|base|isa|tox`, and `DATA_CONTENT_PROFILE = "data"` sits
+deliberately outside that set. So the pipeline spine calls it directly —
+`_validate_populated_tables`, after `_run_fix_loop`, and **only when population
+actually landed rows** (the header-only placeholder #94 materialises is valid by
+construction). Its verdict is returned by `run_pipeline` under its own
+`data_issues` key and is **not** folded into `ok`: a cell contradicting its
+`tableSchema` is a different defect from a SHACL conformance failure, and merging
+them would make `success` in the eval harness mean two different things. It is
+kept out of the fix loop for the same reason — that loop terminates on
+`build_and_validate`'s `ok`, and `fix_required_issues` is keyed on SHACL rules
+and cannot repair a data cell.
+
+The `compound` / `cell_line` foreign-key allow-lists carry entity **names as well
+as ids**, because that is what the cells hold: `propose_condition_rows` writes
+`name` and falls back to `entity_id` only for an entity that has none, and a
+depositor's plate map names compounds the way a bench scientist writes them. An
+id-only allow-list would flag every row of a correct table.
 
 ### Verification Layer
 Checks that identifiers resolve at their source. Verification failures are REQUIRED — the identifier must be corrected or removed. Leaving a field empty is acceptable (shows up in MIT/FAIR scores but does not block).

--- a/builder/agents/llm.py
+++ b/builder/agents/llm.py
@@ -26,7 +26,9 @@ __all__ = [
     "_extract_model_name",
     "_extract_token_usage",
     "_get_request_timeout",
+    "_apply_temperature",
     "_is_openai_reasoning_model",
+    "_resolve_temperature",
     "_recursion_limit",
 ]
 
@@ -138,6 +140,41 @@ def _is_openai_reasoning_model(model_name: str | None) -> bool:
     m = (model_name or "").strip().lower()
     return m.startswith(_OPENAI_REASONING_PREFIXES)
 
+
+_DEFAULT_TEMPERATURE = 0.0
+
+
+def _resolve_temperature() -> float:
+    """The single parse point for ``VITRO_TEMPERATURE``, shared by every provider.
+
+    It lived inline on the OpenAI branch while the Anthropic branch hard-coded
+    ``temperature: 0``, so a temperature experiment on Anthropic silently did
+    nothing — and the two build arms this repo A/B-compares were not actually
+    running the same configuration (#402).
+
+    Blank/whitespace reads as unset rather than raising, matching the convention
+    ``VITRO_OPENAI_REASONING_EFFORT`` already uses. A non-numeric value still
+    raises, naming the variable: a control that is silently ignored is the very
+    defect being fixed here, so a typo must fail loudly rather than resolve to 0.
+    """
+    raw = (os.environ.get("VITRO_TEMPERATURE") or "").strip()
+    if not raw:
+        return _DEFAULT_TEMPERATURE
+    try:
+        return float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"VITRO_TEMPERATURE must be a number, got {raw!r}") from exc
+
+
+def _apply_temperature(kwargs: dict[str, Any], *, supported: bool = True) -> None:
+    """Set the resolved temperature on *kwargs*, or omit it entirely.
+
+    ``supported=False`` leaves the key off rather than sending a default: a
+    Responses-API reasoning model accepts only the provider default and 400s on
+    an explicit value, so "no opinion" must be expressed as absence.
+    """
+    if supported:
+        kwargs["temperature"] = _resolve_temperature()
 
 def _build_chat_model(
     provider: str | None = None,
@@ -281,9 +318,7 @@ def _build_chat_model(
         # (VITRO_TEMPERATURE overrides it), but never force a temperature on a
         # Responses-API-routed reasoning model — it only accepts the provider
         # default (the API 400s on "temperature does not support 0").
-        if not use_responses:
-            temp_override = os.environ.get("VITRO_TEMPERATURE")
-            kwargs["temperature"] = float(temp_override) if temp_override is not None else 0
+        _apply_temperature(kwargs, supported=not use_responses)
         if api_key:
             kwargs["api_key"] = api_key
         if resolved_base:
@@ -323,12 +358,16 @@ def _build_chat_model(
         )
         kwargs: dict[str, Any] = {
             "model": resolved_model,
-            "temperature": 0,
             "max_retries": max_retries,
             # "timeout" is the public alias of ChatAnthropic
             # .default_request_timeout (#263).
             "timeout": timeout,
         }
+        # #402: this was a hard-coded `"temperature": 0` in the literal above, so
+        # VITRO_TEMPERATURE was inert on this provider entirely — an A/B asked to
+        # compare two architectures at one temperature silently compared two
+        # temperatures. Same resolution as the OpenAI branch.
+        _apply_temperature(kwargs)
         if streaming:
             # Anthropic reports usage on the streamed message_start /
             # message_delta events, so no extra opt-in is needed here.

--- a/tests/test_llm_reasoning_model.py
+++ b/tests/test_llm_reasoning_model.py
@@ -74,6 +74,62 @@ def test_explicit_temperature_override_for_standard_model(monkeypatch: pytest.Mo
     assert _build_chat_model(provider="openai").temperature == pytest.approx(0.7)
 
 
+def _anthropic_env(monkeypatch: pytest.MonkeyPatch, model: str) -> None:
+    monkeypatch.setenv("VITRO_ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("VITRO_ANTHROPIC_MODEL", model)
+    monkeypatch.delenv("VITRO_TEMPERATURE", raising=False)
+
+
+def test_temperature_override_applies_to_anthropic_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """VITRO_TEMPERATURE reaches BOTH providers (#402).
+
+    The Anthropic branch hard-coded ``temperature: 0`` and never read the
+    variable, so a temperature experiment on Anthropic silently did nothing — and
+    an A/B asked to compare two architectures at one temperature was in fact
+    comparing two temperatures.
+    """
+    _anthropic_env(monkeypatch, "claude-sonnet-4-20250514")
+    monkeypatch.setenv("VITRO_TEMPERATURE", "0.7")
+    assert _build_chat_model(provider="anthropic").temperature == pytest.approx(0.7)
+
+
+def test_anthropic_keeps_the_deterministic_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _anthropic_env(monkeypatch, "claude-sonnet-4-20250514")
+    assert _build_chat_model(provider="anthropic").temperature == pytest.approx(0.0)
+
+
+def test_blank_temperature_reads_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Matches the convention VITRO_OPENAI_REASONING_EFFORT already uses; before
+    # the fix this raised "could not convert string to float: ''".
+    _openai_env(monkeypatch, "gpt-4o")
+    monkeypatch.setenv("VITRO_TEMPERATURE", "   ")
+    assert _build_chat_model(provider="openai").temperature == pytest.approx(0.0)
+
+
+def test_non_numeric_temperature_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A silently-ignored control is the defect being fixed, so a typo must not
+    # quietly resolve to 0.
+    _openai_env(monkeypatch, "gpt-4o")
+    monkeypatch.setenv("VITRO_TEMPERATURE", "hot")
+    with pytest.raises(ValueError, match="VITRO_TEMPERATURE"):
+        _build_chat_model(provider="openai")
+
+
+def test_reasoning_model_never_receives_a_temperature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with an explicit override: the Responses API 400s on any value."""
+    _openai_env(monkeypatch, "gpt-5.1")
+    monkeypatch.setenv("VITRO_TEMPERATURE", "0.7")
+    model = _build_chat_model(provider="openai")
+    assert model.use_responses_api is True
+    assert model.temperature is None
+
+
 def test_optional_ca_bundle_is_passed_to_openai_clients(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:


### PR DESCRIPTION
Closes #402.

`VITRO_TEMPERATURE` was read on the OpenAI path only. The Anthropic branch hard-coded `"temperature": 0` in its kwargs literal, so the env var was **inert on that provider entirely**.

That is worse than a missing feature: an A/B asked to compare two architectures *at one temperature* was silently comparing two different temperatures, and a temperature sweep on Anthropic produced identical runs while looking like it worked.

## Fix

Both providers now resolve it once through `_resolve_temperature()`, so there is a single place that decides what temperature a run uses.

- Blank/whitespace reads as **unset**, matching how `VITRO_OPENAI_REASONING_EFFORT` already behaves — an empty env var is not a request for temperature 0.
- A non-numeric value **raises** rather than silently falling back. A typo'd sweep parameter that quietly runs at 0 is the failure mode this issue is about.
- Reasoning models (gpt-5.x, o-series) still get no `temperature` at all — they reject it, and that path is unchanged.

`AGENTS.md` records the contract next to the existing provider notes.

`21 passed` (including the doc-toolbox guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)