### PR TITLE
test(ui): the fresh-session summary states the model, and the test says so

### DIFF
--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -1207,12 +1207,16 @@ def print_status_bar(engine: AgentEngine, footer: PinnedFooter | None = None) ->
 def print_resume_summary(engine: AgentEngine, *, resumed: bool) -> None:
     """Print the session summary panel when there is anything to show (both arms).
 
-    A no-op on an empty session (no entities, no scanned files) — there is nothing
-    to summarise — so callers need no guard of their own. That emptiness check is
-    about *content*; it is not a resume test. *resumed* carries provenance and is
-    mandatory precisely so no call site can fall back to inferring it from content
-    (#410) — the two are independent, and conflating them is what labelled every
-    fresh ``--input`` run a resume.
+    On an empty session (no entities, no scanned files) there is no panel to draw,
+    so it degrades to a one-line ``session <id> · model <model>`` header — the
+    model about to spend the user's money is worth stating up front. With no model
+    resolved either, it prints nothing at all, so callers still need no guard of
+    their own.
+
+    That emptiness check is about *content*; it is not a resume test. *resumed*
+    carries provenance and is mandatory precisely so no call site can fall back to
+    inferring it from content (#410) — the two are independent, and conflating
+    them is what labelled every fresh ``--input`` run a resume.
     """
     snap = snapshot_from_engine(engine)
     console = get_console()

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -328,10 +328,53 @@ def test_print_resume_summary_prints_when_populated(monkeypatch) -> None:
     assert "Resumed Session" in rec.export_text()
 
 
-def test_print_resume_summary_is_noop_on_fresh_session(monkeypatch) -> None:
+def test_print_resume_summary_states_the_model_on_a_fresh_session(monkeypatch) -> None:
+    """An empty session prints the model line — and nothing more (#494).
+
+    There is no panel to draw, but the model about to spend the user's money is
+    worth stating up front, so ``print_resume_summary`` deliberately falls back to
+    a one-line header. This test used to pin the older "strict no-op" contract and
+    was the thing making main red; the production branch is the intended
+    behaviour, so the expectation moves rather than the code.
+
+    The assertion is over CONTENT, not emptiness: the session id and the resolved
+    model must both appear, and the panel must NOT — an assertion that only
+    checked for non-empty output would pass on a full panel too.
+    """
+    import builder.config as config_mod
+
     rec = _rec()
     monkeypatch.setattr(ui, "get_console", lambda: rec)
+    # Pin the model through the REAL snapshot producer: `snapshot_from_engine`
+    # falls back to `get_active_model()` when the profile has no model event yet,
+    # which is exactly a fresh session. Stubbing the snapshot itself would bypass
+    # the producer under test.
+    monkeypatch.setattr(config_mod, "get_active_model", lambda: "gpt-4o-mini")
+
     ui.print_resume_summary(_real_engine(populated=False), resumed=False)
+
+    out = rec.export_text()
+    assert "sess-1" in out
+    assert "gpt-4o-mini" in out
+    assert "Resumed Session" not in out
+
+
+def test_print_resume_summary_is_silent_when_no_model_is_resolved(monkeypatch) -> None:
+    """With nothing built AND no model known there is nothing to say (#494).
+
+    The honesty control for the test above: it proves the model line is caused by
+    a RESOLVED model rather than by "the function was called on an empty
+    session". Without it, the pair could not tell the new branch from an
+    unconditional header.
+    """
+    import builder.config as config_mod
+
+    rec = _rec()
+    monkeypatch.setattr(ui, "get_console", lambda: rec)
+    monkeypatch.setattr(config_mod, "get_active_model", lambda: "")
+
+    ui.print_resume_summary(_real_engine(populated=False), resumed=False)
+
     assert rec.export_text() == ""
 
 


### PR DESCRIPTION
Closes #494 — **main is red on this**.

`tests/agents/test_ui.py::test_print_resume_summary_is_noop_on_fresh_session` pins a strict no-op, while `print_resume_summary` deliberately gained an `elif snap.model:` branch printing a one-line `session <id> · model <model>` header on an empty session — *"the model about to spend the user's money is still worth stating up front"*.

Two of the three artifacts (the code and its comment) agree the branch is intended, so the **expectation moves, not the code**.

## The assertion is over content, not emptiness

```
'session sess-1  ·  model gpt-4o-mini\n\n'
```

The test asserts the session id and the resolved model both appear and the panel does not. Asserting merely non-empty output would pass on a full panel too.

The model is pinned through `builder.config.get_active_model` — the fallback the **real** `snapshot_from_engine` consults when a fresh session's profile carries no model event yet. Stubbing `snapshot_from_engine` itself would have bypassed the producer under test, which is the repo's named anti-pattern.

## Plus the honesty control the pair needs

`test_print_resume_summary_is_silent_when_no_model_is_resolved`: with nothing built **and** no model resolved, output is `""`. Without it the pair could not tell the new branch from an unconditional header — it proves the line is caused by a *resolved model*, not by "the function was called".

Both verified against the real code: with a model → the header; without → `''`.

## Docstring

`print_resume_summary`'s docstring still described the old contract ("A no-op on an empty session … so callers need no guard of their own"). Corrected to state what it now does, including that the no-model case still prints nothing so callers still need no guard.

Per the repo's rule I did not run pytest locally (CI owns it); `uvx ruff check` and `uv run ty check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)