### PR TITLE
fix(react): a Ctrl+C must not leave a tool call nobody answered

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -3512,6 +3512,57 @@ def _format_document_context(documents: list[dict[str, Any]] | None) -> str:
     return "\n".join(lines)
 
 
+def _call_ids(message: Any) -> list[str]:
+    """Every tool-call id on *message*, whatever shape the call objects take."""
+    ids: list[str] = []
+    for call in getattr(message, "tool_calls", None) or []:
+        cid = call.get("id") if isinstance(call, dict) else getattr(call, "id", None)
+        if cid:
+            ids.append(str(cid))
+    return ids
+
+
+def _drop_unanswered_tool_calls(messages: list) -> list:
+    """Remove tool calls that never got a result, and the half-answers around them.
+
+    ``start_on="human"`` stops the trimmed window BEGINNING with an orphan, which
+    is the failure mode trimming can create. It cannot help with the other one: a
+    turn interrupted between the model's ``tool_calls`` and the tool node's
+    replies ends the history with a call nobody answered. The provider rejects
+    the entire request for it — ``No tool output found for function call …`` — so
+    a single Ctrl+C otherwise poisons every later turn of the session, and the
+    saved history carries the poison into the next run too.
+
+    Dropping the call is right rather than synthesising a result: the tool never
+    ran, so there is no outcome, and inventing one would tell the model something
+    false about the crate. When only SOME of a message's calls were answered, the
+    surviving ``ToolMessage``s go with it — a result whose call is gone is just
+    the same violation from the other side.
+    """
+    answered = {str(tid) for m in messages if (tid := getattr(m, "tool_call_id", None)) is not None}
+    doomed: set[str] = set()
+    for message in messages:
+        ids = _call_ids(message)
+        if ids and not all(cid in answered for cid in ids):
+            doomed.update(ids)
+    if not doomed:
+        return messages
+
+    kept = [
+        m
+        for m in messages
+        if not (set(_call_ids(m)) & doomed)
+        and str(getattr(m, "tool_call_id", "") or "") not in doomed
+    ]
+    logger.warning(
+        "Dropped %d message(s) for %d tool call(s) that never got a result — "
+        "usually an interrupted turn",
+        len(messages) - len(kept),
+        len(doomed),
+    )
+    return kept
+
+
 def _trim_history(messages: list, *, max_tokens: int) -> list:
     """Bound the per-turn message history so verbose tool outputs aren't replayed.
 
@@ -3527,7 +3578,9 @@ def _trim_history(messages: list, *, max_tokens: int) -> list:
        guarantees the trimmed window never *begins* with a dangling
        ``ToolMessage`` (or an ``AIMessage`` whose tool_call lost its answer),
        i.e. it never produces orphaned tool messages — the provider API rejects
-       those.
+       those. Orphans that arrive already in the history — an interrupted turn
+       leaves a tool_call nobody answered — are removed by
+       ``_drop_unanswered_tool_calls`` before either step.
 
     The leading system prompt and trailing state brief are added by
     ``_assemble_model_messages`` *around* the result, so they are intentionally
@@ -3545,7 +3598,7 @@ def _trim_history(messages: list, *, max_tokens: int) -> list:
     if not messages:
         return []
 
-    pruned = _prune_state_backed_outputs(messages)
+    pruned = _drop_unanswered_tool_calls(_prune_state_backed_outputs(messages))
 
     try:
         trimmed = trim_messages(
@@ -4391,10 +4444,22 @@ def run_interactive_agent(
             # The turn hit the recursion_limit safety net — treat as a graceful
             # end so the loop stops auto-continuing and the backstop can run.
             outcome = "recursion"
+        except BaseException:
+            # Ctrl+C is the one that matters here. Interrupting mid-turn kills the
+            # tool node between an AIMessage's tool_calls and their ToolMessages,
+            # so the checkpoint keeps a function call that was never answered.
+            # Every later turn replays it and the provider refuses the request
+            # ("No tool output found for function call …") — the exact failure
+            # `_rotate_checkpoint` exists to prevent, which never ran for an
+            # interrupt because KeyboardInterrupt is not an Exception and
+            # propagated straight past the call below.
+            outcome = "interrupt"
+            raise
         finally:
             root_logger.setLevel(old_root_level)
-
-        _rotate_checkpoint(outcome)
+            # In `finally` so EVERY exit rotates — including the interrupt above,
+            # which leaves this function without passing the old call site.
+            _rotate_checkpoint(outcome)
 
         # Flush any in-loop auto-export status lines buffered during the invoke
         # (#287 Fix A) now the spinner's Live region is gone, so "Crate written

--- a/tests/test_interrupted_tool_call.py
+++ b/tests/test_interrupted_tool_call.py
@@ -1,0 +1,100 @@
+"""A Ctrl+C must not poison the rest of the session.
+
+Interrupting a turn kills the tool node between the model's ``tool_calls`` and
+their ``ToolMessage`` replies. The checkpoint then holds a function call nobody
+answered, and every later turn replays it:
+
+    BadRequestError: 400 — No tool output found for function call call_YfkY…
+
+`_rotate_checkpoint` was written for exactly this, but never ran for an
+interrupt: ``KeyboardInterrupt`` is not an ``Exception``, so it propagated past
+the call site. And rotation alone does not repair a session whose saved history
+already carries the orphan, so the history is sanitised as well.
+"""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from builder.agents.react.agent_loop import _drop_unanswered_tool_calls, _trim_history
+
+
+def _ai(*calls):
+    return AIMessage(
+        content="",
+        tool_calls=[{"name": name, "args": {}, "id": cid} for cid, name in calls],
+    )
+
+
+class TestDropUnansweredToolCalls:
+    def test_an_answered_call_is_untouched(self):
+        msgs = [
+            HumanMessage(content="go"),
+            _ai(("call_1", "list_entities")),
+            ToolMessage(content="[]", tool_call_id="call_1"),
+        ]
+        assert _drop_unanswered_tool_calls(msgs) == msgs
+
+    def test_a_trailing_unanswered_call_is_removed(self):
+        """The Ctrl+C shape: the model asked, the tool never replied."""
+        msgs = [
+            HumanMessage(content="go"),
+            _ai(("call_1", "list_entities")),
+            ToolMessage(content="[]", tool_call_id="call_1"),
+            _ai(("call_2", "resolve_compound")),
+        ]
+        kept = _drop_unanswered_tool_calls(msgs)
+        assert len(kept) == 3
+        assert all("call_2" not in str(getattr(m, "tool_calls", "")) for m in kept)
+
+    def test_a_partly_answered_message_takes_its_answers_with_it(self):
+        """Half a parallel fan-out is the same violation from the other side.
+
+        Dropping the AIMessage but keeping the ToolMessage that DID land would
+        leave a result whose call no longer exists, which the provider rejects
+        just as firmly.
+        """
+        msgs = [
+            HumanMessage(content="go"),
+            _ai(("call_a", "lookup_orcid"), ("call_b", "lookup_ror")),
+            ToolMessage(content="{}", tool_call_id="call_a"),
+        ]
+        kept = _drop_unanswered_tool_calls(msgs)
+        assert kept == [msgs[0]]
+
+    def test_an_orphan_mid_history_is_removed_without_touching_later_turns(self):
+        msgs = [
+            HumanMessage(content="one"),
+            _ai(("call_x", "read_file")),
+            HumanMessage(content="two"),
+            _ai(("call_y", "list_entities")),
+            ToolMessage(content="[]", tool_call_id="call_y"),
+        ]
+        kept = _drop_unanswered_tool_calls(msgs)
+        assert kept == [msgs[0], msgs[2], msgs[3], msgs[4]]
+
+    def test_plain_conversation_is_returned_unchanged(self):
+        msgs = [HumanMessage(content="hi"), AIMessage(content="hello")]
+        assert _drop_unanswered_tool_calls(msgs) is msgs
+
+    def test_empty_history(self):
+        assert _drop_unanswered_tool_calls([]) == []
+
+
+class TestTrimHistoryRefusesToEmitOrphans:
+    def test_trim_strips_an_interrupted_call(self):
+        """The sanitiser runs inside the path every model turn goes through."""
+        msgs = [
+            HumanMessage(content="go"),
+            _ai(("call_1", "list_entities")),
+            ToolMessage(content="[]", tool_call_id="call_1"),
+            _ai(("call_dead", "export_crate")),
+        ]
+        out = _trim_history(msgs, max_tokens=100_000)
+        dangling = [
+            m
+            for m in out
+            for c in (getattr(m, "tool_calls", None) or [])
+            if (c.get("id") if isinstance(c, dict) else None) == "call_dead"
+        ]
+        assert dangling == []


### PR DESCRIPTION
## The failure

```
BadRequestError: 400 — No tool output found for function call call_YfkYvqE74rCiDIjaluLTR2Jt.
```

Interrupting a turn kills the tool node between an `AIMessage`'s `tool_calls` and their `ToolMessage` replies. The checkpoint keeps a function call with no result, and every later turn replays it.

## Why the existing guard missed it

`_rotate_checkpoint` was written for exactly this — its docstring names the error verbatim:

> Reusing its MemorySaver key could replay a checkpoint containing an unresolved tool call, yielding `No tool output found for function call ...` forever.

It never ran for the interrupt. It sits **after** the try/finally in `_run_turn`, and `KeyboardInterrupt` derives from `BaseException`, not `Exception`, so it propagated straight past. The rotation in the log was triggered by the 400 itself — one turn too late, which is why it appeared next to the error rather than preventing it.

## Two layers

**Root cause.** Rotation moves into the `finally`, with a `BaseException` handler recording the outcome as `interrupt`. Every exit path rotates now.

**Recovery.** `_drop_unanswered_tool_calls` runs inside `_trim_history`, on the path every model turn takes. Rotation only protects *future* turns — a session whose saved history already carries the orphan stays broken without this, including across a restart.

`_trim_history`'s `start_on="human"` already stopped the trimmed window *beginning* with an orphan. Nothing looked at the tail, which is exactly where an interrupt leaves one.

## Two details worth review

- **Partial fan-out.** When only some of a parallel batch was answered, the surviving `ToolMessage`s are dropped along with the `AIMessage` — a result whose call is gone is the same violation from the other side.
- **Nothing is synthesised.** The tool never ran, so there is no outcome; inventing one would tell the model something false about the crate.

## Tests

7 new. `130 passed`, exit 0, across `test_agent_loop.py` + `test_interrupted_tool_call.py`.

Note for anyone running these locally: `langchain-openai` / `langchain-anthropic` are `[project.optional-dependencies]` extras, so a bare `uv run pytest` in a fresh worktree fails 13 `TestBuildChatModel` / `TestModelTiering` / `TestRequestTimeout` tests on missing imports. `uv run --extra langchain pytest` passes clean — which is also why CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)