### PR TITLE
fix(lookups): give a failed ORCID lookup a next step, and catch a mistyped iD

### DIFF
--- a/builder/tools/lookups.py
+++ b/builder/tools/lookups.py
@@ -24,6 +24,7 @@ from lookups.bao import lookup_unit as lookup_unit_ols
 from lookups.cellosaurus import lookup_cellosaurus, search_cellosaurus
 from lookups.comptox import lookup_dtxsid as lookup_dtxsid_comptox
 from lookups.crossref import lookup_doi as lookup_doi_crossref
+from lookups.orcid import is_well_formed_orcid
 from lookups.orcid import lookup_orcid as lookup_orcid_api
 from lookups.pubchem import lookup_pubchem
 from lookups.ror import search_ror
@@ -39,14 +40,26 @@ def _success(data: dict) -> dict[str, Any]:
     return {"found": True, "data": data, "error": None}
 
 
-def _failure(error: str, transient: bool = False) -> dict[str, Any]:
+def _failure(error: str, transient: bool = False, fix: str | None = None) -> dict[str, Any]:
     """Wrap a failure into the standard result format.
 
     ``transient=True`` marks a temporary outage (timeout / 429 / 5xx) as
     distinct from a definitive not-found, so callers (e.g. verify_identifier)
     can keep the user's value and retry rather than treat it as unresolved.
+
+    ``fix`` states what to DO about a definitive failure, in the same spirit as
+    the ``fix`` key on a validation issue. A bare "no" is what makes the model
+    wander: told only that a lookup failed, it has no next action and re-runs
+    the neighbouring lookups that DO succeed. One observed run re-issued the
+    same successful ORCID lookup 8 times after an adjacent one came back
+    unresolvable, burning ~42s of model turns on a cached answer it already
+    held. Omitted when the failure is transient — there the next action is
+    simply to retry, and the caller already knows that from ``transient``.
     """
-    return {"found": False, "data": {}, "error": error, "transient": transient}
+    result = {"found": False, "data": {}, "error": error, "transient": transient}
+    if fix:
+        result["fix"] = fix
+    return result
 
 
 @functools.lru_cache(maxsize=256)
@@ -431,6 +444,16 @@ def lookup_orcid(orcid_id: str) -> dict[str, Any]:
     Args:
         orcid_id: Bare ORCID iD, e.g. "0000-0001-6004-8653".
 
+    A malformed iD is rejected before any network call: an ORCID iD carries an
+    ISO 7064 MOD 11-2 check digit, so a transcription error is detectable
+    locally. Both definitive outcomes — malformed, and well-formed but not
+    registered — carry a ``fix`` naming the next action, because neither is
+    recoverable by retrying and the model otherwise has no exit (see
+    :func:`_failure`).
+
+    Args:
+        orcid_id: Bare ORCID iD, e.g. "0000-0001-6004-8653".
+
     Returns:
         Standard lookup dict with keys:
             found: True if ORCID record was found (always True for valid
@@ -438,7 +461,23 @@ def lookup_orcid(orcid_id: str) -> dict[str, Any]:
             data: Dict with @id, @type, identifier, name, givenName,
                   familyName, affiliation_name, affiliation_ror keys.
             error: Error message or None on success.
+            fix: On a definitive failure, what to do instead.
     """
+    if not is_well_formed_orcid(orcid_id):
+        # Never guess a correction: the digits identify a real person, and the
+        # nearest valid iD belongs to someone else.
+        return _failure(
+            f"'{orcid_id}' is not a valid ORCID iD — it fails the ORCID check digit, "
+            "so it was mistyped or misread rather than deregistered. No lookup was "
+            "attempted, and re-running this will not change the answer.",
+            fix=(
+                "Do not guess a corrected iD. Re-read it from the source document; if "
+                "it still does not check out, draft the person without one — "
+                "draft_person(name='...') with no orcid hint is valid and complete. "
+                "Ask the human with present_to_human only if this identifier has to be "
+                "in the crate."
+            ),
+        )
     try:
         result = lookup_orcid_api(orcid_id)
         if result and "name" in result:
@@ -446,7 +485,16 @@ def lookup_orcid(orcid_id: str) -> dict[str, Any]:
         # ORCID returns a fallback dict even on 404, so check for @id
         if result and result.get("@id"):
             return _success(result)
-        return _failure(f"ORCID lookup failed for '{orcid_id}'")
+        return _failure(
+            f"ORCID has no public record for '{orcid_id}'. The iD is well formed, so "
+            "this is a definitive not-found (unregistered, or the record is private) "
+            "and not a temporary outage — repeating this lookup returns the same result.",
+            fix=(
+                "Draft the person without one — draft_person(name='...') with no orcid "
+                "hint is valid and complete. Ask the human with present_to_human only if "
+                "this identifier has to be in the crate."
+            ),
+        )
     except TransientLookupError as exc:
         return _failure(f"ORCID unavailable (transient): {exc}", transient=True)
     except Exception as exc:

--- a/lookups/orcid.py
+++ b/lookups/orcid.py
@@ -8,12 +8,47 @@ No authentication required (uses the public ORCID API).
 from __future__ import annotations
 
 import functools
+import re
 from urllib.parse import quote
 
 from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
 
 _BASE = "https://pub.orcid.org/v3.0"
 _HEADERS = {"Accept": "application/json"}
+
+# 16 characters as four hyphenated groups; the final one may be "X" (check digit 10).
+_ORCID_SHAPE = re.compile(r"^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$")
+
+
+def is_well_formed_orcid(orcid_id: str) -> bool:
+    """Whether *orcid_id* is a structurally valid ORCID iD — shape AND check digit.
+
+    An ORCID iD carries an ISO 7064 MOD 11-2 check digit, so a mistyped or
+    misread iD is detectable without asking ORCID about it. This is a pure
+    function: it never touches the network.
+
+    Deliberately NOT called by :func:`lookup_orcid`, which stays a thin transport
+    wrapper — a caller holding a synthetic iD (tests, fixtures) must still be able
+    to exercise the 404 and timeout paths. The agent-facing wrapper in
+    ``builder.tools.lookups`` is where a malformed iD is worth catching, because
+    that is the layer that has to tell the model what to do about it.
+
+    Args:
+        orcid_id: Bare ORCID iD, e.g. "0000-0001-6004-8653". A bare iD only —
+            a full ``https://orcid.org/…`` URL is not accepted.
+
+    Returns:
+        True when the shape matches and the check digit agrees with the first 15
+        digits; False otherwise.
+    """
+    if not _ORCID_SHAPE.match(orcid_id or ""):
+        return False
+    digits = orcid_id.replace("-", "")
+    total = 0
+    for char in digits[:15]:
+        total = (total + int(char)) * 2
+    expected = (12 - total % 11) % 11
+    return ("X" if expected == 10 else str(expected)) == digits[15]
 
 
 @functools.lru_cache(maxsize=256)

--- a/tests/test_lookups_contract.py
+++ b/tests/test_lookups_contract.py
@@ -803,6 +803,49 @@ class TestCompToxContract:
 # ===========================================================================
 
 
+class TestORCIDWellFormedness:
+    """`is_well_formed_orcid` — ISO 7064 MOD 11-2, no network."""
+
+    @pytest.mark.parametrize(
+        "orcid_id",
+        [
+            "0000-0001-6004-8653",
+            "0000-0002-1825-0097",
+            "0000-0002-5248-863X",  # check digit 10 is written "X"
+            "0009-0000-5074-6239",  # 0009- prefix (post-2022 block)
+        ],
+    )
+    def test_accepts_valid_ids(self, orcid_id):
+        from lookups.orcid import is_well_formed_orcid
+
+        assert is_well_formed_orcid(orcid_id) is True
+
+    @pytest.mark.parametrize(
+        "orcid_id",
+        [
+            "0009-0003-3960-7523",  # the observed real-world transcription error
+            "0000-0002-1825-0098",  # last digit off by one
+            "0000-0000-0000-0000",  # placeholder-looking, still fails the check digit
+            "0000-1111-2222-3333",
+            "0000-0001-6004-865",  # too short
+            "https://orcid.org/0000-0001-6004-8653",  # a URL, not a bare iD
+            "not-an-orcid",
+            "",
+        ],
+    )
+    def test_rejects_invalid_ids(self, orcid_id):
+        from lookups.orcid import is_well_formed_orcid
+
+        assert is_well_formed_orcid(orcid_id) is False
+
+    def test_does_not_touch_the_network(self):
+        """No `responses` mock registered — a request would raise."""
+        from lookups.orcid import is_well_formed_orcid
+
+        assert is_well_formed_orcid("0000-0001-6004-8653") is True
+        assert is_well_formed_orcid("0000-0001-6004-8654") is False
+
+
 class TestORCIDContract:
     """Contract tests for lookups/orcid.py."""
 

--- a/tests/test_tools_lookups.py
+++ b/tests/test_tools_lookups.py
@@ -532,9 +532,12 @@ class TestLookupOrcid:
             }
 
         monkeypatch.setattr("builder.tools.lookups.lookup_orcid_api", mock_lookup_orcid)
-        result = lookup_orcid("0000-0000-0000-0000")
+        # A well-formed iD, so the wrapper reaches the API rather than rejecting it
+        # up front — "0000-0000-0000-0000" reads like a placeholder but fails the
+        # ORCID check digit, which is now caught before any lookup happens.
+        result = lookup_orcid("0000-0002-1825-0097")
         assert result["found"] is True
-        assert result["data"]["@id"] == "https://orcid.org/0000-0000-0000-0000"
+        assert result["data"]["@id"] == "https://orcid.org/0000-0002-1825-0097"
         assert result["error"] is None
 
     def test_never_throws_exception(self, monkeypatch):
@@ -542,10 +545,60 @@ class TestLookupOrcid:
             raise RuntimeError("ORCID unavailable")
 
         monkeypatch.setattr("builder.tools.lookups.lookup_orcid_api", mock_lookup_orcid)
-        result = lookup_orcid("0000-1111-2222-3333")
+        result = lookup_orcid("0000-0002-1943-7793")
         assert result["found"] is False
         assert result["data"] == {}
         assert isinstance(result["error"], str)
+
+    def test_malformed_id_is_rejected_without_a_lookup(self, monkeypatch):
+        """A bad check digit is caught locally — no network call, and a way out.
+
+        The observed failure was 0009-0003-3960-7523: well-shaped, so it looked
+        like a real iD, but its check digit does not agree with the first 15
+        digits. The old wrapper spent a round-trip on it and reported only
+        "ORCID lookup failed", which left the model nothing to do next.
+        """
+        calls = []
+
+        def mock_lookup_orcid(orcid_id):  # pragma: no cover — must never run
+            calls.append(orcid_id)
+            return {}
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_orcid_api", mock_lookup_orcid)
+        result = lookup_orcid("0009-0003-3960-7523")
+        assert calls == []
+        assert result["found"] is False
+        assert result["transient"] is False
+        assert "not a valid ORCID iD" in result["error"]
+        assert "draft_person" in result["fix"]
+        # Never volunteer a "corrected" iD — it would belong to someone else.
+        assert "0009-0003-3960-7520" not in result["fix"]
+
+    def test_unregistered_id_says_so_and_offers_a_next_step(self, monkeypatch):
+        """Well-formed but unknown to ORCID: definitive, with an exit."""
+
+        def mock_lookup_orcid(orcid_id):
+            return {}
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_orcid_api", mock_lookup_orcid)
+        result = lookup_orcid("0000-0009-9999-9999")
+        assert result["found"] is False
+        assert result["transient"] is False
+        assert "no public record" in result["error"]
+        assert "draft_person" in result["fix"]
+
+    def test_transient_failure_carries_no_fix(self, monkeypatch):
+        """A retry is the next step, and `transient` already says so."""
+        from lookups._http import TransientLookupError
+
+        def mock_lookup_orcid(orcid_id):
+            raise TransientLookupError("ORCID timed out")
+
+        monkeypatch.setattr("builder.tools.lookups.lookup_orcid_api", mock_lookup_orcid)
+        result = lookup_orcid("0000-0001-2345-6789")
+        assert result["found"] is False
+        assert result["transient"] is True
+        assert "fix" not in result
 
 
 class TestLookupROR:


### PR DESCRIPTION
## What the profile showed

Session `20260810_201118` spent ~42s of model turns going nowhere after one ORCID lookup failed.

ORCID `0009-0000-5074-6239` was looked up **8 times**. The first took 0.7s; the other seven returned from cache in **0.0s** — the lookup cache was working perfectly. But each repeat still cost a full ~6s model turn.

The trigger is visible in the trace. At it35 the agent looked up two new iDs. One resolved. The other, `0009-0003-3960-7523`, returned `found: False, transient: False`. From it38 to it43 the agent went back to re-looking-up the iD that *had* worked. Blocked on the thing it couldn't do, it repeated the adjacent thing it could. The loop guard caught it only via the generic idle ladder (`no_progress_streak_3/4/5`) — the precise repeat guard (`_STATE_QUERY_TOOLS`) doesn't cover the `lookup_*` family.

## Two things were wrong with the message

**It didn't say which failure this was.** `0009-0003-3960-7523` fails the ORCID check digit (ISO 7064 MOD 11-2). It was mistyped or misread — not deregistered, not private. We spent a network round-trip discovering that, and then reported it identically to a genuine not-found. The other three iDs in that session all validate, so this is a real discriminator, not a theoretical one.

**It didn't say what to do.** `{found: False, transient: False}` is a bare "no" — accurate, unactionable, and exactly the shape that makes a model wander.

## The change

- `lookups/orcid.py` gains `is_well_formed_orcid` — pure, no network, shape + check digit.
- The agent-facing wrapper rejects a malformed iD **before** any request, and both definitive outcomes now carry a `fix` naming the next action: draft the person without an orcid (valid and complete on its own), or ask the human. This mirrors the `fix` key validation issues already carry.
- A transient failure deliberately carries no `fix` — there the next step is a retry, and `transient` already says so.

Two deliberate constraints:

- The check digit is **not** enforced in `lookups/orcid.py`'s lookup path. That stays a thin transport wrapper, and its contract tests use synthetic iDs to exercise the 404 and timeout branches. Remediation is an agent-facing concern, so it lives in the agent-facing layer.
- **No corrected iD is ever suggested.** The digits identify a real person, and the nearest valid iD belongs to someone else. There's a test asserting we don't volunteer one.

## Tests

255 green across every affected module:

| suite | result |
|---|---|
| `test_tools_lookups.py` + `test_lookups_contract.py` | 131 passed |
| `test_tools_verification.py` + `test_tools_publication_authors.py` | 45 passed |
| `test_agents_guidance.py` + `test_tool_reachability.py` + `test_secret_url_hardening.py` | 79 passed |

Two existing tests changed iDs: `test_returns_fallback_on_failure` used `0000-0000-0000-0000` and `test_never_throws_exception` used `0000-1111-2222-3333` — both fail the check digit, so they'd now be rejected before reaching the mocked API. They were testing the not-found and exception paths with iDs that cannot exist; they now use well-formed ones and test the same paths.

## Not in this PR

The complementary fix — adding the `lookup_*` family to `_STATE_QUERY_TOOLS` so a repeat is caught at the first strike rather than the fifth. The guard is a net; this PR is the reason the model hit the net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
