### PR TITLE
feat(pipeline): the deterministic arm links the Assay to the Key Event it measures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,7 +615,7 @@ format only (D7); the ARC folder tree is materialised at export time by
 ```
 scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=False) → dict  # composite: linked Investigation→Study→Assay in one call (idempotent-WITH-merge: a reused layer's EMPTY fields are filled from the supplied hints, fill-don't-clobber), the fast path to a BASE-passing crate
 materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
-link_assay_to_key_event(assay_id: str, event_name: str) → {ok, assay_id, key_event_id, event_name} | {ok: False, reason, candidates}  # composite: link an Assay to the AOP Key Event it MEASURES (schema:mentions via keyEvent), matched by name against the KeyEvents already in state; commits the in-state AOP-Wiki id, never one built from the name, and writes NOTHING on a zero/ambiguous match because which Key Event an assay measures is a scientific claim (D5)
+link_assay_to_key_event(assay_id: str, event_name: str) → {ok, assay_id, key_event_id, matched_name} | {ok: False, error, candidates}  # composite: link an Assay to the AOP Key Event it MEASURES (schema:mentions via keyEvent), matched by name against the KeyEvents already in state; commits the in-state AOP-Wiki id, never one built from the name, and writes NOTHING on a zero/ambiguous match because which Key Event an assay measures is a scientific claim (D5)
 resolve_compound(name: str, hints: dict | None = None, verify=None) → {entity_id, name, identifiers, verifications, verified, source}  # composite: chemical name → lookup_compound → draft_molecular_entity → verify_identifier (+ best-effort CompTox DTXSID), in one idempotent call; carries the looked-up CAS + PubChem CID + EPA DTXSID and never keeps an unverified id (D5)
 resolve_publication(title: str, verify=None) → {ok, doi, entity_id, title, score} | {ok: False, reason, title}  # composite: publication title → Crossref title-search → confidence gate → draft_publication_with_authors(doi=…), in one idempotent call; commits a DOI only on a high-confidence match (score floor AND near-exact title) and never fabricates one (D5)
 draft_publication_with_authors(doi: str) → {publication_id, doi, authors:[{name, person_id, orcid, resolution}], hitl}  # composite (engine-routed, HITL-capable): publication + every author wired as a Person, each author's @id harmonized to their ORCID via a verify-first cascade
@@ -1966,6 +1966,17 @@ INPUT → Extract → Materialize → Assess → Auto-resolve →  …  →  Gui
   as the *true conditions of the exposure process*, and the Study `mentions` edge
   is a redundant backstop (still load-bearing for a compound the table cannot reach,
   e.g. one resolved with no Exposure in the chain) rather than the primary link.
+  **Assay→Key Event (#382).** Materializing an AOP subgraph used to wire the *Study*
+  and stop, so the crate listed a pathway's key events without ever saying which one
+  the assay measures. Each `aops[]` item now also carries `measured_event_name` — a
+  NAME, never an id (D5) — and after the subgraph lands the spine calls
+  `link_assay_to_key_event(assay_id, event_name)`, which matches that name against
+  the KeyEvents just materialized and commits THEIR AOP-Wiki IRI onto the Assay's
+  `keyEvent` (camelCase: it is the `Assay:keyEvent` MIT slot). A zero or ambiguous
+  match writes nothing and is logged, not raised — which key event an assay measures
+  is a scientific claim, so an unlinked Assay is a legitimate outcome, and the
+  guidance tail (§14.6.1) can still take the answer from the user through the same
+  tool. Counted on `_materialize_plan`'s result as `key_events`.
 - **Assess** (`assess_gaps`, the gap engine #215, this section) — one
   prioritized `GapReport` unifying SHACL + MIT + FAIR.
 - **Auto-resolve** (`fix_required_issues`, §5, the keystone) — clears every

--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -213,6 +213,29 @@ _CITATION_FIELDS = CITATION_FIELDS
 _is_citation_field = is_citation_field
 
 
+# (#382) The Assay's AOP Key Event slot, in all three spellings the crate mapping
+# accepts (``_ASSAY_MENTION_FIELDS``); all expand to ``schema:mentions``. Its value
+# MUST be a reference to a ``KeyEvent`` ALREADY IN THE CRATE — ``_wire_mention``
+# emits nothing for free text, so storing the user's reply as a literal string
+# would report success while the answer vanished and the gap re-emitted: the same
+# #275 / #179 re-ask class as the person and citation fields above. The reply is
+# instead routed to ``link_assay_to_key_event`` (see
+# :func:`_apply_key_event_value`), which resolves the name against the in-crate
+# KeyEvents and commits their AOP-Wiki IRI.
+#
+# Kept local rather than in :mod:`builder.tools.field_kinds`: unlike the person and
+# citation vocabularies, nothing outside this module asks the question — the gap
+# engine has no key-event branch (emitting that gap is deliberately out of scope,
+# #382 "Out of scope"), so a shared constant would advertise a contract no second
+# reader has.
+_KEY_EVENT_FIELDS: frozenset[str] = frozenset({"key_event", "keyEvent", "key_events"})
+
+
+def _is_key_event_field(field: str) -> bool:
+    """Whether ``field`` is the Assay's AOP Key Event reference slot (#382)."""
+    return field in _KEY_EVENT_FIELDS
+
+
 def _gap_is_root(engine: AgentEngine, gap: Gap) -> bool:
     """Whether ``gap`` targets the Root Data Entity (``./`` / no state entity).
 
@@ -546,6 +569,71 @@ def _apply_citation_value(engine: AgentEngine, gap: Gap, value: str) -> bool:
         return False
 
 
+def _apply_key_event_value(
+    engine: AgentEngine, gap: Gap, value: str, *, human: HumanInterface | None = None
+) -> bool:
+    """Resolve an Assay's Key Event answer against the in-crate KeyEvents (#382).
+
+    ``keyEvent`` is a reference-only property (an alias of ``schema:mentions``):
+    the build strips it out of the node's scalar properties and ``_wire_mention``
+    emits nothing for a value that is neither a resolvable IRI nor an index hit.
+    So committing the user's prose ("mitochondrial dysfunction") as a literal
+    string would return ``True`` while the crate carried nothing and the gap
+    re-emitted next round — the #275 / #179 re-ask class.
+
+    The answer is instead routed to ``link_assay_to_key_event`` (never hand-rolled
+    JSON-LD, AGENTS.md §4.7), which matches the name against the ``KeyEvent``
+    entities already in state and commits THEIR AOP-Wiki id.
+
+    Returns ``True`` only when the link was actually written. A zero or ambiguous
+    match returns ``False`` **and commits nothing**: which Key Event an assay
+    measures is a scientific claim, and reporting a refusal as progress would be
+    the same lie in the opposite direction. The candidate names come back on the
+    tool result, so the user is shown what the crate can actually offer instead of
+    being asked the identical question again.
+    """
+    text = (value or "").strip()
+    if not text:
+        return False
+
+    # A MIT gap carries `entity_id=None` + `entity_type="Assay"`, a SHACL gap the
+    # assay node; resolve both the way `_apply_value` resolves its own targets, so
+    # the answer lands on the entity the question was phrased about (#375).
+    assay_id = _resolve_entity_id(engine, gap)
+    if assay_id is None:
+        instances = _instances_for_commit(engine, "Assay")
+        if len(instances) != 1:
+            if len(instances) > 1:
+                _notify(
+                    human,
+                    "there are several Assay entries, so it is not clear which one "
+                    "measures that key event — your answer was not stored.",
+                )
+            return False
+        assay_id = instances[0].entity_id
+
+    try:
+        result = engine.run_tool("link_assay_to_key_event", assay_id=assay_id, event_name=text)
+    except Exception as exc:  # noqa: BLE001 — a tool failure is a guidance skip
+        logger.warning("guidance: key event link failed for %r: %s", text, exc)
+        return False
+
+    if isinstance(result, dict) and result.get("ok"):
+        return True
+
+    offered = result.get("candidates") or [] if isinstance(result, dict) else []
+    candidates = [str(c.get("name")) for c in offered if isinstance(c, dict) and c.get("name")]
+    known = ""
+    if candidates:
+        known = f" The key events in this crate are: {', '.join(candidates)}."
+    _notify(
+        human,
+        f"'{text}' does not name exactly one key event already in the crate, so "
+        f"your answer was not stored.{known}",
+    )
+    return False
+
+
 def _instances_for_commit(engine: AgentEngine, entity_type: str | None) -> list[Any]:
     """In-state instances of ``entity_type`` — the commit-target selection rule.
 
@@ -627,6 +715,12 @@ def _apply_value(
     :func:`_apply_citation_value`: its value must be a ``ScholarlyArticle``
     reference resolved through the publication composites, not a literal string,
     so a string commit dropped the answer and the gap was re-asked every round.
+
+    The Assay's ``keyEvent`` field (#382) is routed to
+    :func:`_apply_key_event_value`, which resolves the answer against the
+    ``KeyEvent`` entities in the crate: ``_wire_mention`` drops free text, so a
+    literal commit would silently lose the one edge that says what the assay
+    actually measures.
     """
     field = _local_name(gap.property) or (gap.property or "")
     if not field:
@@ -639,6 +733,14 @@ def _apply_value(
     # (#179) The root citation gap needs a resolved ScholarlyArticle, not a string.
     if _is_citation_field(field) and _gap_is_root(engine, gap):
         return _apply_citation_value(engine, gap, value)
+
+    # (#382) The Assay's key event needs a reference to a KeyEvent already in the
+    # crate. A value that ALREADY resolves (an AOP-Wiki IRI, or an in-state id the
+    # user pasted) is a reference, not prose, so it falls through to the generic
+    # reference path below — sending it to the name matcher would fail to match an
+    # IRI against the event NAMES and reject a perfectly good answer.
+    if _is_key_event_field(field) and not is_resolvable_reference(engine.state, value):
+        return _apply_key_event_value(engine, gap, value, human=human)
 
     # Assay measurementMethod is a DefinedTerm reference, but the user naturally
     # answers it with a method name (for example, "Gamma counter"). Resolve that

--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -201,6 +201,13 @@ def _process_parameters_schema() -> dict[str, Any]:
 # Pruned from the schema the model sees AND stripped from the result. A superset
 # of :data:`_IDENTIFIER_SCALAR_FIELDS` with the plan-specific aliases the docs
 # might tempt the model toward (``cid``, ``cellosaurus``, ``@id``, ``id``).
+#
+# Membership is matched EXACTLY (see :func:`_strip_plan_identifiers`), never by
+# substring — which is what makes both halves of the #382 Key Event slot safe:
+# the AOP-Wiki event ids (``event_id`` / ``ke_id`` / ``mie_id``) a model might
+# volunteer alongside ``measured_event_name`` have to be listed here to be
+# stripped at all, and listing them cannot take ``measured_event_name`` (a NAME,
+# the only thing the plan is allowed to carry) down with them.
 _PLAN_IDENTIFIER_FIELDS: frozenset[str] = _IDENTIFIER_SCALAR_FIELDS | frozenset(
     {
         "cid",
@@ -208,6 +215,9 @@ _PLAN_IDENTIFIER_FIELDS: frozenset[str] = _IDENTIFIER_SCALAR_FIELDS | frozenset(
         "cellosaurus",
         "cellosaurus_accession",
         "aop_url",
+        "event_id",
+        "ke_id",
+        "mie_id",
         "@id",
         "id",
     }
@@ -234,10 +244,23 @@ _PLAN_SYSTEM_PROMPT = (
     "spaces; drop plate/well/replicate/date codes and the study accession) as a "
     "separate compound NAME. Propose the chemical names you recognise even when "
     "they appear only in a filename. "
+    # #382: the Assay -> Key Event edge is the reason an ISA-Tox crate is more
+    # than a file manifest, and only the documents can say WHICH event the assay
+    # measures. Ask for the wording verbatim: `link_assay_to_key_event` matches
+    # against the AOP-Wiki event names already in the crate and deliberately
+    # refuses to guess, so a paraphrase ("TPO inhibition" for "Thyroperoxidase,
+    # Inhibition") silently drops the link rather than mislinking it.
+    "For each AOP, also report in 'measured_event_name' the NAME of the key "
+    "event or molecular initiating event THIS study's assay measures, worded "
+    "exactly as the source documents word it. Leave it empty unless the "
+    "documents say which event is measured — never infer it from the assay's "
+    "name and never assume an assay measures the initiating event. "
     "Refer to compounds, cell lines, people and "
-    "publications BY NAME ONLY. NEVER include identifiers of any kind: no CAS, "
+    "publications BY NAME ONLY, and key events by their NAME only. NEVER "
+    "include identifiers of any kind: no CAS, "
     "PubChem CID, InChIKey, SMILES, InChI, Cellosaurus accession, ORCID, DOI, "
-    "or @id. Those are resolved later by dedicated lookup services, never by you."
+    "AOP-Wiki event id, or @id. Those are resolved later by dedicated lookup "
+    "services, never by you."
 )
 
 
@@ -331,7 +354,27 @@ def _plan_schema() -> dict[str, Any]:
                 required=["process_type"],
             ),
             "aops": _array_of(
-                {"aop_id": {**str_field, "description": "AOP-Wiki id, only if explicitly stated."}},
+                {
+                    "aop_id": {
+                        **str_field,
+                        "description": "AOP-Wiki id, only if explicitly stated.",
+                    },
+                    # #382: the ONE thing only the documents can say — which event
+                    # of this pathway the assay measures. A NAME, never an id: the
+                    # spine feeds it to `link_assay_to_key_event`, which matches it
+                    # against the KeyEvents AOP-Wiki just put in the crate and
+                    # commits their IRI. Asking for an id here would let the model
+                    # fabricate the very reference the lookup exists to supply (D5).
+                    "measured_event_name": {
+                        **str_field,
+                        "description": (
+                            "NAME ONLY of the key event / molecular initiating "
+                            "event this study's assay measures, worded exactly as "
+                            "the source documents word it. No event id, no IRI. "
+                            "Leave empty unless the documents state it."
+                        ),
+                    },
+                },
                 required=["aop_id"],
             ),
             "people": _array_of(

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1638,7 +1638,13 @@ def _materialize_plan(
       attached is logged. This runs even with NO provider.
     * each ``aops[]`` → :func:`materialize_aop_subgraph` onto the scaffolded
       Study (the only model input is the numeric ``aop_id``; every node id comes
-      from AOP-Wiki — D5).
+      from AOP-Wiki — D5), followed by the Assay → Key Event link (#382) when the
+      plan's ``measured_event_name`` says which event the assay measures. The
+      plan supplies a NAME; :func:`link_assay_to_key_event` matches it against
+      the KeyEvents just materialized and commits their AOP-Wiki IRI, writing
+      NOTHING on a zero or ambiguous match — picking the measured event is a
+      scientific claim, so an unlinked Assay is a legitimate outcome (counted
+      under ``key_events``).
     * each ``people[]`` → ``draft_person`` with the name plus a deterministic
       ``givenName`` / ``familyName`` split of that name (ISA REQUIRES a non-empty
       given name; splitting a name is descriptive parsing, not identifier
@@ -1678,7 +1684,8 @@ def _materialize_plan(
       ids), so re-running the spine mints no duplicates.
 
     Returns ``{"study", "compounds", "cell_lines", "protocols", "processes",
-    "files", "aops", "people", "publications", "publications_deferred"}`` —
+    "files", "aops", "key_events", "people", "publications",
+    "publications_deferred"}`` —
     per-section counts of what was materialized (``processes`` is the standard
     chain's length, ``files`` the number of scanned files attached), plus the
     titles of publications that found no confident DOI match and were deferred for
@@ -1692,6 +1699,12 @@ def _materialize_plan(
         "processes": 0,
         "files": 0,
         "aops": 0,
+        # #382: Assay -> Key Event links actually committed. Counted separately
+        # from `aops` because materializing a pathway and knowing which of its
+        # events was measured are different achievements — a run with aops=1 and
+        # key_events=0 is the honest "we have the pathway, nobody said which
+        # event" outcome, not a failure.
+        "key_events": 0,
         "people": 0,
         "publications": 0,
         "publications_deferred": [],
@@ -1908,8 +1921,13 @@ def _materialize_plan(
                 exc,
             )
 
-    # --- AOPs: materialize each subgraph and wire it onto the scaffolded Study ---
+    # --- AOPs: materialize each subgraph and wire it onto the scaffolded Study,
+    # then link the Assay to the ONE Key Event it measures (#382). Wiring the
+    # Study alone left the Assay connected to nothing in the subgraph: the crate
+    # said "this study is about AOP 42" and "here are AOP 42's eight key events"
+    # and never which one was actually measured. ---
     study_id = _first_entity_id(engine, "Study")
+    assay_id = _first_entity_id(engine, "Assay")
     for aop in plan.get("aops") or []:
         aop_id = str((aop or {}).get("aop_id") or "").strip()
         if not aop_id:
@@ -1918,10 +1936,56 @@ def _materialize_plan(
             aop_result = engine.run_tool(
                 "materialize_aop_subgraph", aop_id=aop_id, study_id=study_id
             )
-            if aop_result.get("aop_entity_id"):
-                result["aops"] += 1
         except Exception as exc:  # noqa: BLE001
             logger.warning("materialize_aop_subgraph failed for %r: %s", aop_id, exc)
+            continue
+        if not aop_result.get("aop_entity_id"):
+            # A lookup miss put no subgraph in the crate. Matching the event name
+            # anyway would resolve it against some OTHER pathway's events, so the
+            # link is skipped with the pathway that should have carried it.
+            continue
+        result["aops"] += 1
+
+        # The plan carries the event's NAME only; the composite matches it against
+        # the KeyEvents the lookup just materialized and commits THEIR AOP-Wiki
+        # IRI, so the reference is never built from the model's words (D5). A
+        # zero/ambiguous match writes nothing and reports it — which Key Event an
+        # assay measures is a scientific claim, so a refusal to guess is a normal
+        # outcome here, not an error, and the crate is simply left unlinked.
+        event_name = str((aop or {}).get("measured_event_name") or "").strip()
+        if not event_name or not assay_id:
+            continue
+        # `keyEvent` holds ONE reference (it is not a collection field), so a
+        # second plan item naming an event would overwrite the first silently and
+        # still increment the counter — the run would claim two links where the
+        # crate carries one. First pathway wins and the rest are reported: an
+        # assay measuring several key events is a modelling question this lane
+        # does not answer, and quietly replacing an edge is the wrong way to
+        # answer it.
+        linked_assay = engine.state.get_entity(assay_id)
+        if linked_assay is not None and linked_assay.fields.get("keyEvent"):
+            logger.info(
+                "assay already linked to a Key Event; not replacing it with %r from AOP %s",
+                event_name,
+                aop_id,
+            )
+            continue
+        try:
+            link_result = engine.run_tool(
+                "link_assay_to_key_event", assay_id=assay_id, event_name=event_name
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("link_assay_to_key_event failed for %r: %s", event_name, exc)
+            continue
+        if isinstance(link_result, dict) and link_result.get("ok"):
+            result["key_events"] += 1
+        else:
+            logger.info(
+                "assay left unlinked: no single Key Event of AOP %s is named %r (%s)",
+                aop_id,
+                event_name,
+                (link_result or {}).get("error") if isinstance(link_result, dict) else link_result,
+            )
 
     # --- people: a Person from the name + a deterministic given/family split,
     # plus an Organization minted (or reused) from `affiliation_name` and wired

--- a/builder/tools/reachability.py
+++ b/builder/tools/reachability.py
@@ -112,13 +112,6 @@ PIPELINE_UNREACHED: Mapping[str, str] = {
         "No caller, though it is report-only and offline — the cheapest genuine "
         "win here, one call after the fix loop."
     ),
-    "link_assay_to_key_event": (
-        "Closes the ReAct half of #382 — `key_event` had zero writers in either "
-        "arm. The deterministic arm still has none: it would need the pipeline to "
-        "decide WHICH Key Event an assay measures, which is a scientific claim "
-        "the tool deliberately refuses to guess at. Delete this row when the "
-        "pipeline learns to supply the event name."
-    ),
     "lookup_unit": (
         "No deterministic unit resolution yet; tied to the placeholder "
         "ParameterValue lane, which is exactly where units are needed."

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -2181,6 +2181,110 @@ class TestReferenceFieldNeverCommittedAsLiteral:
         assert assay is not None and assay.fields.get("measurementMethod") == "term1"
 
 
+class TestKeyEventAnswerIsResolvedNotStored:
+    """#382: the Assay's key event answer must resolve, or not count as progress.
+
+    ``keyEvent`` is an alias of ``schema:mentions`` and reference-only:
+    ``_wire_mention`` emits nothing for a value that is neither a resolvable IRI
+    nor an index hit. Storing the user's prose would report success while the
+    crate carried nothing and the gap re-emitted next round — the #275 / #179
+    re-ask class. The answer is routed to ``link_assay_to_key_event`` instead.
+
+    The gap here is the REAL one the MIT module emits for
+    ``Assay:keyEvent;Study:aop``, taken from the live gap engine.
+    """
+
+    _MITOCHONDRIAL_DYSFUNCTION = "https://aopwiki.org/events/177"
+
+    def _engine_with_events(self, *events: tuple[str, str]) -> AgentEngine:
+        state = _honest_backbone()
+        for entity_id, name in events or (
+            (self._MITOCHONDRIAL_DYSFUNCTION, "Mitochondrial dysfunction"),
+            ("https://aopwiki.org/events/279", "Thyroperoxidase, Inhibition"),
+        ):
+            state.add_entity(_entity(entity_id, "KeyEvent", name=name))
+        return AgentEngine(state=state)
+
+    def _gap(self, engine: AgentEngine) -> Gap:
+        return _mit_gap(engine.state, "Assay", "keyEvent")
+
+    def test_named_event_answer_reaches_the_crate(self):
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = self._engine_with_events()
+        gap = self._gap(engine)
+
+        # The user answers with the event's NAME, as a human would.
+        assert _apply_value(engine, gap, "mitochondrial dysfunction") is True
+
+        from builder.tools.builder import assemble_crate
+
+        graph = assemble_crate(
+            engine.state, output_dir=None, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+        assay_node = next(n for n in graph if n.get("additionalType") == "Assay")
+        # The point of the route: the answer SURVIVES the build as a reference.
+        assert assay_node.get("keyEvent") == [{"@id": self._MITOCHONDRIAL_DYSFUNCTION}]
+
+    def test_unmatched_answer_is_not_progress_and_stores_nothing(self):
+        """Honesty control — and the anti-re-ask guarantee.
+
+        Returning ``True`` on a failed resolution would let the loop record
+        progress for an answer the crate never carried, so the gap would come
+        back every round: exactly #275 / #179. Returning ``False`` puts the gap
+        in the skip-set instead.
+        """
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = self._engine_with_events()
+        gap = self._gap(engine)
+
+        assert _apply_value(engine, gap, "TPO inhibition") is False
+        assay = engine.state.get_entity("as1")
+        assert assay is not None and "keyEvent" not in assay.fields
+
+    def test_ambiguous_answer_stores_nothing(self):
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = self._engine_with_events(
+            ("https://aopwiki.org/events/177", "Mitochondrial dysfunction"),
+            ("https://aopwiki.org/events/9177", "Mitochondrial dysfunction"),
+        )
+        gap = self._gap(engine)
+
+        assert _apply_value(engine, gap, "Mitochondrial dysfunction") is False
+        assay = engine.state.get_entity("as1")
+        assert assay is not None and "keyEvent" not in assay.fields
+
+    def test_answer_that_is_already_a_reference_still_commits(self):
+        """Honesty control: the name matcher is not in the way of an IRI answer.
+
+        A user who pastes the AOP-Wiki IRI has given a resolvable reference, so it
+        takes the generic reference path — sending it to the name matcher would
+        fail to match an IRI against event NAMES and reject a perfect answer.
+        """
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = self._engine_with_events()
+        gap = self._gap(engine)
+
+        assert _apply_value(engine, gap, self._MITOCHONDRIAL_DYSFUNCTION) is True
+        assay = engine.state.get_entity("as1")
+        assert assay is not None
+        assert assay.fields.get("keyEvent") == self._MITOCHONDRIAL_DYSFUNCTION
+
+    def test_no_key_events_in_the_crate_stores_nothing(self):
+        """Nothing to resolve against — the answer must not be kept as prose."""
+        from builder.agents.pipeline.guidance import _apply_value
+
+        engine = AgentEngine(state=_honest_backbone())
+        gap = self._gap(engine)
+
+        assert _apply_value(engine, gap, "mitochondrial dysfunction") is False
+        assay = engine.state.get_entity("as1")
+        assert assay is not None and "keyEvent" not in assay.fields
+
+
 class TestIdentifierNeverCommittedFromProse:
     """#375(c): D5 holds on EVERY commit path, including offline."""
 

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -18,6 +18,7 @@ The headline guarantees under test:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -837,7 +838,10 @@ class TestMaterializePlan:
                         {
                             "@id": mie,
                             "@type": "KeyEvent",
-                            "name": "MIE",
+                            # A REAL event name (#382): the Assay -> Key Event link
+                            # matches the plan's `measured_event_name` against these
+                            # names, so a placeholder "MIE" could not exercise it.
+                            "name": "Mitochondrial dysfunction",
                             "eventType": "Molecular Initiating Event",
                         },
                         {
@@ -1086,6 +1090,204 @@ class TestMaterializePlan:
         for ent in engine.state.list_entities():
             assert ent.fields.get("identifier") != "10.0/FAKE"
             assert ent.fields.get("doi") != "10.0/FAKE"
+
+    # --- the Assay -> AOP Key Event link (#382) ------------------------------
+    #
+    # Materializing a pathway used to be the end of the AOP section: the crate
+    # listed every KeyEvent of AOP 610 and never said which one the assay
+    # measured, so the assay-to-mechanism edge was absent from every crate the
+    # tool had ever produced. The plan now carries the event NAME and the spine
+    # feeds it to `link_assay_to_key_event`, which commits the id AOP-Wiki gave
+    # it. One claim, then controls: the link must be CAUSED by
+    # `measured_event_name` flowing through the tool — so it must NOT appear when
+    # the plan is silent or names an event this pathway does not have, and no id
+    # the plan carries may ever reach the crate.
+
+    def _assay_key_event(self, engine: AgentEngine) -> Any:
+        """The Assay's stored `keyEvent` reference id, or None."""
+        assay = self._by_type(engine, "Assay")[0]
+        ref = assay.fields.get("keyEvent")
+        return ref.get("@id") if isinstance(ref, dict) else ref
+
+    def test_plan_measured_event_wires_assay_to_key_event(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(
+            monkeypatch,
+            {
+                "aops": [
+                    {"aop_id": "610", "measured_event_name": "Mitochondrial dysfunction"}
+                ]
+            },
+        )
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # The committed reference is the IRI the LOOKUP STUB produced for the
+        # event of that name — the test never writes it onto an entity, and the
+        # plan carries only the name.
+        assert self._assay_key_event(engine) == "https://aopwiki.org/events/1"
+        assert result["key_events"] == 1
+        # The MIT slot is `Assay:keyEvent` and MIT scoring keys on the raw state
+        # field name, so the snake_case spelling would score as unfilled.
+        assert "key_event" not in self._by_type(engine, "Assay")[0].fields
+
+    def test_unnamed_event_leaves_assay_unlinked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Honesty control: the default plan names no event, so nothing is linked.
+
+        This is today's behaviour and must stay: it proves the test above is
+        driven by `measured_event_name` rather than by anything the AOP section
+        does unconditionally.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(monkeypatch)  # the default _PLAN: aop_id only
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)
+
+        # The subgraph IS fully materialized; only the assay edge is missing.
+        assert self._by_type(engine, "AdverseOutcomePathway")
+        assert self._by_type(engine, "KeyEvent")
+        assert "keyEvent" not in self._by_type(engine, "Assay")[0].fields
+        assert result["key_events"] == 0
+
+    def test_plan_event_name_matching_nothing_leaves_assay_unlinked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Honesty control: a name AOP-610 does not carry links nothing, quietly.
+
+        "TPO inhibition" vs "Thyroperoxidase, Inhibition" is the real abbreviation
+        gap this refusal exists for — no string matcher may bridge it, and being
+        unable to is a normal outcome, not a spine failure.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._stub_extract_plan(
+            monkeypatch,
+            {
+                "aops": [
+                    {"aop_id": "610", "measured_event_name": "Thyroperoxidase, Inhibition"}
+                ]
+            },
+        )
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        result = pipeline_mod._materialize_plan(engine)  # must not raise
+
+        assert "keyEvent" not in self._by_type(engine, "Assay")[0].fields
+        assert result["key_events"] == 0
+        assert result["aops"] == 1  # the pathway itself still landed
+
+    def test_plan_cannot_supply_an_event_identifier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """D5: an event id an adversarial model attaches never reaches the crate.
+
+        The plan is passed through the REAL `_strip_plan_identifiers` — the same
+        scrub `extract_plan` applies to the model's output — before the spine sees
+        it, so this exercises the guard rather than asserting the stub's own shape.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+        from builder.agents.pipeline.leaves import _strip_plan_identifiers
+
+        self._enable_provider(monkeypatch)
+        raw_plan = {
+            "aops": [
+                {
+                    "aop_id": "610",
+                    "event_id": "999",
+                    "measured_event_name": "Mitochondrial dysfunction",
+                }
+            ]
+        }
+        self._stub_extract_plan(monkeypatch, _strip_plan_identifiers(raw_plan))
+        self._stub_lookups(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        # The NAME still resolves through the lookup, so the link is made — from
+        # the lookup's id, never the plan's.
+        assert self._assay_key_event(engine) == "https://aopwiki.org/events/1"
+        for ent in engine.state.list_entities():
+            assert "999" not in ent.entity_id
+            for value in ent.fields.values():
+                assert "999" not in str(value)
+
+    def test_the_scrub_removes_event_ids_and_keeps_the_event_name(self) -> None:
+        """The scrub itself, not just its effect downstream (D5).
+
+        ``_materialize_plan`` reads only ``aop_id`` and ``measured_event_name``, so
+        an unstripped ``event_id`` cannot reach the crate through it — which means
+        the end-to-end D5 test above stays green even with ``event_id`` / ``ke_id``
+        / ``mie_id`` removed from :data:`_PLAN_IDENTIFIER_FIELDS`, and pins nothing
+        about the guard. Asserting the stripper directly is what makes those three
+        entries load-bearing: they are defense in depth against a FUTURE reader of
+        ``aops[]``, and defense nothing exercises rots.
+        """
+        from builder.agents.pipeline.leaves import _strip_plan_identifiers
+
+        scrubbed = _strip_plan_identifiers(
+            {
+                "aops": [
+                    {
+                        "aop_id": "610",
+                        "event_id": "999",
+                        "ke_id": "888",
+                        "mie_id": "777",
+                        "measured_event_name": "Mitochondrial dysfunction",
+                    }
+                ]
+            }
+        )
+
+        item = scrubbed["aops"][0]
+        assert set(item) == {"aop_id", "measured_event_name"}, (
+            "an AOP-Wiki event id must not survive the scrub; the name must"
+        )
+        assert item["measured_event_name"] == "Mitochondrial dysfunction"
+
+    def test_plan_schema_offers_no_event_identifier_field(self) -> None:
+        """The new slot must never grow an id sibling the model could fill (D5)."""
+        from builder.agents.pipeline.leaves import (
+            _PLAN_IDENTIFIER_FIELDS,
+            _plan_schema,
+        )
+
+        names: set[str] = set()
+
+        def walk(node: Any) -> None:
+            if isinstance(node, dict):
+                properties = node.get("properties")
+                if isinstance(properties, dict):
+                    names.update(properties)
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    walk(item)
+
+        walk(_plan_schema())
+        # The slot that must exist, spelled as a name...
+        assert "measured_event_name" in names
+        # ...and no identifier-shaped property anywhere in the schema.
+        assert not (names & _PLAN_IDENTIFIER_FIELDS)
 
     def test_no_provider_skips_only_the_plan_driven_sections(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -350,6 +350,22 @@ class TestOntologyAnnotations:
         _, by_id = _build(state, tmp_path)
         assert "#DefinedTerm_ke_55" in _ids(by_id["#Assay_assay_1"].get("keyEvent"))
 
+    def test_free_text_key_event_is_not_emitted(self, tmp_path):
+        """#382: prose on ``keyEvent`` reaches no crate — it must not be stored.
+
+        ``_wire_mention`` emits a mention only for a resolvable entity, an inline
+        ``{"@id": …}`` or a bare IRI, so a depositor's words ("Mitochondrial
+        dysfunction") are dropped without a trace. This is why the guidance tail
+        resolves such an answer through ``link_assay_to_key_event`` instead of
+        committing it: a literal commit would report success and lose the answer.
+        Keep the absence asserted — "fixing" this by keeping literals would put an
+        unresolvable string into the exported crate.
+        """
+        state = CrateState()
+        state.add_entity(_ent("assay_1", "Assay", name="A", keyEvent="Mitochondrial dysfunction"))
+        _, by_id = _build(state, tmp_path)
+        assert "keyEvent" not in by_id["#Assay_assay_1"]
+
     def test_mentions_resolve_by_typed_key_when_study_and_assay_share_id(self, tmp_path):
         """Issue #93: with a Study and an Assay sharing an entity_id, each must
         receive its own mention annotations.

--- a/tests/test_tools_aop_subgraph.py
+++ b/tests/test_tools_aop_subgraph.py
@@ -15,6 +15,7 @@ as the existing lookup tests do (per project policy, lookups stay offline).
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 
@@ -45,12 +46,30 @@ def _load(name: str) -> dict:
 
 @pytest.fixture(autouse=True)
 def _offline_aop(monkeypatch):
-    """Serve the bundled AOP-610 fixture instead of hitting AOP-Wiki."""
+    """Serve the bundled AOP-610 fixture instead of hitting AOP-Wiki.
+
+    ``/aops/611.json`` is served too: a second pathway whose only key event
+    REPEATS AOP-610's "Mitochondrial dysfunction" under a different event id. Two
+    pathways in one crate legitimately share an event NAME while owning distinct
+    AOP-Wiki ids, which is the case ``link_assay_to_key_event`` must refuse rather
+    than pick from (#382). It is derived from the same fixture, so the duplicate
+    name is the fixture's own wording, not a string the test invents.
+    """
     aop_data = _load("aopwiki_aop610.json")
+    ambiguous = copy.deepcopy(aop_data)
+    ambiguous["aop"]["aop_kes"] = [
+        {
+            "event_id": 9177,
+            "event": aop_data["aop"]["aop_kes"][0]["event"],
+            "event_type": "KeyEvent",
+        }
+    ]
 
     def fake_get_json(url, **kwargs):
         if url.endswith("/aops/610.json"):
             return aop_data
+        if url.endswith("/aops/611.json"):
+            return ambiguous
         # Per-event detail endpoint: .../events/<id>.json
         eid = url.rsplit("/", 1)[1].removesuffix(".json")
         return {"short_name": f"Event {eid}", "biological_organization": "Cellular"}
@@ -96,6 +115,26 @@ class TestMaterializeState:
         assert result["events"] == 4
         assert result["relationships"] == 3
         assert result["aop_entity_id"] == aops[0].entity_id
+
+    def test_result_reports_materialized_event_iris(self):
+        # (#382) The composite used to report COUNTS only, so a caller that had
+        # just put four KeyEvents in the crate had nothing to pick one WITH — the
+        # reason neither arm ever linked an Assay to the event it measures.
+        state = CrateState()
+        result = materialize_aop_subgraph(state, "610")
+
+        # Every value comes off the fixture through `lookup_aop`; the test writes
+        # none of them into state.
+        assert {
+            "@id": "https://aopwiki.org/events/888",
+            "name": "Binding of inhibitor, NADH-ubiquinone oxidoreductase (complex I)",
+            "eventType": "Molecular Initiating Event",
+        } in result["events_detail"]
+        # Detail and count describe the same materialization.
+        assert len(result["events_detail"]) == result["events"]
+        assert {d["@id"] for d in result["events_detail"]} == {
+            e.entity_id for e in _by_type(state, "KeyEvent")
+        }
 
     def test_event_types_discriminated_only_by_event_type_field(self):
         state = CrateState()
@@ -341,8 +380,120 @@ class TestLinkAssayToKeyEvent:
         assay = next(n for n in graph if n.get("additionalType") == "Assay")
         assert assay["keyEvent"] == [{"@id": "https://aopwiki.org/events/177"}]
 
-    def test_materialize_returns_event_detail_for_picking(self) -> None:
-        # events_detail is additive — the int count stays for existing callers.
-        from builder.tools.composites import materialize_aop_subgraph
 
-        assert callable(materialize_aop_subgraph)
+class TestLinkAssayToMaterializedKeyEvent:
+    """The same link, but over the KeyEvents AOP-Wiki really produced (#382).
+
+    :class:`TestLinkAssayToKeyEvent` hand-builds its KeyEvents, which cannot show
+    that the id committed onto the Assay is one the LOOKUP minted. These tests
+    type only the event's lowercase NAME and let the AOP-610 fixture supply every
+    id, so a name-derived or fabricated IRI fails them.
+    """
+
+    _MITOCHONDRIAL_DYSFUNCTION = "https://aopwiki.org/events/177"
+
+    def _crate(self, aop_ids: tuple[str, ...] = ("610",)):
+        from builder.tools.composites import scaffold_isa_backbone
+
+        state = CrateState()
+        state.metadata.title = "AOP link"
+        scaffold = scaffold_isa_backbone(
+            state,
+            investigation={"name": "I"},
+            study={"name": "S"},
+            assay={"name": "Complex I activity assay"},
+        )
+        for aop_id in aop_ids:
+            materialize_aop_subgraph(state, aop_id, study_id=scaffold["study_id"])
+        return state, scaffold["assay_id"]
+
+    def _assay_node(self, state: CrateState):
+        from builder.tools.builder import assemble_crate
+
+        graph = assemble_crate(
+            state, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+        return next(n for n in graph if n.get("additionalType") == "Assay")
+
+    def test_links_assay_to_uniquely_named_key_event(self):
+        from builder.tools.composites import link_assay_to_key_event
+
+        state, assay_id = self._crate()
+        # Only the lowercase NAME is typed here; the IRI below is the fixture's.
+        link_assay_to_key_event(state, assay_id, "mitochondrial dysfunction")
+
+        assay_node = self._assay_node(state)
+        assert assay_node["keyEvent"] == [{"@id": self._MITOCHONDRIAL_DYSFUNCTION}]
+        # And the target really is a KeyEvent node in the SAME graph — the whole
+        # point is an edge into the AOP subgraph, not a dangling reference.
+        assert self._MITOCHONDRIAL_DYSFUNCTION in {
+            e.entity_id for e in _by_type(state, "KeyEvent")
+        }
+
+    def test_unmatched_name_writes_nothing_and_returns_candidates(self):
+        # Honesty control for the row above: "TPO inhibition" is a real assay
+        # name that matches nothing in AOP-610, and the abbreviation gap it stands
+        # for ("TPO" vs "Thyroperoxidase") is exactly what no matcher may bridge.
+        from builder.tools.composites import link_assay_to_key_event
+
+        state, assay_id = self._crate()
+        result = link_assay_to_key_event(state, assay_id, "TPO inhibition")
+
+        assert result["ok"] is False
+        assert "keyEvent" not in state.get_entity(assay_id).fields
+        assert "keyEvent" not in self._assay_node(state)
+        # The candidates are the four fixture events, offered for a human choice.
+        assert {c["name"] for c in result["candidates"]} == {
+            e.fields.get("name") for e in _by_type(state, "KeyEvent")
+        }
+        assert len(result["candidates"]) == 4
+
+    def test_ambiguous_name_across_two_pathways_writes_nothing(self):
+        # Two materialized pathways share an event NAME under different AOP-Wiki
+        # ids. Picking either would be a fabricated scientific assertion.
+        from builder.tools.composites import link_assay_to_key_event
+
+        state, assay_id = self._crate(("610", "611"))
+        result = link_assay_to_key_event(state, assay_id, "Mitochondrial dysfunction")
+
+        assert result["ok"] is False
+        assert "keyEvent" not in state.get_entity(assay_id).fields
+        duplicated = [
+            c for c in result["candidates"] if c["name"] == "Mitochondrial dysfunction"
+        ]
+        assert len(duplicated) == 2
+        assert {c["@id"] for c in duplicated} == {
+            self._MITOCHONDRIAL_DYSFUNCTION,
+            "https://aopwiki.org/events/9177",
+        }
+
+    def test_never_fabricates_an_iri_from_the_name(self):
+        # D5 control: the committed reference must be an id that is ALREADY in
+        # state, so an id minted from the name (#KeyEvent_mitochondrial_...) or
+        # any other guess fails regardless of how plausible it looks.
+        from builder.tools.composites import link_assay_to_key_event
+
+        state, assay_id = self._crate()
+        link_assay_to_key_event(state, assay_id, "mitochondrial dysfunction")
+
+        committed = state.get_entity(assay_id).fields["keyEvent"]
+        # `set_fields` canonicalises a reference to its bare id, so the stored
+        # value is the IRI string rather than the `{"@id": …}` it was passed.
+        ref_id = committed.get("@id") if isinstance(committed, dict) else committed
+        assert ref_id in {e.entity_id for e in _by_type(state, "KeyEvent")}
+
+    def test_field_status_source_is_lookup_on_the_camel_case_field(self):
+        # The MIT slot is `Assay:keyEvent` and `_count_filled_fields` keys on the
+        # RAW state field name, so writing `key_event` would produce a
+        # correct-looking crate whose maturity row stays unfilled.
+        from builder.tools.composites import link_assay_to_key_event
+
+        state, assay_id = self._crate()
+        link_assay_to_key_event(state, assay_id, "mitochondrial dysfunction")
+
+        assay = state.get_entity(assay_id)
+        assert "key_event" not in assay.fields
+        status = assay.get_field_status("keyEvent")
+        assert status is not None
+        # `lookup`, not `llm`/`user`: the id came from AOP-Wiki, not from prose.
+        assert status.source == "lookup"


### PR DESCRIPTION
Closes #382.

PR #462 shipped the shared composite and closed the **ReAct half**. The deterministic arm still had no writer, and `builder/tools/reachability.py` carried a `PIPELINE_UNREACHED` waiver saying exactly that:

> Delete this row when the pipeline learns to supply the event name.

It has. The row is gone and `assert_pipeline_reachability()` passes — that guard is two-sided, so leaving the row would have turned CI red.

## The defect, restated

Every crate this tool has produced says *"this study is about AOP 42"* and *"here are AOP 42's eight key events"* — and never which one the assay actually measures. In the committed `output/svhps22_input_crate/`, the assay is literally named "TPO inhibition dose-response assay" and the MIE sitting in the same crate is "Thyroperoxidase, Inhibition". Nothing connects them.

## Step 3 — the channel

The plan's `aops[]` item gains `measured_event_name`: the **name** of the key event this study's assay measures, worded as the documents word it, empty unless stated. `_materialize_plan` reads it after `materialize_aop_subgraph` succeeds and calls `link_assay_to_key_event`, so the reference committed is the AOP-Wiki id **the lookup just put in state**, never one built from the model's words (D5).

A zero or ambiguous match writes nothing and is logged. Which Key Event an assay measures is a scientific claim, so a refusal to guess is a normal outcome here, not an error.

Two things review surfaced and this PR handles:

- **A lookup MISS now skips the link.** Without it, the event name would be matched against whatever *other* pathway's events happened to be in state.
- **`keyEvent` holds one reference**, so a second `aops[]` item naming an event would overwrite the first *silently* while `result["key_events"]` incremented twice — the run claiming two links where the crate carries one. First pathway wins, the rest are reported. An assay measuring several key events is a modelling question this lane doesn't answer, and quietly replacing an edge is the wrong way to answer it.

## D5 hygiene, and a test that actually pins it

`event_id` / `ke_id` / `mie_id` join `_PLAN_IDENTIFIER_FIELDS`. I checked the mechanism rather than assuming it: `_strip_plan_identifiers` matches keys **exactly**, not by substring — which is what makes both halves safe. Those ids have to be listed to be stripped at all, and listing them cannot take `measured_event_name` down with them.

Review caught that the end-to-end D5 test stays **green with all three removed**, because `_materialize_plan` never reads an event id anyway. So there is now a direct assertion on the stripper. Verified it bites:

```
scrub keys: ['aop_id', 'measured_event_name']                    -> passes
without the three entries: ['aop_id', 'event_id', ...]           -> test FAILS
```

They are defense in depth against a *future* reader of `aops[]`, and defense nothing exercises rots.

## Step 4 — a human's answer commits

`_apply_value` would have stored a reply as a literal string, which `_wire_mention` drops (free text is neither a resolvable IRI nor an index hit) — so the answer vanishes and the gap re-emits: the #275 / #179 re-ask class. `_apply_key_event_value` routes the reply through the same composite, returns `True` only on a real write, and on a refusal tells the user which key events the crate actually holds. A value that **already** resolves (an IRI, or an in-state id) falls through to the generic reference path, since matching an IRI against event *names* would reject a perfectly good answer.

**Honest note: this route ships untriggered.** The only `keyEvent` gap today is the MIT row `Assay:keyEvent;Study:aop`, which `_is_committable` makes `report-only`, so the guidance loop never draws it. Emitting an askable gap is deliberately out of scope per the issue; the user-visible half that ships here is the plan-driven link.

## Also

AGENTS.md §5 documented the composite's return as `{ok, assay_id, key_event_id, event_name} | {ok: False, reason, candidates}` while the code returns `matched_name` / `error`. Pre-existing drift from #462, corrected here since it's the same feature. The new code reads the real keys.

## Verification

Tests are offline — the AOP-Wiki fixture plus a derived `/aops/611.json` whose only KE repeats AOP-610's "Mitochondrial dysfunction", so the ambiguous-match refusal is exercised against two real pathways rather than a hand-built collision. Guidance tests drive the **real** gap the gap engine emits for `Assay:keyEvent`.

Per the repo's rule I did not run pytest locally this session (CI owns it). `uvx ruff check` and `uv run ty check` are clean, `assert_pipeline_reachability()` passes, and every new test body was re-executed against the real functions in a standalone harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)