### PR TITLE
fix(readers): find the header row when a sheet opens with authoring prose

### DIFF
--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -595,6 +595,97 @@ def _guidance_is_droppable(
     )
 
 
+# Guidance columns a candidate row must name before it may overrule row 0.
+#
+# Measured, not guessed. Across 1,046 sheets of the real corpus (220 readable
+# workbooks: the three S-VHPS deposits plus the committed fixtures) there are
+# 79,146 pipe rows. **Exactly two of them name two or more guidance columns —
+# and both are the same RIVM header**, ``Veldnaam | Optionaliteit | Hoe vaak in
+# te vullen | Beschrijving | Tips | Hier invullen``, which names four. 140 rows
+# name exactly one; 79,004 name none.
+#
+# One is nowhere near enough: at a threshold of 1 the search re-picks on 16
+# sheets across 11 workbooks, every one of them a mis-pick. 2, 3 and 4 all
+# re-pick on the RIVM sheet and nothing else, because the corpus has NOTHING
+# between one guidance word and that header's four — so anything in 2..4 costs
+# the same on real data and the only question is which is hardest to trip by
+# accident.
+#
+# 3, therefore: the middle of the empty gap rather than its near edge. The
+# difference is not hypothetical. Two rows carrying two vocabulary words each is
+# a shape this domain really produces — a legend or a DataCite crosswalk that
+# TABULATES column names as data ("Beschrijving | Toelichting | 1.0 | RIVM") —
+# and under a narrow title row such a row is the first spanning row, so it would
+# be promoted, deleted, and its column struck from every row below it. At 2 that
+# sheet is destroyed; at 3 it is left alone, and the RIVM header still wins with
+# four.
+#
+# This is what makes the re-pick safe at all. A key/value data row —
+# ``Toelichting | zie protocol | RIVM`` — carries at most one vocabulary word,
+# so it can never be promoted and have its label deleted as scaffolding.
+_MIN_GUIDANCE_COLUMNS = 3
+
+
+def _table_span(rows: list[list[str]]) -> int:
+    """How many columns this sheet's rows actually occupy.
+
+    The median row width, deliberately: a value containing a literal ``|`` splits
+    into extra cells at this layer — the RIVM sheet tells depositors to separate
+    repeated values with a pipe and then does so itself — which makes the widest
+    row a lie, while the mode is a coin-flip whenever two widths tie.
+
+    Measured on the real S-VHPS22 template, whose table is six columns wide: the
+    median row is 5 cells, but its ``Trefwoorden`` row lists ten pipe-separated
+    keywords and arrives here as **15**. A max-width span therefore demands 15
+    cells of the header, no row can reach that, and the search finds nothing —
+    the file goes back to the 18,777 chars of #421.
+    """
+    widths = sorted(sum(1 for cell in cells if cell) for cells in rows)
+    return widths[len(widths) // 2]
+
+
+def _header_index(rows: list[list[str]]) -> int:
+    """Index of the sheet's header among its pipe rows — 0 unless prose precedes it.
+
+    S-VHPS22's top-level RIVM template opens with six rows of Dutch instructions
+    on how to fill the sheet in, and only then names its columns (``Veldnaam |
+    Optionaliteit | Hoe vaak in te vullen | Beschrijving | Tips | Hier
+    invullen``). Reading the first pipe row as the header matched the guidance
+    vocabulary against a sentence, so not one guidance column was recognised and
+    the file compacted to 18,777 chars against a 9,000-char tier-0 share (#421).
+
+    Row 0 keeps the job unless a lower row **earns** it, and only one shape can:
+    a fill-in-the-blanks template whose header names at least
+    :data:`_MIN_GUIDANCE_COLUMNS` authoring-guidance columns, sitting under
+    preamble that does not reach across the table. Two things are asked of the
+    candidate and nothing else is enough — it spans the table
+    (:func:`_table_span`), and it names two guidance columns.
+
+    Only the *first* spanning row is ever considered. Once a row reaches across
+    the table the preamble is over; the rows after it are data, not further
+    chances, and a sheet whose first spanning row is not a guidance header is
+    left exactly as it was.
+
+    Refusing is the safe outcome because a wrong pick loses data silently:
+    :func:`_compact_sheet` deletes the row it calls the header and reads the
+    guidance vocabulary off it, so promoting a data row would delete a real
+    column from every row below it.
+    """
+    if not rows:
+        return 0
+    span = _table_span(rows)
+    for idx, cells in enumerate(rows):
+        if sum(1 for cell in cells if cell) < span:
+            continue  # still preamble: this row does not reach across the table
+        if idx and len(_guidance_columns(cells)) >= _MIN_GUIDANCE_COLUMNS:
+            return idx
+        # The first spanning row is the only candidate there is. If it does not
+        # name guidance columns, the row after it is a data row, not a second
+        # chance — keep row 0 and change nothing about this sheet.
+        return 0
+    return 0
+
+
 def _compact_sheet(lines: list[str]) -> list[str]:
     """Apply the row/column rules to one sheet's worth of lines."""
     rows: dict[int, list[str]] = {}
@@ -605,15 +696,29 @@ def _compact_sheet(lines: list[str]) -> list[str]:
     if not rows:
         return list(lines)
 
-    header_idx, header_cells = next(iter(rows.items()))
+    ordered = list(rows.items())
+    position = _header_index([cells for _, cells in ordered])
+    header_idx, header_cells = ordered[position]
     guidance = _guidance_columns(header_cells)
     last = len(header_cells) - 1
     overflow_from = last if last in guidance else None
-    if guidance and not _guidance_is_droppable(
-        [cells for idx, cells in rows.items() if idx != header_idx], guidance, overflow_from
-    ):
+    # A header speaks for the table under it and for nothing above it. Judging a
+    # preamble row by the header's column meanings deletes real content: the RIVM
+    # sheet's ``Versienummer | 1.2.0 | 2025-06-26`` sits in the columns the header
+    # later calls Optionaliteit and Hoe vaak in te vullen, and would lose two of
+    # its three cells — then the whole row, for falling under two.
+    body = [cells for idx, cells in ordered if idx > header_idx]
+    if guidance and not _guidance_is_droppable(body, guidance, overflow_from):
         guidance, overflow_from = set(), None
-    drop_header = bool(guidance) or bool(header_cells) and header_cells[0].lower() == "parameter"
+    # ``Parameter`` in the first cell marks the repeated boilerplate header of a
+    # depositor workbook, which is why that row goes even when no guidance column
+    # was recognised. It is only ever safe on **row 0**: a searched row starting
+    # with ``Parameter`` is a row this function inferred, and deleting it outright
+    # — with no guidance column involved, so none of `_guidance_is_droppable`'s
+    # protection — would silently destroy a data row under a title row.
+    drop_header = bool(guidance) or (
+        position == 0 and bool(header_cells) and header_cells[0].lower() == "parameter"
+    )
 
     out: list[str] = []
     seen_iris: set[str] = set()
@@ -625,11 +730,14 @@ def _compact_sheet(lines: list[str]) -> list[str]:
         if idx == header_idx and drop_header:
             continue
         # Dropped by index, not by position: a ragged row shorter than the
-        # header would otherwise lose whichever column happened to be last.
+        # header would otherwise lose whichever column happened to be last. Only
+        # rows the header actually describes — itself and everything below it —
+        # are read through its columns (see the ``body`` note above).
+        in_table = idx >= header_idx
         kept = [
             c
             for i, c in enumerate(cells)
-            if c and not _is_guidance_cell(i, guidance, overflow_from)
+            if c and not (in_table and _is_guidance_cell(i, guidance, overflow_from))
         ]
         if len(kept) < 2:
             continue
@@ -655,6 +763,12 @@ def compact_grid_text(text: str) -> str:
     sheet, columns of authoring instructions, and empty cells. On the real
     S-VHPS26 workbook that noise pushes the cell line, RRID, author and
     chemicals 2-5 past any affordable context slice.
+
+    Every column rule is read off the sheet's header, which is **found, not
+    assumed to be row 1** (:func:`_header_index`): an RIVM template spends six
+    rows telling the depositor how to fill the sheet in before naming a single
+    column, and matching the guidance vocabulary against that prose recognised
+    nothing (#421).
 
     Four rules, in order: drop the repeated header row; drop the sheet's
     authoring-guidance columns **only when that sheet's own header names them**

--- a/tests/test_file_readers.py
+++ b/tests/test_file_readers.py
@@ -774,3 +774,364 @@ class TestGuidanceColumnCompaction:
         )
 
         assert "| Documenttype | Beschrijving |" in out
+
+
+class TestHeaderRowDetection:
+    """The header is found, not assumed to be row 1 (#421).
+
+    Every column rule in `compact_grid_text` is read off the header, so a sheet
+    that opens with preamble prose had its whole vocabulary matched against a
+    sentence. The real S-VHPS22 file this reproduces — an RIVM template with six
+    rows of Dutch fill-in instructions above `Veldnaam | Optionaliteit | Hoe vaak
+    in te vullen | Beschrijving | Tips | Hier invullen` — recognised no guidance
+    column at all and compacted to 18,777 chars against a 9,000-char tier-0
+    share, cut off before Licentie, Status and Metadata-auteur. Measured on that
+    workbook, header detection alone takes it to 8,059.
+
+    That workbook is a committed fixture, so the acceptance criterion is asserted
+    on the real file (`test_the_real_rivm_workbook_fits_the_tier_0_share`). The
+    synthetic grids are here for the shapes the fix must NOT touch — a re-pick is
+    a licence to delete a row and a column, so most of this class is about
+    refusing to use it.
+
+    The evidence that makes a re-pick safe is measured, not assumed: across the
+    real corpus (1,046 sheets, 79,146 pipe rows) exactly two rows name two or
+    more guidance columns, and both are this one RIVM header.
+    """
+
+    _PREAMBLE = [
+        "| Metadatavelden voor de catalogus |  |  |  |  |  |",
+        "| Elke rij laat de veldnaam zien, hoe belangrijk het veld is, en wat je "
+        "moet invullen. |  |  |  |  |  |",
+        "| Versienummer | 1.2.0 | 2025-06-26 |  |  |  |",
+    ]
+
+    _TABLE = [
+        "| Veldnaam | Optionaliteit | Hoe vaak in te vullen | Beschrijving | Tips "
+        "| Hier invullen |",
+        "| Titel | Verplicht | Eenmalig | De titel van de dataset zoals getoond in de "
+        "catalogus | Bijv. 'Effect van X op Y' | Thyroid hormone transport in CHO-K1 |",
+        "| Auteur | Verplicht | Per auteur | De volledige naam van de auteur "
+        "| Voornaam Achternaam | Fabian Wagenaars |",
+        "| ORCID | Aanbevolen | Per auteur | Persistent identifier voor de auteur "
+        "| Zie orcid.org | 0009-0000-5074-6239 |",
+    ]
+
+    _WITH_PREAMBLE = "\n".join(["[Sheet: Metadata]", *_PREAMBLE, *_TABLE])
+    _HEADER_FIRST = "\n".join(["[Sheet: Metadata]", *_TABLE])
+
+    _RIVM_WORKBOOK = (
+        Path(__file__).parent / "fixtures/svhps22_real_input/Metadataveldenlijst_1.2.0.xlsx"
+    )
+
+    def test_the_real_rivm_workbook_fits_the_tier_0_share(self):
+        """The acceptance criterion of #421, on the committed workbook itself.
+
+        Not a synthetic stand-in: this is the file that failed. Read whole and
+        compacted, it has to come in under the 9,000-char tier-0 share it blew
+        with 18,777 — and it has to still be the file, so the depositor's own
+        answers are named one by one. Those two together are the whole issue:
+        halving the size by losing Metadata-auteur would pass a length check and
+        fail the user.
+        """
+        from builder.tools.file_readers import compact_grid_text, read_excel
+
+        raw = read_excel(str(self._RIVM_WORKBOOK), max_rows=1000)
+        assert raw is not None
+        out = compact_grid_text(raw)
+
+        assert len(out) < 9000, len(out)
+        for answer in (
+            "Nathalie Dierichs",
+            "0009-0000-5074-6239",
+            "ellen.hessel@rivm.nl",
+            "Metadata-auteur",
+            "Licentie",
+        ):
+            assert answer in out, answer
+
+    def test_guidance_columns_are_recognised_below_preamble_prose(self):
+        """The defect itself: three rows of prose hid the header, so nothing fired."""
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(self._WITH_PREAMBLE)
+
+        # The header was found, so its guidance columns went…
+        assert "De titel van de dataset" not in out
+        assert "Voornaam Achternaam" not in out
+        assert "Optionaliteit" not in out
+        # …and the depositor's answers stayed, still paired with their field.
+        assert "| ORCID | 0009-0000-5074-6239 |" in out
+        assert "| Auteur | Fabian Wagenaars |" in out
+        assert "Thyroid hormone transport in CHO-K1" in out
+
+    def test_the_preamble_is_not_read_through_the_table_columns(self):
+        """A header speaks for the rows under it and for nothing above it.
+
+        `Versienummer | 1.2.0 | 2025-06-26` sits in the columns the header later
+        calls Optionaliteit and Hoe vaak in te vullen. Judging it by those names
+        costs it two of its three cells and then the whole row, for falling under
+        two — the template's version and date deleted by a rule about a table the
+        row is not part of.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(self._WITH_PREAMBLE)
+
+        assert "| Versienummer | 1.2.0 | 2025-06-26 |" in out
+
+    def test_a_sheet_whose_first_row_is_the_header_is_unchanged(self):
+        """HONESTY CONTROL: finding the header must cost the ordinary sheet nothing.
+
+        Same table, once with the preamble and once without. The compacted table
+        must come out identical, so the search cannot be paying for the RIVM file
+        with a different answer on every workbook that was already fine.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        plain = compact_grid_text(self._HEADER_FIRST)
+        with_preamble = compact_grid_text(self._WITH_PREAMBLE)
+
+        assert plain.split("\n")[1:] == [
+            "| Titel | Thyroid hormone transport in CHO-K1 |",
+            "| Auteur | Fabian Wagenaars |",
+            "| ORCID | 0009-0000-5074-6239 |",
+        ]
+        table = [ln for ln in with_preamble.split("\n") if ln.startswith("|")]
+        assert table[-3:] == plain.split("\n")[1:]
+
+    def test_a_narrow_header_is_not_overruled_by_wider_rows_below_it(self):
+        """A header may be narrower than the ragged rows it heads, and still be it.
+
+        The S-VHPS26 sheets spill a long Comments entry into an unheadered third
+        column, so every body row is wider than the header. Row 0 keeps the job
+        anyway — it is not asked to be the widest row, only not to be overruled
+        by a lower row that names guidance columns, and none of these do. Drop
+        that requirement and `| Adverse outcome pathway | … |` is promoted, which
+        this test sees as the `Parameter` boilerplate surviving.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Endpoint]",
+                    "| Parameter | Value |",
+                    "| Adverse outcome pathway | AOP 464 | URL: https://aopwiki.org/aops/464 |",
+                    "| Key event | MCT8 uptake | URL: https://aopwiki.org/events/2258 |",
+                    "| Endpoint | T4 uptake | URL: https://aopwiki.org/events/2376 |",
+                ]
+            )
+        )
+
+        assert "| Adverse outcome pathway | AOP 464 | URL: https://aopwiki.org/aops/464 |" in out
+        assert "| Key event | MCT8 uptake | URL: https://aopwiki.org/events/2258 |" in out
+        # …and row 0 is still read as the header, so the boilerplate goes (#378).
+        assert "| Parameter | Value |" not in out
+
+    def test_a_dutch_key_value_row_is_never_promoted_to_header(self):
+        """A key/value sheet under a title row, which the first attempt destroyed.
+
+        Every row here is content. `Toelichting` is one of the twelve guidance
+        words, so promoting row 1 both deletes that row and strikes column 0 from
+        every row under it — five real cells gone with nothing said. One
+        vocabulary word is a coincidence, not a guidance header; two is the bar.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Notes]",
+                    "| Rat liver microsome study |  |  |",
+                    "| Toelichting | zie protocol | RIVM |",
+                    "| Methode | LC-MS | RIVM |",
+                    "| Datum | mei 2024 | RIVM |",
+                ]
+            )
+        )
+
+        assert "| Toelichting | zie protocol | RIVM |" in out
+        assert "| Methode | LC-MS | RIVM |" in out
+        assert "| Datum | mei 2024 | RIVM |" in out
+
+    def test_an_english_key_value_row_is_never_promoted_to_header(self):
+        """The same destruction in English: `Description` is in the vocabulary too."""
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Notes]",
+                    "| Rat liver microsome study |  |  |",
+                    "| Description | see protocol | RIVM |",
+                    "| Method | LC-MS | RIVM |",
+                    "| Author | N. Dierichs | RIVM |",
+                ]
+            )
+        )
+
+        assert "| Description | see protocol | RIVM |" in out
+        assert "| Method | LC-MS | RIVM |" in out
+        assert "| Author | N. Dierichs | RIVM |" in out
+
+    def test_a_plate_layout_row_is_never_promoted_to_header(self):
+        """A real corpus mis-pick, asserted on the search itself rather than its output.
+
+        S-VHPS21's `220317_SK_MCT8_MDCK1_P3_BSP+Desipramide.xls` sheet `Layout`
+        is a 96-well plate map under three lines of run metadata, and the first
+        attempt declared plate row **B** its header. Nothing downstream happened
+        to change, because none of those cells is a vocabulary word — which is
+        luck, not a guarantee, so this asserts the index directly.
+        """
+        from builder.tools.file_readers import _header_index
+
+        rows = [
+            ["Plate layout", "", "", "", "", "", "", ""],
+            ["Compound", "BSP", "Desipramide", "", "", "", "", ""],
+            ["", "1", "2", "3", "4", "5", "6", "7"],
+            ["B", "x", "DMSO (0.1%)", "0,03 uM", "1 uM", "0,3 uM", "1 uM", "3 uM"],
+            ["C", "x", "DMSO (0.1%)", "0,03 uM", "1 uM", "0,3 uM", "1 uM", "3 uM"],
+            ["D", "x", "Blanco", "0,03 uM", "1 uM", "0,3 uM", "1 uM", "3 uM"],
+        ]
+
+        assert _header_index(rows) == 0
+
+    def test_a_legend_sheet_that_lists_guidance_words_as_data_keeps_them(self):
+        """Once a row reaches across the table the preamble is over — stop looking.
+
+        A rename legend is the one sheet whose *values* are column names, so row
+        2 carries two vocabulary words and reads exactly like a guidance header.
+        It is not one: the real header is row 1, the first row to reach across
+        the table, and it names no guidance column, which ends the search. Read
+        past it and row 2 is promoted — deleted outright, and columns 0-1 struck
+        from both rows under it, which is every word this sheet exists to say.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Legenda]",
+                    "| Legenda: hernoemde kolommen |  |  |  |",
+                    "| Oude naam | Nieuwe naam | Sinds | Door |",
+                    "| Beschrijving | Toelichting | 1.0 | RIVM |",
+                    "| Tips | Voorbeeld | 1.1 | RIVM |",
+                    "| Commentaar | Opmerking | 1.2 | RIVM |",
+                ]
+            )
+        )
+
+        assert "| Beschrijving | Toelichting | 1.0 | RIVM |" in out
+        assert "| Tips | Voorbeeld | 1.1 | RIVM |" in out
+        assert "| Commentaar | Opmerking | 1.2 | RIVM |" in out
+
+    def test_a_searched_header_starting_with_parameter_is_not_deleted(self):
+        """`Parameter` drops row 0's boilerplate; it may not drop a row we inferred.
+
+        The header is found here (`Description` and `Comments` are two guidance
+        words), but the answer column is empty and `Description` carries the
+        study, so nothing is droppable and every column stays — the guard from
+        `test_a_description_column_holding_real_content_is_untouched`. What must
+        not then happen is the `Parameter` rule finishing the job on its own and
+        deleting the header row anyway, with none of that guard's protection.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Study]",
+                    "| Metadata for the OATP1C1 uptake study |  |  |  |",
+                    "| Parameter | Description | Value | Comments |",
+                    "| Study title | Thyroid hormone disruption screen in CHO-K1 |  |  |",
+                    "| Study aim | Identify inhibitors of OATP1C1-mediated uptake |  |  |",
+                ]
+            )
+        )
+
+        assert "| Parameter | Description | Value | Comments |" in out
+        assert "| Study title | Thyroid hormone disruption screen in CHO-K1 |" in out
+
+    def test_a_preamble_row_cannot_make_the_guidance_columns_droppable(self):
+        """Whether the guidance columns are droppable is decided by the table only.
+
+        `Beschrijving` and `Tips` are all this sheet says — the depositor left
+        `Hier invullen` empty — so no row stands up without them and every column
+        stays. Counting the preamble's `Versienummer … 1.2.0` as a row that does
+        stand up flips that verdict and deletes the sheet down to its version
+        number.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Metadatavelden]",
+                    "| Metadatavelden voor de catalogus |  |  |  |",
+                    "| Versienummer |  |  | 1.2.0 |",
+                    "| Veldnaam | Beschrijving | Tips | Hier invullen |",
+                    "| Titel | De titel van de dataset | Bijv. 'Effect van X' |  |",
+                    "| Auteur | De volledige naam van de auteur | Voornaam Achternaam |  |",
+                ]
+            )
+        )
+
+        assert "| Titel | De titel van de dataset | Bijv. 'Effect van X' |" in out
+        assert "| Auteur | De volledige naam van de auteur | Voornaam Achternaam |" in out
+
+    def test_a_row_naming_two_guidance_words_is_data_not_a_header(self) -> None:
+        """A crosswalk that TABULATES column names must survive intact (#421).
+
+        This is the shape the threshold exists to refuse, and it is one this
+        domain really produces: a legend mapping renamed RIVM field names. Its
+        rows carry two vocabulary words each —
+        as a KEY and a VALUE, not as column headings — and under a narrow title
+        row such a row is the first row to span the table, so nothing but the
+        threshold stands between it and promotion. Promoted, it would be deleted
+        as scaffolding and its column struck from every row below.
+
+        The corpus has no row between one guidance word and the RIVM header's
+        four, so 2, 3 and 4 all behave identically on real data; this asserts the
+        threshold sits in the MIDDLE of that gap rather than on its near edge,
+        which is the whole difference between destroying this sheet and not.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Legenda]",
+                    "| Legenda: hernoemde kolommen |  |  |  |",
+                    "| Beschrijving | Toelichting | 1.0 | RIVM |",
+                    "| Tips | Voorbeeld | 1.0 | RIVM |",
+                    "| Titel | Naam | 1.1 | RIVM |",
+                ]
+            )
+        )
+
+        for cell in ("Beschrijving", "Toelichting", "Tips", "Voorbeeld", "Titel", "Naam"):
+            assert cell in out, f"{cell!r} was deleted — a data row was promoted to header"
+
+    def test_the_rivm_header_still_wins_above_the_threshold(self) -> None:
+        """The control for the test above: four guidance words still re-picks.
+
+        Raising the bar must not raise it past the file this issue is about, so
+        this pins the other side of the gap — otherwise "refuse everything" would
+        pass the sibling test and silently undo the fix.
+        """
+        from builder.tools.file_readers import compact_grid_text
+
+        out = compact_grid_text(
+            "\n".join(
+                [
+                    "[Sheet: Metadatavelden]",
+                    "| Vul dit blad in volgens de instructies hieronder. |  |  |  |  |  |",
+                    "| Veldnaam | Optionaliteit | Hoe vaak in te vullen | Beschrijving | Tips | Hier invullen |",
+                    "| Titel | Verplicht | 1x | De titel van de dataset | Bijv. 'Effect van X' | Mijn dataset |",
+                ]
+            )
+        )
+
+        assert "Mijn dataset" in out
+        assert "Bijv." not in out, "the guidance columns were not dropped — the re-pick did not fire"


### PR DESCRIPTION
Refs #421 (Failure 1). Failure 2 — unfilled template sheets / `e.g.` example text — stays open as its own follow-up.

## The vocabulary was never the problem

The fix this issue proposes — widening `compact_grid_text`'s guidance-column vocabulary — **already shipped**, guard and regression test included. It just never fired on the file the issue is about, which is why #421 looked done and wasn't. `_compact_sheet` took the **first pipe row** as the header; S-VHPS22's RIVM template opens with six rows of Dutch fill-in instructions and only names its columns on row 7. So the vocabulary was matched against a sentence.

Result: 18,777 chars against a 9,000 tier-0 share, cut at line ~26 of 69 — losing Licentie, Gebruiksvoorwaarden, Versie and the rest.

## The re-pick has to earn itself

Row 0 keeps the job unless a lower row earns it, and only one shape can: it **spans the table** and **names ≥3 authoring-guidance columns**.

The threshold is measured, not guessed. Across **1,046 sheets / 79,146 pipe rows**:

| guidance columns named | rows |
|---|---|
| 0 | 79,004 |
| 1 | 140 |
| 2–3 | 0 |
| 4 | 2 — both the same RIVM header |

Nothing sits between 1 and 4, so 2, 3 and 4 cost the same on real data; the only question is which is hardest to trip by accident. **3 is the middle of that gap rather than its near edge**, and that is not hypothetical — a legend sheet that *tabulates* column names as data carries two vocabulary words per row:

```
| Legenda: hernoemde kolommen |  |  |  |
| Beschrijving | Toelichting | 1.0 | RIVM |
```

Under a narrow title row that legend row is the first spanning row. At a threshold of **2 it loses every content cell it has**; at 3 it is untouched. Both sides of the gap are pinned by tests.

Only the first spanning row is ever a candidate — once a row reaches across the table the preamble is over, and the rows after it are data, not further chances.

## Two smaller correctness fixes in the same function

- **Guidance drops are scoped to the header row and below.** A header speaks for its table, not for rows above it. Without this the preamble row `Versienummer | 1.2.0 | 2025-06-26` sits in the columns the header later calls `Optionaliteit`/`Tips`, loses two of three cells, then the whole row for falling under two.
- **`drop_header`'s `"parameter"` rule is pinned back to row 0.** It marks a depositor workbook's repeated boilerplate header; applied to an *inferred* row it deleted a data row outright, with none of `_guidance_is_droppable`'s protection. Pinning `header_idx = 0` had been shielding this by accident.

## Blast radius

`_compact_sheet` runs on every sheet of every workbook the scanner reads, so a wrong header pick silently deletes content the crate never sees. Measured over **220 readable workbooks** across the three deposits plus every committed fixture:

- **exactly one file's output changes** — the target, 18,777 → 8,059
- corpus re-picks: **42 sheets → 2**, both the target (an earlier, looser rule mis-picked a plate-layout row as a header)
- adversarial grids all clean: Dutch and English key/value under a title row, a data row starting with `Parameter`, plate layouts with text wells, no-header ragged logs, one-row sheets, two candidate headers

## Tests

The acceptance criterion is asserted against the **committed** fixture (`tests/fixtures/svhps22_real_input/Metadataveldenlijst_1.2.0.xlsx`) — `< 9,000` chars with the depositor's name, ORCID and contact address present — not against a synthetic. Reverting the median-span choice sends it back to exactly 18,777 and the test goes red.

Every guard kept has a test that dies when it is mutated; guards that nothing could protect were **deleted** rather than kept as decoration (`_MAX_PREAMBLE_ROWS`, `_MIN_TABLE_ROWS_BELOW`, `_HEADER_LABEL_MAX_CHARS`, `_NUMERIC_CELL`, `_names_columns`) — each was subsumed by the guidance bar and mutating it changed no sheet in the corpus.

`tests/test_file_readers.py` lines 1–776 are byte-identical to main; the diff is a pure addition. The `Description`-carries-real-content regression test is untouched and passes.

Per the repo's rule I did not run pytest locally (CI owns it). `uvx ruff check` and `uv run ty check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)