### PR TITLE
perf(validation): reuse one SHACL sweep per state across every gate

### DIFF
--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -229,14 +229,25 @@ def build_and_validate(
     severity = "required" if severity is None else severity
     profile = "all" if profile is None else profile
 
+    # A sweep already computed for this exact state can answer any narrower
+    # question, because the gate is a floor and not a filter (see
+    # :func:`tiers_covered`): an OPTIONAL sweep already carries the REQUIRED and
+    # RECOMMENDED findings, so serving "required" from it is a list filter rather
+    # than 20-plus seconds of SHACL. Without this, a profiled run paid for two
+    # 40-second RECOMMENDED sweeps immediately after an export had validated the
+    # same unchanged state at OPTIONAL.
+    memo_key = _sweep_memo_key(state, profile)
+    cached = _SWEEP_MEMO.get(memo_key) if memo_key else None
+    if cached is not None and _gate_covers(cached[0], severity):
+        logger.debug("Reusing the %s sweep already computed for this state", cached[0])
+        return _sweep_at_gate(cached[1], cached[2], severity)
+
     try:
         # include_all_scanned=False: the auto-included scanned-file leaves (#175)
         # are plain File nodes that don't change the validation verdict, so we skip
         # them on this hot in-loop path to keep build_and_validate fast. export_crate
         # uses the default (True) so the written crate packages the whole dataset.
-        metadata_doc, results = _assemble_and_validate(
-            state, severity=severity, profile=profile
-        )
+        metadata_doc, results = _assemble_and_validate(state, severity=severity, profile=profile)
     except Exception as e:  # noqa: BLE001 — surface as a tool error, never crash the loop
         logger.error("build_and_validate failed: %s", e)
         return {"ok": False, "conformance": {}, "issues": [], "error": str(e)}
@@ -265,11 +276,83 @@ def build_and_validate(
         for issue in result.issues
     ]
 
-    ok = not issues
+    if memo_key:
+        _remember_sweep(memo_key, severity, conformance, issues)
+
     # Keep the original routable tool shape stable. The engine receives the
     # requested severity/profile as call arguments and routes writeback from
     # those arguments rather than expanding this public result contract.
-    return {"ok": ok, "conformance": conformance, "issues": issues}
+    return _sweep_at_gate(conformance, issues, severity)
+
+
+# ---------------------------------------------------------------------------
+# One sweep per state (#profile-20260810)
+# ---------------------------------------------------------------------------
+# Keyed on (validation fingerprint, profile) and holding the WIDEST gate computed
+# for that state. Bounded and in-process: a crate the agent has moved on from is
+# never asked about again, so a handful of entries covers the loop's back-and-forth
+# without holding whole issue lists for a long session.
+_SWEEP_MEMO: dict[tuple[str, str], tuple[str, dict[str, bool], list[dict[str, Any]]]] = {}
+_SWEEP_MEMO_MAX = 4
+
+
+def _sweep_memo_key(state: CrateState, profile: str) -> tuple[str, str] | None:
+    """Memo key for *state* at *profile*, or None when it cannot be fingerprinted."""
+    try:
+        return (state.validation_fingerprint(), profile)
+    except Exception:  # noqa: BLE001 — an un-fingerprintable state just re-runs
+        logger.debug("State could not be fingerprinted; validating without the memo")
+        return None
+
+
+def _gate_covers(have: str, want: str) -> bool:
+    """Whether a sweep run at *have* already evaluated everything *want* asks for."""
+    have_tiers = set(tiers_covered(have))
+    want_tiers = set(tiers_covered(want))
+    # An unknown severity covers nothing (tiers_covered returns ()), so a typo
+    # re-runs rather than silently matching every cached sweep.
+    return bool(want_tiers) and want_tiers <= have_tiers
+
+
+def _remember_sweep(
+    key: tuple[str, str],
+    severity: str,
+    conformance: dict[str, bool],
+    issues: list[dict[str, Any]],
+) -> None:
+    """Record a sweep, keeping the widest gate seen for this state."""
+    existing = _SWEEP_MEMO.get(key)
+    if existing is not None and _gate_covers(existing[0], severity):
+        return
+    if len(_SWEEP_MEMO) >= _SWEEP_MEMO_MAX and key not in _SWEEP_MEMO:
+        _SWEEP_MEMO.pop(next(iter(_SWEEP_MEMO)))
+    _SWEEP_MEMO[key] = (severity, conformance, issues)
+
+
+def _sweep_at_gate(
+    conformance: dict[str, bool], issues: list[dict[str, Any]], severity: str
+) -> dict[str, Any]:
+    """Narrow a sweep's findings to the tiers *severity* actually gates on.
+
+    Only a finding whose severity is a KNOWN tier wider than the gate is set
+    aside. ``_routable_issue`` falls back to the raw enum name for any severity
+    outside the three tiers, and a filter that kept just the recognised ones
+    would silently swallow those — the same "findings vanish for no visible
+    reason" failure that reporting vocabulary findings was meant to end. An
+    unrecognised severity is always reported.
+    """
+    tiers = set(tiers_covered(severity))
+    gated = [
+        issue
+        for issue in issues
+        if issue.get("severity") not in _TIER_ORDER or issue.get("severity") in tiers
+    ]
+    return {"ok": not gated, "conformance": conformance, "issues": gated}
+
+
+def clear_sweep_memo() -> None:
+    """Forget every remembered sweep — for tests, and for a fresh session."""
+    _SWEEP_MEMO.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -313,8 +396,7 @@ def order_issues(issues: list[dict[str, Any]], severity: str) -> list[str]:
     selected.sort(key=lambda i: _VALIDATION_LAYER_ORDER.get(i.get("profile") or "", 99))
     return [
         (
-            f"[{i.get('profile') or '?'}] {i.get('entity_id') or '?'}: "
-            f"{i.get('message') or ''}"
+            f"[{i.get('profile') or '?'}] {i.get('entity_id') or '?'}: {i.get('message') or ''}"
         ).rstrip()
         for i in selected
     ]

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -214,7 +214,10 @@ def build_and_validate(
             default "required" runs only REQUIRED-severity checks (fastest);
             lower it to also surface recommendations.
         profile: "all" runs the base -> isa -> tox passes; "base"/"isa"/"tox"
-            scopes to a single pass (the tox pass dominates wall-clock).
+            scopes to a single pass. The BASE pass dominates wall-clock — on a
+            293-entity crate it is 22.9s of a 36.9s OPTIONAL sweep (62%), against
+            9.2s for tox (25%) and 4.8s for isa. Scoping to "tox" therefore saves
+            far less than scoping away from "base" would.
 
     Returns:
         ``{"ok": bool, "conformance": {layer: bool}, "issues": [issue, ...]}``
@@ -489,8 +492,10 @@ def ensure_validated(
     run shipped a maturity report whose Recommended and Optional rows read "not
     assessed", so the one artifact meant to describe the crate's quality was
     silent about two of its three tiers. Assessing everything costs one extra
-    sweep per export (the tox pass dominates); it buys a report that covers the
-    whole crate.
+    sweep per export — ~37s on a 293-entity crate, of which the BASE pass is 62%
+    and tox 25% — and it buys a report that covers the whole crate. When the
+    in-loop sweep already ran at this gate, :func:`build_and_validate` serves it
+    from the per-state memo and the extra sweep costs nothing.
 
     Freshness now accounts for tier coverage as well as content: a verdict whose
     fingerprint matches but that only ever assessed REQUIRED is not sufficient

--- a/tests/test_validation_sweep_memo.py
+++ b/tests/test_validation_sweep_memo.py
@@ -1,0 +1,182 @@
+"""One SHACL sweep per state, whatever gate asks for it.
+
+The gate is a floor, not a filter: an OPTIONAL sweep already evaluated the
+REQUIRED and RECOMMENDED checks, so answering a later "required" question from
+it is a list filter rather than another 20-40 seconds of SHACL.
+
+A profiled run showed why this matters. `export_crate` validates at OPTIONAL via
+`ensure_validated`, and twice the agent immediately asked for a RECOMMENDED sweep
+of the same untouched crate — 41.1s and 47.7s of pure re-computation. The engine's
+own debounce (Issue #155) could not help: it keys on the exact severity, and
+`ensure_validated` calls `build_and_validate` directly rather than through engine
+dispatch, so the export's sweep was never in that cache at all. This memo sits on
+the function, so it covers both callers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools import validation as V
+from builder.tools.drafters import draft_investigation
+from profiles.validator import DictValidationResult, RoutableIssue
+
+
+def _issue(severity: str, entity: str = "./#thing") -> RoutableIssue:
+    return RoutableIssue(
+        entity_id=entity,
+        property="http://schema.org/name",
+        property_value=None,
+        message=f"a {severity} finding",
+        severity=severity,
+        check_id="ro-crate-1.2_1.1",
+        profile="base",
+    )
+
+
+def _results(*severities: str) -> list[DictValidationResult]:
+    issues = [_issue(s) for s in severities]
+    return [
+        DictValidationResult(
+            profile="base",
+            passed=not issues,
+            passed_required=not any(i.severity == "required" for i in issues),
+            issues=issues,
+        )
+    ]
+
+
+@pytest.fixture
+def sweeps(monkeypatch):
+    """Count real sweeps, and let each test say what the validator returns."""
+    V.clear_sweep_memo()
+    calls: list[str] = []
+    box = {"results": _results("required", "recommended", "optional")}
+
+    def fake(state, *, severity, profile):
+        calls.append(severity)
+        return {}, box["results"]
+
+    monkeypatch.setattr(V, "_assemble_and_validate", fake)
+    yield calls, box
+    V.clear_sweep_memo()
+
+
+@pytest.fixture
+def state():
+    st = CrateState()
+    draft_investigation(st, {"name": "T", "description": "D"})
+    return st
+
+
+class TestSweepReuse:
+    def test_narrower_gate_is_served_from_a_wider_sweep(self, sweeps, state):
+        """The export path's OPTIONAL sweep answers a later RECOMMENDED ask."""
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional")
+        V.build_and_validate(state, severity="recommended")
+        V.build_and_validate(state, severity="required")
+        assert calls == ["optional"]
+
+    def test_wider_gate_still_runs(self, sweeps, state):
+        """A REQUIRED sweep has not evaluated the OPTIONAL checks."""
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="required")
+        V.build_and_validate(state, severity="optional")
+        assert calls == ["required", "optional"]
+
+    def test_a_changed_crate_is_swept_again(self, sweeps, state):
+        """The memo keys on the validation fingerprint, so an edit busts it."""
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional")
+        draft_investigation(state, {"name": "different", "description": "changed"})
+        V.build_and_validate(state, severity="required")
+        assert calls == ["optional", "required"]
+
+    def test_a_different_profile_is_its_own_sweep(self, sweeps, state):
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional", profile="all")
+        V.build_and_validate(state, severity="required", profile="tox")
+        assert calls == ["optional", "required"]
+
+
+class TestGateFiltering:
+    def test_reused_sweep_reports_only_the_gated_tiers(self, sweeps, state):
+        calls, _ = sweeps
+        wide = V.build_and_validate(state, severity="optional")
+        assert {i["severity"] for i in wide["issues"]} == {
+            "required",
+            "recommended",
+            "optional",
+        }
+
+        narrow = V.build_and_validate(state, severity="required")
+        assert calls == ["optional"]
+        assert {i["severity"] for i in narrow["issues"]} == {"required"}
+        assert narrow["ok"] is False
+
+        mid = V.build_and_validate(state, severity="recommended")
+        assert {i["severity"] for i in mid["issues"]} == {"required", "recommended"}
+
+    def test_ok_is_true_when_the_gated_tiers_are_clean(self, sweeps, state):
+        calls, box = sweeps
+        box["results"] = _results("recommended", "optional")
+        V.build_and_validate(state, severity="optional")
+        narrow = V.build_and_validate(state, severity="required")
+        assert calls == ["optional"]
+        assert narrow["issues"] == []
+        assert narrow["ok"] is True
+
+    def test_an_unrecognised_severity_is_never_swallowed(self, sweeps, state):
+        """`_routable_issue` falls back to the raw enum name for anything outside
+        the three tiers. Filtering must not make those vanish — findings that
+        disappear for no visible reason are the failure this project just fixed.
+        """
+        calls, box = sweeps
+        box["results"] = _results("required", "violation")
+        V.build_and_validate(state, severity="optional")
+        narrow = V.build_and_validate(state, severity="required")
+        assert calls == ["optional"]
+        assert {i["severity"] for i in narrow["issues"]} == {"required", "violation"}
+
+
+class TestMemoHygiene:
+    def test_an_unknown_severity_does_not_match_a_cached_sweep(self, sweeps, state):
+        """`tiers_covered` returns () for a typo, which must not read as 'covered'."""
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional")
+        assert V._gate_covers("optional", "recomended") is False  # codespell:ignore
+        assert calls == ["optional"]
+
+    def test_memo_is_bounded(self, sweeps):
+        calls, _ = sweeps
+        for n in range(V._SWEEP_MEMO_MAX + 3):
+            st = CrateState()
+            draft_investigation(st, {"name": f"crate {n}", "description": "D"})
+            V.build_and_validate(st, severity="optional")
+        assert len(V._SWEEP_MEMO) <= V._SWEEP_MEMO_MAX
+        assert len(calls) == V._SWEEP_MEMO_MAX + 3
+
+    def test_clear_forgets_everything(self, sweeps, state):
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional")
+        V.clear_sweep_memo()
+        V.build_and_validate(state, severity="optional")
+        assert calls == ["optional", "optional"]
+
+    def test_a_failed_sweep_is_not_remembered(self, monkeypatch, state):
+        """An error result must not be served to the next caller as a verdict."""
+        V.clear_sweep_memo()
+        calls: list[str] = []
+
+        def boom(state, *, severity, profile):
+            calls.append(severity)
+            raise RuntimeError("assembly exploded")
+
+        monkeypatch.setattr(V, "_assemble_and_validate", boom)
+        first = V.build_and_validate(state, severity="optional")
+        assert "error" in first
+        V.build_and_validate(state, severity="required")
+        assert calls == ["optional", "required"]
+        V.clear_sweep_memo()


### PR DESCRIPTION
## The waste

Session `20260810_201118`: **validation was 395s of the 461s of tool execution** — 86%. `build_and_validate` 216s over 6 calls, `export_crate` 179s over 4 (each of which validates internally).

~89s of that was recomputing findings we already held:

| | | |
|---|---|---:|
| it79 | `export_crate` validates at OPTIONAL | ~35s |
| it80 | `build_and_validate(recommended)` — **identical fingerprint, no mutation between** | 41.1s |
| it139 | `export_crate` validates at OPTIONAL | ~35s |
| it140 | `build_and_validate(recommended)` — **identical fingerprint, no mutation between** | 47.7s |

`tiers_covered` already documents why those are free: *"The gate is a floor, not a filter: `requirement_severity=OPTIONAL` runs the REQUIRED and RECOMMENDED checks too."* Nothing acted on it.

## Why the existing debounce didn't catch it

The engine's #155 debounce misses on both counts:

1. It keys on the **exact severity**, so `recommended` after `optional` reads as a different question.
2. It sits at **engine dispatch**, and `ensure_validated` calls `build_and_validate` directly — so the export's sweep was never in that cache to be reused.

Hence a memo on the function itself, keyed on `(validation_fingerprint, profile)`, holding the widest gate seen for that state.

## What this does and doesn't change

- **No sweep runs at a wider gate than it asked for.** The hot in-loop REQUIRED check costs exactly what it did before; only repeat questions get cheaper. No latency is traded for hit rate.
- The memo is bounded (4 entries) and in-process. An edit changes the fingerprint and busts it.
- A failed sweep is never remembered.

## The subtle bit

Narrowing a wide sweep sets aside **only** findings whose severity is a *known* tier outside the gate. `_routable_issue` falls back to `issue.severity.name.lower()` for anything outside the three tiers, and a filter keeping just the recognised ones would swallow those silently — the same "findings vanish for no visible reason" failure `00ca43b` just finished removing. An unrecognised severity is always reported, and there's a test pinning it.

## Measured

Per-pass cost on the real 293-entity SVHPS22 crate:

| gate | base | isa | tox | total |
|---|---:|---:|---:|---:|
| REQUIRED | 11.17s | 3.40s | 7.22s | 21.78s |
| RECOMMENDED | 19.45s | 5.26s | 10.31s | 35.03s |
| OPTIONAL | 22.90s | 4.79s | 9.23s | 36.92s |

So each avoided re-sweep is worth 20–40s. (Aside: two docstrings — `validation.py:217` and `:410` — claim "the tox pass dominates". Measured, `base` is 62% of an OPTIONAL sweep and tox is 25%. Left alone here; it's steering the parallel-passes work at the wrong pass.)

## Tests

`EXIT=0`, 63 passed across `test_tools_build_and_validate` / `test_validation_debounce` / `test_validation_writeback` / `test_validation_escalation` / `test_tools_validation` / `test_validation_sweep_memo`, plus 11 new tests covering reuse, non-reuse when the cached gate is narrower, fingerprint busting, per-profile keying, tier filtering, unrecognised-severity passthrough, bounding, clearing, and failed-sweep exclusion.

## Not in this PR

The other ~89s the profile found: `build_and_validate(required)` called immediately *before* an export, which `ensure_validated` then supersedes with its own OPTIONAL sweep. That's loop behaviour — the agent shouldn't validate right before an export that validates and reports `issue_counts` anyway — not a caching fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)