### PR TITLE
fix(guidance): ask once for the responsible person, not four times

### DIFF
--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -41,6 +41,12 @@ The loop (:func:`run_guidance`) per round:
      deterministic ask-and-set — still routed through
      :func:`_deterministic_decision`, so the D5 identifier skip applies offline too.
 
+   A person/agent gap is the one case where a round settles SEVERAL gaps: the
+   root ``publisher`` / ``creator`` and the Investigation/Study/Assay ``creator``
+   are four gaps with one answer, so they are gathered and asked ONCE (#337,
+   Part B), with the single minted Person applied to every target through the
+   ordinary ``_apply_value``.
+
 4. Re-assess after each committed change; **never loop forever** — bounded by
    ``max_rounds`` and a per-report skip-set. A gap the loop cannot progress this
    round (e.g. the user skips it) is *skipped*, not fatal: the loop advances to the
@@ -83,6 +89,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -1325,6 +1332,192 @@ def _resolve_from_file(
     return None
 
 
+def _gap_record(gap: Gap) -> dict[str, Any]:
+    """The per-gap summary record ``resolved`` / ``asked`` carry.
+
+    Factored out of :func:`_resolve_gap` so the grouped person path (#337, Part B)
+    reports gaps in exactly the same shape rather than growing a second, drifting
+    record format for the same summary lists.
+    """
+    return {
+        "tier": gap.tier,
+        "source": gap.source,
+        "entity_id": gap.entity_id,
+        # A typed gap (MIT) carries no entity_id, so entity_type is the only thing
+        # identifying WHICH entity it was about — and after #375 it is also what
+        # decides where the answer is written. Recorded so a caller can tell two
+        # same-property gaps apart (e.g. Assay:description vs LabProtocol:description).
+        "entity_type": gap.entity_type,
+        "property": gap.property,
+        "fix_hint": gap.fix_hint,
+    }
+
+
+# Fix hints that are NOT the ask-user route. ``auto_fixable`` is checked
+# separately (it wins over the hint in :func:`_resolve_gap`). Everything else —
+# including an unknown or absent hint — falls back to ask-user, mirroring
+# :func:`_next_actionable_index`'s actionability rule.
+_NON_ASK_HINTS: frozenset[str | None] = frozenset({REPORT_ONLY, "draft", "fix_required_issues"})
+
+
+def _is_ask_user_gap(gap: Gap) -> bool:
+    """Whether the loop would resolve ``gap`` by ASKING the user."""
+    return not gap.auto_fixable and gap.fix_hint not in _NON_ASK_HINTS
+
+
+def _is_person_gap(gap: Gap) -> bool:
+    """Whether ``gap`` asks for a person/agent, by the rule ``_apply_value`` uses.
+
+    Deliberately the same expression :func:`_apply_value` evaluates
+    (``_is_person_field`` over the property's LOCAL name) rather than a looser
+    "does the property mention creator" test: a gap grouped here that
+    ``_apply_value`` would not route to :func:`_apply_person_value` would be
+    answered with a person's name and then committed as a literal string.
+    """
+    field = _local_name(gap.property) or (gap.property or "")
+    return _is_person_field(field)
+
+
+def _person_gap_group(
+    report: GapReport,
+    index: int,
+    *,
+    skipped: set[int],
+    tried_identities: set[GapIdentity],
+) -> list[int]:
+    """Indices of every open person/agent gap ONE answer settles (#337, Part B).
+
+    The scaffolded backbone opens four gaps that all mean "who is the responsible
+    person?" — the root Data Entity's ``creator`` and ``publisher``, plus a
+    ``creator`` on the Study and on the Assay. :func:`_gap_identity` keys on
+    ``(source, entity_id, property, message)``, so they are four unrelated gaps to
+    the loop: it drew them one at a time and ``phrase_gap_question`` re-worded each
+    into its own LLM variant, asking the same human the same thing three or four
+    times. Each ask was individually correct and the aggregate was absurd.
+
+    Gathering is restricted to gaps the loop would otherwise have ASKED about and
+    has not already retired, so the group can never resurrect a gap the user
+    declined (``skipped`` / ``tried_identities``) or steal a turn from the
+    draft-confirm or auto-fix routes. Identities are de-duplicated so the caller's
+    applied-vs-cleared bookkeeping stays 1:1 even if a report lists the same gap
+    twice.
+
+    Returns ``[index]`` unchanged when the primary gap is not a groupable person
+    gap, or when it is the only one — a single person gap keeps exactly today's
+    behaviour.
+    """
+    primary = report.gaps[index]
+    if not (_is_person_gap(primary) and _is_ask_user_gap(primary)):
+        return [index]
+    group = [index]
+    seen: set[GapIdentity] = {_gap_identity(primary)}
+    for other, gap in enumerate(report.gaps):
+        if other == index or other in skipped:
+            continue
+        identity = _gap_identity(gap)
+        if identity in tried_identities or identity in seen:
+            continue
+        if _is_person_gap(gap) and _is_ask_user_gap(gap):
+            group.append(other)
+            seen.add(identity)
+    return group
+
+
+def _person_group_target(engine: AgentEngine, gap: Gap) -> str:
+    """One gap in a person group, described the way a human would name it."""
+    field = _local_name(gap.property) or (gap.property or "creator")
+    name = _gap_entity_name(engine, gap)
+    if name and gap.entity_type:
+        return f"{field} of the {gap.entity_type} '{name}'"
+    if gap.entity_type:
+        return f"{field} of the {gap.entity_type}"
+    # A root/crate-level gap has no state entity and no type — `./` folds the
+    # Investigation, so naming it "the crate itself" is the honest description.
+    return f"{field} of the crate itself"
+
+
+def _join_roles(roles: list[str]) -> str:
+    """``['creator', 'publisher']`` -> ``"creator and publisher"``."""
+    if len(roles) == 1:
+        return roles[0]
+    return f"{', '.join(roles[:-1])} and {roles[-1]}"
+
+
+def _person_group_message(engine: AgentEngine, gaps: list[Gap]) -> str:
+    """The ONE question's ``message`` for a group of person gaps (#337, Part B).
+
+    This is the gap message the ask-user step phrases, so it reaches BOTH paths
+    that put words in front of the user: ``_ask_user_prompt`` prints it verbatim
+    as the "Why:" line on the offline/no-provider path, and ``_gap_context``
+    hands it to ``phrase_gap_question`` on the LLM path.
+
+    It spells the roles out on purpose. ``publisher`` is not ``creator``:
+    defaulting the publisher to the researcher is right for a single-lab dataset
+    and wrong for one deposited by an institution or a repository, so answering
+    once must not quietly credit someone as publisher without saying that is what
+    is happening. The coalescing is a convenience; it is not licence to infer.
+    """
+    targets = [_person_group_target(engine, gap) for gap in gaps]
+    roles = sorted({_local_name(g.property) or (g.property or "creator") for g in gaps})
+    return (
+        f"The crate still needs a responsible person in {len(targets)} places: "
+        f"{'; '.join(targets)}. One name fills all of them — the person you give "
+        f"will be credited as {_join_roles(roles)}, which is what you want for a "
+        "single-lab dataset but not if the publisher is a separate institution or "
+        "repository."
+    )
+
+
+def _resolve_person_group(
+    engine: AgentEngine,
+    human: HumanInterface,
+    gaps: list[Gap],
+    *,
+    asked: list[dict[str, Any]],
+    usage_sink: UsageSink | None,
+    overrides: ModelOverrides | None = None,
+) -> list[tuple[GapIdentity, dict[str, Any]]]:
+    """Ask ONE question for ``gaps`` and apply the answer to every one (#337, B).
+
+    The answer goes through the SAME :func:`_apply_value` every other commit uses,
+    once per gap — no parallel apply path. That is what keeps the grouped route
+    consistent with :func:`_record_root_attribution` rather than competing with
+    it: an entity-scoped gap links the Person by reference, and a root gap records
+    the Person against the ``CrateMetadata`` slot it asked about, exactly as a
+    singly-answered gap does. ``draft_person`` dedups by name, so N applies mint
+    ONE Person and every target points at it.
+
+    Returns ``(identity, record)`` pairs for the gaps whose apply succeeded, in
+    apply order. It deliberately does NOT append to ``resolved`` itself: the
+    caller must first re-assess and drop any gap that did not actually clear
+    (#375), and a helper that had already claimed them resolved would make that
+    correction a deletion instead of a decision.
+    """
+    for gap in gaps:
+        # Every gathered gap WAS surfaced to the user — in one question, but the
+        # summary's `asked` list counts gaps, not prompts, and under-reporting
+        # here would hide the coalescing rather than demonstrate it.
+        asked.append(_gap_record(gap))
+
+    # A synthetic gap carrying the group's message: `_resolve_ask_user` phrases
+    # whatever gap it is handed, so re-messaging a copy of the primary is how the
+    # group's wording reaches both the LLM and the offline prompt without
+    # threading an extra parameter through five call sites. The copy is never
+    # recorded anywhere — identities and applies use the REAL gaps.
+    question_gap = replace(gaps[0], message=_person_group_message(engine, gaps))
+    value = _resolve_ask_user(
+        engine, human, question_gap, usage_sink=usage_sink, overrides=overrides
+    )
+    if value is None:
+        return []
+
+    applied: list[tuple[GapIdentity, dict[str, Any]]] = []
+    for gap in gaps:
+        if _apply_value(engine, gap, value, human):
+            applied.append((_gap_identity(gap), {**_gap_record(gap), "via": "ask-user-grouped"}))
+    return applied
+
+
 def _resolve_gap(
     engine: AgentEngine,
     human: HumanInterface,
@@ -1348,18 +1541,7 @@ def _resolve_gap(
     user) for the run summary. ``usage_sink`` is threaded to every leaf this gap
     may reach so the tail's token spend is accounted (#384).
     """
-    record = {
-        "tier": gap.tier,
-        "source": gap.source,
-        "entity_id": gap.entity_id,
-        # A typed gap (MIT) carries no entity_id, so entity_type is the only thing
-        # identifying WHICH entity it was about — and after #375 it is also what
-        # decides where the answer is written. Recorded so a caller can tell two
-        # same-property gaps apart (e.g. Assay:description vs LabProtocol:description).
-        "entity_type": gap.entity_type,
-        "property": gap.property,
-        "fix_hint": gap.fix_hint,
-    }
+    record = _gap_record(gap)
 
     # --- auto-fixable: deterministic repair, no human prompt -------------------
     if gap.auto_fixable:
@@ -1436,6 +1618,16 @@ def run_guidance(
     aborting, so one un-committable gap never abandons the ones behind it (#230).
     The loop is bounded by ``max_rounds`` and terminates once the whole report is
     exhausted with no progress, or once no MUST gap remains and the user is done.
+
+    One exception to "one gap per round" (#337, Part B): when the drawn gap asks
+    for a **person/agent**, every other open person gap is gathered with it
+    (:func:`_person_gap_group`) and the group is settled by ONE question whose
+    answer is applied to each target through the ordinary :func:`_apply_value`.
+    The backbone opens four such gaps — root ``publisher`` and ``creator``, Study
+    and Assay ``creator`` — and asking "who is responsible?" four times, reworded
+    by the phrase leaf each time, is what Part B removes. Every gathered gap is
+    accounted for in the same round (cleared, or retired into
+    ``tried_identities``), so the group can never be re-asked.
     CODE owns control flow; the LLM only drafts; the user confirms every uncertain
     commit (D5). HITL is never bypassed.
 
@@ -1512,6 +1704,42 @@ def run_guidance(
             break
 
         rounds += 1
+
+        # --- (#337, Part B) one question for every gap asking "who?" ----------
+        # Several distinct gaps (root publisher + root/Study/Assay creator) all
+        # want the same person. Resolve them TOGETHER so the user is asked once.
+        group = _person_gap_group(report, index, skipped=skipped, tried_identities=tried_identities)
+        if len(group) > 1:
+            grouped = [report.gaps[i] for i in group]
+            group_identities = {_gap_identity(g) for g in grouped}
+            applied = _resolve_person_group(engine, human, grouped, asked=asked, usage_sink=sink)
+            cleared: set[GapIdentity] = set()
+            if applied:
+                # State changed: re-assess, then run the #375 "did it actually
+                # clear?" test PER GATHERED GAP. One answer satisfying three gaps
+                # must not let a fourth that silently failed be counted resolved.
+                report = assess_gaps(engine.state)
+                skipped = set()
+                still_open = {_gap_identity(g) for g in report.gaps}
+                for gap_identity, record in applied:
+                    if gap_identity not in still_open:
+                        resolved.append(record)
+                        cleared.add(gap_identity)
+            else:
+                # The whole group made no progress (skipped, or no usable name).
+                # Skip every gathered index so this report advances past all of
+                # them rather than re-drawing the second member next round.
+                skipped.update(group)
+            # THE termination invariant for the grouped path: every gap in the
+            # group is now either CLEARED or in ``tried_identities``. Without this
+            # the members that did not clear are still actionable, the next round
+            # draws one of them, and the user is asked the identical question
+            # again — the exact re-ask loop #337/#375 exist to stop. Each round
+            # therefore retires at least ``len(group)`` gaps, so the loop cannot
+            # spin on a grouped answer that fails to apply.
+            tried_identities.update(group_identities - cleared)
+            continue
+
         identity = _gap_identity(gap)
         resolved_before = len(resolved)
         progressed = _resolve_gap(

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -2241,10 +2241,19 @@ class TestNonClearingGapIsNotReAsked:
         assertion is over *repeats*, not over one hard-coded prompt, so it
         cannot pass vacuously by the loop never reaching a particular gap.
         """
+        import builder.tools.lookups as lookups_mod
         from builder.agents.pipeline import guidance
         from builder.agents.pipeline.guidance import run_guidance
 
         monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        # Hermetic, for the same reason as TestMeasurementMethodIsResolved: the
+        # measurementMethod route reaches the live BAO service, and it is NOT
+        # gated on a provider. Person-gap grouping (#337) settles four gaps in one
+        # round, so a bounded run now gets FURTHER down the report than it used
+        # to and reaches that gap — which is the point of the grouping, but it
+        # must not make this test's verdict depend on the network.
+        monkeypatch.setattr(lookups_mod, "lookup_bao_term", lambda *a, **k: {})
+
         engine = AgentEngine(state=_honest_backbone())
 
         human = ScriptedHuman(input_answers=[_value("resazurin viability assay")] * 8)
@@ -2258,10 +2267,15 @@ class TestNonClearingGapIsNotReAsked:
     def test_resolved_count_only_includes_gaps_that_actually_cleared(self, monkeypatch):
         """``format_guidance_summary`` prints ``resolved: N`` straight from this
         list, so a commit that did not clear its gap must not be counted."""
+        import builder.tools.lookups as lookups_mod
         from builder.agents.pipeline import guidance
         from builder.agents.pipeline.guidance import run_guidance
 
         monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        # Hermetic — see the sibling test above: grouping lets a bounded run reach
+        # the measurementMethod gap, whose route calls the live BAO service.
+        monkeypatch.setattr(lookups_mod, "lookup_bao_term", lambda *a, **k: {})
+
         engine = AgentEngine(state=_honest_backbone())
 
         human = ScriptedHuman(input_answers=[_value("resazurin viability assay")] * 8)
@@ -2560,3 +2574,298 @@ class TestRootPublisherGapClosesOnceAnswered:
         recorded = engine.state.get_entity(publisher_id)
         assert recorded is not None
         assert recorded.fields.get("familyName") == "Hopper"
+
+
+# ---------------------------------------------------------------------------
+# #337 (Part B) — the several gaps that all mean "who is responsible?" must be
+# ONE question.
+#
+# Part A (a root person answer that could never be satisfied) is fixed:
+# `_record_root_attribution` records the answer against the `CrateMetadata` slot
+# it was asked for. What remained is the DUPLICATION: the scaffolded backbone
+# opens four distinct SHOULD gaps naming a person — the root's `schema:creator`
+# and `schema:publisher`, plus `schema:creator` on the Study and the Assay — and
+# `_gap_identity` keys on (source, entity_id, property, message), so they are four
+# unrelated gaps to the loop. Each was drawn on its own round and re-worded by
+# `phrase_gap_question`, so one run asked the same human the same thing four times
+# in four different phrasings. Each ask was individually correct; the aggregate
+# was absurd.
+#
+# The gaps below come from the REAL gap engine over the real backbone, so these
+# tests fail if the engine stops emitting them rather than passing vacuously.
+# ---------------------------------------------------------------------------
+
+
+def _open_person_gaps(engine: AgentEngine) -> list[Gap]:
+    """The live person/agent gaps the loop would ask about, from the real engine."""
+    from builder.agents.pipeline.guidance import _is_ask_user_gap, _is_person_gap
+
+    gaps = [
+        g
+        for g in assess_gaps(engine.state).gaps
+        if _is_person_gap(g) and _is_ask_user_gap(g)
+    ]
+    assert len(gaps) >= 3, (
+        "expected the real backbone to open several person gaps (root publisher / "
+        f"creator, Study and Assay creator); got {[(g.entity_id, g.property) for g in gaps]}"
+    )
+    return gaps
+
+
+def _report_then_empty(monkeypatch, gaps: list[Gap]) -> None:
+    """Offer ``gaps`` once, then a clean report so the loop terminates promptly."""
+    from builder.agents.pipeline import guidance
+
+    reports = iter(
+        [
+            GapReport(
+                gaps=list(gaps),
+                counts={"must_open": 0, "should_open": len(gaps), "may_open": 0},
+            ),
+            GapReport(gaps=[], counts={"must_open": 0, "should_open": 0, "may_open": 0}),
+        ]
+    )
+    monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
+
+
+def _constant_report(monkeypatch, gaps: list[Gap]) -> None:
+    """Re-emit ``gaps`` EVERY round — the shape that used to spin the loop."""
+    from builder.agents.pipeline import guidance
+
+    monkeypatch.setattr(
+        guidance,
+        "assess_gaps",
+        lambda _state: GapReport(
+            gaps=list(gaps),
+            counts={"must_open": 0, "should_open": len(gaps), "may_open": 0},
+        ),
+    )
+
+
+def _local_property(gap: Gap) -> str:
+    """The gap's local field name — the same token `_apply_value` writes to."""
+    from builder.agents.pipeline.guidance import _local_name
+
+    return _local_name(gap.property)
+
+
+class TestPersonGapsAreAskedOnce:
+    """#337 Part B: one question, one Person, every target written."""
+
+    def test_one_question_writes_every_gathered_target(self, monkeypatch):
+        """Honesty control: the grouped answer must reach EVERY gap it gathered,
+        not just the one that happened to be drawn.
+
+        A first-only implementation writes exactly one of these four places and
+        passes any assertion phrased as "a Person was minted" — so the oracle is
+        per-target, and it is read off the real state the build will publish.
+        """
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+        from builder.tools._crate_mapping import _mint_id
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_backbone())
+        gaps = _open_person_gaps(engine)
+        # Both target SHAPES must be represented or the check below could pass by
+        # only ever exercising one of the two write routes.
+        assert any(guidance._resolve_entity_id(engine, g) is not None for g in gaps)
+        assert any(guidance._resolve_entity_id(engine, g) is None for g in gaps)
+        _report_then_empty(monkeypatch, gaps)
+
+        human = ScriptedHuman(input_answers=[_value("Fabian Wagenaars")] * 6)
+        summary = run_guidance(engine, human, max_rounds=6)
+
+        assert len(human.inputs) == 1, (
+            f"{len(gaps)} person gaps must cost ONE question; the user was asked "
+            f"{len(human.inputs)} times"
+        )
+
+        # ONE Person, minted once (draft_person dedups by name).
+        persons = engine.state.list_entities("Person")
+        assert len(persons) == 1, f"one answer must mint one Person, got {len(persons)}"
+        person = persons[0]
+        reference = {"@id": _mint_id(person)}
+
+        # …and it landed on EVERY target, checked per gathered gap rather than at
+        # a hard-coded list of entities. An entity-scoped gap gets the Person as a
+        # reference on its own entity; a root gap gets the CrateMetadata slot it
+        # asked about — the Part A mechanism reused, not a second one.
+        unwritten: list[tuple[str | None, str]] = []
+        for gap in gaps:
+            field = _local_property(gap)
+            state_id = guidance._resolve_entity_id(engine, gap)
+            if state_id is not None:
+                if _get(engine, state_id).fields.get(field) != reference:
+                    unwritten.append((gap.entity_id, field))
+                continue
+            slot = guidance._ROOT_ATTRIBUTION_SLOTS.get(field)
+            assert slot is not None, f"unexpected root person property: {field}"
+            if getattr(engine.state.metadata, slot) != person.entity_id:
+                unwritten.append((gap.entity_id, field))
+        assert not unwritten, (
+            f"the one answer reached {len(gaps) - len(unwritten)} of {len(gaps)} "
+            f"gathered targets; never written: {unwritten}"
+        )
+        assert len(summary["resolved"]) == len(gaps), (
+            "every gathered gap that cleared must be reported resolved"
+        )
+
+    def test_the_question_says_the_person_is_credited_in_every_role(self, monkeypatch):
+        """`publisher` is not `creator`. Defaulting one to the other is fine for a
+        single-lab dataset and wrong for an institutional deposit, so it must be
+        stated in the question — never applied silently."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_backbone())
+        _report_then_empty(monkeypatch, _open_person_gaps(engine))
+
+        human = ScriptedHuman(input_answers=[_value("Fabian Wagenaars")] * 6)
+        run_guidance(engine, human, max_rounds=6)
+
+        prompt = human.inputs[0][0]
+        lowered = prompt.lower()
+        assert "publisher" in lowered and "creator" in lowered, (
+            f"the question must name the roles it will fill: {prompt}"
+        )
+        assert "credited" in lowered, (
+            f"the question must say the one name is credited in all of them: {prompt}"
+        )
+
+    def test_a_group_that_never_clears_is_asked_once_and_claims_nothing(self, monkeypatch):
+        """Termination + #375 honesty for the grouped path.
+
+        With a report that re-emits the same person gaps every round, the answer
+        applies but nothing clears. Every gathered gap must be retired anyway, or
+        the next round redraws one of them and asks the identical question again —
+        the re-ask loop #337 and #375 exist to stop. And none of them may be
+        counted resolved: `format_guidance_summary` prints that list verbatim.
+        """
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_backbone())
+        _constant_report(monkeypatch, _open_person_gaps(engine))
+
+        human = ScriptedHuman(input_answers=[_value("Fabian Wagenaars")] * 20)
+        summary = run_guidance(engine, human, max_rounds=20)
+
+        assert len(human.inputs) == 1, (
+            f"a grouped answer that does not clear must not spin: {len(human.inputs)} asks"
+        )
+        assert summary["resolved"] == [], (
+            "no gap cleared, so nothing may be reported resolved"
+        )
+
+    def test_a_skipped_group_is_not_re_asked(self, monkeypatch):
+        """A grouped question the user declines retires the whole group — one
+        refusal must not be re-litigated once per member."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_backbone())
+        gaps = _open_person_gaps(engine)
+        _constant_report(monkeypatch, gaps)
+
+        human = ScriptedHuman(input_answers=[_skip()] * 20)
+        run_guidance(engine, human, max_rounds=20)
+
+        assert len(human.inputs) == 1
+        assert engine.state.list_entities("Person") == []
+        assert engine.state.metadata.publisher is None
+
+    def test_the_grouped_answer_still_refuses_prose_it_cannot_use(self, monkeypatch):
+        """The group is a batching decision, not a relaxation: an answer with no
+        usable name commits nothing, anywhere."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        monkeypatch.setattr(guidance, "get_provider", lambda: None)
+        engine = AgentEngine(state=_backbone())
+        _constant_report(monkeypatch, _open_person_gaps(engine))
+
+        human = ScriptedHuman(input_answers=[_value("0000-0002-1825-0097")] * 20)
+        run_guidance(engine, human, max_rounds=20)
+
+        # A bare ORCID parses to an EMPTY name, so `_apply_person_value` refuses
+        # it — no Person, no slot, and no second attempt.
+        assert engine.state.list_entities("Person") == []
+        assert engine.state.metadata.publisher is None
+        assert engine.state.metadata.creator is None
+        assert len(human.inputs) == 1
+
+
+class TestPersonGapGrouping:
+    """Which gaps `_person_gap_group` will and will not gather."""
+
+    @staticmethod
+    def _gap(prop: str, *, entity_id: str | None = "st1", fix_hint: str = "ask-user") -> Gap:
+        return Gap(
+            tier="SHOULD",
+            source="shacl",
+            entity_id=entity_id,
+            entity_type="Study",
+            property=prop,
+            message=f"missing {prop}",
+            suggestion=None,
+            fix_hint=fix_hint,
+            auto_fixable=False,
+        )
+
+    def _group(self, gaps: list[Gap], index: int = 0, **kw) -> list[int]:
+        from builder.agents.pipeline.guidance import _person_gap_group
+
+        return _person_gap_group(
+            GapReport(gaps=gaps, counts={}),
+            index,
+            skipped=kw.get("skipped", set()),
+            tried_identities=kw.get("tried_identities", set()),
+        )
+
+    def test_a_lone_person_gap_is_not_grouped(self):
+        """One person gap must take exactly today's path — grouping is only a fix
+        for the duplication, so a single ask must not change shape."""
+        gaps = [
+            self._gap("http://schema.org/creator"),
+            self._gap("http://schema.org/description"),
+        ]
+        assert self._group(gaps) == [0]
+
+    def test_every_open_person_gap_is_gathered(self):
+        gaps = [
+            self._gap("http://schema.org/creator"),
+            self._gap("http://schema.org/description"),
+            self._gap("http://schema.org/publisher", entity_id="./"),
+        ]
+        assert self._group(gaps) == [0, 2]
+
+    def test_a_report_only_person_gap_is_never_gathered(self):
+        """The loop never draws a report-only gap, so answering one in a group
+        would spend the answer on a target `_apply_value` cannot write."""
+        gaps = [
+            self._gap("http://schema.org/creator"),
+            self._gap("author", fix_hint="report-only"),
+        ]
+        assert self._group(gaps) == [0]
+
+    def test_an_already_retired_person_gap_is_never_gathered(self):
+        """A gap the user already declined must not be dragged back in by a later
+        group — `tried_identities` is a per-RUN retirement, not a per-round one."""
+        from builder.agents.pipeline.guidance import _gap_identity
+
+        gaps = [
+            self._gap("http://schema.org/creator"),
+            self._gap("http://schema.org/publisher", entity_id="./"),
+        ]
+        assert self._group(gaps, tried_identities={_gap_identity(gaps[1])}) == [0]
+
+    def test_a_non_person_gap_never_starts_a_group(self):
+        gaps = [
+            self._gap("http://schema.org/description"),
+            self._gap("http://schema.org/creator"),
+        ]
+        assert self._group(gaps) == [0]


### PR DESCRIPTION
Closes #337 (Part B — Part A is already on main).

Part A landed via #441/#469: `_record_root_attribution` means each person gap is now asked **once**. They are still asked **separately**. The scaffolded backbone opens four:

- root `schema:publisher`
- root `schema:creator`
- Study `schema:creator`
- Assay `schema:creator`

`_gap_identity` keys on `(source, entity_id, property, message)`, so nothing relates them. The user answers *"who is responsible for this dataset"* four times, in four LLM-reworded variants. To a first-time user that reads as broken.

## The change

`run_guidance` gathers every open ask-user person/agent gap alongside the drawn one and settles them with **one** question, applying the single answer to each gap through the existing `_apply_value`. So an entity-scoped gap gets the Person by reference and a root gap goes through `_record_root_attribution` — not a second competing mechanism. `draft_person` already dedups by name, so one Person is minted and every target points at it.

Measured against the real gap engine over the honest backbone:

```
questions asked: 5 | repeats: set()
persons minted: ['person_resazurin_viability_assay']
metadata publisher: person_… | creator: person_…
```

Four person gaps → one question → one Person → all four targets written.

## `publisher` is not `creator`

The publisher is often the institution and the creator the researcher. Defaulting one from the other is a fine guess for a single-lab dataset, but not a *silent* one — so the grouped question states whose name will be credited where, rather than quietly fanning one answer across four properties.

## Why two existing tests gained a stub

This is the one thing worth reviewing carefully. Grouping settles four gaps in a single round, so a bounded five-round run gets **further down the report** than it used to, and now reaches the Assay `measurementMethod` gap. That route calls the live BAO service and is **not** gated on a provider, so `test_no_question_is_asked_twice_in_one_run` and `test_resolved_count_only_includes_gaps_that_actually_cleared` would have started depending on `api.ebi.ac.uk`.

That is the grouping working as intended — but it must not make those verdicts network-dependent. Both now stub `lookup_bao_term`, exactly as `TestMeasurementMethodIsResolved` in the same module already does, and for the reason its docstring gives ("it previously reached the live BAO service and its verdict depended on whether the network happened to agree").

Their assertions are **untouched**: no question asked twice, and nothing counted resolved that is still open. Both verified passing with the grouping in place.

I confirmed the stub is load-bearing rather than defensive:

```
WITH grouping, lookup_bao_term called: 1 [('resazurin viability assay',)]
```

And I checked the remaining outbound call is not mine to fix: with a socket tripwire, both `main` and this branch make exactly **one** network attempt from these tests, to ORCID via `draft_person -> _resolve_person_orcid`. Pre-existing on `main`, unchanged here, and out of scope for this PR.

## Scope

#338 was originally bundled with this (both touch the guidance tail). Review found the compound-retry half had defects of its own, so it is **not** in this PR — this branch is Part B only, and `builder/agents/pipeline/guidance.py` is the sole production file changed.

Per the repo's rule I did not run pytest locally this session (CI owns it). `uvx ruff check` and `uv run ty check` are clean, and every claim above was produced by driving the real `run_guidance` over the real gap engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)