### PR TITLE
feat(report): every capped finding stays reachable, behind a disclosure

### DIFF
--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -129,6 +129,14 @@
 .mat ul.sugg { margin:.8rem 0 0; padding-left:1.1rem; font-size:.85rem; } .mat ul.sugg li.must { color:var(--low-ink); }
 .mat ul.sugg li.opt { color:var(--muted); } .mat ul.sugg li.more { color:var(--muted); font-style:italic;
   list-style:none; margin-left:-1.1rem; }
+/* The capped tiers hide their remainder behind a disclosure rather than
+   dropping it — the summary keeps the muted/italic "more" treatment, the
+   findings inside read exactly like the ones above the cut. */
+.mat ul.sugg li.more > details > summary { cursor:pointer; }
+.mat ul.sugg li.more ul.more-list { font-style:normal; margin:.5rem 0 .2rem; padding-left:2.2rem;
+  display:grid; gap:.2rem; }
+.mat ul.sugg li.more ul.more-list li { color:var(--ink-2); }
+.mat ul.sugg li.more ul.more-list li.opt { color:var(--muted); }
 
 /* profile adherence — severity tiers (#306) */
 .mat .sev { display:flex; flex-direction:column; gap:.32rem; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -463,8 +463,15 @@ def _suggestion_items(val: ValidationReport) -> list[str]:
     RECOMMENDED or OPTIONAL finding is the point of assessing it — a crate whose
     author can see the twelve things that would make it better is more likely to
     get them than one told only that it clears the bar. REQUIRED findings stay
-    first and uncapped; the advisory tiers are capped, and a cap that bites says
-    how many it hid rather than trailing off silently.
+    first and uncapped.
+
+    The advisory tiers are capped so the section stays readable, but the cap
+    HIDES rather than discards: the remainder goes behind a disclosure. A count
+    on its own ("+232 further recommended findings not listed here") tells an
+    author there is more without telling them what, which is the one thing they
+    cannot act on — and the report is the only place those findings are shown.
+    ``<details>`` keeps that a click away and costs no script, so the page stays
+    self-contained and offline.
     """
     esc = html.escape
     tiers: list[tuple[str, list[str], str]] = [
@@ -479,11 +486,15 @@ def _suggestion_items(val: ValidationReport) -> list[str]:
         cap = _SUGGESTION_CAPS[tier]
         shown = issues if cap is None else issues[:cap]
         items.extend(template.format(msg=esc(msg)) for msg in shown)
-        hidden = len(issues) - len(shown)
+        hidden = issues[len(shown) :]
         if hidden:
+            rest = "".join(template.format(msg=esc(msg)) for msg in hidden)
+            noun = "finding" if len(hidden) == 1 else "findings"
+            them = "it" if len(hidden) == 1 else "them"
             items.append(
-                f'<li class="more">+{hidden} further {tier} '
-                f"{'finding' if hidden == 1 else 'findings'} not listed here</li>"
+                f'<li class="more"><details class="more-d">'
+                f"<summary>+{len(hidden)} further {tier} {noun} — show {them}</summary>"
+                f'<ul class="more-list">{rest}</ul></details></li>'
             )
     return items
 

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1485,3 +1485,72 @@ class TestUnreachableRepairEstimate:
 
         assert "Every entity is reachable from the crate root." in page
         assert "would reconnect" not in page
+
+
+class TestCappedTiersKeepTheirRemainder:
+    """A cap that bites must hide the rest, not discard it.
+
+    The advisory tiers are capped so the section stays readable, but the report
+    is the only place these findings are shown. A bare count told an author
+    there were 232 more without telling them what — the one thing they cannot
+    act on. The remainder now sits behind a <details>, which costs no script and
+    keeps the page self-contained.
+    """
+
+    def _page(self, n_recommended: int = 30, n_optional: int = 20) -> str:
+        validation = ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            required_issues=["root MUST have a name"],
+            should_issues=[f"recommended finding {i}" for i in range(n_recommended)],
+            may_issues=[f"optional finding {i}" for i in range(n_optional)],
+        )
+        return build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=validation)
+
+    def test_every_recommended_finding_is_in_the_page(self):
+        page = self._page()
+        for i in range(30):
+            assert f"recommended finding {i}" in page, f"recommended finding {i} was dropped"
+
+    def test_every_optional_finding_is_in_the_page(self):
+        page = self._page()
+        for i in range(20):
+            assert f"optional finding {i}" in page, f"optional finding {i} was dropped"
+
+    def test_the_overflow_is_behind_a_disclosure(self):
+        page = self._page()
+        assert "<details" in page and "more-list" in page
+        # The count still leads, so the summary says how much is folded away.
+        assert "+20 further recommended findings" in page
+        assert "+15 further optional findings" in page
+
+    def test_the_findings_above_the_cap_stay_directly_visible(self):
+        # The disclosure is for the remainder only — the first ten recommended
+        # findings must not be buried behind a click.
+        page = self._page()
+        head, _, tail = page.partition("+20 further recommended findings")
+        assert "recommended finding 0" in head
+        assert "recommended finding 9" in head
+        assert "recommended finding 10" in tail
+
+    def test_no_disclosure_when_nothing_is_capped(self):
+        page = self._page(n_recommended=2, n_optional=2)
+        assert "further recommended" not in page
+        assert "further optional" not in page
+        assert "recommended finding 1" in page
+
+    def test_a_single_hidden_finding_reads_as_one(self):
+        page = self._page(n_recommended=11, n_optional=0)
+        assert "+1 further recommended finding — show it" in page
+
+    def test_hidden_findings_are_escaped(self):
+        validation = ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            should_issues=[f"pad {i}" for i in range(10)] + ["<script>alert(1)</script>"],
+        )
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=validation)
+        assert "<script>alert(1)</script>" not in page
+        assert "&lt;script&gt;" in page


### PR DESCRIPTION
The maturity report caps the advisory tiers so the section stays readable — but the cap **discarded** what it hid:

```
+232 further recommended findings not listed here
+264 further optional findings not listed here
```

That count tells an author there is more without telling them *what*, which is the one thing they cannot act on. And the report is the only place these findings are surfaced at all, so capping them there means they are never seen.

## What changes

The remainder now sits in a `<details>` under the summary that already counted it:

```html
<li class="more"><details class="more-d">
  <summary>+222 further recommended findings — show them</summary>
  <ul class="more-list">…every remaining finding…</ul>
</details></li>
```

- The first **10** RECOMMENDED and **5** OPTIONAL stay directly visible, so the section still reads the same at a glance.
- Everything past the cut is one click away instead of gone.
- REQUIRED is still uncapped and never folded — those block conformance.

Native `<details>`, no script, so the page stays self-contained, offline and print-friendly. This matches how the FAIR indicator lists (`details.disc`) already disclose, and reuses the existing print rule.

## Cost
On a real crate (232 recommended + 264 optional) the page is **74.5 KB**.

## Tests
Seven new tests: every finding present at both tiers, the overflow is behind a disclosure, the above-cap findings stay *outside* it, no disclosure when nothing is capped, singular wording for one hidden finding, and escaping of hidden findings. Verified by mutation — restoring the old dead-end count fails five of them.

- `ruff check` — clean
- `ty check` — clean
- `pytest tests/test_maturity_report.py` — 98 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)