### PR TITLE
docs: drop the `system-certs` extra the project never defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ The builder is a toolbox-based agent system that helps researchers create ISA-To
 # Clone the repo
 git clone <repo-url> && cd vitro-crate
 
-# Install with all extras (dev tools, LangChain, system certs)
-uv sync --group dev --extra langchain --extra system-certs
+# Install with everything (dev tools + LangChain)
+uv sync --group dev --extra langchain
 
 # Minimal install (just the builder library, no agent):
 uv sync
 
 # With LangChain agent support:
 uv sync --extra langchain
-
-# With LangChain + system CA certs (corporate proxies):
-uv sync --extra langchain --extra system-certs
 ```
+
+Behind a corporate proxy or a private CA? Nothing extra to install — see
+[Corporate / Private CA Certificates](#corporate--private-ca-certificates).
 
 ### Set up your LLM provider
 
@@ -332,7 +332,7 @@ See **[docs/profiling.md](docs/profiling.md)** for details on:
 ## Development
 
 See **[CONTRIBUTING.md](CONTRIBUTING.md)** for:
-- `uv sync --dev --extra langchain --extra system-certs` — full dev setup
+- `uv sync --dev --extra langchain` — full dev setup
 - `uv run pytest` — run tests
 - `uv run ty` — type checking
 - `uvx ruff check` — linting


### PR DESCRIPTION
Closes #465.

README's install instructions told a fresh clone to run:

```
uv sync --group dev --extra langchain --extra system-certs
```

which fails outright — `error: Extra `system-certs` is not defined in the project's `optional-dependencies` table`. `[project.optional-dependencies]` defines only `langchain`, and `git log -S "system-certs" -- pyproject.toml` is empty: the extra was never defined at any point in the project's history. Nothing in the tree imports `truststore` or otherwise touches a system cert store, so even had it installed, it would have activated nothing.

## Removed rather than invented

Defining the extra would be a feature, not a doc fix — and the need it gestured at is already met three ways:

- the **Corporate / Private CA Certificates** section documents `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` and a manual `certifi-system-store` install;
- `VITRO_OPENAI_CA_BUNDLE` (`builder/agents/llm.py`) covers the OpenAI client specifically.

So the install block now links to that section instead of promising a switch that does not exist.

Three references removed (`README.md:24-25`, `:33-34`, `:335`); `grep -rn system-certs` over the tree is now empty. Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)