### PR TITLE
fix(react): don't re-export an unchanged crate; describe the ISA backbone nodes

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -285,6 +285,8 @@ _EXPORTED_FLAG = "_crate_exported_this_session"
 # the session (`set_fields`, `set_crate_metadata`, `fix_required_issues`,
 # `link`), so counting silently kept all of that work off disk.
 _AUTO_EXPORT_FINGERPRINT_FLAG = "_crate_auto_export_fingerprint"
+# Where the last successful export landed, so a suppressed repeat can name it.
+_EXPORT_PATH_FLAG = "_crate_last_export_path"
 
 # Attribute holding the optional single-arg console sink the loop installs so an
 # in-loop auto-export can surface the absolute crate path to the user (#287 Fix
@@ -2017,6 +2019,33 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                         # already been handed is the clearest no-progress signal
                         # there is.
                         return _track_progress(engine, tool_name, progress_before, served)
+                if tool_name in ("export_crate", "build_crate") and not kwargs.get("output_path"):
+                    # Exporting an unchanged crate rewrites the identical bytes.
+                    # One session called export_crate FIFTEEN times, twice per
+                    # turn around a pair of set_fields — and each export now runs
+                    # a full three-profile, all-tier validation sweep before it
+                    # writes, so the ritual cost more than the work it wrapped.
+                    # An explicit output_path is always honoured: writing the
+                    # same crate to a NEW location is a real request.
+                    try:
+                        export_fp = engine.state.export_fingerprint()
+                    except Exception:  # noqa: BLE001 — the guard never blocks a call
+                        export_fp = None
+                    last_fp = getattr(engine, _AUTO_EXPORT_FINGERPRINT_FLAG, None)
+                    if export_fp is not None and export_fp == last_fp:
+                        _log_suppressed(engine, tool_name, "export_unchanged", kwargs)
+                        crate_path = getattr(engine, _EXPORT_PATH_FLAG, None) or "the output path"
+                        return _track_progress(
+                            engine,
+                            tool_name,
+                            progress_before,
+                            f"Already exported this exact crate to {crate_path} — nothing "
+                            "has changed since, so re-writing it would produce identical "
+                            "bytes. Change something first (the outstanding list says "
+                            "what), or answer the user. The crate on disk is current.",
+                            signature=signature,
+                        )
+
                 if tool_name == "build_and_validate":
                     bv_sig = _build_validate_signature(kwargs)
                     try:
@@ -2176,6 +2205,7 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                         and result.get("success")
                     ):
                         setattr(engine, _EXPORTED_FLAG, True)
+                        setattr(engine, _EXPORT_PATH_FLAG, result.get("crate_path"))
                         try:
                             setattr(
                                 engine,

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1416,7 +1416,11 @@ def _add_structural(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> N
     investigations = state.list_entities("Investigation")
     if len(investigations) == 1:
         inv = investigations[0]
-        for key, value in _scalar_props(inv).items():
+        # Same skip as the unfolded branch: agent references are resolved later
+        # by `_wire_dataset_aliases`. Folding them on raw put the state id
+        # `org_erasmus_mc` on the ROOT — the most visible node in the crate —
+        # pointing at nothing, while the Organization itself sat under its ROR.
+        for key, value in _scalar_props(inv, skip=_AGENT_REFERENCE_FIELDS).items():
             if key == "identifier":
                 continue
             if root.get(key) in (None, ""):
@@ -1426,7 +1430,14 @@ def _add_structural(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> N
         _idx_add(idx, inv, root)
     else:
         for inv in investigations:
-            props = {"@type": "Dataset", "additionalType": "Investigation", **_scalar_props(inv)}
+            props = {
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                # Agent references are stripped here and re-emitted RESOLVED by
+                # _wire_dataset_aliases; left in, the raw state id ships beside
+                # the resolved one and the crate carries both.
+                **_scalar_props(inv, skip=_AGENT_REFERENCE_FIELDS),
+            }
             props["identifier"] = _isa_identifier(inv, None, "investigation")
             node = crate.add(DataEntity(crate, _mint_id(inv), properties=props))
             _idx_add(idx, inv, node)
@@ -1435,7 +1446,11 @@ def _add_structural(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> N
     root_ident = root.get("identifier") or "./"
 
     for st in state.list_entities("Study"):
-        props = {"@type": "Dataset", "additionalType": "Study", **_scalar_props(st)}
+        props = {
+            "@type": "Dataset",
+            "additionalType": "Study",
+            **_scalar_props(st, skip=_AGENT_REFERENCE_FIELDS),
+        }
         props["identifier"] = _isa_identifier(st, root_ident, "study")
         node = crate.add(DataEntity(crate, _mint_id(st), properties=props))
         _idx_add(idx, st, node)
@@ -1443,7 +1458,11 @@ def _add_structural(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> N
         _attach_explicit_parts(node, st, idx, root)
 
     for asy in state.list_entities("Assay"):
-        props = {"@type": "Dataset", "additionalType": "Assay", **_scalar_props(asy)}
+        props = {
+            "@type": "Dataset",
+            "additionalType": "Assay",
+            **_scalar_props(asy, skip=_AGENT_REFERENCE_FIELDS),
+        }
         parent = _resolve_one(idx, asy.fields.get("study_id")) or root
         props["identifier"] = _isa_identifier(asy, parent.get("identifier") or root_ident, "assay")
         node = crate.add(DataEntity(crate, _mint_id(asy), properties=props))
@@ -2490,6 +2509,13 @@ def _append_unique_ref(node: Any, prop: str, ref_id: str) -> None:
         node.append_to(prop, {"@id": ref_id})
 
 
+# People/organisation references an ISA dataset can carry. Held here (not in
+# _REF_FIELDS) because `affiliation` on a Person is wired separately with
+# keep_literal=True — a free-text affiliation is valid schema.org and dropping it
+# would lose data — while on a Dataset it is always meant to be an Organization.
+_AGENT_REFERENCE_FIELDS: tuple[str, ...] = ("contributor", "affiliation", "publisher", "creator")
+
+
 def _wire_dataset_aliases(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
     """Resolve root funder/about + assay measurementMethod/dataFiles/resources.
 
@@ -2506,6 +2532,21 @@ def _wire_dataset_aliases(state: CrateState, crate: ROCrate, idx: dict[str, Any]
       schema:hasPart, so reachability and containment are preserved).
     """
     root = crate.root_dataset
+
+    # Agent/organisation references on the ISA datasets. These were emitted
+    # straight out of `_scalar_props`, i.e. as the raw STATE id — which happens
+    # to be right for a Person (keyed by their ORCID, so state id == crate id)
+    # and wrong for an Organization (state `org_utrecht_university`, crate
+    # `https://ror.org/04pp8hn57`). The reference then pointed at nothing: an
+    # undescribed node with no type and no name, tripping three checks each.
+    # Resolving them through the index is what `funder` already does.
+    for kind in ("Investigation", "Study", "Assay"):
+        for entity in state.list_entities(kind):
+            node = _node_for(idx, entity)
+            if node is None:
+                continue
+            for field in _AGENT_REFERENCE_FIELDS:
+                _wire_references(node, field, entity.fields.get(field), idx)
 
     for inv in state.list_entities("Investigation"):
         node = _node_for(idx, inv)


### PR DESCRIPTION
Two independent fixes harvested together.

## Re-exporting an unchanged crate

`export_crate` / `build_crate` with no explicit `output_path` re-ran even when nothing had changed since the last export. The guard now compares `state.export_fingerprint()` against the last one and, when they match, tells the model the crate is already written and where — instead of paying a full assembly and validation sweep to produce a byte-identical result.

It reports the actual path rather than a generic message, so the answer is useful rather than just a refusal. Routed through `_track_progress` like every other guarded return, so the idle ladder still sees it and remains the single authority on ending a turn.

## Undescribed ISA backbone nodes

Investigation / Study / Assay were resolved by a path that could leave an undescribed node with no type and no name, tripping three checks each. They now resolve through the index — the same route `funder` already uses.

Also drops a `ty: ignore` that no longer suppresses anything.

`188 passed` across `test_agent_loop`, `test_csvw_payload` and `test_condition_table`. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)