### PR TITLE
feat(react): surface what the run already knows — split people, and why it failed

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -2710,6 +2710,23 @@ def open_items(state: CrateState, *, actionable_only: bool = False) -> list[str]
                     "draft_publication_with_authors, or link the Person entities"
                 )
 
+        # A duplicate person is a question for the human, not a guess for us.
+        # An abbreviated and a spelled-out form of one name are almost certainly
+        # one researcher — but only almost, and merging silently would be worse
+        # than the duplicate. The pair goes to the user with the evidence.
+        try:
+            from builder.tools.drafters import probable_duplicate_people
+
+            for first, second, why in probable_duplicate_people(state):
+                items.append(
+                    f"{first.entity_id} and {second.entity_id} may be the same person "
+                    f"({why}) — ASK the user to confirm before merging; if they are one "
+                    f"person, keep the ORCID-backed entity and remove_entity the other, "
+                    f"repointing anything that referenced it"
+                )
+        except Exception:  # noqa: BLE001 — a checklist entry must never break the loop
+            logger.debug("duplicate-person check failed", exc_info=True)
+
         orphans = _unreferenced_entities(state)
         for etype, ids in sorted(orphans.items()):
             items.append(
@@ -4148,7 +4165,7 @@ def run_interactive_agent(
             _print_reply(reply)
         else:
             _print_fresh_fallback()
-        if verbose and outcome == "error" and greeting_diagnostic:
+        if outcome == "error" and greeting_diagnostic:
             diagnostic_record: dict[str, Any] = {
                 "event": "model_error",
                 "exception_type": greeting_diagnostic["exception_type"],
@@ -4157,8 +4174,15 @@ def run_interactive_agent(
                 "traceback_tail": greeting_diagnostic["traceback_tail"],
                 "stage": "legacy_greeting",
             }
+            # Recorded whether or not -v was passed: the diagnostic is already
+            # redacted and length-capped, and it goes to the profile, not the
+            # screen. Gating the WRITE on the flag meant the one artifact that
+            # could explain a failure existed only for a run that had already
+            # been told to expect one — so diagnosing a crash required
+            # reproducing it. -v still controls what is printed.
             if engine.profiler is not None:
                 engine.profiler.log_event(**diagnostic_record)
+        if verbose and outcome == "error" and greeting_diagnostic:
             console.print(
                 "[yellow]Legacy greeting error[/yellow]: "
                 f"{greeting_diagnostic['exception_chain']}"
@@ -4329,7 +4353,9 @@ def run_interactive_agent(
             )
             console.print()
         elif outcome == "error":
-            if verbose and diagnostic:
+            if diagnostic:
+                # Always recorded — see the greeting path above. The profile is
+                # where a failed run explains itself after the fact.
                 diagnostic_record: dict[str, Any] = {
                     "event": "model_error",
                     "exception_type": diagnostic["exception_type"],
@@ -4340,6 +4366,11 @@ def run_interactive_agent(
                 }
                 if engine.profiler is not None:
                     engine.profiler.log_event(**diagnostic_record)
+                logger.error(
+                    "Model turn failed: %s",
+                    diagnostic["exception_chain"],
+                )
+            if verbose and diagnostic:
                 console.print(
                     "[yellow]Legacy model error[/yellow]: "
                     f"{diagnostic['exception_type']}: {diagnostic['message']}"
@@ -4349,11 +4380,20 @@ def run_interactive_agent(
                 console.print("Your work so far is saved.")
             else:
                 # Reserved for a GENUINE failure now that timeouts, loop guards
-                # and the step limit each report themselves.
+                # and the step limit each report themselves. The cause is named
+                # here rather than withheld: telling someone to reproduce a
+                # failure that cost them a long session, just to learn what it
+                # was, spends their time to recover something already captured.
+                cause = (
+                    f" [dim]({diagnostic['exception_type']}: {diagnostic['message']})[/dim]"
+                    if diagnostic
+                    else ""
+                )
                 console.print(
                     "[yellow]Something actually went wrong on that step[/yellow] and I "
-                    "stopped. The session is saved. Re-run with [bold]-v[/bold] to see "
-                    "the underlying error."
+                    f"stopped.{cause} The session is saved; the full traceback is in the "
+                    "session profile (`model_error`). Re-run with [bold]-v[/bold] to see "
+                    "it on screen."
                 )
             console.print()
 

--- a/builder/tools/drafters.py
+++ b/builder/tools/drafters.py
@@ -115,6 +115,83 @@ def _existing_person(
     return None
 
 
+_ORCID_RE = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$")
+
+
+def _real_orcid(entity: Entity) -> str:
+    """The entity's ORCID, or "" when it has none.
+
+    ``_bare_orcid`` takes the last path segment of whatever it is given, so a
+    locally minted id comes back as a non-empty string that is not an ORCID.
+    That is harmless when comparing against a known ORCID (nothing matches it),
+    but comparing two such values to each other reads as "two different ORCIDs,
+    so two different people" and dismisses the pair. So the shape is checked.
+    """
+    candidate = _bare_orcid(entity.fields.get("orcid") or entity.entity_id)
+    return candidate if _ORCID_RE.match(candidate) else ""
+
+
+def _name_parts(name: Any) -> tuple[str, str]:
+    """A person's name split into (given-part, family-name), both normalised."""
+    tokens = _person_key(name).split()
+    if len(tokens) < 2:
+        return "", " ".join(tokens)
+    return " ".join(tokens[:-1]), tokens[-1]
+
+
+def _is_initials(given: str) -> bool:
+    """Whether a given-name part is initials rather than a spelled-out name.
+
+    ``"j."``, ``"j m"`` and ``"jm"`` are initials; a spelled-out given name is not.
+    """
+    stripped = given.replace(".", " ").split()
+    return bool(stripped) and all(len(tok) == 1 for tok in stripped)
+
+
+def probable_duplicate_people(state: CrateState) -> list[tuple[Entity, Entity, str]]:
+    """Person pairs that plausibly name one human, for a person to confirm.
+
+    ``_existing_person`` merges only on an exact ORCID or an exact name, and that
+    strictness is right — silently fusing two researchers is worse than a
+    duplicate. It leaves one gap standing: the same author written once with
+    initials and once with a spelled-out given name becomes two Person nodes,
+    splitting one researcher's provenance.
+
+    Whether they are the same person is a question about the world, not about the
+    data, so this only FINDS the pairs — it never merges. The answer comes from
+    the human, who knows.
+
+    Two ORCIDs that differ settle it: those are two people, and the pair is not
+    reported.
+    """
+    people = list(state.list_entities("Person"))
+    pairs: list[tuple[Entity, Entity, str]] = []
+    for i, a in enumerate(people):
+        for b in people[i + 1 :]:
+            orcid_a, orcid_b = _real_orcid(a), _real_orcid(b)
+            if orcid_a and orcid_b and orcid_a != orcid_b:
+                continue  # the identifier has already answered this
+            given_a, family_a = _name_parts(a.fields.get("name"))
+            given_b, family_b = _name_parts(b.fields.get("name"))
+            if not family_a or family_a != family_b:
+                continue
+            if given_a == given_b:
+                continue  # identical names are _existing_person's business
+            # One side abbreviated, and the surviving initial agrees.
+            initials = (_is_initials(given_a), _is_initials(given_b))
+            if not any(initials) or not (given_a[:1] and given_a[:1] == given_b[:1]):
+                continue
+            pairs.append(
+                (
+                    a,
+                    b,
+                    f"{a.fields.get('name')!r} and {b.fields.get('name')!r} share the "
+                    f"surname {family_a!r} and first initial",
+                )
+            )
+    return pairs
+
+
 def _fill_empty_fields(entity: Entity, hints: dict) -> None:
     """Fill only what is missing, and never trade a cleaner name for a noisier one.
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2739,3 +2739,53 @@ class TestRepeatedNonProgressLoopBreaker:
             )
 
 
+
+
+class TestDuplicatePeopleReachTheChecklist:
+    """A split researcher is surfaced as work, not silently merged or ignored.
+
+    ``probable_duplicate_people`` only finds candidate pairs; ``open_items`` is
+    where they become something the user is asked about. The entry must name both
+    entities and say to ASK rather than to merge.
+    """
+
+    def _state_with_split_person(self):
+        from builder.state import CrateState
+        from builder.tools.drafters import draft_person
+
+        state = CrateState()
+        draft_person(state, "J. Doe", {})
+        draft_person(state, "John Doe", {})
+        return state
+
+    def test_the_pair_is_listed_as_an_open_item(self):
+        from builder.agents.react.agent_loop import open_items
+
+        items = open_items(self._state_with_split_person())
+        hits = [i for i in items if "same person" in i]
+        assert len(hits) == 1
+        assert "ASK" in hits[0]
+
+    def test_no_duplicates_means_no_entry(self):
+        from builder.agents.react.agent_loop import open_items
+        from builder.state import CrateState
+        from builder.tools.drafters import draft_person
+
+        state = CrateState()
+        draft_person(state, "John Doe", {})
+        draft_person(state, "Jane Roe", {})
+        assert [i for i in open_items(state) if "same person" in i] == []
+
+    def test_a_failing_check_never_breaks_the_checklist(self, monkeypatch):
+        """A checklist entry is a convenience; it must not be able to end a run."""
+        import builder.tools.drafters as drafters
+        from builder.agents.react.agent_loop import open_items
+
+        def _explode(state):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(drafters, "probable_duplicate_people", _explode)
+        # Must not raise, and the rest of the checklist must still be produced.
+        items = open_items(self._state_with_split_person())
+        assert isinstance(items, list)
+        assert [i for i in items if "same person" in i] == []

--- a/tests/test_tools_drafters.py
+++ b/tests/test_tools_drafters.py
@@ -21,6 +21,7 @@ from builder.tools.drafters import (
     draft_publication,
     draft_sample,
     draft_study,
+    probable_duplicate_people,
 )
 from profiles.context import ISA_TOX_CONTEXT
 
@@ -684,3 +685,80 @@ class TestUnitsThreadedIntoProcesses:
         names = {n.get("name") for n in graph}
         assert "Organ" not in names
         assert "Tissue" not in names
+
+
+class TestProbableDuplicatePeople:
+    """Finding the split-researcher case that exact matching cannot.
+
+    ``_existing_person`` merges only on an exact ORCID or an exact name, and
+    that strictness is right — silently fusing two researchers is worse than a
+    duplicate. It leaves one gap: the same author written once with initials and
+    once spelled out becomes two Person nodes, splitting one researcher's
+    provenance. This only FINDS such pairs; whether they are one human is a
+    question for the user, never a guess.
+    """
+
+    def _people(self, *names_and_orcids):
+        state = CrateState()
+        for i, (name, orcid) in enumerate(names_and_orcids):
+            hints = {"orcid": orcid} if orcid else {}
+            draft_person(state, name, hints)
+        return state
+
+    def test_finds_initials_against_a_spelled_out_name(self):
+        state = self._people(("J. Doe", None), ("John Doe", None))
+        pairs = probable_duplicate_people(state)
+        assert len(pairs) == 1
+        first, second, why = pairs[0]
+        assert {first.fields["name"], second.fields["name"]} == {"J. Doe", "John Doe"}
+        assert "doe" in why.lower()
+
+    def test_two_different_people_are_not_reported(self):
+        # Both given names are spelled out and differ: that is two researchers.
+        state = self._people(("Jane Doe", None), ("John Doe", None))
+        assert probable_duplicate_people(state) == []
+
+    def test_a_shared_surname_alone_is_not_enough(self):
+        state = self._people(("A. Doe", None), ("John Doe", None))
+        assert probable_duplicate_people(state) == []
+
+    def test_different_surnames_are_never_paired(self):
+        state = self._people(("J. Doe", None), ("John Smith", None))
+        assert probable_duplicate_people(state) == []
+
+    def test_two_different_orcids_settle_it(self):
+        # The identifier has already answered the question; do not second-guess it.
+        state = self._people(
+            ("J. Doe", "0000-0001-2345-6789"),
+            ("John Doe", "0000-0002-9876-5432"),
+        )
+        assert probable_duplicate_people(state) == []
+
+    def test_one_orcid_and_one_bare_name_is_still_reported(self):
+        state = self._people(("J. Doe", "0000-0001-2345-6789"), ("John Doe", None))
+        assert len(probable_duplicate_people(state)) == 1
+
+    def test_locally_minted_ids_are_not_mistaken_for_orcids(self):
+        """Two id-only people must not read as "two different ORCIDs".
+
+        ``_bare_orcid`` returns the last path segment of whatever it is given, so
+        a locally minted id comes back as a non-empty non-ORCID string. Comparing
+        two of those to each other would dismiss the pair.
+        """
+        state = self._people(("J. Doe", None), ("John Doe", None))
+        assert len(probable_duplicate_people(state)) == 1
+
+    def test_a_single_person_yields_nothing(self):
+        state = self._people(("John Doe", None))
+        assert probable_duplicate_people(state) == []
+
+    def test_a_mononym_is_not_paired_with_everyone(self):
+        # "Doe" has no given part, so there is no initial to agree on.
+        state = self._people(("Doe", None), ("John Doe", None))
+        assert probable_duplicate_people(state) == []
+
+    def test_it_never_merges_anything(self):
+        state = self._people(("J. Doe", None), ("John Doe", None))
+        before = {e.entity_id for e in state.list_entities("Person")}
+        probable_duplicate_people(state)
+        assert {e.entity_id for e in state.list_entities("Person")} == before


### PR DESCRIPTION
Two places where the loop held information the user needed and didn't show it.

## A duplicate person

`_existing_person` merges only on an exact ORCID or an exact name, and that strictness is right — silently fusing two researchers is worse than a duplicate. But it leaves one gap: **the same author written once with initials and once spelled out becomes two Person nodes**, splitting one researcher's provenance across the crate.

`probable_duplicate_people` finds those pairs; `open_items` asks the user to confirm. It **never merges** — whether "J. Doe" and "John Doe" are one human is a question about the world, not about the data, and the answer comes from the person who knows. Two differing ORCIDs settle it and the pair isn't raised. The check is wrapped so a checklist entry can never end a run.

## A failure that wouldn't say what it was

The `model_error` diagnostic was written to the profile **only when `-v` was passed** — so the one artifact that could explain a crash existed only for a run that had already been told to expect one. Diagnosing a failure meant reproducing it, after it had already cost someone a long session.

The record is now always written (it's already redacted and length-capped, and goes to the profile, not the screen), the cause is named in the console message instead of withheld behind a re-run, and the error is logged. `-v` still controls what is *printed*.

## Tests
13 new tests. The duplicate-detection ones were checked by mutation — dropping the ORCID shape check fails 3 of them, dropping the initials requirement fails another — so they're pinning behavior, not just executing it.

- `ruff check` — clean
- `ty check` — clean
- `pytest tests/test_agent_loop.py tests/test_tools_drafters.py` — 172 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)