### PR TITLE
perf(validation): one sweep answers every scope, not just every gate

### DIFF
--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -239,11 +239,15 @@ def build_and_validate(
     # than 20-plus seconds of SHACL. Without this, a profiled run paid for two
     # 40-second RECOMMENDED sweeps immediately after an export had validated the
     # same unchanged state at OPTIONAL.
-    memo_key = _sweep_memo_key(state, profile)
+    memo_key = _sweep_memo_key(state)
     cached = _SWEEP_MEMO.get(memo_key) if memo_key else None
-    if cached is not None and _gate_covers(cached[0], severity):
-        logger.debug("Reusing the %s sweep already computed for this state", cached[0])
-        return _sweep_at_gate(cached[1], cached[2], severity)
+    if cached is not None and _sweep_covers(cached, profile, severity):
+        logger.debug(
+            "Reusing the (%s, %s) sweep already computed for this state",
+            cached[0],
+            cached[1],
+        )
+        return _sweep_scoped(cached[2], cached[3], profile, severity)
 
     try:
         # include_all_scanned=False: the auto-included scanned-file leaves (#175)
@@ -280,29 +284,39 @@ def build_and_validate(
     ]
 
     if memo_key:
-        _remember_sweep(memo_key, severity, conformance, issues)
+        _remember_sweep(memo_key, profile, severity, conformance, issues)
 
     # Keep the original routable tool shape stable. The engine receives the
     # requested severity/profile as call arguments and routes writeback from
     # those arguments rather than expanding this public result contract.
-    return _sweep_at_gate(conformance, issues, severity)
+    return _sweep_scoped(conformance, issues, profile, severity)
 
 
 # ---------------------------------------------------------------------------
 # One sweep per state (#profile-20260810)
 # ---------------------------------------------------------------------------
-# Keyed on (validation fingerprint, profile) and holding the WIDEST gate computed
-# for that state. Bounded and in-process: a crate the agent has moved on from is
-# never asked about again, so a handful of entries covers the loop's back-and-forth
-# without holding whole issue lists for a long session.
-_SWEEP_MEMO: dict[tuple[str, str], tuple[str, dict[str, bool], list[dict[str, Any]]]] = {}
+# Keyed on the validation fingerprint alone, holding the widest (profile, gate)
+# computed for that state. Bounded and in-process: a crate the agent has moved on
+# from is never asked about again, so a handful of entries covers the loop's
+# back-and-forth without holding whole issue lists for a long session.
+_SWEEP_MEMO: dict[str, tuple[str, str, dict[str, bool], list[dict[str, Any]]]] = {}
 _SWEEP_MEMO_MAX = 4
 
+# Which passes each `profile` argument actually runs. Mirrors the dispatch in
+# `profiles.validator.validate_crate_dict`; kept here as data so scoping a cached
+# sweep and validating one stay the same statement.
+_PROFILE_SCOPES: dict[str, tuple[str, ...]] = {
+    "all": ("base", "isa", "tox"),
+    "base": ("base",),
+    "isa": ("isa",),
+    "tox": ("tox",),
+}
 
-def _sweep_memo_key(state: CrateState, profile: str) -> tuple[str, str] | None:
-    """Memo key for *state* at *profile*, or None when it cannot be fingerprinted."""
+
+def _sweep_memo_key(state: CrateState) -> str | None:
+    """Memo key for *state*, or None when it cannot be fingerprinted."""
     try:
-        return (state.validation_fingerprint(), profile)
+        return state.validation_fingerprint()
     except Exception:  # noqa: BLE001 — an un-fingerprintable state just re-runs
         logger.debug("State could not be fingerprinted; validating without the memo")
         return None
@@ -317,25 +331,64 @@ def _gate_covers(have: str, want: str) -> bool:
     return bool(want_tiers) and want_tiers <= have_tiers
 
 
+def _scope_covers(have: str, want: str) -> bool:
+    """Whether a sweep over *have* already ran the passes *want* asks for.
+
+    "all" is base + isa + tox, so it answers any single-profile question by
+    filtering; the single profiles are disjoint and answer only themselves. This
+    is the same containment the severity gate has, in the other dimension — and
+    leaving it out is why a profiled session paid for six consecutive
+    ``profile="base"`` sweeps after an ``profile="all"`` sweep of the identical
+    state: the memo was keyed on the profile, so "all" and "base" looked like
+    unrelated questions and not one of the six could hit.
+    """
+    if want not in _PROFILE_SCOPES:
+        return False  # a typo re-runs rather than matching every cached sweep
+    return have == want or have == "all"
+
+
 def _remember_sweep(
-    key: tuple[str, str],
+    key: str,
+    profile: str,
     severity: str,
     conformance: dict[str, bool],
     issues: list[dict[str, Any]],
 ) -> None:
-    """Record a sweep, keeping the widest gate seen for this state."""
+    """Record a sweep, keeping the widest (profile, gate) seen for this state."""
     existing = _SWEEP_MEMO.get(key)
-    if existing is not None and _gate_covers(existing[0], severity):
-        return
+    if (
+        existing is not None
+        and _scope_covers(existing[0], profile)
+        and _gate_covers(existing[1], severity)
+    ):
+        return  # what we already hold answers strictly more
     if len(_SWEEP_MEMO) >= _SWEEP_MEMO_MAX and key not in _SWEEP_MEMO:
         _SWEEP_MEMO.pop(next(iter(_SWEEP_MEMO)))
-    _SWEEP_MEMO[key] = (severity, conformance, issues)
+    _SWEEP_MEMO[key] = (profile, severity, conformance, issues)
 
 
-def _sweep_at_gate(
-    conformance: dict[str, bool], issues: list[dict[str, Any]], severity: str
+def _sweep_covers(
+    cached: tuple[str, str, dict[str, bool], list[dict[str, Any]]],
+    profile: str,
+    severity: str,
+) -> bool:
+    """Whether a cached sweep answers this (profile, severity) question outright."""
+    return _scope_covers(cached[0], profile) and _gate_covers(cached[1], severity)
+
+
+def _sweep_scoped(
+    conformance: dict[str, bool],
+    issues: list[dict[str, Any]],
+    profile: str,
+    severity: str,
 ) -> dict[str, Any]:
-    """Narrow a sweep's findings to the tiers *severity* actually gates on.
+    """Narrow a sweep to the passes and tiers this call actually asked for.
+
+    Both narrowings matter for the same reason: the answer must be
+    indistinguishable from a real run at that scope and gate. Reporting isa and
+    tox conformance to a caller that asked for ``profile="base"`` would hand back
+    verdicts it did not request and, on the next call, did not necessarily still
+    hold.
 
     Only a finding whose severity is a KNOWN tier wider than the gate is set
     aside. ``_routable_issue`` falls back to the raw enum name for any severity
@@ -345,12 +398,17 @@ def _sweep_at_gate(
     unrecognised severity is always reported.
     """
     tiers = set(tiers_covered(severity))
-    gated = [
+    passes = set(_PROFILE_SCOPES.get(profile, ()))
+    scoped = [
         issue
         for issue in issues
-        if issue.get("severity") not in _TIER_ORDER or issue.get("severity") in tiers
+        if issue.get("profile") in passes
+        and (issue.get("severity") not in _TIER_ORDER or issue.get("severity") in tiers)
     ]
-    return {"ok": not gated, "conformance": conformance, "issues": gated}
+    gated_conformance = {
+        layer: passed for layer, passed in conformance.items() if layer in passes
+    }
+    return {"ok": not scoped, "conformance": gated_conformance, "issues": scoped}
 
 
 def clear_sweep_memo() -> None:

--- a/tests/test_validation_sweep_memo.py
+++ b/tests/test_validation_sweep_memo.py
@@ -94,11 +94,38 @@ class TestSweepReuse:
         V.build_and_validate(state, severity="required")
         assert calls == ["optional", "required"]
 
-    def test_a_different_profile_is_its_own_sweep(self, sweeps, state):
+    def test_a_narrower_profile_is_served_from_all(self, sweeps, state):
+        """ "all" runs base + isa + tox, so it answers any single-profile ask.
+
+        This test used to assert the opposite. The memo was keyed on the profile,
+        so "all" and "base" looked like unrelated questions — and a profiled
+        session paid for six consecutive profile="base" sweeps immediately after
+        an profile="all" sweep of the identical state, none of which could hit.
+        """
         calls, _ = sweeps
         V.build_and_validate(state, severity="optional", profile="all")
         V.build_and_validate(state, severity="required", profile="tox")
-        assert calls == ["optional", "required"]
+        V.build_and_validate(state, severity="required", profile="base")
+        assert calls == ["optional"]
+
+    def test_a_wider_profile_still_runs(self, sweeps, state):
+        """A base-only sweep never ran the isa or tox passes."""
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional", profile="base")
+        V.build_and_validate(state, severity="optional", profile="all")
+        assert calls == ["optional", "optional"]
+
+    def test_disjoint_profiles_each_run(self, sweeps, state):
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional", profile="base")
+        V.build_and_validate(state, severity="optional", profile="tox")
+        assert calls == ["optional", "optional"]
+
+    def test_an_unknown_profile_never_matches(self, sweeps, state):
+        calls, _ = sweeps
+        V.build_and_validate(state, severity="optional", profile="all")
+        assert V._scope_covers("all", "bse") is False
+        assert calls == ["optional"]
 
 
 class TestGateFiltering:
@@ -179,4 +206,38 @@ class TestMemoHygiene:
         assert "error" in first
         V.build_and_validate(state, severity="required")
         assert calls == ["optional", "required"]
+        V.clear_sweep_memo()
+
+
+class TestScoping:
+    """A served answer must be indistinguishable from a real run at that scope."""
+
+    def test_only_the_asked_for_passes_are_reported(self, monkeypatch, state):
+        V.clear_sweep_memo()
+        calls: list[str] = []
+
+        def fake(state, *, severity, profile):
+            calls.append(profile)
+            issues = [_issue("required"), _issue("required")]
+            issues[1].profile = "tox"
+            return {}, [
+                DictValidationResult(
+                    profile="base", passed=False, passed_required=False, issues=[issues[0]]
+                ),
+                DictValidationResult(
+                    profile="tox", passed=False, passed_required=False, issues=[issues[1]]
+                ),
+            ]
+
+        monkeypatch.setattr(V, "_assemble_and_validate", fake)
+        wide = V.build_and_validate(state, severity="optional", profile="all")
+        assert {i["profile"] for i in wide["issues"]} == {"base", "tox"}
+        assert set(wide["conformance"]) == {"base", "tox"}
+
+        narrow = V.build_and_validate(state, severity="optional", profile="base")
+        assert calls == ["all"]
+        assert {i["profile"] for i in narrow["issues"]} == {"base"}
+        assert set(narrow["conformance"]) == {"base"}, (
+            "a base-scoped caller must not be handed tox conformance it never asked for"
+        )
         V.clear_sweep_memo()


### PR DESCRIPTION
## The gap

#501 taught the sweep memo that **severity** subsumes — an OPTIONAL sweep already carries the REQUIRED and RECOMMENDED findings, so a narrower gate is a list filter rather than another 20–40s of SHACL.

It left the same containment out of the neighbouring dimension. The memo keyed on `(fingerprint, profile)`, so `"all"` and `"base"` looked like unrelated questions. They are not: **`all` IS base + isa + tox.**

Session `20260811_133825` shows the cost:

```
t+582   9.03s  severity=required, profile=all
t+619   7.25s  severity=required, profile=base
t+673   6.69s  severity=required, profile=base
t+693   SUPPRESSED  unchanged_state_strike_1   ← guard confirms the state never moved
t+751   6.90s  severity=required, profile=base
t+1171  6.81s  severity=required, profile=base
t+1205 10.46s  severity=required, profile=base
t+1257  9.71s  severity=required, profile=base
```

Six `base` sweeps after an `all` sweep of a state the loop guard itself confirmed was unchanged — and **not one could hit**, because the key said they were different questions.

## The change

The memo now keys on the **fingerprint alone** and holds the widest `(profile, gate)` computed for that state. `_scope_covers` is the containment: `all` answers any single profile, the single profiles answer only themselves, an unrecognised profile matches nothing and re-runs (same defensive shape as `_gate_covers` for a mistyped severity).

**A served answer is scoped as well as gated.** Handing isa and tox conformance to a caller that asked for `profile="base"` would report verdicts it never requested — and which, on the next call, need not still hold. `_sweep_scoped` narrows the conformance map and the issue list together, so the result is indistinguishable from a real run at that scope. There's a test on exactly that.

Unrecognised severities are still never swallowed — unchanged from #501.

## A test that asserted the bug

`test_a_different_profile_is_its_own_sweep` pinned the old behaviour outright. It now states the containment instead, and says in its docstring why it flipped.

## Tests

`79 passed`, exit 0, across `test_validation_sweep_memo` / `test_tools_build_and_validate` / `test_validation_debounce` / `test_validation_writeback` / `test_validation_escalation` / `test_tools_validation` / `test_pipeline_e2e`. Five new memo tests.

## Note on the neighbouring guard

The agent-loop `build_and_validate` suppression fires *before* the tool runs, so on the in-loop path the memo can never demonstrate a hit — the guard gets there first. That interaction is worth revisiting once a session runs with both changes live, but it is deliberately untouched here: the two mechanisms overlap and only one of them needs to change, and which one should be decided on evidence rather than now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)