### PR TITLE
test(pipeline): pin the provider in the no-provider test, not the machine

### DIFF
--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -3864,9 +3864,20 @@ class TestCompoundIdentifierRetry:
     ) -> None:
         """The determinism guarantee: with no provider the spine reaches no
         network at all, so a state seeded with an identifier-less compound must
-        not fire a lookup (``TestDeterminism`` seeds exactly such a state)."""
+        not fire a lookup (``TestDeterminism`` seeds exactly such a state).
+
+        ``get_provider`` is pinned to ``None`` for the same reason its sibling
+        above pins it to ``"openai"``: this asserts the GATE, and leaving it to
+        the ambient configuration means asserting the machine instead. That is
+        not hypothetical — ``config.get_provider`` falls back to ``load_config()``
+        after the environment, so a developer with an api_key in their vitro
+        config gets ``"openai"`` with no env var set anywhere. CI has no config
+        file, so this test passed there and failed on every machine that has one.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
         from builder.agents.pipeline.pipeline import run_pipeline
 
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: None)
         queried = self._record_lookup(monkeypatch, hits={})
         engine = _engine(self._state_with("Triiodothyronine"))
 


### PR DESCRIPTION
Found by the full `-n auto --maxprocesses=4` run (the one #340/#406 asked for). **`main` is red on any machine with a vitro config file**; CI is green, which is why it got through.

## The defect

`TestCompoundIdentifierRetry::test_the_no_provider_spine_stays_offline` asserts that the spine's compound retry is gated on a provider — but never pinned `get_provider`. It relied on the ambient configuration to supply the "no provider" half. Its sibling `test_run_pipeline_runs_the_retry_and_returns_what_is_still_missing` pins the positive case to `"openai"`; only the negative case was left to chance.

`config.get_provider()` checks four API-key env vars and **then falls back to `load_config()`**:

```
$ env | grep -c 'API_KEY='      ->  0
$ get_provider()                ->  'openai'      # from the config file
```

So a developer with an `api_key` in their vitro config gets `"openai"` with no env var set anywhere, the gate opens, the retry runs, and the test fails:

```
AssertionError: assert ['Triiodothyronine'] == []
```

CI has no config file, so it returns `None` there and the test passed.

## Not #406

It **fails in isolation**, so this is not the load-sensitivity class. The same run's other two failures (`test_http_resilience.py::TestHttpGetJson::test_passes_params_and_headers`, `test_tools_session.py::TestSaveSessionForce::test_force_always_writes_even_if_unchanged`) both pass alone and are that class — reported separately on #406.

## The fix

Pin `get_provider` to `None`, so the test asserts the **gate** rather than the environment, symmetric with its sibling.

Verified it still bites: deleting the `if get_provider() is not None` guard at the call site turns it red. `TestCompoundIdentifierRetry` is 11/11 green with the fix in place.

Worth noting the general hazard, since it is not the first time: any test whose premise is "no provider configured" is asserting the developer's machine unless it pins `get_provider` explicitly — env vars alone are not the whole story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)