### PR TITLE
fix(scanner): prune the session root too, and re-check containment on resolve

### DIFF
--- a/builder/tools/scanner.py
+++ b/builder/tools/scanner.py
@@ -494,19 +494,36 @@ def _safe_walk(root: Path) -> list[Path]:
     Hidden and special directories (``.git``, ``__MACOSX``, dot-prefixed)
     are pruned in-place during the walk so they are never descended.
 
-    **Nested RO-Crates are pruned too (#416).** A directory holding an
-    ``ro-crate-metadata.json`` is a crate — in practice one this tool produced,
-    under ``sessions/<id>/working_crate/`` or ``output/<name>_crate/``. Walking
-    into it makes the builder ingest its own prior output as if it were source
-    research data, so a second run over a folder is contaminated by the first.
-    Stating the invariant ("do not descend into a crate") rather than listing
-    directory names avoids a list that drifts.
+    The tool's OWN artifacts are pruned too (#416). Scanning a directory that
+    already holds previous runs re-ingested the builder's own crates and session
+    state as if they were source research data — and because
+    ``ro-crate-metadata.json`` and ``crate_state.json`` match the metadata/JSON
+    priority rules, that self-produced material OUTRANKED the real assay files in
+    the drafter's context budget. Two prunes, both drift-free:
 
-    The walk *root* is deliberately exempt: pointing the scanner straight at a
-    crate is an explicit request to read that crate, not self-ingestion.
+    * a nested directory containing ``ro-crate-metadata.json`` is an RO-Crate
+      root by spec, so it is skipped wholesale. Identifying it by the sentinel
+      rather than by a directory name list also catches a user-chosen output path
+      and cannot misfire on legitimate research data in a folder named
+      ``output/``;
+    * the configured session root (honouring ``VITRO_SESSION_DIR``), because
+      ``sessions/<id>/crate_state.json`` lives outside any crate root and is a
+      complete serialization of the previous run.
+
+    The scan target itself is exempt from both, so explicitly pointing at a crate
+    or a session directory still works.
     """
+    import builder.config as _config
+
     results: list[Path] = []
-    root = root.resolve()
+    try:
+        target = root.resolve()
+    except OSError:
+        target = root
+    try:
+        session_root = Path(_config.session_root()).resolve()
+    except Exception:  # noqa: BLE001 — an unresolvable session root just skips this prune
+        session_root = None
 
     def _onerror(err: OSError) -> None:
         logger.warning("Skipping unreadable directory: %s", err.filename or err)
@@ -522,12 +539,20 @@ def _safe_walk(root: Path) -> list[Path]:
             dirnames[:] = [d for d in dirnames if not _should_prune(d)]
 
             dirpath = Path(dirpath_str)
-            # Self-ingestion guard (#416): skip a nested crate entirely — its
-            # manifest, its CSVW tables and its copied payload.
-            if _CRATE_MANIFEST in filenames and dirpath.resolve() != root:
-                logger.info("Skipping nested RO-Crate (not source data): %s", dirpath)
-                dirnames[:] = []
-                continue
+            try:
+                resolved = dirpath.resolve()
+            except OSError:
+                resolved = dirpath
+
+            if resolved != target:
+                if _CRATE_MANIFEST in filenames:
+                    logger.info("Skipping nested RO-Crate root: %s", dirpath)
+                    dirnames[:] = []
+                    continue
+                if session_root is not None and resolved == session_root:
+                    logger.info("Skipping the tool's session root: %s", dirpath)
+                    dirnames[:] = []
+                    continue
 
             for name in filenames:
                 results.append(dirpath / name)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1170,3 +1170,83 @@ class TestDefaultFileCap:
             "engine now passes max_files explicitly — update this test to assert "
             "the value it passes instead of the inherited default"
         )
+
+
+class TestSelfProducedArtifactsArePruned:
+    """The scanner must not re-ingest the tool's own output (#416).
+
+    A scan root that already holds previous runs fed the builder's own crates and
+    session state back in as source research data — and because
+    ``ro-crate-metadata.json`` / ``crate_state.json`` match the metadata/JSON
+    priority rules, that self-produced material OUTRANKED the real assay files in
+    the drafter's limited context budget.
+
+    Both prunes key off structure, not directory names: a folder legitimately
+    called ``output/`` full of real measurements must survive.
+    """
+
+    def _tree(self, root):
+        (root / "assays").mkdir()
+        (root / "assays" / "plate.xlsx").write_text("x", encoding="utf-8")
+        (root / "assays" / "sop.docx").write_text("y", encoding="utf-8")
+        crate = root / "output" / "crate_v9"
+        crate.mkdir(parents=True)
+        (crate / "ro-crate-metadata.json").write_text("{}", encoding="utf-8")
+        (crate / "ro-crate-preview.html").write_text("h", encoding="utf-8")
+        (crate / "data").mkdir()
+        (crate / "data" / "table.csv").write_text("a,b", encoding="utf-8")
+        real = root / "output" / "raw_measurements"
+        real.mkdir(parents=True, exist_ok=True)
+        (real / "run1.csv").write_text("1", encoding="utf-8")
+        return crate
+
+    def _walk(self, root):
+        from builder.tools.scanner import _safe_walk
+
+        return sorted(str(p.relative_to(root)) for p in _safe_walk(root))
+
+    def test_nested_ro_crate_root_is_skipped_wholesale(self, tmp_path) -> None:
+        self._tree(tmp_path)
+        found = self._walk(tmp_path)
+        assert not any("crate_v9" in f for f in found), found
+
+    def test_real_research_data_is_untouched(self, tmp_path) -> None:
+        self._tree(tmp_path)
+        found = self._walk(tmp_path)
+        assert any(f.endswith("assays/plate.xlsx") for f in found), found
+
+    def test_a_folder_merely_named_output_is_not_pruned(self, tmp_path) -> None:
+        # The prune keys off the ro-crate-metadata.json sentinel, not a name
+        # list, so it cannot misfire on legitimate data under output/.
+        self._tree(tmp_path)
+        found = self._walk(tmp_path)
+        assert any(f.endswith("raw_measurements/run1.csv") for f in found), found
+
+    def test_pointing_directly_at_a_crate_still_scans_it(self, tmp_path) -> None:
+        # The scan target itself is exempt — "explicitly point at a crate" must
+        # keep working.
+        crate = self._tree(tmp_path)
+        found = self._walk(crate)
+        assert "ro-crate-metadata.json" in found
+        assert "data/table.csv" in found
+
+    def test_session_root_is_skipped(self, tmp_path, monkeypatch) -> None:
+        # sessions/<id>/crate_state.json lives OUTSIDE any crate root and is a
+        # complete serialization of the previous run — the single most
+        # contaminating file, which the crate-sentinel prune alone misses.
+        import importlib
+
+        import builder.config as config
+
+        self._tree(tmp_path)
+        sessions = tmp_path / "sessions" / "20260101"
+        sessions.mkdir(parents=True)
+        (sessions / "crate_state.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv("VITRO_SESSION_DIR", str(tmp_path / "sessions"))
+        importlib.reload(config)
+        try:
+            found = self._walk(tmp_path)
+            assert not any("sessions" in f for f in found), found
+        finally:
+            monkeypatch.delenv("VITRO_SESSION_DIR", raising=False)
+            importlib.reload(config)


### PR DESCRIPTION
Follow-up to #454, which closed #416 by pruning nested RO-Crate roots. This adds the **second** prune that fix was missing.

## What #454 left open

`sessions/<id>/crate_state.json` lives **outside** any crate root, so the manifest sentinel never sees it — and it is a complete serialization of the previous run. Worse, because `ro-crate-metadata.json` and `crate_state.json` both match the metadata/JSON priority rules, that self-produced material **outranked the real assay files** in the drafter's limited context budget.

So a scan could still feed the builder its own prior session state, ranked above the actual measurements.

## Fix

Two prunes, both keyed off structure rather than directory names:

- a nested directory containing `ro-crate-metadata.json` is an RO-Crate root by spec (unchanged from #454);
- **the configured session root**, honouring `VITRO_SESSION_DIR` rather than assuming `sessions/`, so a relocated session dir is pruned too and a user's folder that happens to be called `sessions/` is not.

The scan target itself stays exempt from both, so explicitly pointing at a crate — or at a session directory — still works.

Also hardens the walk: `Path.resolve()` is wrapped for `OSError`, since a broken symlink inside a scan root previously took the whole walk down.

## Tests

`TestSelfProducedArtifactsArePruned` covers the session-root prune, the sentinel-not-name rule (a legitimate `output/` full of real measurements survives), and the target exemption — alongside the `TestSelfIngestionGuard` / `TestDefaultFileCap` classes from #454, which still pass unchanged.

`95 passed` across `test_scanner` and `test_scan_loop_fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)