### PR TITLE
chore(ci): raise the calibration timeout for the grown suite

### DIFF
--- a/.github/workflows/calibrate-durations.yml
+++ b/.github/workflows/calibrate-durations.yml
@@ -15,7 +15,10 @@ on:
 jobs:
   measure:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # The whole suite, serial, on a 2-vCPU runner. It was 60 when the suite was
+    # ~1100 recorded tests; it is now 2113 and the export-heavy tail got slower
+    # (every export runs the full severity sweep, #446), so 60 no longer clears it.
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -35,8 +38,10 @@ jobs:
         run: uv sync --dev --extra langchain
 
       - name: Measure runner durations (full suite, serial)
-        # Same --ignore set as the `test` job so the recorded set matches exactly
-        # what gets sharded. Generous --timeout=120 so a test that is slow on the
+        # No --ignore, matching the `test` job exactly (#456 retired the last of
+        # them), so the recorded set is exactly what gets sharded. A module the
+        # sharded job runs but this one skips would be balanced blind.
+        # Generous --timeout=120 so a test that is slow on the
         # runner is MEASURED, not killed (the sharded job keeps its tight
         # --timeout=30). Serial (no -n) so each test's recorded duration is its
         # true single-process runner cost. `|| true` so a stray failure still lets


### PR DESCRIPTION
`.test_durations` was last regenerated **2026-06-26** and records **1092** tests. The suite now collects **2113**, so pytest-split balances roughly **half the shards blind** — which is why shard load, and therefore which test trips `--timeout=30`, behaves like a lottery rather than a property of the change. That is what put `main` red after #446.

Regenerating it needs the calibration job to actually finish. `timeout-minutes` was 60, sized when ~1100 tests were recorded; the suite has roughly doubled and the export-heavy tail got slower (#446), so 60 no longer clears it.

Also corrects a comment that still claimed this job shares an `--ignore` set with the sharded job — #456 retired the last of those.

Regenerating the durations file itself is a separate step: run this workflow, download the artifact, commit it as `.test_durations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)