### PR TITLE
feat(ui): the footer shows what is still open, and the dashboard says where the crate is

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -3283,7 +3283,19 @@ def _format_user_answers(engine: AgentEngine, *, limit: int = 8) -> str:
     )
 
 
-def _handback_panel(engine: AgentEngine, *, headline: str) -> Any:
+def _will_self_continue(engine: AgentEngine, self_continues: int) -> bool:
+    """Whether a guard-stopped turn is about to resume without asking the user.
+
+    The panel and the resume decision have to agree, and they used to be made in
+    two places — the panel inside the turn, the decision after it — so a turn
+    that was about to pick itself back up still printed "Paused … Your call",
+    immediately followed by "Picking that back up myself". The box asked a
+    question that had already been answered. One predicate, both call sites.
+    """
+    return self_continues < _MAX_SELF_CONTINUES and bool(open_items(engine.state))
+
+
+def _handback_panel(engine: AgentEngine, *, headline: str, handing_back: bool = True) -> Any:
     """Render "here is where we got to, here is what you can do" for a stopped turn.
 
     A turn that ends on a guard used to print one dim sentence and return the
@@ -3365,6 +3377,19 @@ def _handback_panel(engine: AgentEngine, *, headline: str) -> Any:
     except Exception:  # noqa: BLE001 — a hand-back must never raise
         logger.debug("hand-back: state summary failed", exc_info=True)
         entities, required = [], 0
+
+    if not handing_back:
+        # A turn that is about to resume itself is not paused and is not asking
+        # anything, so it gets no question and no yellow. Same body — where we
+        # got to, what is still open — because that IS worth reading; only the
+        # framing changes, from "your call" to "carrying on".
+        return Panel(
+            "\n".join(lines),
+            title="[bold]Still working — picking this back up myself[/bold]",
+            title_align="left",
+            border_style="cyan",
+            padding=(0, 1),
+        )
 
     options: list[tuple[str, str]] = [
         (
@@ -4396,6 +4421,10 @@ def run_interactive_agent(
         finally:
             engine.on_tool_event = prior_tool_event
 
+    # Seeded before `_run_turn` closes over it: the stopped-branch panel reads it
+    # to decide whether it is handing back or carrying on.
+    self_continues = 0
+
     def _run_turn(message_content: str) -> tuple[str, str]:
         """Run ONE model invocation and return ``(reply, outcome)`` (#263).
 
@@ -4494,13 +4523,16 @@ def run_interactive_agent(
             )
             console.print()
         elif outcome == "stopped":
+            resuming = _will_self_continue(engine, self_continues)
             console.print(
                 _handback_panel(
                     engine,
                     headline=(
                         "I was repeating the same step without getting anywhere, so I "
-                        "stopped rather than keep spending on it. The session is saved."
+                        "stopped rather than keep spending on it."
+                        + (" Carrying on from here." if resuming else " The session is saved.")
                     ),
+                    handing_back=not resuming,
                 )
             )
             console.print()
@@ -4662,7 +4694,7 @@ def run_interactive_agent(
                     # refill a counter is not a decision, it is a keystroke, so
                     # do it here: same reset, same directive, bounded so a
                     # genuinely stuck model still reaches the user.
-                    if outcome == "stopped" and self_continues < _MAX_SELF_CONTINUES:
+                    if outcome == "stopped" and _will_self_continue(engine, self_continues):
                         outstanding = open_items(engine.state)
                         if outstanding:
                             self_continues += 1

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -139,9 +139,7 @@ def install_notice_handler(
     """
     root = logging.getLogger()
     for handler in list(root.handlers):
-        if isinstance(handler, logging.StreamHandler) and not isinstance(
-            handler, NoticeHandler
-        ):
+        if isinstance(handler, logging.StreamHandler) and not isinstance(handler, NoticeHandler):
             root.removeHandler(handler)
     handler = NoticeHandler(console or get_console(), level=level)
     root.addHandler(handler)
@@ -287,9 +285,7 @@ def _read_token_totals(session_id: str) -> tuple[int, int, str]:
         key = str(profile_path)
         tail = _TOKEN_TAILS.get(key)
         if tail is None or tail.inode != stat.st_ino or stat.st_size < tail.offset:
-            tail = _TokenTail(
-                inode=stat.st_ino, offset=0, tokens_in=0, tokens_out=0, last_model=""
-            )
+            tail = _TokenTail(inode=stat.st_ino, offset=0, tokens_in=0, tokens_out=0, last_model="")
             _TOKEN_TAILS[key] = tail
 
         if stat.st_size > tail.offset:
@@ -375,9 +371,7 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
             from builder.config import get_model_provider
             from builder.pricing import compute_cost
 
-            info = compute_cost(
-                tokens_in, tokens_out, last_model, provider=get_model_provider()
-            )
+            info = compute_cost(tokens_in, tokens_out, last_model, provider=get_model_provider())
             cost_usd = info.get("total_cost")
         except Exception:
             logger.debug("cost unavailable for %s", state.session_id, exc_info=True)
@@ -455,6 +449,43 @@ def _compact_tokens(count: int) -> str:
     return f"{count / 1_000_000:.1f}M".replace(".0M", "M")
 
 
+def _work_field(snap: UiSnapshot) -> tuple[str, str]:
+    """The middle status slot: the scan at first, then what is left to fix.
+
+    Returns ``(field_key, text)``.
+
+    The file count is a startup fact — it is settled by the time the first entity
+    exists and then never moves again, so a run spends its whole life looking at
+    "54 files" telling it nothing. Once drafting begins the slot earns its place
+    by showing the open findings instead.
+
+    A tier that has not been swept shows as **locked** rather than as ``0``. This
+    is honest, not decorative: ``build_and_validate`` defaults to the REQUIRED
+    gate, and a gate is a floor — RECOMMENDED and OPTIONAL checks are not
+    evaluated at all until the gate is lowered, so their counts are genuinely
+    unknown, not zero. ``assessed_tiers`` is what the validator actually
+    assessed, so it is the thing to read.
+    """
+    if snap.entity_count == 0:
+        return "files", f"{snap.file_count} files"
+
+    assessed = set(snap.assessed_tiers)
+    parts: list[str] = []
+    locked: list[str] = []
+    for tier, label, count in (
+        ("required", "req", snap.required_issue_count),
+        ("recommended", "rec", snap.should_issue_count),
+        ("optional", "opt", snap.may_issue_count),
+    ):
+        if tier in assessed:
+            parts.append(f"{count} {label}")
+        else:
+            locked.append(label)
+    if locked:
+        parts.append(f"{'/'.join(locked)} locked")
+    return "issues", " ".join(parts) if parts else "not validated"
+
+
 def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None = None) -> str:
     """The status line as one line of Rich markup (no padding, no newline).
 
@@ -476,9 +507,12 @@ def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None =
 
     token_str = ""
     if snap.tokens_in + snap.tokens_out > 0:
-        from builder.pricing import format_cost
-
-        cost_str = f" @{format_cost(snap.cost_usd)}" if snap.cost_usd is not None else ""
+        # Two decimals here, not `format_cost`'s six-then-four. This line is read
+        # at a glance while the run moves; $0.004821 is precision nobody acts on,
+        # and it changes width as it grows, which makes the whole segment jitter.
+        # `format_cost` keeps its resolution for the places that settle up — the
+        # goodbye summary and the dashboard.
+        cost_str = f" @${snap.cost_usd:.2f}" if snap.cost_usd is not None else ""
         total = snap.tokens_in + snap.tokens_out
         # ↑/↓ are THIS turn — the prompt is rebuilt every call, so ↑ is the live
         # context size and its drift is the bloat signal. Before the first call
@@ -494,16 +528,22 @@ def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None =
         # Model time, not wall clock: the clock beside it counts the user
         # thinking, which is not what the run cost.
         time_str = f"  {_compact_seconds(snap.model_seconds)}" if snap.model_seconds else ""
-        token_str = "  " + _SEP + "  " + model_prefix + field(
-            "tokens",
-            f"↑{_compact_tokens(turn_in)} ↓{_compact_tokens(turn_out)}"
-            f"  {_compact_tokens(total)} tok{cost_str}{time_str}",
+        token_str = (
+            "  "
+            + _SEP
+            + "  "
+            + model_prefix
+            + field(
+                "tokens",
+                f"↑{_compact_tokens(turn_in)} ↓{_compact_tokens(turn_out)}"
+                f"  {_compact_tokens(total)} tok{cost_str}{time_str}",
+            )
         )
 
     return (
         f"{field('session', snap.session_id)}  {_SEP}  "
         f"{field('entities', f'{snap.entity_count} entities')}  {_SEP}  "
-        f"{field('files', f'{snap.file_count} files')}  {_SEP}  "
+        f"{field(*_work_field(snap))}  {_SEP}  "
         f"{_dot(snap.base_passed)} {field('base', 'base')}  "
         f"{_dot(snap.isa_passed)} {field('isa', 'ISA')}  "
         f"{_dot(snap.tox_passed)} {field('tox', 'Tox')}"
@@ -518,6 +558,15 @@ def status_field_values(snap: UiSnapshot) -> dict[str, Any]:
         "model": snap.model,
         "entities": snap.entity_count,
         "files": snap.file_count,
+        # The middle slot swaps from the scan to the open findings once drafting
+        # starts (`_work_field`); both keys are listed so the fader tints
+        # whichever one is currently on screen.
+        "issues": (
+            snap.required_issue_count,
+            snap.should_issue_count,
+            snap.may_issue_count,
+            snap.assessed_tiers,
+        ),
         "base": snap.base_passed,
         "isa": snap.isa_passed,
         "tox": snap.tox_passed,
@@ -685,9 +734,7 @@ def render_resume_summary(snap: UiSnapshot, *, resumed: bool) -> RenderableType:
         summary.add_row("Issues:", f"[red]{snap.required_issue_count} REQUIRED[/red]")
 
     if snap.entity_counts:
-        parts = ", ".join(
-            f"[cyan]{k}[/cyan]={v}" for k, v in sorted(snap.entity_counts.items())
-        )
+        parts = ", ".join(f"[cyan]{k}[/cyan]={v}" for k, v in sorted(snap.entity_counts.items()))
         summary.add_row("Breakdown:", parts)
 
     title = "Resumed Session" if resumed else "Session"
@@ -1150,9 +1197,7 @@ class TransientReplies:
         self._console.print(renderable)
         if erasable and transient:
             try:
-                self._height = len(
-                    self._console.render_lines(renderable, pad=False)
-                )
+                self._height = len(self._console.render_lines(renderable, pad=False))
             except Exception:  # noqa: BLE001 — fall back to leaving it on screen
                 logger.debug("transient reply height failed", exc_info=True)
 

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -224,9 +224,7 @@ def _load_cratestate(session_id: str) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
-def format_mit_coverage(
-    overall_score: float | None, *, assessed: bool
-) -> tuple[str, str]:
+def format_mit_coverage(overall_score: float | None, *, assessed: bool) -> tuple[str, str]:
     """Format an MIT coverage score for display — the single source of truth
     shared by the profiler dashboard panel and the interactive UI
     (:mod:`builder.agents.ui`) so both build arms render coverage identically
@@ -265,6 +263,32 @@ def _format_export_timestamp(raw: str) -> str:
         return datetime.fromisoformat(raw).strftime("%Y-%m-%d %H:%M")
     except (TypeError, ValueError):
         return raw
+
+
+def _build_crate_path_line(state: dict[str, Any] | None) -> Any:
+    """The header's crate line: where this session's crate is written.
+
+    Prefers the configured destination over the last-export stamp, so the path is
+    on screen from the start of the run rather than only after the first export —
+    "where will my crate go" is the same question as "where did it go", asked
+    earlier, and a dashboard that answers it only in hindsight is answering it
+    too late. Falls back to the export record, then to saying plainly that no
+    destination is set yet.
+    """
+    from rich.text import Text
+
+    metadata = (state or {}).get("metadata") or {}
+    configured = metadata.get("output_path")
+    exported = metadata.get("exported_at")
+    if not configured:
+        return Text.assemble(("Crate: ", HEADER_STYLE), ("no output path set yet", LABEL_STYLE))
+    when = f"written {_format_export_timestamp(exported)}" if exported else "not written yet"
+    return Text.assemble(
+        ("Crate: ", HEADER_STYLE),
+        (str(configured), OK_STYLE if exported else LABEL_STYLE),
+        ("  │  ", BORDER_STYLE),
+        (when, "" if exported else LABEL_STYLE),
+    )
 
 
 def _last_export_span(metadata: dict[str, Any]) -> Any:
@@ -367,9 +391,7 @@ def _build_cratestate_panel(
     # Kept as a SPAN, not as markup inside the string: this goes into
     # Text.assemble, which takes (text, style) pairs and does not parse console
     # markup — an embedded "[red]…[/red]" rendered literally in the dashboard.
-    issue_span = (
-        (f"  {required_count} REQUIRED", ERR_STYLE) if required_count > 0 else ("", "")
-    )
+    issue_span = (f"  {required_count} REQUIRED", ERR_STYLE) if required_count > 0 else ("", "")
 
     # MIT score — shared formatter keeps this identical to the interactive UI.
     mit = state.get("mit_assessment", {})
@@ -855,25 +877,32 @@ def format_session_summary(session_id: str, records: list[dict[str, Any]]) -> An
 
     layout = Layout()
     layout.split_column(
-        Layout(name="header", size=3),
+        # Four rows, not three: the header carries the output path on its own
+        # line. "Where did my crate go" is the question a dashboard is opened to
+        # answer, and the path was only reachable by reading down into the
+        # CrateState panel — present, but not where anyone looks first.
+        Layout(name="header", size=4),
         Layout(name="body"),
         Layout(name="footer", size=1),
     )
+
+    # Load CrateState first: the header shows where the crate is written, so it
+    # needs the metadata before it can be built.
+    crate_state = _load_cratestate(session_id)
 
     # Header
     now = _config.now().strftime("%Y-%m-%d %H:%M:%S %Z")
     header_text = Text()
     header_text.append(" Agent Profiler Dashboard", style=HEADER_STYLE)
     header_text.append(f"  |  Session: {session_id}", style=BORDER_STYLE)
+    header_text.append("\n ")
+    header_text.append_text(_build_crate_path_line(crate_state))
     layout["header"].update(Panel(header_text, style=BORDER_STYLE))
 
     if not records:
         layout["body"].update(_NoDataPanel(session_id))
         layout["footer"].update(Text(f"Last refresh: {now}", style=LABEL_STYLE))
         return layout
-
-    # Load CrateState
-    crate_state = _load_cratestate(session_id)
     # Agent status (▶ driving / ⏸ awaiting input / ⏹ idle) — issue #193.
     agent_status = determine_agent_status(records)
     crate_panel = _build_cratestate_panel(crate_state, status=agent_status)

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -194,10 +194,19 @@ def test_snapshot_from_fresh_engine_is_empty() -> None:
 
 
 def test_render_status_bar_shows_counts_and_validation() -> None:
+    """The middle slot carries findings once drafting has started, not the scan.
+
+    ``3 files`` is settled before the first entity exists and never moves again,
+    so once ``entity_count`` is non-zero the slot is spent on what is still open
+    instead. This snapshot has entities and no assessed tiers, so the honest
+    answer there is "locked" — not a zero for checks nobody ran. The slot's own
+    cases live in ``tests/test_status_footer.py``.
+    """
     text = _render(ui.render_status_bar(_snapshot()))
     assert "sess-1" in text
     assert "3 entities" in text
-    assert "3 files" in text
+    assert "3 files" not in text
+    assert "req/rec/opt locked" in text
     assert "base" in text
     assert "ISA" in text
     assert "Tox" in text

--- a/tests/test_status_footer.py
+++ b/tests/test_status_footer.py
@@ -1,0 +1,126 @@
+"""What the status footer spends its width on.
+
+Three complaints, all about the same thing — the line was showing facts that had
+stopped being news:
+
+* the cost read ``@$0.004821``, six digits nobody acts on, changing width as it
+  grew so the whole segment jittered;
+* ``54 files`` is settled before the first entity exists and never moves again,
+  so a run spends its life looking at it;
+* what a run actually wants there is what is still open — and, while the gate is
+  REQUIRED, the honest answer for the other tiers is "not looked at yet", which
+  is not the same as zero.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from builder.agents.ui import UiSnapshot, render_status_markup, status_field_values
+
+
+def _plain(markup: str) -> str:
+    return re.sub(r"\[[^\]]*\]", "", markup)
+
+
+def _snap(**kw) -> UiSnapshot:
+    base = dict(
+        session_id="s1",
+        entity_count=0,
+        file_count=54,
+        base_passed=True,
+        isa_passed=True,
+        tox_passed=True,
+        required_issue_count=0,
+    )
+    base.update(kw)
+    return UiSnapshot(**base)  # ty: ignore[missing-argument]
+
+
+class TestCost:
+    @pytest.mark.parametrize(
+        ("cost", "shown"),
+        [(0.004821, "@$0.00"), (12.3456, "@$12.35"), (0.0, "@$0.00"), (999.999, "@$1000.00")],
+    )
+    def test_two_decimal_places(self, cost, shown):
+        line = _plain(render_status_markup(_snap(tokens_in=1000, tokens_out=50, cost_usd=cost)))
+        assert shown in line
+
+    def test_no_cost_segment_when_unknown(self):
+        line = _plain(render_status_markup(_snap(tokens_in=1000, tokens_out=50, cost_usd=None)))
+        assert "@$" not in line
+
+
+class TestTheMiddleSlot:
+    def test_shows_the_scan_before_anything_is_drafted(self):
+        line = _plain(render_status_markup(_snap(entity_count=0)))
+        assert "54 files" in line
+
+    def test_swaps_to_open_findings_once_drafting_starts(self):
+        line = _plain(
+            render_status_markup(
+                _snap(
+                    entity_count=97,
+                    required_issue_count=2,
+                    should_issue_count=121,
+                    may_issue_count=66,
+                    assessed_tiers=("required", "recommended", "optional"),
+                )
+            )
+        )
+        assert "54 files" not in line
+        assert "2 req" in line
+        assert "121 rec" in line
+        assert "66 opt" in line
+
+    def test_unassessed_tiers_read_as_locked_not_zero(self):
+        """A REQUIRED-gated sweep did not evaluate the other tiers at all.
+
+        Printing `0 rec` there would claim a clean bill of health for checks that
+        were never run — the same lie the maturity report used to ship when an
+        export followed a REQUIRED-only validation.
+        """
+        line = _plain(
+            render_status_markup(
+                _snap(entity_count=97, required_issue_count=0, assessed_tiers=("required",))
+            )
+        )
+        assert "0 req" in line
+        assert "rec/opt locked" in line
+        assert "0 rec" not in line
+        assert "0 opt" not in line
+
+    def test_partial_gate_locks_only_what_was_not_swept(self):
+        line = _plain(
+            render_status_markup(
+                _snap(
+                    entity_count=97,
+                    should_issue_count=121,
+                    assessed_tiers=("required", "recommended"),
+                )
+            )
+        )
+        assert "121 rec" in line
+        assert "opt locked" in line
+        assert "rec/opt" not in line
+
+    def test_nothing_validated_yet_says_so(self):
+        line = _plain(render_status_markup(_snap(entity_count=3, assessed_tiers=())))
+        assert "req/rec/opt locked" in line
+
+
+class TestFader:
+    def test_issue_counts_are_comparable_for_highlighting(self):
+        """The fader tints a field when its value changes, so the new slot needs one."""
+        before = status_field_values(_snap(entity_count=97, assessed_tiers=("required",)))
+        after = status_field_values(
+            _snap(
+                entity_count=97,
+                should_issue_count=121,
+                assessed_tiers=("required", "recommended"),
+            )
+        )
+        assert "issues" in before
+        assert before["issues"] != after["issues"]

--- a/tests/test_status_footer.py
+++ b/tests/test_status_footer.py
@@ -15,6 +15,7 @@ stopped being news:
 from __future__ import annotations
 
 import re
+from typing import Any
 
 import pytest
 
@@ -26,7 +27,12 @@ def _plain(markup: str) -> str:
 
 
 def _snap(**kw) -> UiSnapshot:
-    base = dict(
+    # Annotated `dict[str, Any]`: inferred from the literal, ty narrows the value
+    # type to `str | int | bool` and then rejects every `**base` field whose real
+    # type is anything else (`assessed_tiers` is a tuple, `cost_usd` a float) — 21
+    # errors for a helper that is correct. The annotation says what this genuinely
+    # is: a bag of keyword defaults, typed by UiSnapshot at the call below.
+    base: dict[str, Any] = dict(
         session_id="s1",
         entity_count=0,
         file_count=54,
@@ -36,7 +42,7 @@ def _snap(**kw) -> UiSnapshot:
         required_issue_count=0,
     )
     base.update(kw)
-    return UiSnapshot(**base)  # ty: ignore[missing-argument]
+    return UiSnapshot(**base)
 
 
 class TestCost:


### PR DESCRIPTION
Four changes to what the chrome spends its space on.

## Cost, two decimals

`@$0.004821` is precision nobody acts on, and it changed width as it grew so the whole spend segment jittered. `format_cost` keeps its resolution for the places that settle up — the goodbye summary and the dashboard.

## The file count leaves once drafting starts

`54 files` is a startup fact: settled before the first entity exists, unchanged for the rest of the run. A session spends its whole life reading it. The slot now shows open findings instead, falling back to the scan only while there is nothing else to say.

```
startup            s1 · 0 entities  · 54 files            · ● base ● ISA ● Tox · ↑1k ↓50 1.1k tok @$0.00
required gate      s1 · 97 entities · 0 req rec/opt locked · ● base ● ISA ● Tox · ↑1k ↓50 1.1k tok @$12.35
all tiers swept    s1 · 97 entities · 0 req 121 rec 66 opt · ● base ● ISA ● Tox · ↑1k ↓50 1.1k tok @$12.35
```

## Unswept tiers read as locked, not zero

`build_and_validate` defaults to the REQUIRED gate, and a gate is a floor — the RECOMMENDED and OPTIONAL checks are not evaluated at all until it is lowered. Their counts are **unknown**, not clean.

Printing `0 rec` there would claim a clean bill of health for checks nobody ran — the same lie the maturity report used to ship after a REQUIRED-only export. `assessed_tiers` is what the validator actually assessed, so that is what is read.

## The hand-back panel stops asking a question it already answered

The panel was built inside the turn; the resume decision was made after it. So a turn about to pick itself back up still printed:

```
╭─ Paused — the crate is not finished ─╮
│ … Your call — reply with one of:     │
╰──────────────────────────────────────╯
· Picking that back up myself (2/2) — 5 item(s) still open
```

One predicate, `_will_self_continue`, now drives both. When it is resuming, the same body — where we got to, what is still open — appears under **Still working — picking this back up myself** in cyan, with no question and no yellow. Yellow and a question mean "I need you"; neither was true.

## The dashboard header carries the crate path

"Where did my crate go" is the question a dashboard is opened to answer, and the path was only reachable by reading down into the CrateState panel. It now sits on its own header line, and prefers the configured destination over the last-export stamp so it is on screen from the start of the run rather than only in hindsight:

```
Crate: output/svhps22_real_input_crate_v5  │  written 2026-08-11 12:09
Crate: output/pending_crate                │  not written yet
Crate: no output path set yet
```

## Tests

11 new (`test_status_footer.py`). `189 passed`, exit 0, across `test_status_footer` / `test_dashboard` / `test_dashboard_status` / `test_agent_loop` / `test_agent_graph`.

Run with `uv run --extra langchain pytest` — `langchain-openai` / `langchain-anthropic` are optional extras, and without them 13 unrelated `TestBuildChatModel` / `TestModelTiering` / `TestRequestTimeout` tests fail on missing imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)