### PR TITLE
fix(tools): say which entity you meant, and answer the read you suppressed

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -1638,10 +1638,45 @@ def _guard_state_query(
     return (
         f"{tool_name} has already been answered for this exact crate state, and nothing "
         "has changed since — reading it again cannot return anything new.\n\n"
-        f"{_format_compact_state_summary(engine)}\n\n"
-        "Use the state summary above (it is included in every message) instead of "
-        "re-querying. Your next call must CHANGE something — draft, link, attach, "
-        "set a field — or answer the user."
+        f"{_format_compact_state_summary(engine)}"
+        f"{_suppressed_query_answer(engine, tool_name, kwargs)}\n\n"
+        "Use the answer above instead of re-querying. Your next call must CHANGE "
+        "something — draft, link, attach, set a field — or answer the user."
+    )
+
+
+def _suppressed_query_answer(engine: AgentEngine, tool_name: str, kwargs: dict[str, Any]) -> str:
+    """The ids a suppressed ``list_entities`` was asking for, so the refusal answers it.
+
+    Suppressing a read while withholding what it would have returned is what makes
+    the model bounce. It was not being stubborn: it needed an entity id to write
+    with, the ids are minted from names and only LOOK derivable, so it rebuilt one
+    from the pattern, got it subtly wrong, and went to `list_entities` to find the
+    real one. The corrective then pointed at the compact state summary — which
+    carries per-type COUNTS and at most eight recent ids, so with sixteen
+    LabProcesses the answer structurally was not in there. Four bounces per turn,
+    in every session profiled.
+
+    So the guard now hands back the list, the same way the repeated-lookup guard
+    hands back the previous answer. Only for a typed `list_entities`: `get_status`
+    and the rest are already fully answered by the summary above.
+    """
+    if tool_name != "list_entities":
+        return ""
+    wanted = kwargs.get("entity_type") or kwargs.get("type")
+    if not wanted:
+        return ""
+    try:
+        ids = [e.entity_id for e in engine.state.list_entities(str(wanted))]
+    except Exception:  # noqa: BLE001 — a corrective must never raise
+        logger.debug("could not list %s for the corrective", wanted, exc_info=True)
+        return ""
+    if not ids:
+        return f"\n\nThere are no {wanted} entities. Draft one before referring to it."
+    listed = "\n".join(f"  - {eid}" for eid in ids)
+    return (
+        f"\n\nThe {len(ids)} {wanted} id(s), which is what you asked for:\n{listed}\n"
+        "Copy one of these verbatim — do not rebuild an id from an entity's name."
     )
 
 

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -115,9 +115,7 @@ def _split_named_list(state: CrateState, value: Any) -> list[str] | None:
     matched = sum(1 for name, out in zip(names, resolved, strict=True) if out != name)
     if not matched:
         return None  # nothing recognised — leave the original string untouched
-    logger.info(
-        "Split a %d-name list into references (%d matched an entity)", len(names), matched
-    )
+    logger.info("Split a %d-name list into references (%d matched an entity)", len(names), matched)
     return resolved
 
 
@@ -290,6 +288,57 @@ def resolve_entity_id(state: CrateState, raw: str) -> str:
     return raw
 
 
+def entity_not_found_message(state: CrateState, entity_id: str, *, limit: int = 3) -> str:
+    """ "Entity not found", plus the ids it was most likely reaching for.
+
+    Ids are minted by the drafting tools from the entity's name, which makes them
+    look derivable — so the model rebuilds them from the pattern instead of
+    copying the value the tool handed back. It gets them nearly right:
+
+        passed  proc_cell_culture_for_sk_n_as_cell_culture_for_thyroid_receptor_transactivation
+        exists  proc_sk_n_as_cell_culture_for_thyroid_receptor_transactivation
+
+    (``proc_cell_culture_for_`` bolted onto an id that already began that way),
+    and
+
+        passed  proc_analysis_of_radioactive_t3t4_transporter_assay
+        exists  proc_analysis_of_thyroid_hormone_uptake_counts
+                proc_radioactive_t3t4_transporter_exposure
+
+    (the subject of one step welded to the verb of another). A bare "not found"
+    then sends it hunting through ``list_entities``, which the repeat guard
+    suppresses, and the turn is spent bouncing. Naming the near misses turns that
+    into one correction.
+
+    Suggestion only — :func:`resolve_entity_id` stays exact on purpose, because
+    silently accepting the closest id would edit a DIFFERENT entity than the one
+    asked for. This tells the model what exists and lets it choose.
+    """
+    import difflib
+
+    base = f"Entity not found: {entity_id}"
+    try:
+        known = [e.entity_id for e in state.list_entities()]
+    except Exception:  # noqa: BLE001 — an error message must never raise
+        return base
+    if not known:
+        return f"{base}. The crate has no entities yet — draft one first."
+
+    close = difflib.get_close_matches(str(entity_id), known, n=limit, cutoff=0.6)
+    if not close:
+        # Nothing similar: naming a few real ids still beats a dead end, and the
+        # count tells the model whether the list it is seeing is the whole crate.
+        shown = ", ".join(known[:limit])
+        more = f" (+{len(known) - limit} more)" if len(known) > limit else ""
+        return f"{base}. Existing ids include: {shown}{more}."
+    suggestions = ", ".join(close)
+    return (
+        f"{base}. Did you mean: {suggestions}? "
+        "Ids are minted by the drafting tools — use the one they returned rather "
+        "than rebuilding it from the entity's name."
+    )
+
+
 def set_fields(
     state: CrateState,
     entity_id: str,
@@ -318,13 +367,17 @@ def set_fields(
     entity_id = resolve_entity_id(state, entity_id)
     entity = state.get_entity(entity_id)
     if entity is None:
-        raise ValueError(f"Entity not found: {entity_id}")
+        raise ValueError(entity_not_found_message(state, entity_id))
 
     supplied = dict(fields)
     fields = {
-        name: (_normalize_reference_value(
-                   state, entity_id, _materialize_property_values(state, name, value), name)
-               if is_reference_field(name) else value)
+        name: (
+            _normalize_reference_value(
+                state, entity_id, _materialize_property_values(state, name, value), name
+            )
+            if is_reference_field(name)
+            else value
+        )
         for name, value in fields.items()
     }
     _reject_fully_dropped_references(entity_id, supplied, fields)
@@ -651,8 +704,15 @@ def set_crate_metadata(
     metadata.
     """
     supplied = (
-        title, description, accession, release_date, date_modified,
-        publisher, creator, contact, license,
+        title,
+        description,
+        accession,
+        release_date,
+        date_modified,
+        publisher,
+        creator,
+        contact,
+        license,
     )
     if all(value in (None, "") for value in supplied):
         return {
@@ -678,9 +738,7 @@ def set_crate_metadata(
         m.date_modified = date_modified
     # Attribution: an entity id or a resolvable IRI, never free text — a name
     # string credits nobody a registry can resolve (D5).
-    for attr, value in (
-        ("publisher", publisher), ("creator", creator), ("contact", contact)
-    ):
+    for attr, value in (("publisher", publisher), ("creator", creator), ("contact", contact)):
         if value in (None, ""):
             continue
         if not is_resolvable_reference(state, value):
@@ -750,6 +808,8 @@ def set_validation_preference(
         "tiers_that_will_run": ["required"]
         + [tier for tier in ("recommended", "optional") if prefs.get(tier)],
     }
+
+
 # ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -288,6 +288,12 @@ def resolve_entity_id(state: CrateState, raw: str) -> str:
     return raw
 
 
+# Every way the crate's Root Data Entity gets written. The graph calls it "./",
+# validation findings quote it as "./" or "./#…", and a model reaching for the
+# crate itself tries the bare forms too.
+_ROOT_ALIASES: frozenset[str] = frozenset({"./", ".", "/", "#", "./#", "root", "#root", "./#root"})
+
+
 def entity_not_found_message(state: CrateState, entity_id: str, *, limit: int = 3) -> str:
     """ "Entity not found", plus the ids it was most likely reaching for.
 
@@ -317,6 +323,21 @@ def entity_not_found_message(state: CrateState, entity_id: str, *, limit: int = 
     import difflib
 
     base = f"Entity not found: {entity_id}"
+
+    # "./" is the Root Data Entity, and it is NOT in the entity store — it is
+    # built from `state.metadata`, so there is nothing here to resolve it to.
+    # Deliberately not taught to `resolve_entity_id`: mapping it to some entity
+    # would silently write crate-level fields (title, licence, publisher) onto
+    # the wrong node. The model is not confused about what "./" means, only about
+    # which tool owns it, so name that tool.
+    if str(entity_id).strip() in _ROOT_ALIASES:
+        return (
+            f"{base}. `./` is the crate's Root Data Entity, which is not an entity in "
+            "the store — it is built from the crate metadata. Use set_crate_metadata("
+            "title=…, description=…, license=…, publisher=…, creator=…, contact=…) "
+            "to change it."
+        )
+
     try:
         known = [e.entity_id for e in state.list_entities()]
     except Exception:  # noqa: BLE001 — an error message must never raise

--- a/tests/test_entity_id_recovery.py
+++ b/tests/test_entity_id_recovery.py
@@ -121,3 +121,34 @@ class TestTheSuppressedReadAnswersTheQuestion:
         from builder.agents.react.agent_loop import _suppressed_query_answer
 
         assert _suppressed_query_answer(engine, "get_status", {}) == ""
+
+
+class TestTheCrateRoot:
+    """`./` is the Root Data Entity, and it is not in the entity store.
+
+    Session 20260811_133825 hit this alongside the two rebuilt process ids:
+    `set_fields(state, "./", …)` -> "Entity not found: ./". The model is not
+    confused about what `./` means, only about which tool owns it — the root is
+    built from `state.metadata` and `set_crate_metadata` writes it.
+
+    Deliberately NOT taught to `resolve_entity_id`: there is no entity to resolve
+    `./` TO, and mapping it to one would silently write crate-level fields onto
+    the wrong node.
+    """
+
+    @pytest.mark.parametrize("alias", ["./", ".", "#root", "./#root", "root", "./#"])
+    def test_root_aliases_name_the_right_tool(self, state, alias):
+        msg = entity_not_found_message(state, alias)
+        assert "Root Data Entity" in msg
+        assert "set_crate_metadata" in msg
+        assert "Did you mean" not in msg
+
+    def test_a_normal_id_is_unaffected(self, state):
+        real = next(e.entity_id for e in state.list_entities() if "klf9" in e.entity_id)
+        msg = entity_not_found_message(state, real + "_typo")
+        assert "Root Data Entity" not in msg
+
+    def test_set_fields_on_the_root_says_so(self, state):
+        with pytest.raises(ValueError) as exc:
+            set_fields(state, "./", {"license": "CC-BY-4.0"})
+        assert "set_crate_metadata" in str(exc.value)

--- a/tests/test_entity_id_recovery.py
+++ b/tests/test_entity_id_recovery.py
@@ -1,0 +1,123 @@
+"""A wrong entity id should cost one turn, not a hunt.
+
+Session 20260811_133825, traced end to end:
+
+* `draft_process_chain` returns its minted `process_ids`, so the model HAS them;
+* it later passes `proc_cell_culture_for_sk_n_as_cell_culture_for_thyroid_receptor_transactivation`
+  where `proc_sk_n_as_cell_culture_for_thyroid_receptor_transactivation` exists —
+  the id rebuilt from the naming pattern rather than copied;
+* `set_fields` answers "Entity not found" and nothing else;
+* so it calls `list_entities(LabProcess)` to find the real id;
+* the repeat guard suppresses that and points at the compact state summary,
+  which carries counts and eight recent ids — not the list it needs;
+* four bounces, then the idle ladder ends the turn.
+
+Both ends of that are fixed here: the error names the near misses, and the
+suppressed read hands back the ids it was asked for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools.drafters import draft_assay, draft_investigation
+from builder.tools.management import entity_not_found_message, set_fields
+
+
+@pytest.fixture
+def state():
+    st = CrateState()
+    draft_investigation(st, {"name": "S-VHPS22", "description": "D"})
+    for name in (
+        "SK N AS cell culture for thyroid receptor transactivation",
+        "Analysis of KLF9 expression",
+        "Radioactive T3T4 transporter exposure",
+    ):
+        draft_assay(st, "study_x", {"name": name})
+    return st
+
+
+class TestTheErrorNamesTheNearMiss:
+    def test_the_observed_id_gets_its_real_one_suggested(self, state):
+        real = next(e.entity_id for e in state.list_entities() if "sk_n_as" in e.entity_id)
+        msg = entity_not_found_message(
+            state, "assay_cell_culture_for_sk_n_as_cell_culture_for_thyroid_receptor"
+        )
+        assert "Entity not found" in msg
+        assert real in msg
+        assert "Did you mean" in msg
+
+    def test_it_says_where_ids_come_from(self, state):
+        """The behaviour to correct is rebuilding the id, not mistyping it."""
+        real = next(e.entity_id for e in state.list_entities() if "klf9" in e.entity_id)
+        msg = entity_not_found_message(state, real + "_readout")
+        assert "minted by the drafting tools" in msg
+
+    def test_nothing_similar_still_names_real_ids(self, state):
+        msg = entity_not_found_message(state, "completely_unrelated_xyzzy")
+        assert "Existing ids include" in msg
+        assert "Did you mean" not in msg
+
+    def test_an_empty_crate_says_so(self):
+        msg = entity_not_found_message(CrateState(), "proc_anything")
+        assert "no entities yet" in msg
+
+    def test_it_never_resolves_silently(self, state):
+        """Suggesting is safe; resolving would edit a DIFFERENT entity.
+
+        `resolve_entity_id` is exact on purpose, and this must not change that.
+        """
+        real = next(e.entity_id for e in state.list_entities() if "klf9" in e.entity_id)
+        with pytest.raises(ValueError) as exc:
+            set_fields(state, real + "_typo", {"description": "x"})
+        assert real in str(exc.value)
+        # The near-miss entity is untouched — nothing was written to it.
+        assert state.get_entity(real).fields.get("description") != "x"
+
+    def test_the_message_survives_a_broken_state(self):
+        class Exploding(CrateState):
+            def list_entities(self, *a, **k):
+                raise RuntimeError("boom")
+
+        msg = entity_not_found_message(Exploding(), "proc_x")
+        assert msg == "Entity not found: proc_x"
+
+
+class TestTheSuppressedReadAnswersTheQuestion:
+    def _corrective(self, engine, entity_type):
+        from builder.agents.react.agent_loop import _suppressed_query_answer
+
+        return _suppressed_query_answer(engine, "list_entities", {"entity_type": entity_type})
+
+    def test_it_lists_the_ids_of_the_type_asked_for(self):
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        draft_investigation(engine.state, {"name": "I", "description": "D"})
+        draft_assay(engine.state, "study_x", {"name": "Thyroid hormone uptake assay"})
+        out = self._corrective(engine, "Assay")
+        assert "assay_thyroid_hormone_uptake_assay" in out
+        assert "Copy one of these verbatim" in out
+
+    def test_an_empty_type_says_to_draft_one(self):
+        from builder.engine import AgentEngine
+
+        out = self._corrective(AgentEngine(), "LabProcess")
+        assert "no LabProcess entities" in out
+
+    def test_an_untyped_query_adds_nothing(self):
+        """`list_entities()` with no type is already answered by the summary."""
+        from builder.agents.react.agent_loop import _suppressed_query_answer
+        from builder.engine import AgentEngine
+
+        assert _suppressed_query_answer(AgentEngine(), "list_entities", {}) == ""
+
+    def test_other_state_queries_add_nothing(self):
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        draft_investigation(engine.state, {"name": "I", "description": "D"})
+        from builder.agents.react.agent_loop import _suppressed_query_answer
+
+        assert _suppressed_query_answer(engine, "get_status", {}) == ""


### PR DESCRIPTION
## The loop, traced end to end

`list_entities` thrash has appeared in every session profiled. It isn't stubbornness — it's a starved corrective. Session `20260811_133825`:

1. `draft_process_chain` **returns** its minted ids, so the model has them:
   ```
   process_ids: ['proc_sk_n_as_cell_culture_for_thyroid_receptor_transactivation',
                 'proc_thyroid_receptor_transactivation_exposure', …]
   ```

2. It later passes something else:

   | passed | exists |
   |---|---|
   | `proc_cell_culture_for_sk_n_as_cell_culture_for_thyroid_receptor_transactivation` | `proc_sk_n_as_cell_culture_for_thyroid_receptor_transactivation` |
   | `proc_analysis_of_radioactive_t3t4_transporter_assay` | `proc_analysis_of_thyroid_hormone_uptake_counts` + `proc_radioactive_t3t4_transporter_exposure` |

   The first bolts `proc_cell_culture_for_` onto an id that already began that way. The second welds the subject of one chain step to the verb of another. **The model is rebuilding ids from the naming pattern rather than copying them** — which it does because `_make_entity_id` mints them from the name, so they look derivable.

3. `set_fields` answers `Entity not found` and nothing else.

4. So it calls `list_entities(LabProcess)` to find the real id.

5. The repeat guard suppresses that and points at the compact state summary — which carries per-type **counts** and at most **eight recent** ids. With sixteen LabProcesses the answer is structurally not in there.

6. Four bounces (t+263/269/277/283), then the idle ladder ends the turn.

## Both ends now answer

**`entity_not_found_message`** names the near misses and says where ids come from:

```
Entity not found: proc_cell_culture_for_sk_n_as_cell_culture_for_thyroid_receptor_transactivation.
Did you mean: proc_sk_n_as_cell_culture_for_thyroid_receptor_transactivation?
Ids are minted by the drafting tools — use the one they returned rather than
rebuilding it from the entity's name.
```

**Suggestion only.** `resolve_entity_id` stays exact on purpose — accepting the closest id would silently edit a *different* entity than the one asked for. There's a test pinning that the near-miss entity is left untouched.

**The suppressed read hands back its answer.** A suppressed `list_entities(entity_type=X)` now returns the ids of that type, exactly as the repeated-lookup guard in #502 hands back the previous answer. Suppressing a read while withholding what it would have returned is what made the model bounce.

## Deliberately not done

Putting every id in the compact state summary. That summary is re-sent on **every** model call — one session was 1.27M input tokens across 52 calls — so sixteen process ids per turn is a permanent tax to fix an occasional miss. Both changes here pay only when something actually goes wrong.

## Tests

10 new, `173 passed` exit 0 across `test_entity_id_recovery` / `test_tools_management` / `test_agent_loop` / `test_lookup_repeat_guard`.

Run with `uv run --extra langchain pytest`; without the extra, 13 unrelated `TestBuildChatModel` / `TestModelTiering` / `TestRequestTimeout` tests fail on missing imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)