### PR TITLE
fix(pipeline): an unusable plate-map candidate falls back to the proposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1726,7 +1726,11 @@ re-implementation. Its parts:
   a bug, not a spare field — the plan is not paid for in drafter tokens to be
   discarded. Plan-named files resolve through `_scanned_path_for_name`: matched by
   **basename** (the leaf only ever sees `f.filename`, never `f.path`) and fail-closed
-  to `approved_scan_roots`, since plan paths are LLM free text.
+  to `approved_scan_roots`, since plan paths are LLM free text. An unusable single
+  candidate — no path, outside the roots, unreadable, or read-but-unmappable — falls
+  back to the propose-from-entities path (#422), so it never yields less table
+  content than having no candidate at all; only the several-candidates ambiguity
+  refuses without fallback, because choosing among real plate maps is a human call.
 - **The spine** — `run_pipeline` (`builder/agents/pipeline/pipeline.py`, §14.5), the
   code-driven orchestrator and the default `main.py --interactive` build (via
   `run_interactive_build`, §14.6.1); also selectable in the eval harness

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -650,6 +650,21 @@ def format_gap_summary(pipeline_result: dict[str, Any] | None) -> str:
         f"  open gaps: {must_open} MUST (SHOULD/MAY not assessed on the fast build)",
         (f"  conformance: base={_mark('base')} isa={_mark('isa')} tox={_mark('tox')}"),
     ]
+
+    # Condition-table posture (#422): the central domain table staying empty used
+    # to live only in a discarded reason string while this summary read clean.
+    table = (result.get("materialized") or {}).get("condition_table")
+    if isinstance(table, dict) and table:
+        if not table.get("populated"):
+            reason = str(table.get("reason") or "no reason recorded")
+            lines.append(f"  condition table: not populated — {reason}")
+        elif table.get("proposed"):
+            lines.append(
+                f"  condition table: proposed from crate entities "
+                f"({table.get('rows')} row(s), awaiting confirmation)"
+            )
+        else:
+            lines.append(f"  condition table: {table.get('rows')} row(s)")
     return "\n".join(lines)
 
 

--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -351,7 +351,14 @@ def _plan_schema() -> dict[str, Any]:
                     "role": {
                         "type": "string",
                         "enum": ["raw", "processed", "condition_table", "other"],
-                        "description": "What kind of data file this is.",
+                        "description": (
+                            "What kind of data file this is. `condition_table` "
+                            "means a per-well experimental DESIGN table or plate "
+                            "map — rows or grid cells per well giving compound, "
+                            "concentration, duration. A metadata or parameter "
+                            "template (Parameter/Value sheets) is `other`, never "
+                            "`condition_table`."
+                        ),
                     },
                 },
                 required=["path"],

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1369,6 +1369,26 @@ def _propose_condition_table(engine: AgentEngine, exposure_id: str) -> dict[str,
     }
 
 
+def _fall_back_to_proposal(
+    engine: AgentEngine, exposure_id: str, primary: dict[str, Any]
+) -> dict[str, Any]:
+    """An unusable plate-map candidate must not beat having none at all (#422).
+
+    The #438 proposal used to fire only at ZERO candidates, so a single
+    unreadable or unmappable candidate left the crate with strictly less table
+    content than an absent plate map. On proposal success the result carries
+    ``fallback_from`` — the primary failure — so the rows' provenance stays
+    visible; on proposal failure the PRIMARY reason survives as ``reason`` with
+    the proposal's own failure alongside as ``proposal_reason``, never swapped.
+    """
+    proposed = _propose_condition_table(engine, exposure_id)
+    if proposed.get("populated"):
+        proposed["fallback_from"] = str(primary.get("reason") or "")
+        return proposed
+    primary["proposal_reason"] = str(proposed.get("reason") or "")
+    return primary
+
+
 def _populate_condition_table_from_plan(
     engine: AgentEngine, plan: dict[str, Any], exposure_id: str
 ) -> dict[str, Any]:
@@ -1395,11 +1415,15 @@ def _populate_condition_table_from_plan(
       to the tool, which resolves it the same way ``export_crate`` does (#381).
 
     Never raises: a tool failure is logged and reported as a reason, so one bad
-    plate map cannot break the spine.
+    plate map cannot break the spine. A single candidate that cannot be used —
+    no path, outside the scan roots, unreadable, or read-but-unmappable — falls
+    back to the #438 proposal via :func:`_fall_back_to_proposal` (#422); only
+    the several-candidates ambiguity refuses without fallback.
 
     Returns:
         ``{"populated": bool, "reason": str}`` plus, on success, the tool's
-        ``rows`` / ``path`` / ``unmapped_source_columns``. Surfaced in
+        ``rows`` / ``path`` / ``unmapped_source_columns`` — or the proposal's
+        result carrying ``proposed`` / ``fallback_from``. Surfaced in
         :func:`_materialize_plan`'s result so it reaches ``run_pipeline``.
     """
     entries = [f for f in (plan.get("files") or []) if isinstance(f, dict)]
@@ -1413,6 +1437,9 @@ def _populate_condition_table_from_plan(
         # human; no concentration is ever invented.
         return _propose_condition_table(engine, exposure_id)
     if len(candidates) > 1:
+        # Deliberately NO proposal fallback here (#422): several claimed plate
+        # maps is genuine ambiguity a human must settle — synthesizing rows
+        # while real design tables sit unread would paper over the question.
         names = ", ".join(sorted(str(c.get("path") or "?") for c in candidates))
         return {
             "populated": False,
@@ -1421,14 +1448,22 @@ def _populate_condition_table_from_plan(
 
     named = str(candidates[0].get("path") or "").strip()
     if not named:
-        return {"populated": False, "reason": "the condition_table entry carries no path"}
+        return _fall_back_to_proposal(
+            engine,
+            exposure_id,
+            {"populated": False, "reason": "the condition_table entry carries no path"},
+        )
 
     path = _scanned_path_for_name(engine, named)
     if path is None:
-        return {
-            "populated": False,
-            "reason": f"{named!r} matches no scanned file inside the approved scan roots",
-        }
+        return _fall_back_to_proposal(
+            engine,
+            exposure_id,
+            {
+                "populated": False,
+                "reason": f"{named!r} matches no scanned file inside the approved scan roots",
+            },
+        )
 
     try:
         outcome = engine.run_tool(
@@ -1438,7 +1473,11 @@ def _populate_condition_table_from_plan(
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("populate_condition_table failed for %s: %s", path, exc)
-        return {"populated": False, "reason": f"populate_condition_table raised: {exc}"}
+        return _fall_back_to_proposal(
+            engine,
+            exposure_id,
+            {"populated": False, "reason": f"populate_condition_table raised: {exc}"},
+        )
 
     outcome = outcome if isinstance(outcome, dict) else {}
     if not outcome.get("ok"):
@@ -1456,11 +1495,15 @@ def _populate_condition_table_from_plan(
             )
         else:
             logger.info("Condition table not populated from %s: %s", named, reason)
-        return {
-            "populated": False,
-            "reason": reason,
-            "read_failed": bool(outcome.get("read_failed")),
-        }
+        return _fall_back_to_proposal(
+            engine,
+            exposure_id,
+            {
+                "populated": False,
+                "reason": reason,
+                "read_failed": bool(outcome.get("read_failed")),
+            },
+        )
 
     logger.info(
         "Populated condition table from %s: %s row(s) (#408).", named, outcome.get("rows")

--- a/eval/agent_api.py
+++ b/eval/agent_api.py
@@ -16,7 +16,7 @@ tool-call metrics). A failed build sets ``error`` and may return a partial state
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 from builder.state import CrateState
 from eval.corpus import EvalCase
@@ -38,12 +38,17 @@ class BuildOutcome:
             classify termination (e.g. a mock). A ``"cap_hit"`` preserves the
             partial crate and leaves ``error`` unset, so the conformance predicate
             still measures what the run produced at the cap.
+        pipeline_result: The deterministic spine's structured report — the dict
+            ``run_pipeline`` returns (conformance, issues, materialization
+            outcomes incl. ``condition_table``, ``data_issues``). ``None`` for
+            producers that do not report one (the ReAct arm, mocks) — see #422.
     """
 
     state: CrateState
     session_id: str | None = None
     error: str | None = None
     stop_reason: str | None = None
+    pipeline_result: dict[str, Any] | None = None
 
 
 @runtime_checkable

--- a/eval/pipeline_factory.py
+++ b/eval/pipeline_factory.py
@@ -31,7 +31,7 @@ the wiring is unit-testable in isolation.
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Any, Callable
 
 from builder.agents.llm import ModelOverrides
 from builder.engine import AgentEngine
@@ -122,12 +122,18 @@ class PipelineBuildAgent:
 
         error: str | None = None
         stop_reason = "completed"
+        report: dict[str, Any] | None = None
         try:
             runner = self._runner()
             if self._overrides is not None and _accepts_overrides(runner):
-                runner(engine, overrides=self._overrides)
+                raw = runner(engine, overrides=self._overrides)
             else:
-                runner(engine)
+                raw = runner(engine)
+            # run_pipeline's structured report (conformance, issues, the
+            # materialization outcomes incl. condition_table, data_issues) used
+            # to be discarded here, hiding every domain-level failure that does
+            # not raise (#422). Keep it whenever the runner returns one.
+            report = raw if isinstance(raw, dict) else None
         except Exception as exc:  # noqa: BLE001 — a failed build is a measured result
             logger.warning("Pipeline build failed for case %s: %s", case.case_id, exc)
             error = str(exc)
@@ -140,6 +146,7 @@ class PipelineBuildAgent:
             session_id=engine.state.session_id,
             error=error,
             stop_reason=stop_reason,
+            pipeline_result=report,
         )
 
 

--- a/eval/tests/test_pipeline_result_capture.py
+++ b/eval/tests/test_pipeline_result_capture.py
@@ -1,0 +1,46 @@
+"""#422 observability: the harness must not discard ``run_pipeline``'s report.
+
+``run_pipeline`` returns a structured report — conformance, issues, the
+materialization outcomes (including ``condition_table.populated``) and the
+Frictionless ``data_issues`` (#409) — and the eval harness used to drop it on
+the floor: only a raised exception was recorded. A silent domain-level failure
+(a header-only condition table) was therefore invisible to every eval metric.
+
+Offline: injected runner, no LLM, no network.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from builder.state import CrateState
+from eval.agent_api import BuildOutcome
+from eval.corpus import DEFAULT_CORPUS
+from eval.pipeline_factory import PipelineBuildAgent, PipelineRunner
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class TestPipelineResultCapture:
+    def test_the_runners_report_reaches_the_outcome(self) -> None:
+        report = {
+            "ok": True,
+            "materialized": {"condition_table": {"populated": False, "reason": "declined"}},
+        }
+        agent = PipelineBuildAgent(pipeline_runner=lambda engine: dict(report))
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.pipeline_result == report
+
+    def test_a_runner_without_a_report_yields_none(self) -> None:
+        # Deliberately violates PipelineRunner's declared `-> dict` to pin the
+        # defensive capture: a misbehaving runner yields None, never garbage.
+        misbehaving = cast(PipelineRunner, lambda engine: None)
+        agent = PipelineBuildAgent(pipeline_runner=misbehaving)
+        outcome = agent.build(DEFAULT_CORPUS[0])
+        assert outcome.pipeline_result is None
+
+    def test_the_field_defaults_to_none_for_other_producers(self) -> None:
+        outcome = BuildOutcome(state=CrateState())
+        assert outcome.pipeline_result is None

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -127,9 +127,7 @@ class TestDrafterTier:
             "the leaf must build the chat model on the drafter tier (role='drafter')"
         )
 
-    def test_explicit_model_is_forwarded(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_explicit_model_is_forwarded(self, _patch_build_chat_model: dict[str, Any]) -> None:
         rec = _patch_build_chat_model
         rec["model"] = FakeChatModel({"name": "Acetaminophen"})
 
@@ -140,12 +138,33 @@ class TestDrafterTier:
         assert rec["calls"][0].get("model") == "gpt-4o-mini"
 
 
+class TestConditionTableRoleGuidance:
+    """#422: the plan schema must define what a ``condition_table`` IS.
+
+    The real S-VHPS26 mislabel: with the role described only as "What kind of
+    data file this is.", the leaf labelled a Parameter|Value assay-metadata
+    template ``condition_table``, and the populator was handed a file that can
+    never map. The enum description is the leaf's ONLY definition of the term —
+    it must say per-well design/plate map and steer templates to ``other``.
+    """
+
+    def test_role_description_defines_condition_table_and_steers_templates(self) -> None:
+        from builder.agents.pipeline.leaves import _plan_schema
+
+        role = _plan_schema()["properties"]["files"]["items"]["properties"]["role"]
+        desc = str(role.get("description") or "").lower()
+        assert "per-well" in desc or "per well" in desc, (
+            "the description must define condition_table as a per-well design table"
+        )
+        assert "template" in desc and "other" in desc, (
+            "metadata/parameter templates must be steered to the `other` role"
+        )
+
+
 class TestStructuredOutput:
     """The leaf must use structured output bound once to the hints schema."""
 
-    def test_uses_structured_output_once(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_uses_structured_output_once(self, _patch_build_chat_model: dict[str, Any]) -> None:
         fake = FakeChatModel({"name": "Acetaminophen"})
         _patch_build_chat_model["model"] = fake
 
@@ -181,9 +200,7 @@ class TestOutputValidatesAgainstSchema:
         jsonschema.validate(out, draft_hints_schema("MolecularEntity"))
         assert out["name"] == "Acetaminophen"
 
-    def test_study_output_validates(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_study_output_validates(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"name": "Liver tox study", "description": "Hepatotoxicity assays."}
         )
@@ -224,9 +241,7 @@ class TestD5NoFabricatedIdentifiers:
                 f"D5 violated: fabricated identifier field {ident!r} leaked through"
             )
 
-    def test_person_strips_fabricated_orcid(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_person_strips_fabricated_orcid(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"name": "Jane Doe", "orcid": "0000-0002-1825-0097"}
         )
@@ -295,9 +310,7 @@ class TestSchemaExclusion:
 class TestUnknownEntityType:
     """An unknown entity type still returns a dict (open schema fallback)."""
 
-    def test_unknown_type_returns_dict(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_unknown_type_returns_dict(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel({"name": "x"})
 
         out = leaves.draft_entity_fields("NotAType", "context")
@@ -338,9 +351,7 @@ Files: plate_raw.csv (raw), results.xlsx (processed), conditions.csv.
 class TestExtractPlanDrafterTier:
     """The plan extractor must run on the cheap drafter tier (mirrors the leaf)."""
 
-    def test_requests_drafter_role(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_requests_drafter_role(self, _patch_build_chat_model: dict[str, Any]) -> None:
         rec = _patch_build_chat_model
         rec["model"] = FakeChatModel({"study": {"name": "x"}})
 
@@ -351,9 +362,7 @@ class TestExtractPlanDrafterTier:
             "extract_plan must build the chat model on the drafter tier"
         )
 
-    def test_explicit_model_is_forwarded(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_explicit_model_is_forwarded(self, _patch_build_chat_model: dict[str, Any]) -> None:
         rec = _patch_build_chat_model
         rec["model"] = FakeChatModel({})
 
@@ -365,9 +374,7 @@ class TestExtractPlanDrafterTier:
 class TestExtractPlanStructuredOutput:
     """One bounded structured-output bind + one invocation (a leaf)."""
 
-    def test_single_structured_output_call(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_single_structured_output_call(self, _patch_build_chat_model: dict[str, Any]) -> None:
         fake = FakeChatModel({"study": {"name": "x"}})
         _patch_build_chat_model["model"] = fake
 
@@ -380,9 +387,7 @@ class TestExtractPlanStructuredOutput:
 class TestExtractPlanShape:
     """A doc-like context yields a populated plan with the right shape."""
 
-    def test_populated_plan_round_trips(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_populated_plan_round_trips(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {
                 "study": {"name": "AAP renal tox", "description": "Hepatotox study."},
@@ -500,8 +505,10 @@ class TestExtractPlanMinesCompoundsFromFilenames:
         text = _prompt_text(fake)
         # The names-only / no-identifier discipline is still asserted in the prompt.
         assert "name" in text
-        assert ("no identifier" in text) or ("never include identifiers" in text) or (
-            "identifiers of any kind" in text
+        assert (
+            ("no identifier" in text)
+            or ("never include identifiers" in text)
+            or ("identifiers of any kind" in text)
         ), "the filename-mining prompt must still forbid identifiers (D5)"
 
     def test_filename_derived_compound_plan_round_trips(
@@ -595,9 +602,7 @@ class TestExtractPlanD5NoIdentifiersInSchema:
         # The schema must be usable as a function-calling tool (carries a title).
         assert schema.get("title"), "plan schema must carry a title"
 
-    def test_schema_is_convertible_to_a_tool(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_schema_is_convertible_to_a_tool(self, _patch_build_chat_model: dict[str, Any]) -> None:
         from langchain_core.utils.function_calling import convert_to_openai_tool
 
         fake = FakeChatModel({})
@@ -631,9 +636,7 @@ class TestExtractPlanD5StripsFabricatedIdentifiers:
                     }
                 ],
                 "cell_lines": [{"name": "MDCK", "accession": "CVCL_0027"}],
-                "people": [
-                    {"name": "Jane Doe", "orcid": "0000-0002-1825-0097"}
-                ],
+                "people": [{"name": "Jane Doe", "orcid": "0000-0002-1825-0097"}],
                 "publications": [{"title": "P", "doi": "10.1234/fake"}],
             }
         )
@@ -674,9 +677,7 @@ class TestExtractPlanD5StripsFabricatedIdentifiers:
 
 
 class TestDraftEntityFieldsUsageCapture:
-    def test_usage_sink_receives_token_usage(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_usage_sink_receives_token_usage(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"name": "Acetaminophen"},
             usage_metadata={"input_tokens": 120, "output_tokens": 35, "total_tokens": 155},
@@ -721,9 +722,7 @@ class TestDraftEntityFieldsUsageCapture:
 
 
 class TestExtractPlanUsageCapture:
-    def test_usage_sink_receives_token_usage(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_usage_sink_receives_token_usage(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"study": {"name": "S"}},
             usage_metadata={"input_tokens": 500, "output_tokens": 80, "total_tokens": 580},
@@ -777,9 +776,7 @@ _GAP_CONTEXT = {
 class TestPhraseGapQuestionDrafterTier:
     """Phrasing runs on the cheap drafter tier and is a single bounded call."""
 
-    def test_requests_drafter_role(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_requests_drafter_role(self, _patch_build_chat_model: dict[str, Any]) -> None:
         rec = _patch_build_chat_model
         rec["model"] = FakeChatModel({"question": "What does this study examine?"})
 
@@ -790,9 +787,7 @@ class TestPhraseGapQuestionDrafterTier:
             "phrase_gap_question must build the chat model on the drafter tier"
         )
 
-    def test_single_structured_output_call(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_single_structured_output_call(self, _patch_build_chat_model: dict[str, Any]) -> None:
         fake = FakeChatModel({"question": "What does this study examine?"})
         _patch_build_chat_model["model"] = fake
 
@@ -805,9 +800,7 @@ class TestPhraseGapQuestionDrafterTier:
 class TestPhraseGapQuestionShape:
     """The leaf returns one human question string."""
 
-    def test_returns_the_question_string(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_returns_the_question_string(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"question": "In one sentence, what does this study examine?"}
         )
@@ -832,9 +825,7 @@ class TestPhraseGapQuestionShape:
 class TestInterpretGapReplyDrafterTier:
     """Interpretation runs on the cheap drafter tier and is a single call."""
 
-    def test_requests_drafter_role(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_requests_drafter_role(self, _patch_build_chat_model: dict[str, Any]) -> None:
         rec = _patch_build_chat_model
         rec["model"] = FakeChatModel({"action": "skip"})
 
@@ -845,9 +836,7 @@ class TestInterpretGapReplyDrafterTier:
             "interpret_gap_reply must build the chat model on the drafter tier"
         )
 
-    def test_single_structured_output_call(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_single_structured_output_call(self, _patch_build_chat_model: dict[str, Any]) -> None:
         fake = FakeChatModel({"action": "commit", "value": "x"})
         _patch_build_chat_model["model"] = fake
 
@@ -860,9 +849,7 @@ class TestInterpretGapReplyDrafterTier:
 class TestInterpretGapReplyDecision:
     """The leaf returns a STRUCTURED decision, not free text."""
 
-    def test_commit_returns_clean_value(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_commit_returns_clean_value(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"action": "commit", "value": "A hepatotoxicity dose-response study."}
         )
@@ -876,9 +863,7 @@ class TestInterpretGapReplyDecision:
         assert decision["action"] == "commit"
         assert decision["value"] == "A hepatotoxicity dose-response study."
 
-    def test_idk_reply_returns_skip(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_idk_reply_returns_skip(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel({"action": "skip"})
 
         decision = leaves.interpret_gap_reply(
@@ -891,9 +876,7 @@ class TestInterpretGapReplyDecision:
         # A musing must NEVER carry a value.
         assert not decision.get("value")
 
-    def test_clarify_returns_one_follow_up(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_clarify_returns_one_follow_up(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"action": "clarify", "question": "Do you mean the in-vitro assay?"}
         )
@@ -905,9 +888,7 @@ class TestInterpretGapReplyDecision:
         assert decision["action"] == "clarify"
         assert decision["question"] == "Do you mean the in-vitro assay?"
 
-    def test_from_file_returns_filename_hint(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_from_file_returns_filename_hint(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"action": "from_file", "filename": "README.txt"}
         )
@@ -928,9 +909,7 @@ class TestInterpretGapReplyDecision:
     ) -> None:
         # An adversarial / malformed action must be coerced to the safe default
         # (skip) so it can never become a field value.
-        _patch_build_chat_model["model"] = FakeChatModel(
-            {"action": "nonsense", "value": "garbage"}
-        )
+        _patch_build_chat_model["model"] = FakeChatModel({"action": "nonsense", "value": "garbage"})
 
         decision = leaves.interpret_gap_reply("Q?", "whatever", _GAP_CONTEXT)
 
@@ -942,9 +921,7 @@ class TestInterpretGapReplyDecision:
     ) -> None:
         # A "commit" with no usable value is not a commit — coerce to skip so the
         # loop never writes an empty/whitespace value.
-        _patch_build_chat_model["model"] = FakeChatModel(
-            {"action": "commit", "value": "   "}
-        )
+        _patch_build_chat_model["model"] = FakeChatModel({"action": "commit", "value": "   "})
 
         decision = leaves.interpret_gap_reply("Q?", "...", _GAP_CONTEXT)
 
@@ -961,9 +938,7 @@ class TestGuidanceLeavesD5:
     def test_identifier_gap_commit_is_refused(
         self, _patch_build_chat_model: dict[str, Any]
     ) -> None:
-        _patch_build_chat_model["model"] = FakeChatModel(
-            {"action": "commit", "value": "103-90-2"}
-        )
+        _patch_build_chat_model["model"] = FakeChatModel({"action": "commit", "value": "103-90-2"})
 
         decision = leaves.interpret_gap_reply(
             "What is the CAS number?",
@@ -992,9 +967,7 @@ class TestPhraseGapQuestionNamesEntity:
     def test_entity_name_reaches_the_model_prompt(
         self, _patch_build_chat_model: dict[str, Any]
     ) -> None:
-        fake = FakeChatModel(
-            {"question": "What is the CAS Registry Number for Silychristin A?"}
-        )
+        fake = FakeChatModel({"question": "What is the CAS Registry Number for Silychristin A?"})
         _patch_build_chat_model["model"] = fake
 
         leaves.phrase_gap_question(
@@ -1057,9 +1030,9 @@ class TestPhraseGapQuestionForbidsFabricatedName:
         # and explicitly forbid fabricating a specific name / identifier / example.
         assert "no" in prompt and "name" in prompt, prompt
         # It must forbid INVENTING / FABRICATING / MAKING UP a specific value.
-        assert any(
-            word in prompt for word in ("invent", "fabricat", "make up", "made-up")
-        ), "the phrase prompt must forbid fabricating a name/identifier (D5)"
+        assert any(word in prompt for word in ("invent", "fabricat", "make up", "made-up")), (
+            "the phrase prompt must forbid fabricating a name/identifier (D5)"
+        )
 
     def test_no_name_prompt_does_not_seed_a_specific_example_name(self) -> None:
         # D5 regression: the prompt must not seed a concrete entity NAME the model
@@ -1099,9 +1072,7 @@ class TestExtractFieldFromFile:
         assert len(fake.structured_schemas) == 1, "exactly one structured-output bind"
         assert len(fake.invoke_calls) == 1, "exactly one model invocation (a leaf)"
 
-    def test_extracts_a_clean_value(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_extracts_a_clean_value(self, _patch_build_chat_model: dict[str, Any]) -> None:
         _patch_build_chat_model["model"] = FakeChatModel(
             {"value": "A dose-response viability assay in CHO-K1 cells."}
         )
@@ -1129,9 +1100,7 @@ class TestExtractFieldFromFile:
         human_msg = fake.invoke_calls[0][-1].content
         assert "UNIQUE-FILE-MARKER-12345" in human_msg
 
-    def test_no_value_returns_empty_string(
-        self, _patch_build_chat_model: dict[str, Any]
-    ) -> None:
+    def test_no_value_returns_empty_string(self, _patch_build_chat_model: dict[str, Any]) -> None:
         # The file does not contain the field -> the model returns nothing usable.
         _patch_build_chat_model["model"] = FakeChatModel({})
 
@@ -1156,9 +1125,7 @@ class TestExtractFieldFromFile:
             {"property": "cas", "entity_type": "MolecularEntity"},
         )
 
-        assert value == "", (
-            "D5: an identifier value must come from a lookup, not file text"
-        )
+        assert value == "", "D5: an identifier value must come from a lookup, not file text"
 
 
 def _flatten_keys(schema: Any) -> set[str]:
@@ -1247,9 +1214,7 @@ class TestPlanSchemaProcessParameters:
         """
         from builder.agents.pipeline.leaves import _plan_schema
 
-        params = _plan_schema()["properties"]["process_chain"]["items"]["properties"][
-            "parameters"
-        ]
+        params = _plan_schema()["properties"]["process_chain"]["items"]["properties"]["parameters"]
         assert params.get("additionalProperties") is False
 
 

--- a/tests/test_agents_build.py
+++ b/tests/test_agents_build.py
@@ -141,8 +141,9 @@ class TestInteractiveGating:
         result = run_interactive_build(
             engine,
             pipeline_runner=lambda eng: dict(_PIPELINE_RESULT),
-            guidance_runner=lambda eng, human, **kw: guidance_calls.append(human)
-            or dict(_GUIDANCE_RESULT),
+            guidance_runner=lambda eng, human, **kw: (
+                guidance_calls.append(human) or dict(_GUIDANCE_RESULT)
+            ),
         )
 
         assert guidance_calls == []
@@ -286,8 +287,9 @@ class TestHeadlessGapSummary:
         run_interactive_build(
             engine,
             pipeline_runner=lambda eng: dict(self._PIPELINE_WITH_GAPS),
-            guidance_runner=lambda eng, human, **kw: guidance_calls.append(human)
-            or dict(_GUIDANCE_RESULT),
+            guidance_runner=lambda eng, human, **kw: (
+                guidance_calls.append(human) or dict(_GUIDANCE_RESULT)
+            ),
             output=lines.append,
         )
 
@@ -423,6 +425,51 @@ class TestHeadlessGapSummary:
 
         text = format_gap_summary({})
         assert isinstance(text, str)
+
+    def test_format_gap_summary_reports_an_unpopulated_condition_table(self) -> None:
+        """#422: the central domain table staying empty must be SAID, with the
+        reason — it used to live only in a discarded reason string while the
+        summary reported a clean build."""
+        from builder.agents.build import format_gap_summary
+
+        result = {
+            "issues": [],
+            "conformance": {"base": True, "isa": True, "tox": True},
+            "materialized": {
+                "condition_table": {
+                    "populated": False,
+                    "reason": "populate_condition_table declined",
+                }
+            },
+        }
+        text = format_gap_summary(result).lower()
+        assert "condition table" in text
+        assert "not populated" in text
+        assert "declined" in text, "the reason must ride along"
+
+    def test_format_gap_summary_marks_a_proposed_condition_table(self) -> None:
+        """A #438-proposed table is populated but unconfirmed — say which."""
+        from builder.agents.build import format_gap_summary
+
+        result = {
+            "issues": [],
+            "conformance": {},
+            "materialized": {"condition_table": {"populated": True, "proposed": True, "rows": 6}},
+        }
+        text = format_gap_summary(result).lower()
+        assert "condition table" in text
+        assert "proposed" in text
+
+    def test_format_gap_summary_stays_calm_when_the_table_is_populated(self) -> None:
+        from builder.agents.build import format_gap_summary
+
+        result = {
+            "issues": [],
+            "conformance": {},
+            "materialized": {"condition_table": {"populated": True, "rows": 12}},
+        }
+        text = format_gap_summary(result).lower()
+        assert "not populated" not in text
         assert text  # non-empty, no crash
 
 

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -202,9 +202,7 @@ class TestDraftEntitiesWiring:
 
         monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
 
-    def test_stub_leaf_applies_non_identifier_fields(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_stub_leaf_applies_non_identifier_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import builder.agents.pipeline.pipeline as pipeline_mod
 
         self._enable_provider(monkeypatch)
@@ -253,9 +251,7 @@ class TestDraftEntitiesWiring:
         assert isinstance(result.get("fields_applied"), int)
         assert result["fields_applied"] >= 1
 
-    def test_does_not_overwrite_existing_fields(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_does_not_overwrite_existing_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import builder.agents.pipeline.pipeline as pipeline_mod
 
         self._enable_provider(monkeypatch)
@@ -275,9 +271,7 @@ class TestDraftEntitiesWiring:
         # …but the missing `description` is filled.
         assert study.fields.get("description") == "leaf desc"
 
-    def test_no_provider_is_strict_noop(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_provider_is_strict_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import builder.agents.pipeline.pipeline as pipeline_mod
 
         # No provider configured.
@@ -299,9 +293,7 @@ class TestDraftEntitiesWiring:
         assert result.get("drafted") == []
         assert result.get("fields_applied") == 0
 
-    def test_no_context_is_strict_noop(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_context_is_strict_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import builder.agents.pipeline.pipeline as pipeline_mod
 
         self._enable_provider(monkeypatch)
@@ -842,15 +834,26 @@ class TestMaterializePlan:
                         "has_key_event_relationship": [{"@id": ker}],
                     },
                     "events": [
-                        {"@id": mie, "@type": "KeyEvent", "name": "MIE",
-                         "eventType": "Molecular Initiating Event"},
-                        {"@id": ao, "@type": "KeyEvent", "name": "AO",
-                         "eventType": "Adverse Outcome"},
+                        {
+                            "@id": mie,
+                            "@type": "KeyEvent",
+                            "name": "MIE",
+                            "eventType": "Molecular Initiating Event",
+                        },
+                        {
+                            "@id": ao,
+                            "@type": "KeyEvent",
+                            "name": "AO",
+                            "eventType": "Adverse Outcome",
+                        },
                     ],
                     "relationships": [
-                        {"@id": ker, "@type": "KeyEventRelationship",
-                         "upstream_event": {"@id": mie},
-                         "downstream_event": {"@id": ao}},
+                        {
+                            "@id": ker,
+                            "@type": "KeyEventRelationship",
+                            "upstream_event": {"@id": mie},
+                            "downstream_event": {"@id": ao},
+                        },
                     ],
                 },
                 "error": None,
@@ -864,9 +867,7 @@ class TestMaterializePlan:
 
         monkeypatch.setattr(composites_mod, "lookup_compound", fake_lookup_compound)
         monkeypatch.setattr(composites_mod, "verify_identifier", fake_verify_identifier)
-        monkeypatch.setattr(
-            composites_mod, "search_works_by_title", fake_search_works_by_title
-        )
+        monkeypatch.setattr(composites_mod, "search_works_by_title", fake_search_works_by_title)
         monkeypatch.setattr(tool_lookups, "lookup_aop", fake_lookup_aop)
 
     def _by_type(self, engine: AgentEngine, type_name: str) -> list[Entity]:
@@ -903,18 +904,12 @@ class TestMaterializePlan:
         # Protocol → LabProtocol minted from the name/description (D5: no id), and
         # linked to the EndpointReadout process it governs (executesLabProtocol).
         protos = self._by_type(engine, "LabProtocol")
-        assert [p.fields.get("name") for p in protos] == [
-            "Amplex Red TPO activity readout"
-        ]
+        assert [p.fields.get("name") for p in protos] == ["Amplex Red TPO activity readout"]
         proto_id = protos[0].entity_id
-        readout = next(
-            p for p in procs if p.fields.get("process_type") == "EndpointReadout"
-        )
+        readout = next(p for p in procs if p.fields.get("process_type") == "EndpointReadout")
         labprotocol_ref = readout.fields.get("labprotocol")
         ref_id = (
-            labprotocol_ref.get("@id")
-            if isinstance(labprotocol_ref, dict)
-            else labprotocol_ref
+            labprotocol_ref.get("@id") if isinstance(labprotocol_ref, dict) else labprotocol_ref
         )
         assert str(ref_id).lstrip("#") == proto_id
         assert result["protocols"] >= 1
@@ -945,9 +940,7 @@ class TestMaterializePlan:
         assert result["aops"] >= 1
         assert result["people"] >= 1
 
-    def test_protocol_minted_and_linked_to_process(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_protocol_minted_and_linked_to_process(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """#222: a plan protocol mints a LabProtocol linked to a process (D5).
 
         A plan carries a protocol NAME/description only (no identifier). The spine
@@ -958,9 +951,7 @@ class TestMaterializePlan:
 
         self._enable_provider(monkeypatch)
         plan = {
-            "protocols": [
-                {"name": "MTT viability protocol", "description": "MTT assay."}
-            ],
+            "protocols": [{"name": "MTT viability protocol", "description": "MTT assay."}],
             "process_chain": [
                 {"process_type": "Exposure", "name": "Dose"},
                 {"process_type": "EndpointReadout", "name": "Read viability"},
@@ -1016,9 +1007,7 @@ class TestMaterializePlan:
                 "error": None,
             }
 
-        monkeypatch.setattr(
-            composites_mod, "search_works_by_title", fake_search_works_by_title
-        )
+        monkeypatch.setattr(composites_mod, "search_works_by_title", fake_search_works_by_title)
         monkeypatch.setattr(composites_mod, "lookup_doi", fake_lookup_doi)
 
         engine = _engine(self._titled_state())
@@ -1051,9 +1040,7 @@ class TestMaterializePlan:
         def boom_lookup_doi(doi):  # pragma: no cover - must not be reached
             raise AssertionError("lookup_doi must not run without a confident match")
 
-        monkeypatch.setattr(
-            composites_mod, "search_works_by_title", fake_search_works_by_title
-        )
+        monkeypatch.setattr(composites_mod, "search_works_by_title", fake_search_works_by_title)
         monkeypatch.setattr(composites_mod, "lookup_doi", boom_lookup_doi)
 
         engine = _engine(self._titled_state())
@@ -1064,9 +1051,7 @@ class TestMaterializePlan:
         assert result["publications"] == 0
         assert title in result["publications_deferred"]
 
-    def test_d5_no_fabricated_identifiers_from_plan(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_d5_no_fabricated_identifiers_from_plan(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """D5: identifiers come from the composites' lookups, never the plan.
 
         The plan carries only names. A MolecularEntity's `cas`/`pubchem_cid` must
@@ -1171,15 +1156,29 @@ class TestMaterializePlan:
         pipeline_mod._materialize_plan(engine)
         counts_1 = {
             t: len(self._by_type(engine, t))
-            for t in ("MolecularEntity", "CellLineSample", "LabProcess",
-                      "AdverseOutcomePathway", "KeyEvent", "Person", "Publication")
+            for t in (
+                "MolecularEntity",
+                "CellLineSample",
+                "LabProcess",
+                "AdverseOutcomePathway",
+                "KeyEvent",
+                "Person",
+                "Publication",
+            )
         }
         # Re-run on the SAME engine — composites are idempotent, so no dups.
         pipeline_mod._materialize_plan(engine)
         counts_2 = {
             t: len(self._by_type(engine, t))
-            for t in ("MolecularEntity", "CellLineSample", "LabProcess",
-                      "AdverseOutcomePathway", "KeyEvent", "Person", "Publication")
+            for t in (
+                "MolecularEntity",
+                "CellLineSample",
+                "LabProcess",
+                "AdverseOutcomePathway",
+                "KeyEvent",
+                "Person",
+                "Publication",
+            )
         }
         assert counts_1 == counts_2
 
@@ -1216,22 +1215,16 @@ class TestMaterializePlan:
 
         # (a) an Organization named after the plan affiliation exists in state.
         orgs = self._by_type(engine, "Organization")
-        analytical = [
-            o for o in orgs if o.fields.get("name") == "Analytical Engine"
-        ]
+        analytical = [o for o in orgs if o.fields.get("name") == "Analytical Engine"]
         assert len(analytical) == 1, "exactly one Organization should be minted"
 
         # (b) the Person's affiliation references that Organization's id.
         ada = next(
-            p
-            for p in self._by_type(engine, "Person")
-            if p.fields.get("name") == "Ada Lovelace"
+            p for p in self._by_type(engine, "Person") if p.fields.get("name") == "Ada Lovelace"
         )
         assert self._affiliation_ref_id(ada) == analytical[0].entity_id
 
-    def test_shared_affiliation_is_deduplicated(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_shared_affiliation_is_deduplicated(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Two people with the SAME affiliation_name produce ONE Organization,
         both referencing it (no duplicate orgs)."""
         import builder.agents.pipeline.pipeline as pipeline_mod
@@ -1258,9 +1251,7 @@ class TestMaterializePlan:
         assert len(orgs) == 1, "shared affiliation must mint exactly one Organization"
 
         org_id = orgs[0].entity_id
-        people = {
-            p.fields.get("name"): p for p in self._by_type(engine, "Person")
-        }
+        people = {p.fields.get("name"): p for p in self._by_type(engine, "Person")}
         assert self._affiliation_ref_id(people["Ada Lovelace"]) == org_id
         assert self._affiliation_ref_id(people["Charles Babbage"]) == org_id
 
@@ -1284,9 +1275,7 @@ class TestMaterializePlan:
 
         assert self._by_type(engine, "Organization") == []
         ada = next(
-            p
-            for p in self._by_type(engine, "Person")
-            if p.fields.get("name") == "Ada Lovelace"
+            p for p in self._by_type(engine, "Person") if p.fields.get("name") == "Ada Lovelace"
         )
         assert not ada.fields.get("affiliation")
 
@@ -1302,9 +1291,7 @@ class TestMaterializePlan:
         # test isolates materialization + the existing build/fix path.
         import builder.agents.pipeline.pipeline as pipeline_mod
 
-        monkeypatch.setattr(
-            pipeline_mod, "draft_entity_fields", lambda *a, **k: {}
-        )
+        monkeypatch.setattr(pipeline_mod, "draft_entity_fields", lambda *a, **k: {})
 
         engine = _engine(self._titled_state())
         result = run_pipeline(engine)
@@ -1423,15 +1410,11 @@ class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
 
         # The CellCulture references the actual cell-line Sample via `cell_line`
         # (not a synthesized generic `_input`).
-        cell_culture = next(
-            p for p in procs if p.fields.get("process_type") == "CellCulture"
-        )
+        cell_culture = next(p for p in procs if p.fields.get("process_type") == "CellCulture")
         cell_ids = {c.entity_id for c in self._by_type(engine, "CellLineSample")}
         assert cell_ids, "no CellLineSample resolved — test setup is wrong"
         wired_cell = cell_culture.fields.get("cell_line")
-        wired_cell_id = (
-            wired_cell.get("@id") if isinstance(wired_cell, dict) else wired_cell
-        )
+        wired_cell_id = wired_cell.get("@id") if isinstance(wired_cell, dict) else wired_cell
         assert str(wired_cell_id).lstrip("#") in {c.lstrip("#") for c in cell_ids}
 
         # No resolved MolecularEntity / CellLineSample is an orphan in the BUILT
@@ -1461,9 +1444,7 @@ class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
         # The Study surfaces every compound + the cell line via schema:mentions
         # (emitted under the context-aliased `chemicals` / `biologicalModels`
         # keys), so each is reachable from the backbone at a glance (#273).
-        study_node = next(
-            n for n in graph if str(n.get("@id", "")).startswith("#Study_")
-        )
+        study_node = next(n for n in graph if str(n.get("@id", "")).startswith("#Study_"))
 
         def _ref_ids(prop: object) -> set[str]:
             items = prop if isinstance(prop, list) else [prop]
@@ -1494,7 +1475,6 @@ class TestMaterializeLinksResolvedEntities(TestMaterializePlan):
 
         assert result["conformance"] == {"base": True, "isa": True, "tox": True}
         assert result["ok"] is True
-
 
 
 class TestMaterializeCompoundsFromFilenames:
@@ -1539,10 +1519,7 @@ class TestMaterializeCompoundsFromFilenames:
                     path=str(path),
                     filename=name,
                     size=path.stat().st_size,
-                    mime_type=(
-                        "application/vnd.openxmlformats-officedocument."
-                        "spreadsheetml.sheet"
-                    ),
+                    mime_type=("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
                     # A tabular preview so _gather_context lists the filename
                     # WITHOUT a disk read (the filename carries the compound names).
                     first_rows=["well,value", "A1,1.0"],
@@ -1551,9 +1528,7 @@ class TestMaterializeCompoundsFromFilenames:
         state.scanned_files = files
         return state
 
-    def _fake_extract_plan_chat_model(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> list[str]:
+    def _fake_extract_plan_chat_model(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
         """Fake the REAL leaf's chat model so the genuine ``extract_plan`` code
         path runs (its enriched prompt is built and fed the gathered context),
         but the model deterministically returns the filename-derived compounds a
@@ -1572,19 +1547,13 @@ class TestMaterializeCompoundsFromFilenames:
                         seen_prompts.append(content)
                 # A steered model proposes the compound NAMES it read off the
                 # filenames — names only (D5: no identifiers).
-                return {
-                    "compounds": [
-                        {"name": n, "role": "test"} for n in sorted(expected)
-                    ]
-                }
+                return {"compounds": [{"name": n, "role": "test"} for n in sorted(expected)]}
 
         class _Model:
             def with_structured_output(self, schema, *, include_raw=False, **k):
                 return _Runnable()
 
-        monkeypatch.setattr(
-            leaves_mod, "_build_chat_model", lambda *a, **k: _Model()
-        )
+        monkeypatch.setattr(leaves_mod, "_build_chat_model", lambda *a, **k: _Model())
         return seen_prompts
 
     # Per-name LOOKED-UP identifiers (offline) — the verified ids PubChem would
@@ -1672,7 +1641,6 @@ class TestMaterializeCompoundsFromFilenames:
             assert chems[name].fields.get("cas") == expected["cas"]
 
 
-
 class TestPublicationFromPDF:
     """Issue #245 — when a plan publication's "title" is actually a PDF FILENAME,
     `_materialize_plan` must recover the real DOI/title from the PDF *text* and
@@ -1754,9 +1722,7 @@ class TestPublicationFromPDF:
 
         # resolve_publication (title path) must NOT be called with the filename.
         def boom_search(query):  # pragma: no cover - must not run
-            raise AssertionError(
-                f"Crossref title search must not be called with {query!r}"
-            )
+            raise AssertionError(f"Crossref title search must not be called with {query!r}")
 
         monkeypatch.setattr(composites_mod, "search_works_by_title", boom_search)
 
@@ -1805,11 +1771,7 @@ class TestPublicationFromPDF:
 
         def fake_extract_pdf_text(path):
             # First non-trivial line is the article title; no DOI anywhere.
-            return (
-                "[Page 1]\n"
-                f"[Text] {real_title}\n"
-                "[Text] Fabian Wagenaars, et al. 2025\n"
-            )
+            return f"[Page 1]\n[Text] {real_title}\n[Text] Fabian Wagenaars, et al. 2025\n"
 
         monkeypatch.setattr(scanner_mod, "extract_pdf_text", fake_extract_pdf_text)
 
@@ -1861,9 +1823,7 @@ class TestPublicationFromPDF:
         monkeypatch.setattr(scanner_mod, "extract_pdf_text", lambda path: None)
 
         def boom_search(query):  # pragma: no cover - must not run
-            raise AssertionError(
-                f"Crossref title search must not be called with {query!r}"
-            )
+            raise AssertionError(f"Crossref title search must not be called with {query!r}")
 
         def boom_lookup_doi(doi):  # pragma: no cover - must not run
             raise AssertionError("DOI lookup must not run without a recovered DOI")
@@ -1967,9 +1927,7 @@ class TestTokenAccounting:
         assert pm.output_tokens == 20 * n_calls
         assert pm.total_tokens == 120 * n_calls
 
-    def test_no_provider_records_clean_zero(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_provider_records_clean_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import builder.agents.pipeline.pipeline as pipeline_mod
 
         # No provider → the leaf is never called and no model events are written.
@@ -1988,9 +1946,7 @@ class TestTokenAccounting:
         assert pm.output_tokens == 0
         assert pm.total_tokens == 0
 
-    def test_run_pipeline_returns_usage_dict(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_run_pipeline_returns_usage_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``run_pipeline``'s result additively surfaces the accumulated usage."""
         import builder.agents.pipeline.pipeline as pipeline_mod
         from builder.agents.pipeline.pipeline import run_pipeline
@@ -2016,9 +1972,7 @@ class TestTokenAccounting:
             result = run_pipeline(engine)
         finally:
             engine.close_profiler()
-            shutil.rmtree(
-                Path(SESSION_DIR) / engine.state.session_id, ignore_errors=True
-            )
+            shutil.rmtree(Path(SESSION_DIR) / engine.state.session_id, ignore_errors=True)
 
         assert "usage" in result
         usage = result["usage"]
@@ -2333,9 +2287,7 @@ class TestDraftPersonSplit:
         from builder.tools.drafters import draft_person
 
         state = CrateState()
-        person = draft_person(
-            state, "Ada Lovelace", {"givenName": "A.", "familyName": "Lovelace"}
-        )
+        person = draft_person(state, "Ada Lovelace", {"givenName": "A.", "familyName": "Lovelace"})
         # The caller's explicit split is preserved, not recomputed from name.
         assert person.fields.get("givenName") == "A."
         assert person.fields.get("familyName") == "Lovelace"
@@ -2428,9 +2380,7 @@ class TestMaterializeBackboneNaming:
         assert study.fields.get("description") == "A TPO assay."
         assert result["study"] == 1
 
-    def test_no_plan_name_keeps_default_nonempty(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_plan_name_keeps_default_nonempty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Regression: with no plan study (and no title) the Study keeps a
         non-empty default name — ISA REQUIRES a non-empty Study name."""
         import builder.agents.pipeline.pipeline as pipeline_mod
@@ -2445,9 +2395,7 @@ class TestMaterializeBackboneNaming:
         name = self._study(engine).fields.get("name")
         assert isinstance(name, str) and name.strip(), "Study name must stay non-empty"
 
-    def test_existing_specific_name_is_not_clobbered(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_existing_specific_name_is_not_clobbered(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Fill-don't-clobber: a Study that already carries a real (non-default)
         name must NOT be overwritten by the plan."""
         import builder.agents.pipeline.pipeline as pipeline_mod
@@ -2651,9 +2599,7 @@ class TestMaterializeStandardProcessChain:
             "DataAnalysis",
         }
         # Every process belongs to the scaffolded Assay.
-        assay_id = next(
-            e.entity_id for e in engine.state.list_entities() if e.type == "Assay"
-        )
+        assay_id = next(e.entity_id for e in engine.state.list_entities() if e.type == "Assay")
         for proc in procs:
             assay_ref = proc.fields.get("assay") or proc.fields.get("partOf")
             ref = assay_ref.get("@id") if isinstance(assay_ref, dict) else assay_ref
@@ -2662,9 +2608,7 @@ class TestMaterializeStandardProcessChain:
         # The result trace reflects the materialized chain.
         assert result["processes"] >= 4
 
-    def test_endpoint_and_analysis_carry_outputs(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_endpoint_and_analysis_carry_outputs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """§14.3: EndpointReadout/DataAnalysis must carry a result (no Violation trap).
 
         ``draft_process_chain`` synthesizes placeholder File outputs for the two
@@ -2684,9 +2628,7 @@ class TestMaterializeStandardProcessChain:
                 f"{ptype} must carry a result output (the §14.3 no-output trap)"
             )
 
-    def test_chain_is_idempotent_across_repeats(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_chain_is_idempotent_across_repeats(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Re-running the spine mints no duplicate processes (deterministic ids)."""
         import builder.agents.pipeline.pipeline as pipeline_mod
 
@@ -2753,9 +2695,7 @@ class TestMaterializeAttachScannedFiles:
         ]
         return state
 
-    def test_no_provider_attaches_every_scanned_file(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_provider_attaches_every_scanned_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """With NO provider, each scanned file becomes a File entity in the crate."""
         import builder.agents.pipeline.pipeline as pipeline_mod
 
@@ -2808,9 +2748,7 @@ class TestMaterializeAttachScannedFiles:
             "SOP.pdf",
         }
         scanned_files = [
-            f
-            for f in self._by_type(engine, "File")
-            if f.fields.get("name") in scanned_basenames
+            f for f in self._by_type(engine, "File") if f.fields.get("name") in scanned_basenames
         ]
         assert scanned_files, "the scanned data files must be added as File entities"
         for fe in scanned_files:
@@ -2819,9 +2757,7 @@ class TestMaterializeAttachScannedFiles:
                 f"process/assay (hasPart/result/object)"
             )
 
-    def test_no_scanned_files_attaches_nothing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_scanned_files_attaches_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """With no scanned files the attach step attaches nothing (no crash).
 
         The chain composite still synthesizes its §14.3 placeholder File outputs,
@@ -2839,9 +2775,7 @@ class TestMaterializeAttachScannedFiles:
 
         assert result["files"] == 0
 
-    def test_attachment_is_idempotent(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_attachment_is_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Re-running mints no duplicate File entities (deduped by on-disk source)."""
         import builder.agents.pipeline.pipeline as pipeline_mod
 
@@ -2870,9 +2804,7 @@ class TestGatherContextPreviewedFilesGetABudget:
 
     _SENTINEL = "ROW{:03d}-marker"
 
-    def _state(
-        self, tmp_path: Path, spec: list[tuple[str, int]], row_pad: int = 0
-    ) -> CrateState:
+    def _state(self, tmp_path: Path, spec: list[tuple[str, int]], row_pad: int = 0) -> CrateState:
         """Build a state whose files carry *n* sentinel preview rows each.
 
         ``row_pad`` widens each row, so a test can breach the total budget with
@@ -2888,9 +2820,7 @@ class TestGatherContextPreviewedFilesGetABudget:
                     filename=filename,
                     size=1,
                     mime_type="text/csv",
-                    first_rows=[
-                        self._SENTINEL.format(i) + "x" * row_pad for i in range(n_rows)
-                    ],
+                    first_rows=[self._SENTINEL.format(i) + "x" * row_pad for i in range(n_rows)],
                 )
             )
         return state
@@ -3113,12 +3043,14 @@ class TestConditionTableFromPlan:
         ]
         return state, plate
 
-    def _run(self, monkeypatch, state, plan_files):
+    def _run(self, monkeypatch, state, plan_files, plan_extra=None):
         """Drive `_materialize_plan` with a stubbed leaf returning *plan_files*.
 
         The backbone is scaffolded first exactly as the spine's step 1 does, so the
         standard chain (#262) lays down the Exposure the table hangs off — without
-        it there is no Exposure and the test would pass vacuously.
+        it there is no Exposure and the test would pass vacuously. ``plan_extra``
+        merges further plan keys (e.g. ``compounds``) for tests that need the
+        Exposure wired the way a real extraction would leave it.
         """
         import builder.agents.pipeline.pipeline as pipeline_mod
 
@@ -3126,6 +3058,7 @@ class TestConditionTableFromPlan:
             "study": {"name": "OATP1C1 uptake", "description": "An uptake assay."},
             "files": plan_files,
         }
+        plan.update(plan_extra or {})
         monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
         monkeypatch.setattr(
             pipeline_mod,
@@ -3202,8 +3135,10 @@ class TestConditionTableFromPlan:
             monkeypatch, state, [{"path": self._PLATE, "role": "condition_table"}]
         )
         table = self._table_path(engine)
-        assert table is None or not table.is_file() or (
-            len(table.read_text(encoding="utf-8").strip().splitlines()) == 1
+        assert (
+            table is None
+            or not table.is_file()
+            or (len(table.read_text(encoding="utf-8").strip().splitlines()) == 1)
         ), "a file outside the approved roots must never be read"
         assert not (result.get("condition_table") or {}).get("populated")
 
@@ -3234,14 +3169,113 @@ class TestConditionTableFromPlan:
         assert not outcome.get("populated"), "two candidates — the spine must not guess"
         assert outcome.get("reason"), "the refusal must be recorded, not silent"
 
-    def test_no_condition_table_role_records_a_reason(
-        self, monkeypatch, tmp_path: Path
-    ) -> None:
+    def test_no_condition_table_role_records_a_reason(self, monkeypatch, tmp_path: Path) -> None:
         state, _ = self._state(tmp_path)
         state.metadata.output_path = str(tmp_path / "crate")
-        engine, result = self._run(
-            monkeypatch, state, [{"path": self._PLATE, "role": "raw"}]
-        )
+        engine, result = self._run(monkeypatch, state, [{"path": self._PLATE, "role": "raw"}])
         outcome = result.get("condition_table") or {}
         assert not outcome.get("populated")
         assert outcome.get("reason")
+
+    # -- #422: an unusable candidate must not beat having no candidate at all --
+
+    def _offline_compound_seams(self, monkeypatch) -> None:
+        """Canned offline lookup hit: a MISS mints no MolecularEntity at all, and
+        the proposal needs the compound wired to the Exposure to have anything
+        to propose. The CAS is the canned lookup value, never plan-fabricated (D5)."""
+        import builder.tools.composites as composites_mod
+
+        monkeypatch.setattr(
+            composites_mod,
+            "lookup_compound",
+            lambda name: {
+                "found": True,
+                "data": {"cas": "51-48-9", "pubchem_cid": 5819, "source": "pubchem"},
+                "error": None,
+            },
+        )
+
+        def _fake_verify(state, entity_id, field):
+            ent = state.get_entity(entity_id)
+            if ent is not None:
+                ent.set_field_status(field, "verified", "lookup")
+            return {"verified": True, "entity_id": entity_id, "field": field}
+
+        monkeypatch.setattr(composites_mod, "verify_identifier", _fake_verify)
+
+    _COMPOUND_PLAN = {"compounds": [{"name": "Thyroxine", "role": "substrate"}]}
+
+    def test_a_declined_candidate_falls_back_to_the_proposal(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """#422 — the S-VHPS26 shape in miniature: the plan labels a
+        Parameter|Value metadata sheet ``condition_table``; the tool reads it and
+        correctly refuses (no canonical column maps). Refusing must then fall
+        back to the #438 proposal — a readable-but-unmappable candidate must not
+        leave the crate with LESS than no candidate at all."""
+        self._offline_compound_seams(monkeypatch)
+        state, _ = self._state(
+            tmp_path,
+            name="assay_metadata.csv",
+            body="Parameter,Value\nExposure duration_1,30\nTime unit_1,minutes\n",
+        )
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(
+            monkeypatch,
+            state,
+            [{"path": "assay_metadata.csv", "role": "condition_table"}],
+            plan_extra=dict(self._COMPOUND_PLAN),
+        )
+        outcome = result.get("condition_table") or {}
+        assert outcome.get("populated") is True, f"no fallback fired: {outcome}"
+        assert outcome.get("proposed") is True
+        assert outcome.get("fallback_from"), "the original refusal must be preserved"
+        table = self._table_path(engine)
+        assert table is not None and table.is_file()
+        assert "Thyroxine" in table.read_text(encoding="utf-8")
+
+    def test_an_unreadable_candidate_falls_back_to_the_proposal(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """#422 — a candidate no reader can open (here: a text file wearing an
+        ``.xlsx`` suffix) must likewise fall back rather than ship header-only."""
+        self._offline_compound_seams(monkeypatch)
+        state, _ = self._state(tmp_path, name="plate_map.xlsx", body="this is not a workbook")
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(
+            monkeypatch,
+            state,
+            [{"path": "plate_map.xlsx", "role": "condition_table"}],
+            plan_extra=dict(self._COMPOUND_PLAN),
+        )
+        outcome = result.get("condition_table") or {}
+        assert outcome.get("populated") is True, f"no fallback fired: {outcome}"
+        assert outcome.get("proposed") is True
+        assert outcome.get("fallback_from")
+        table = self._table_path(engine)
+        assert table is not None and table.is_file()
+        assert "Thyroxine" in table.read_text(encoding="utf-8")
+
+    def test_when_the_proposal_also_fails_the_primary_reason_survives(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """#422 — with nothing to propose (no compounds wired), the recorded
+        reason must stay the PRIMARY failure (the decline), with the proposal's
+        own failure alongside it — never silently swapped."""
+        state, _ = self._state(
+            tmp_path, name="assay_metadata.csv", body="Parameter,Value\nfoo,bar\n"
+        )
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(
+            monkeypatch,
+            state,
+            [{"path": "assay_metadata.csv", "role": "condition_table"}],
+        )
+        outcome = result.get("condition_table") or {}
+        assert not outcome.get("populated")
+        assert "column" in str(outcome.get("reason") or "").lower(), (
+            f"the primary decline must survive as the reason: {outcome}"
+        )
+        assert outcome.get("proposal_reason"), (
+            "the proposal's own failure must be recorded alongside"
+        )

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -438,9 +438,7 @@ class TestRealInputPipeline:
         bulk = _emitted_for("220825_RA_CHO-K1_hOATP1C1_P1_Timecourse.pzfx")
         assert metadata > bulk, f"metadata {metadata} chars vs bulk {bulk} chars"
 
-    def test_a_second_metadata_file_does_not_starve_the_tiers_below(
-        self, tmp_path: Path
-    ) -> None:
+    def test_a_second_metadata_file_does_not_starve_the_tiers_below(self, tmp_path: Path) -> None:
         """STARVATION CONTROL for the tier-0 raise (#419).
 
         A tier's share is granted PER FILE, so raising tier 0 to 9,000 let two
@@ -536,6 +534,44 @@ class TestRealInputPipeline:
         assert any(p.fields.get("labprotocol") for p in procs), (
             "the LabProtocol must be linked to a LabProcess"
         )
+
+    def test_a_mislabelled_metadata_workbook_still_yields_a_populated_table(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#422 acceptance, on the genuine fixture: the real leaf labels the
+        assay-metadata workbook ``condition_table``. The tool reads it (#469's
+        Excel intake) and correctly refuses — it is a Parameter|Value template
+        with no per-well rows — and the spine must then fall back to the #438
+        proposal built from the entities the SAME plan materialized, landing
+        real rows: ``condition_table.populated is True`` on the real deposit."""
+        import builder.agents.pipeline.pipeline as pipeline_mod
+        from builder.agents.pipeline.pipeline import run_pipeline
+
+        _install_offline_seams(monkeypatch)
+        base = pipeline_mod.extract_plan
+
+        def plan_with_the_real_mislabel(
+            context: str, *, overrides: Any = None, usage_sink: Any = None
+        ) -> dict[str, Any]:
+            plan = base(context, overrides=overrides, usage_sink=usage_sink)
+            plan.setdefault("files", []).append(
+                {"path": _METADATA_XLSX_NAME, "role": "condition_table"}
+            )
+            return plan
+
+        monkeypatch.setattr(pipeline_mod, "extract_plan", plan_with_the_real_mislabel)
+        engine = _scanning_engine(FIXTURE_DIR)
+        result = run_pipeline(engine)
+
+        table = (result.get("materialized") or {}).get("condition_table") or {}
+        assert table.get("populated") is True, f"header-only table shipped: {table}"
+        assert table.get("proposed") is True
+        assert table.get("fallback_from"), "the original refusal must be recorded"
+        path = table.get("path")
+        assert path and Path(path).is_file()
+        body = Path(path).read_text(encoding="utf-8")
+        assert len(body.strip().splitlines()) > 1, "the table is header-only"
+        assert "Thyroxine" in body, "the proposed rows must carry the real compound"
 
     def test_raw_and_processed_data_files_attached_to_crate(
         self, monkeypatch: pytest.MonkeyPatch
@@ -657,7 +693,5 @@ class TestRealSopParametersReachTheCrate:
         # being inferred from the placeholder's presence.
         assert "Exposure Duration" not in values
         assert "Detection Instrument" not in values
-        chain = {
-            p.fields.get("process_type") for p in engine.state.list_entities("LabProcess")
-        }
+        chain = {p.fields.get("process_type") for p in engine.state.list_entities("LabProcess")}
         assert {"Exposure", "EndpointReadout"} <= chain, chain


### PR DESCRIPTION
Closes #422.

## What

Four commits, strict TDD (9 failing-first tests):

1. **fix(pipeline)** — `_populate_condition_table_from_plan` routes every unusable-single-candidate failure (no path, outside the scan roots, reader raise, `read_failed`, tool declined) through a new `_fall_back_to_proposal` to the #438 propose-from-entities path. On proposal success the result carries `fallback_from` (the primary failure, provenance-visible); on double failure the primary reason survives with `proposal_reason` alongside. The several-candidates ambiguity still refuses without fallback — choosing among real plate maps is a human call (now a stated invariant in AGENTS.md §Plan-file-roles).
2. **fix(leaves)** — the plan-schema role description now defines `condition_table` (per-well design table / plate map) and steers Parameter/Value metadata templates to `other`, attacking the real S-VHPS26 mislabel at its source.
3. **feat(eval)** — `BuildOutcome.pipeline_result` keeps `run_pipeline`'s report instead of discarding it, so the harness can see `condition_table.populated` and the #469 `data_issues`.
4. **feat(build)** — the headless gap summary names the condition-table posture (not populated + reason / proposed + rows / landed rows).

## Why

Deep-research finding (see the #422 rescope comment): the propose path fired only at **zero** candidates, so one unreadable or unmappable candidate left the crate with strictly *less* table content than no plate map at all — silently, since the reason string had no consumer anywhere. On the real S-VHPS26 deposit (no well identifiers exist in any of its 42 workbooks; the leaf labels the key/value assay-metadata workbook `condition_table`) every build shipped a header-only table carrying full vacuous CSVW typing claims.

## Acceptance

`test_a_mislabelled_metadata_workbook_still_yields_a_populated_table` drives `run_pipeline` over the genuine committed S-VHPS26 fixture with the real mislabel injected and asserts `condition_table.populated is True`, `proposed is True`, `fallback_from` recorded, and real rows (the real compound) on disk — #422's acceptance criterion.

## Test plan

- Full suite green locally (exit 0).
- `ruff check` and `ty check` clean.
- Targeted: 109 tests across the touched files + 15 real-input tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)