### PR TITLE
fix(readers): don't report the workbook features openpyxl drops while reading

### DIFF
--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -11,10 +11,46 @@ from __future__ import annotations
 import json
 import logging
 import re
+import warnings
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _silence_openpyxl_extension_warnings() -> None:
+    """Stop openpyxl reporting the workbook features it drops while reading.
+
+    openpyxl warns once per worksheet extension it cannot round-trip —
+    ``"Data Validation extension is not supported and will be removed"``, and the
+    same sentence for Conditional Formatting, Sparkline Group, Slicer List,
+    Protected Range, Ignored Error, Web Extension and Timeline Ref
+    (``openpyxl.xml.constants.EXT_TYPES``).
+
+    Every one of those is an Excel *presentation* feature: a dropdown, a colour
+    rule, a slicer. We open workbooks ``read_only=True, data_only=True`` to take
+    cell VALUES, and we never write a workbook back — so nothing openpyxl drops
+    can change what we read, and "will be removed" describes openpyxl's in-memory
+    model, not the file on disk. A depositor workbook with validated columns
+    emitted pages of it, and neither the user nor the agent can act on any of it.
+
+    Registered at import rather than around each ``load_workbook``:
+    :func:`warnings.catch_warnings` mutates process-global state and is not
+    thread-safe, and these readers run concurrently in the tools node.
+
+    Matched on the message alone. The ``module`` argument matches the module that
+    *issues* the warning, which openpyxl reaches through a ``warn()`` helper — a
+    detail of theirs we would rather not depend on. The sentence is distinctive
+    enough on its own, and the filter is pinned to UserWarning.
+    """
+    warnings.filterwarnings(
+        "ignore",
+        message=r".*extension is not supported and will be removed",
+        category=UserWarning,
+    )
+
+
+_silence_openpyxl_extension_warnings()
 
 # ---------------------------------------------------------------------------
 # Limits
@@ -126,9 +162,7 @@ def read_excel_rows(
         logger.error("read_excel_rows: openpyxl is not installed")
         return None
     try:
-        book = openpyxl.load_workbook(
-            src, read_only=True, data_only=True, keep_links=False
-        )
+        book = openpyxl.load_workbook(src, read_only=True, data_only=True, keep_links=False)
     except Exception:
         logger.exception("read_excel_rows: could not open %s", path)
         return None
@@ -153,9 +187,7 @@ def read_excel_rows(
                     header = [str(c).strip() for c in cells]
                     continue
                 row = {
-                    key: cells[i] if i < len(cells) else ""
-                    for i, key in enumerate(header)
-                    if key
+                    key: cells[i] if i < len(cells) else "" for i, key in enumerate(header) if key
                 }
                 rows.append(row)
                 if max_rows is not None and len(rows) >= max_rows:
@@ -737,9 +769,7 @@ def _collapse_numbered_series(rows: list[str]) -> list[str]:
     for row in rows:
         stripped = row.strip()
         cells = (
-            [c.strip() for c in stripped.strip("|").split("|")]
-            if stripped.startswith("|")
-            else []
+            [c.strip() for c in stripped.strip("|").split("|")] if stripped.startswith("|") else []
         )
         match = _SERIES_KEY.match(cells[0]) if len(cells) >= 2 else None
         if match is None:
@@ -831,9 +861,7 @@ def compact_attribute_json(text: str) -> str:
         parsed = json.loads(text)
     except (ValueError, TypeError):
         return text
-    if not isinstance(parsed, dict) or not (
-        "attributes" in parsed or "section" in parsed
-    ):
+    if not isinstance(parsed, dict) or not ("attributes" in parsed or "section" in parsed):
         return text
 
     out: list[str] = []

--- a/tests/test_openpyxl_warning_quiet.py
+++ b/tests/test_openpyxl_warning_quiet.py
@@ -1,0 +1,130 @@
+"""openpyxl's dropped-extension warnings never reach the user.
+
+Reading a depositor workbook printed
+
+    UserWarning: Data Validation extension is not supported and will be removed
+
+once per affected sheet. It describes openpyxl's in-memory model, not the file
+on disk, and we never write a workbook back — so it reports nothing that
+happened to anyone's data, and neither the user nor the agent can act on it.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from builder.tools.file_readers import (
+    _silence_openpyxl_extension_warnings,
+    read_excel,
+    read_excel_rows,
+)
+
+# The whole family openpyxl can emit (openpyxl.xml.constants.EXT_TYPES), all of
+# them Excel presentation features that cannot affect a cell value.
+EXTENSION_NAMES = [
+    "Data Validation",
+    "Conditional Formatting",
+    "Sparkline Group",
+    "Slicer List",
+    "Protected Range",
+    "Ignored Error",
+    "Web Extension",
+    "Timeline Ref",
+    "Unknown",
+]
+
+
+@pytest.mark.parametrize("extension", EXTENSION_NAMES)
+def test_every_extension_warning_is_silenced(extension):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # catch_warnings(record=True) resets the filters, so re-apply ours
+        # inside the sandbox — this tests the filter, not the import order.
+        _silence_openpyxl_extension_warnings()
+        warnings.warn(
+            f"{extension} extension is not supported and will be removed",
+            UserWarning,
+            stacklevel=1,
+        )
+    assert caught == []
+
+
+def test_importing_the_module_arms_the_filter():
+    """Nothing has to call the helper — importing the readers is enough.
+
+    Checked by reloading inside a `catch_warnings` sandbox rather than by
+    inspecting the live filters: pytest's own warnings plugin installs a fresh
+    filter set around every test, so the registration done at interpreter start
+    is not visible here. It persists normally in the running app, which is the
+    case that matters and the reason this is import-time at all.
+    """
+    import importlib
+
+    import builder.tools.file_readers as readers
+
+    with warnings.catch_warnings():
+        warnings.resetwarnings()
+        importlib.reload(readers)
+        assert any(
+            entry[0] == "ignore"
+            and entry[1] is not None
+            and entry[1].search("Data Validation extension is not supported and will be removed")
+            for entry in warnings.filters
+        )
+
+
+def test_unrelated_warnings_still_get_through():
+    """The filter is a scalpel, not a blanket."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _silence_openpyxl_extension_warnings()
+        warnings.warn("something the user really should see", UserWarning, stacklevel=1)
+        warnings.warn("a deprecation that matters", DeprecationWarning, stacklevel=1)
+    assert len(caught) == 2
+
+
+def test_openpyxl_warnings_about_other_things_still_get_through():
+    """Only the dropped-extension sentence is silenced."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _silence_openpyxl_extension_warnings()
+        warnings.warn("Workbook contains no default style", UserWarning, stacklevel=1)
+    assert len(caught) == 1
+
+
+class TestRealWorkbooksStayQuiet:
+    @pytest.fixture
+    def workbook(self, tmp_path):
+        openpyxl = pytest.importorskip("openpyxl")
+        path = tmp_path / "conditions.xlsx"
+        book = openpyxl.Workbook()
+        sheet = book.active
+        sheet.title = "Conditions"
+        sheet.append(["compound", "dose_uM", "timepoint_h"])
+        sheet.append(["Amiodarone", 10, 24])
+        sheet.append(["Chlorpyrifos", 25, 48])
+        # A dropdown is the feature that produced the report in the first place.
+        validation = openpyxl.worksheet.datavalidation.DataValidation(
+            type="list", formula1='"Amiodarone,Chlorpyrifos"', allow_blank=True
+        )
+        sheet.add_data_validation(validation)
+        validation.add("A2:A3")
+        book.save(path)
+        return path
+
+    def test_read_excel_rows_emits_nothing(self, workbook):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _silence_openpyxl_extension_warnings()
+            sheets = read_excel_rows(str(workbook))
+        assert sheets is not None
+        assert [w for w in caught if "extension is not supported" in str(w.message)] == []
+
+    def test_read_excel_still_returns_the_values(self, workbook):
+        """Silencing the warning must not silence the data."""
+        text = read_excel(str(workbook))
+        assert text is not None
+        assert "Amiodarone" in text
+        assert "Chlorpyrifos" in text


### PR DESCRIPTION
## The noise

```
openpyxl/worksheet/_reader.py:329: UserWarning: Data Validation extension is not supported and will be removed
  warn(msg)
```

…once per affected sheet, and the same sentence for Conditional Formatting, Sparkline Group, Slicer List, Protected Range, Ignored Error, Web Extension and Timeline Ref (`openpyxl.xml.constants.EXT_TYPES`).

Every one is an Excel **presentation** feature — a dropdown, a colour rule, a slicer. We open workbooks `read_only=True, data_only=True` to take cell VALUES and never write one back, so nothing openpyxl drops can change what we read. "will be removed" describes openpyxl's in-memory model, not the file on disk. It reports nothing that happened to anyone's data, and gives neither the user nor the agent anything to act on.

## Scope

Registered at import rather than around each `load_workbook`: `warnings.catch_warnings` mutates process-global state and is not thread-safe, and these readers run concurrently in the tools node.

Pinned to that one sentence and to `UserWarning`. Everything else still reaches the user — tests assert that an unrelated `UserWarning`, a `DeprecationWarning`, and openpyxl's own "Workbook contains no default style" all get through.

## An honest caveat on reproduction

I could **not** reproduce this from any current code path, and it's worth saying so.

Built a workbook carrying a real x14 Data Validation `extLst` and read it both ways:

| mode | result |
|---|---|
| `read_only=True` | silent |
| `read_only=False` | `Data Validation extension is not supported and will be removed` |

`read_only=True` streams cells via `ReadOnlyWorksheet` and never reaches `WorksheetReader.parse_extensions`, which is where line 329 lives. Scanning all 911 `.xlsx` files in the repo through our reader produced zero warnings.

And every openpyxl call site in this repo already passes `read_only=True`: `file_readers.read_excel_rows`, `file_readers.read_excel`, `scanner.py:999`, `scripts/gen_fair_indicators.py`. `petl` and `pandas` (which do open non-read-only) are not imported at runtime — verified.

So the reported traceback came from a path I have not found. This filter is process-wide once `builder.tools` is imported, so it suppresses the warning **wherever** it originates — but if something is opening a workbook without `read_only=True`, that is worth finding on its own merits, because read-only is also faster and bounded-memory. Happy to chase it with a session id or command.

## Tests

14 new, 193 passed across `test_file_readers` / `test_scanner` / `test_condition_table` / `test_openpyxl_warning_quiet`.

One test is shaped by a pytest detail worth recording: pytest's warnings plugin installs a fresh filter set around every test, so the import-time registration is invisible to a naive assertion on `warnings.filters`. The test reloads the module inside a `catch_warnings` sandbox instead. The registration persists normally in the running app — which is the case that matters, and the reason it is import-time at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)