### PR TITLE
feat(report): every validation finding folds out of its own severity row (#510)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1514,16 +1514,23 @@ a green zero; REQUIRED/RECOMMENDED issue text is still surfaced as `Must fix` / 
 suggestions. Rendering this from `state.validation` alone (no new validation machinery) keeps the
 pure/cheap contract.
 
-The improvement list groups findings **per profile and per severity tier** (#510): one fold-out
-`<details>` per profile layer, in the base → ISA → ISA-Tox fix order the gate-ordering contract
-prescribes, whose summary counts the group's findings per tier. A group holding REQUIRED findings is
-born `open` — a collapsed fold must never hide a blocking issue — while advisory-only groups start
-collapsed with their counts still visible in the summary. The grouping renders from
-`validation.issue_records`, the structured view both validation write-back paths record alongside
-the flat display lists (which are themselves a parsed contract and stay byte-stable); a verdict
-without records — one recorded before the field existed — falls back to the flat ungrouped list
-rather than dropping findings. Advisory caps apply per profile group, and a cap that bites names
-how many findings it hid.
+**Every finding folds out of the severity row it belongs to** (#510). Severity is the primary axis
+because it is the fix order — REQUIRED blocks the build, the advisory tiers do not — so a tier row
+that has findings becomes a `<details>` whose summary is the row itself, listing those findings
+grouped by profile layer inside it (base → ISA → ISA-Tox, the gate-ordering contract). A second
+per-profile index alongside the rows would restate the same counts twice, so there is none, and the
+profile cards stay non-interactive: they assert REQUIRED-gate conformance and nothing else. A row
+holding REQUIRED findings is born `open` (a collapsed fold must never hide a blocking issue); a row
+with nothing to show does not fold at all, so a disclosure caret always means there is something
+there. Print keeps every row AND unfolds it.
+
+The rendering source is chosen **per tier, never once for the report**: `validation.issue_records`
+for a tier that has them (grouped by layer, entity ids shown as chips), else that tier's flat
+display list (ungrouped — such a verdict carries no attribution to group by). A verdict can hold
+records for one tier and only strings for another — a pre-records checkpoint that then takes a
+REQUIRED-gate write-back — and deciding globally there would hide the string-only tiers' findings
+while the row went on counting them. The count a row advertises is the count of what it unfolds.
+Advisory caps apply per profile group, and a cap that bites names how many findings it hid.
 
 When `export_crate` embeds the report it passes the crate's serialized `@graph`
 (`build_maturity_html(state, graph=crate.metadata.generate())`), which folds in a **Provenance &

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,11 @@ CrateState {
     validation: {
         base_passed: bool, isa_passed: bool, tox_passed: bool,
         required_issues: [str], should_issues: [str], may_issues: [str],
+        # the same findings with structure intact (#510) — the flat lists above
+        # are their display projection and stay byte-stable (the ReAct loop
+        # parses them); empty on a verdict recorded before the field existed
+        issue_records: [{ profile, severity, entity_id, message }],
+        assessed_tiers: set[str], input_fingerprint: str,
     },
     mit_assessment: { module_scores: { m: { completed, total } }, overall_score },
     fair_assessment: { indicator_results, dsm_level },
@@ -1508,6 +1513,17 @@ renders as an explicit **"not assessed"** neutral state (glyph + label, never co
 a green zero; REQUIRED/RECOMMENDED issue text is still surfaced as `Must fix` / `Recommended`
 suggestions. Rendering this from `state.validation` alone (no new validation machinery) keeps the
 pure/cheap contract.
+
+The improvement list groups findings **per profile and per severity tier** (#510): one fold-out
+`<details>` per profile layer, in the base → ISA → ISA-Tox fix order the gate-ordering contract
+prescribes, whose summary counts the group's findings per tier. A group holding REQUIRED findings is
+born `open` — a collapsed fold must never hide a blocking issue — while advisory-only groups start
+collapsed with their counts still visible in the summary. The grouping renders from
+`validation.issue_records`, the structured view both validation write-back paths record alongside
+the flat display lists (which are themselves a parsed contract and stay byte-stable); a verdict
+without records — one recorded before the field existed — falls back to the flat ungrouped list
+rather than dropping findings. Advisory caps apply per profile group, and a cap that bites names
+how many findings it hid.
 
 When `export_crate` embeds the report it passes the crate's serialized `@graph`
 (`build_maturity_html(state, graph=crate.metadata.generate())`), which folds in a **Provenance &

--- a/builder/state.py
+++ b/builder/state.py
@@ -624,6 +624,15 @@ class ValidationReport:
         required_issues: REQUIRED-severity issue descriptions.
         should_issues: SHOULD-severity issue descriptions.
         may_issues: MAY-severity (informational) issue descriptions.
+        issue_records: The same findings with their structure intact — one
+            ``{"profile", "severity", "entity_id", "message"}`` dict per finding
+            (``profile`` is ``base``/``isa``/``tox``, ``severity`` a tier name,
+            ``entity_id`` empty when the producer had none). The three flat
+            lists above are the display projection of these records and stay
+            byte-stable because the ReAct loop parses them; the records exist so
+            renderers (the maturity report's per-profile fold-outs, #510) never
+            have to re-parse that display format. Empty on a verdict recorded
+            before the field existed — consumers must fall back, not infer.
         input_fingerprint: :meth:`CrateState.validation_fingerprint` as it was
             when this verdict was recorded — the answer to "does this verdict
             still describe the crate?". Empty means unknown (a report restored
@@ -637,6 +646,7 @@ class ValidationReport:
     should_issues: list[str] = field(default_factory=list)
     may_issues: list[str] = field(default_factory=list)
     assessed_tiers: set[str] = field(default_factory=set)
+    issue_records: list[dict[str, str]] = field(default_factory=list)
     input_fingerprint: str = ""
 
     def is_stale_for(self, state: CrateState) -> bool:
@@ -659,6 +669,7 @@ class ValidationReport:
             "should_issues": list(self.should_issues),
             "may_issues": list(self.may_issues),
             "assessed_tiers": sorted(self.assessed_tiers),
+            "issue_records": [dict(r) for r in self.issue_records],
             "input_fingerprint": self.input_fingerprint,
         }
 
@@ -672,6 +683,7 @@ class ValidationReport:
             should_issues=data.get("should_issues", []),
             may_issues=data.get("may_issues", []),
             assessed_tiers=set(data.get("assessed_tiers", [])),
+            issue_records=data.get("issue_records", []),
             input_fingerprint=data.get("input_fingerprint", ""),
         )
 

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -506,11 +506,13 @@ def apply_validation_result(
     fingerprint = state.validation_fingerprint()
     # The structured records shadow the string lists tier for tier: retired
     # together, refreshed together, so neither view can describe a different
-    # validation than the other.
-    tier_records = {
-        tier: [r for r in report.issue_records if r.get("severity") == tier]
-        for tier in _TIER_ORDER
-    }
+    # validation than the other. Bucketing by the severity actually present —
+    # rather than by the three known tiers — keeps a record this run neither
+    # evaluated nor retired: no writer emits one today, but a checkpoint can
+    # carry it, and the report renders such findings rather than dropping them.
+    tier_records: dict[str, list[dict[str, str]]] = {tier: [] for tier in _TIER_ORDER}
+    for record in report.issue_records:
+        tier_records.setdefault(str(record.get("severity") or ""), []).append(record)
     # Retire the tiers this run did NOT cover, whenever the state has moved on
     # since the last verdict. `assessed_tiers` is otherwise additive: once an
     # export assessed all three, a later REQUIRED-only run refreshed the required
@@ -534,7 +536,9 @@ def apply_validation_result(
         setattr(report, _TIER_FIELDS[tier], order_issues(issues, tier))
         report.assessed_tiers.add(tier)
         tier_records[tier] = _issue_records(issues, tier)
-    report.issue_records = [r for tier in _TIER_ORDER for r in tier_records[tier]]
+    report.issue_records = [r for tier in _TIER_ORDER for r in tier_records[tier]] + [
+        r for tier, records in tier_records.items() if tier not in _TIER_ORDER for r in records
+    ]
     report.input_fingerprint = fingerprint
 
 

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -82,22 +82,33 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
     required_issues: list[str] = []
     should_issues: list[str] = []
     may_issues: list[str] = []
+    issue_records: list[dict[str, str]] = []
 
     base_passed = True
     isa_passed = True
     tox_passed = True
 
-    for result in results:
-        profile_name = result.profile.lower()
-        required_issues.extend(result.required_issues)
+    def _record(profile: str, severity: str, text: str) -> dict[str, str]:
+        # The disk path has no per-issue entity routing; the "[Required] " style
+        # prefix is structure (already carried by `severity`), not message.
+        return {
+            "profile": profile,
+            "severity": severity,
+            "entity_id": "",
+            "message": text.removeprefix(f"[{severity.capitalize()}] "),
+        }
 
-        # Classify issues by severity
+    for result in results:
+        profile_key = _profile_key(result.profile)
+        required_issues.extend(result.required_issues)
+        issue_records.extend(_record(profile_key, "required", i) for i in result.required_issues)
+
         if not result.passed_required:
-            if "base" in profile_name or "ro-crate" in profile_name:
+            if profile_key == "base":
                 base_passed = False
-            elif "isa" in profile_name and "tox" not in profile_name:
+            elif profile_key == "isa":
                 isa_passed = False
-            elif "tox" in profile_name:
+            elif profile_key == "tox":
                 tox_passed = False
 
         # Non-required issues go to should/may
@@ -108,9 +119,11 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
             elif issue.startswith("[Recommended]"):
                 if issue not in should_issues:
                     should_issues.append(issue)
+                issue_records.append(_record(profile_key, "recommended", issue))
             elif issue.startswith("[Optional]"):
                 if issue not in may_issues:
                     may_issues.append(issue)
+                issue_records.append(_record(profile_key, "optional", issue))
 
     return ValidationReport(
         base_passed=base_passed,
@@ -119,7 +132,28 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
         required_issues=required_issues,
         should_issues=should_issues,
         may_issues=may_issues,
+        issue_records=issue_records,
     )
+
+
+def _profile_key(profile_name: str) -> str:
+    """Map a validator pass's display name to its canonical layer key.
+
+    The disk path labels its passes with prose names ("Base RO-Crate 1.2",
+    "ISA RO-Crate Profile", "ISA-Tox RO-Crate Profile") rather than the
+    ``base``/``isa``/``tox`` keys the dict path uses. Every one of those names
+    contains "ro-crate", so the most-specific token must be tested first — the
+    old ``"ro-crate" in name`` guard classified an ISA or ISA-Tox failure as a
+    BASE failure.
+    """
+    name = profile_name.lower()
+    if "tox" in name:
+        return "tox"
+    if "isa" in name:
+        return "isa"
+    if "base" in name or "ro-crate" in name:
+        return "base"
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -393,15 +427,38 @@ def tiers_covered(severity: str) -> tuple[str, ...]:
     return _TIER_ORDER[: _TIER_ORDER.index(severity) + 1]
 
 
-def order_issues(issues: list[dict[str, Any]], severity: str) -> list[str]:
-    """Return one severity tier as stable, layer-ordered display strings."""
+def _select_tier(issues: list[dict[str, Any]], severity: str) -> list[dict[str, Any]]:
+    """One severity tier of *issues*, in stable base → isa → tox layer order."""
     selected = [i for i in issues if i.get("severity") == severity]
     selected.sort(key=lambda i: _VALIDATION_LAYER_ORDER.get(i.get("profile") or "", 99))
+    return selected
+
+
+def order_issues(issues: list[dict[str, Any]], severity: str) -> list[str]:
+    """Return one severity tier as stable, layer-ordered display strings."""
     return [
         (
             f"[{i.get('profile') or '?'}] {i.get('entity_id') or '?'}: {i.get('message') or ''}"
         ).rstrip()
-        for i in selected
+        for i in _select_tier(issues, severity)
+    ]
+
+
+def _issue_records(issues: list[dict[str, Any]], severity: str) -> list[dict[str, str]]:
+    """One severity tier as structured records, ordered like :func:`order_issues`.
+
+    The records carry the attribution the display strings flatten away, so the
+    maturity report can group findings per profile without re-parsing the
+    ``[profile] entity: message`` shape the ReAct loop depends on (#510).
+    """
+    return [
+        {
+            "profile": str(i.get("profile") or ""),
+            "severity": severity,
+            "entity_id": str(i.get("entity_id") or ""),
+            "message": str(i.get("message") or ""),
+        }
+        for i in _select_tier(issues, severity)
     ]
 
 
@@ -447,6 +504,13 @@ def apply_validation_result(
     severity = str(severity or result.get("severity") or "required")
     covered = tiers_covered(severity)
     fingerprint = state.validation_fingerprint()
+    # The structured records shadow the string lists tier for tier: retired
+    # together, refreshed together, so neither view can describe a different
+    # validation than the other.
+    tier_records = {
+        tier: [r for r in report.issue_records if r.get("severity") == tier]
+        for tier in _TIER_ORDER
+    }
     # Retire the tiers this run did NOT cover, whenever the state has moved on
     # since the last verdict. `assessed_tiers` is otherwise additive: once an
     # export assessed all three, a later REQUIRED-only run refreshed the required
@@ -461,6 +525,7 @@ def apply_validation_result(
             if tier not in covered:
                 setattr(report, _TIER_FIELDS[tier], [])
                 report.assessed_tiers.discard(tier)
+                tier_records[tier] = []
     # File EVERY tier the gate evaluated, not just the tier named. A gate is
     # inclusive (see `tiers_covered`), so a "recommended" run's result already
     # holds the REQUIRED findings; recording only the SHOULD ones left the
@@ -468,6 +533,8 @@ def apply_validation_result(
     for tier in covered:
         setattr(report, _TIER_FIELDS[tier], order_issues(issues, tier))
         report.assessed_tiers.add(tier)
+        tier_records[tier] = _issue_records(issues, tier)
+    report.issue_records = [r for tier in _TIER_ORDER for r in tier_records[tier]]
     report.input_fingerprint = fingerprint
 
 

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -104,6 +104,7 @@
 .mat .topo-detail-h { margin:.7rem 0 .1rem; font-size:.76rem; font-weight:640; color:var(--ink); }
 .mat .topo-detail-h:first-of-type { margin-top:.55rem; }
 .mat .topo-detail code,
+.mat ul.sugg li code,
 .mat .disc ul.ind li code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.76rem;
   background:var(--surface-2); border:1px solid var(--border); border-radius:3px;
   padding:.02rem .32rem; color:var(--ink); }
@@ -129,6 +130,27 @@
 .mat ul.sugg { margin:.8rem 0 0; padding-left:1.1rem; font-size:.85rem; } .mat ul.sugg li.must { color:var(--low-ink); }
 .mat ul.sugg li.opt { color:var(--muted); } .mat ul.sugg li.more { color:var(--muted); font-style:italic;
   list-style:none; margin-left:-1.1rem; }
+/* each severity row unfolds its own findings (#510). The caret is absolutely
+   positioned so it never becomes a grid track — the row keeps one column layout
+   whether or not it folds, and the mobile override below still applies. */
+.mat details.sev-fold > summary { position:relative; cursor:pointer; list-style:none;
+  padding-right:1.1rem; border-radius:6px; }
+.mat details.sev-fold > summary::-webkit-details-marker { display:none; }
+.mat details.sev-fold > summary:hover { background:var(--surface-2); }
+.mat details.sev-fold > summary:focus-visible { outline:2px solid var(--cat-process);
+  outline-offset:2px; }
+.mat details.sev-fold > summary::after { content:""; position:absolute; right:.25rem; top:50%;
+  width:.36rem; height:.36rem; margin-top:-.25rem; border-right:1.5px solid var(--muted);
+  border-bottom:1.5px solid var(--muted); transform:rotate(-45deg);
+  transition:transform .12s ease; }
+.mat details.sev-fold[open] > summary::after { transform:rotate(45deg); margin-top:-.32rem; }
+.mat .sev-body { padding:.15rem 0 .5rem 1.85rem; }
+.mat .sugg-prof-h { display:flex; align-items:baseline; gap:.4rem; margin:.7rem 0 0;
+  font-size:.76rem; font-weight:640; color:var(--ink); }
+.mat .sugg-prof-h:first-child { margin-top:.35rem; }
+.mat .sugg-prof-h .pc { font-size:.7rem; font-weight:600; color:var(--muted);
+  font-variant-numeric:tabular-nums; }
+.mat .sev-body ul.sugg { margin-top:.25rem; }
 
 /* profile adherence — severity tiers (#306) */
 .mat .sev { display:flex; flex-direction:column; gap:.32rem; }
@@ -337,6 +359,10 @@ __CATEGORY_STYLES__
   .mat{background:#fff;color:#000;padding:0;--surface:#fff;--surface-2:#fff;}
   .mat section,.mat .kpi{break-inside:avoid;border:1px solid #ccc;box-shadow:none;}
   .mat details{display:block;} .mat .disc[open] summary{display:none;}
+  /* A severity row is the index of what it holds, so print keeps the row AND
+     unfolds it — a printed report never loses findings to a closed fold. */
+  .mat details.sev-fold > .sev-body{display:block !important;}
+  .mat details.sev-fold > summary::after{display:none;}
   /* Tabs are an on-screen affordance: print every view, each under its own
      heading, so a printed report never silently loses two of the three. */
   .mat .tabbar{display:none;}

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -7,7 +7,9 @@ assets) covering the four axes from the issue:
   three SHACL severity tiers Required / Recommended / Optional (#306), with the
   findings from every assessed tier surfaced as actionable suggestions — an author
   who can see what is merely recommended is far likelier to add it than one told
-  only that the crate clears the required bar;
+  only that the crate clears the required bar. When the verdict carries structured
+  ``issue_records`` each severity row unfolds its own findings, grouped by profile
+  layer inside (#510); a pre-records verdict falls back to the flat list;
 * **FAIR** — the RDA-style indicators rolled up into F/A/I/R pillars plus the Data
   Stewardship Maturity (DSM) level;
 * **OECD MIT coverage** — per-module coverage of the in-vitro tox MIT checklist;
@@ -163,6 +165,7 @@ def _severity_tiers(val: ValidationReport) -> list[dict[str, str]]:
     req_ok = n_pass == 3 and not val.required_issues
     tiers: list[dict[str, str]] = [
         {
+            "key": "required",
             "tier": "Required",
             "state": "ok" if req_ok else "no",
             "summary": f"{n_pass} / 3 profiles",
@@ -173,17 +176,25 @@ def _severity_tiers(val: ValidationReport) -> list[dict[str, str]]:
         ("Recommended", val.should_issues, "SHOULD-level quality checks."),
         ("Optional", val.may_issues, "MAY-level informational checks."),
     ):
+        key = label.casefold()
         if issues:
             tiers.append(
-                {"tier": label, "state": "no", "summary": _plural_issues(len(issues)), "note": note}
+                {
+                    "key": key,
+                    "tier": label,
+                    "state": "no",
+                    "summary": _plural_issues(len(issues)),
+                    "note": note,
+                }
             )
-        elif label.casefold() in val.assessed_tiers:
+        elif key in val.assessed_tiers:
             tiers.append(
-                {"tier": label, "state": "ok", "summary": "0 issues", "note": note}
+                {"key": key, "tier": label, "state": "ok", "summary": "0 issues", "note": note}
             )
         else:
             tiers.append(
                 {
+                    "key": key,
                     "tier": label,
                     "state": "na",
                     "summary": "not assessed",
@@ -447,44 +458,182 @@ def _render_kpis(
     return f'<div class="kpis">{prof_tile}{fair_tile}{mit_tile}{chem_tile}{repro_tile}</div>\n'
 
 
+# The three profile layers in fix order: base must pass before ISA is
+# meaningful, ISA before ISA-Tox (the validation-gate ordering contract). The
+# adherence cards and the grouped improvement list both follow it.
+_PROFILE_LAYERS: tuple[tuple[str, str], ...] = (
+    ("base", "RO-Crate 1.2"),
+    ("isa", "ISA"),
+    ("tox", "ISA-Tox"),
+)
+
 # How many findings of each tier the suggestion list shows before it summarises
 # the rest. REQUIRED is uncapped: those block conformance, so every one is named.
+# With grouped rendering (#510) the advisory caps apply per profile group — the
+# cap exists to bound the page, and a bound per group still bounds the page.
 _SUGGESTION_CAPS: dict[str, int | None] = {
     "required": None,
     "recommended": 10,
     "optional": 5,
 }
 
+# Per-tier item templates, shared by the fold-outs and the flat fallback so the
+# two renderings can never drift apart in vocabulary.
+_TIER_TEMPLATES: dict[str, str] = {
+    "required": '<li class="must"><strong>Must fix:</strong> {msg}</li>',
+    "recommended": "<li>Recommended: {msg}</li>",
+    "optional": '<li class="opt">Optional: {msg}</li>',
+}
+_TIER_RENDER_ORDER: tuple[str, ...] = ("required", "recommended", "optional")
 
-def _suggestion_items(val: ValidationReport) -> list[str]:
-    """Render the improvement list: what to fix, across every assessed tier.
 
-    The export assesses all three tiers, so the report shows all three. Naming a
-    RECOMMENDED or OPTIONAL finding is the point of assessing it — a crate whose
-    author can see the twelve things that would make it better is more likely to
-    get them than one told only that it clears the bar. REQUIRED findings stay
-    first and uncapped; the advisory tiers are capped, and a cap that bites says
-    how many it hid rather than trailing off silently.
+def _capped_tier_items(tier: str, rendered: list[str]) -> list[str]:
+    """Apply the tier's cap to already-rendered ``<li>`` items, naming the rest."""
+    cap = _SUGGESTION_CAPS.get(tier)
+    shown = rendered if cap is None else rendered[:cap]
+    hidden = len(rendered) - len(shown)
+    if hidden:
+        shown = [
+            *shown,
+            f'<li class="more">+{hidden} further {tier} '
+            f"{'finding' if hidden == 1 else 'findings'} not listed here</li>",
+        ]
+    return shown
+
+
+def _tier_findings_html(records: list[dict[str, str]], tier: str) -> str:
+    """One severity tier's findings, grouped by profile layer (#510).
+
+    Profile is the *secondary* axis: severity is the fix order (REQUIRED blocks
+    the build, the advisory tiers do not), and only within a tier does layer
+    order matter — base before ISA before ISA-Tox, per the validation-gate
+    ordering contract. So each layer gets a subheading and its own list inside
+    the tier's fold, rather than a second index restating the same counts. A
+    finding the validator does not attribute to a layer lands under
+    "unattributed" — reported, never dropped. The tier's cap applies per layer.
     """
     esc = html.escape
-    tiers: list[tuple[str, list[str], str]] = [
-        ("required", val.required_issues, '<li class="must"><strong>Must fix:</strong> {msg}</li>'),
-        ("recommended", val.should_issues, "<li>Recommended: {msg}</li>"),
-        ("optional", val.may_issues, '<li class="opt">Optional: {msg}</li>'),
+    labels = dict(_PROFILE_LAYERS)
+    layer_rank = {key: i for i, (key, _) in enumerate(_PROFILE_LAYERS)}
+    groups: dict[str, list[dict[str, str]]] = {}
+    for record in records:
+        groups.setdefault(str(record.get("profile") or ""), []).append(record)
+
+    template = _TIER_TEMPLATES.get(tier, "<li>{msg}</li>")
+    out: list[str] = []
+    for key in sorted(groups, key=lambda k: (layer_rank.get(k, len(layer_rank)), k)):
+        items = []
+        for record in groups[key]:
+            entity = str(record.get("entity_id") or "")
+            chip = f"<code>{esc(entity)}</code> " if entity else ""
+            items.append(template.format(msg=f"{chip}{esc(str(record.get('message') or ''))}"))
+        out.append(
+            f'<p class="sugg-prof-h">{esc(labels.get(key, key or "unattributed"))}'
+            f'<span class="pc">{len(groups[key])}</span></p>'
+            f'<ul class="sugg">{"".join(_capped_tier_items(tier, items))}</ul>'
+        )
+    return "".join(out)
+
+
+def _tier_records(val: ValidationReport) -> dict[str, list[dict[str, str]]] | None:
+    """The verdict's findings bucketed by severity tier, or ``None`` if unstructured.
+
+    ``None`` means the verdict carries no ``issue_records`` — one recorded
+    before the field existed — and the caller falls back to the flat display
+    list rather than silently dropping findings.
+    """
+    if not val.issue_records:
+        return None
+    buckets: dict[str, list[dict[str, str]]] = {tier: [] for tier in _TIER_RENDER_ORDER}
+    for record in val.issue_records:
+        buckets.setdefault(str(record.get("severity") or ""), []).append(record)
+    return buckets
+
+
+def _render_severity_detail(val: ValidationReport, tiers: list[dict[str, str]]) -> str:
+    """The "By severity" block, each row unfolding its own findings (#510).
+
+    The severity rows are the index: a row that has findings becomes a
+    ``<details>`` whose summary is the row itself and whose body lists those
+    findings grouped by profile. A row with nothing to show — clean, or a tier
+    the sweep never assessed (#306) — stays a plain row with no fold, so a
+    disclosure caret always means "there is something here".
+
+    A row holding REQUIRED findings is born ``open``: a collapsed fold must
+    never hide a blocking issue.
+    """
+    buckets = _tier_records(val)
+    rows: list[str] = []
+    for tier in tiers:
+        row = (
+            f'{_mk(tier["state"])}<span class="st">{tier["tier"]}</span>'
+            f'<span class="sc">{tier["summary"]}</span><span class="sn">{tier["note"]}</span>'
+        )
+        records = (buckets or {}).get(tier["key"], [])
+        if not records:
+            rows.append(f'<div class="sev-drow">{row}</div>')
+            continue
+        # Where the summary IS a count of findings, it is the count of what the
+        # row unfolds — never a number taken from a different list. REQUIRED is
+        # left alone: its summary counts passing profiles, a different quantity,
+        # and the fold answers "which findings" underneath it.
+        if tier["key"] != "required":
+            row = row.replace(
+                f'<span class="sc">{tier["summary"]}</span>',
+                f'<span class="sc">{_plural_issues(len(records))}</span>',
+                1,
+            )
+        rows.append(
+            f'<details class="sev-fold"{" open" if tier["key"] == "required" else ""}>'
+            f'<summary class="sev-drow">{row}</summary>'
+            f'<div class="sev-body">{_tier_findings_html(records, tier["key"])}</div>'
+            "</details>"
+        )
+    # A finding whose severity is none of the three tiers has no row of its own
+    # to fold out of. The writers cannot produce one today, but this report does
+    # not silently drop findings — it grows a row rather than losing them.
+    for key, records in (buckets or {}).items():
+        if key in _TIER_RENDER_ORDER or not records:
+            continue
+        rows.append(
+            '<details class="sev-fold">'
+            f'<summary class="sev-drow">{_mk("no")}'
+            f'<span class="st">{html.escape(key.capitalize() or "Other")}</span>'
+            f'<span class="sc">{_plural_issues(len(records))}</span>'
+            '<span class="sn">Reported at a severity outside the three tiers.</span></summary>'
+            f'<div class="sev-body">{_tier_findings_html(records, key)}</div>'
+            "</details>"
+        )
+    return (
+        '<div class="sev-detail"><span class="sev-detail-label">By severity</span>'
+        f'{"".join(rows)}</div>'
+    )
+
+
+def _suggestion_items(val: ValidationReport) -> list[str]:
+    """Render the flat improvement list: what to fix, across every assessed tier.
+
+    The fallback for a verdict without structured ``issue_records`` (recorded
+    before #510): the display strings are all such a verdict carries, so they
+    are shown as-is, ungrouped. Naming a RECOMMENDED or OPTIONAL finding is the
+    point of assessing it — a crate whose author can see the twelve things that
+    would make it better is more likely to get them than one told only that it
+    clears the bar. REQUIRED findings stay first and uncapped; the advisory
+    tiers are capped, and a cap that bites says how many it hid rather than
+    trailing off silently.
+    """
+    esc = html.escape
+    tiers: list[tuple[str, list[str]]] = [
+        ("required", val.required_issues),
+        ("recommended", val.should_issues),
+        ("optional", val.may_issues),
     ]
     items: list[str] = []
-    for tier, issues, template in tiers:
+    for tier, issues in tiers:
         if not issues:
             continue
-        cap = _SUGGESTION_CAPS[tier]
-        shown = issues if cap is None else issues[:cap]
-        items.extend(template.format(msg=esc(msg)) for msg in shown)
-        hidden = len(issues) - len(shown)
-        if hidden:
-            items.append(
-                f'<li class="more">+{hidden} further {tier} '
-                f"{'finding' if hidden == 1 else 'findings'} not listed here</li>"
-            )
+        rendered = [_TIER_TEMPLATES[tier].format(msg=esc(msg)) for msg in issues]
+        items.extend(_capped_tier_items(tier, rendered))
     return items
 
 
@@ -526,34 +675,33 @@ def _render_profile_section(
             "</section>\n"
         )
 
-    profiles = [
-        ("RO-Crate 1.2", val.base_passed),
-        ("ISA", val.isa_passed),
-        ("ISA-Tox", val.tox_passed),
-    ]
+    passed_by_layer = {"base": val.base_passed, "isa": val.isa_passed, "tox": val.tox_passed}
     cards = "".join(
-        f'<div class="prof-card">{_mk(_kind(passed))}<span>{esc(name)}</span>'
+        f'<div class="prof-card">{_mk(_kind(passed_by_layer[key]))}<span>{esc(name)}</span>'
         "<em>REQUIRED</em></div>"
-        for name, passed in profiles
+        for key, name in _PROFILE_LAYERS
     )
-    detail_rows = "".join(
-        f'<div class="sev-drow">{_mk(t["state"])}<span class="st">{t["tier"]}</span>'
-        f'<span class="sc">{t["summary"]}</span><span class="sn">{t["note"]}</span></div>'
-        for t in tiers
-    )
-    sugg_items = _suggestion_items(val)
-    if sugg_items:
-        sugg = f'<ul class="sugg">{"".join(sugg_items)}</ul>'
+    severity_detail = _render_severity_detail(val, tiers)
+    # The findings live in the severity rows when the verdict is structured; a
+    # pre-records verdict has only the flat display strings, so it keeps the
+    # flat list under the block. Either way the empty state stays honest about
+    # how much of the crate was actually checked.
+    if _tier_records(val) is not None:
+        sugg = ""
     else:
-        sugg = f'<p class="good-note">{_clean_note(val)}</p>'
+        sugg_items = _suggestion_items(val)
+        sugg = (
+            f'<ul class="sugg">{"".join(sugg_items)}</ul>'
+            if sugg_items
+            else f'<p class="good-note">{_clean_note(val)}</p>'
+        )
 
     return (
         "<section>\n"
         '  <div class="sec-h"><h2>Profile adherence</h2>'
         '<span class="sec-meta">3 layers · 3 severity tiers</span></div>\n'
         f'  <div class="prof-grid">{cards}</div>\n'
-        '  <div class="sev-detail"><span class="sev-detail-label">By severity</span>'
-        f"{detail_rows}</div>\n"
+        f"  {severity_detail}\n"
         f"  {sugg}\n"
         "</section>\n"
     )

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -535,19 +535,46 @@ def _tier_findings_html(records: list[dict[str, str]], tier: str) -> str:
     return "".join(out)
 
 
-def _tier_records(val: ValidationReport) -> dict[str, list[dict[str, str]]] | None:
-    """The verdict's findings bucketed by severity tier, or ``None`` if unstructured.
-
-    ``None`` means the verdict carries no ``issue_records`` — one recorded
-    before the field existed — and the caller falls back to the flat display
-    list rather than silently dropping findings.
-    """
-    if not val.issue_records:
-        return None
+def _tier_records(val: ValidationReport) -> dict[str, list[dict[str, str]]]:
+    """The verdict's structured findings, bucketed by severity tier."""
     buckets: dict[str, list[dict[str, str]]] = {tier: [] for tier in _TIER_RENDER_ORDER}
     for record in val.issue_records:
         buckets.setdefault(str(record.get("severity") or ""), []).append(record)
     return buckets
+
+
+# Which display list each tier's findings live in when the verdict carries no
+# structured records for it (mirrors the write-back's own tier→field mapping).
+_TIER_STRING_FIELDS: dict[str, str] = {
+    "required": "required_issues",
+    "recommended": "should_issues",
+    "optional": "may_issues",
+}
+
+
+def _tier_body(val: ValidationReport, tier: str) -> tuple[str, int]:
+    """One tier's findings as ``(html, count)`` — records first, strings second.
+
+    The choice is made per tier, never once for the whole report: a verdict can
+    legitimately hold records for one tier and only display strings for another
+    (a pre-records checkpoint that then takes a REQUIRED-gate write-back).
+    Deciding globally hid the string-only tiers' findings while the severity row
+    went on counting them, so the report counted findings its own list omitted.
+
+    Records carry the profile attribution and render grouped by layer; strings
+    have none and render as one ungrouped list. Either way the count returned is
+    the count of what the caller is about to show.
+    """
+    records = _tier_records(val).get(tier, [])
+    if records:
+        return _tier_findings_html(records, tier), len(records)
+    field = _TIER_STRING_FIELDS.get(tier)
+    issues: list[str] = getattr(val, field) if field else []
+    if not issues:
+        return "", 0
+    template = _TIER_TEMPLATES.get(tier, "<li>{msg}</li>")
+    items = [template.format(msg=html.escape(str(msg))) for msg in issues]
+    return f'<ul class="sugg">{"".join(_capped_tier_items(tier, items))}</ul>', len(issues)
 
 
 def _render_severity_detail(val: ValidationReport, tiers: list[dict[str, str]]) -> str:
@@ -562,37 +589,33 @@ def _render_severity_detail(val: ValidationReport, tiers: list[dict[str, str]]) 
     A row holding REQUIRED findings is born ``open``: a collapsed fold must
     never hide a blocking issue.
     """
-    buckets = _tier_records(val)
     rows: list[str] = []
     for tier in tiers:
-        row = (
-            f'{_mk(tier["state"])}<span class="st">{tier["tier"]}</span>'
-            f'<span class="sc">{tier["summary"]}</span><span class="sn">{tier["note"]}</span>'
-        )
-        records = (buckets or {}).get(tier["key"], [])
-        if not records:
-            rows.append(f'<div class="sev-drow">{row}</div>')
-            continue
+        body, count = _tier_body(val, tier["key"])
+        summary = tier["summary"]
         # Where the summary IS a count of findings, it is the count of what the
         # row unfolds — never a number taken from a different list. REQUIRED is
         # left alone: its summary counts passing profiles, a different quantity,
         # and the fold answers "which findings" underneath it.
-        if tier["key"] != "required":
-            row = row.replace(
-                f'<span class="sc">{tier["summary"]}</span>',
-                f'<span class="sc">{_plural_issues(len(records))}</span>',
-                1,
-            )
+        if count and tier["key"] != "required":
+            summary = _plural_issues(count)
+        row = (
+            f'{_mk(tier["state"])}<span class="st">{tier["tier"]}</span>'
+            f'<span class="sc">{summary}</span><span class="sn">{tier["note"]}</span>'
+        )
+        if not count:
+            rows.append(f'<div class="sev-drow">{row}</div>')
+            continue
         rows.append(
             f'<details class="sev-fold"{" open" if tier["key"] == "required" else ""}>'
             f'<summary class="sev-drow">{row}</summary>'
-            f'<div class="sev-body">{_tier_findings_html(records, tier["key"])}</div>'
+            f'<div class="sev-body">{body}</div>'
             "</details>"
         )
     # A finding whose severity is none of the three tiers has no row of its own
     # to fold out of. The writers cannot produce one today, but this report does
     # not silently drop findings — it grows a row rather than losing them.
-    for key, records in (buckets or {}).items():
+    for key, records in _tier_records(val).items():
         if key in _TIER_RENDER_ORDER or not records:
             continue
         rows.append(
@@ -608,33 +631,6 @@ def _render_severity_detail(val: ValidationReport, tiers: list[dict[str, str]]) 
         '<div class="sev-detail"><span class="sev-detail-label">By severity</span>'
         f'{"".join(rows)}</div>'
     )
-
-
-def _suggestion_items(val: ValidationReport) -> list[str]:
-    """Render the flat improvement list: what to fix, across every assessed tier.
-
-    The fallback for a verdict without structured ``issue_records`` (recorded
-    before #510): the display strings are all such a verdict carries, so they
-    are shown as-is, ungrouped. Naming a RECOMMENDED or OPTIONAL finding is the
-    point of assessing it — a crate whose author can see the twelve things that
-    would make it better is more likely to get them than one told only that it
-    clears the bar. REQUIRED findings stay first and uncapped; the advisory
-    tiers are capped, and a cap that bites says how many it hid rather than
-    trailing off silently.
-    """
-    esc = html.escape
-    tiers: list[tuple[str, list[str]]] = [
-        ("required", val.required_issues),
-        ("recommended", val.should_issues),
-        ("optional", val.may_issues),
-    ]
-    items: list[str] = []
-    for tier, issues in tiers:
-        if not issues:
-            continue
-        rendered = [_TIER_TEMPLATES[tier].format(msg=esc(msg)) for msg in issues]
-        items.extend(_capped_tier_items(tier, rendered))
-    return items
 
 
 def _clean_note(val: ValidationReport) -> str:
@@ -682,19 +678,15 @@ def _render_profile_section(
         for key, name in _PROFILE_LAYERS
     )
     severity_detail = _render_severity_detail(val, tiers)
-    # The findings live in the severity rows when the verdict is structured; a
-    # pre-records verdict has only the flat display strings, so it keeps the
-    # flat list under the block. Either way the empty state stays honest about
-    # how much of the crate was actually checked.
-    if _tier_records(val) is not None:
-        sugg = ""
-    else:
-        sugg_items = _suggestion_items(val)
-        sugg = (
-            f'<ul class="sugg">{"".join(sugg_items)}</ul>'
-            if sugg_items
-            else f'<p class="good-note">{_clean_note(val)}</p>'
-        )
+    # Every finding lives in the severity row it belongs to, so the only thing
+    # left to say underneath is that there were none — and that line stays
+    # honest about how much of the crate was actually checked (#306).
+    has_findings = any(_tier_body(val, tier["key"])[1] for tier in tiers) or any(
+        records
+        for key, records in _tier_records(val).items()
+        if key not in _TIER_RENDER_ORDER
+    )
+    sugg = "" if has_findings else f'<p class="good-note">{_clean_note(val)}</p>'
 
     return (
         "<section>\n"

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1206,6 +1206,202 @@ class TestSeverityTiers:
         assert "3 / 3 profiles" not in page
 
 
+class TestGroupedSuggestions:
+    """Warnings fold out of the severity row they belong to (#510).
+
+    Severity is the primary axis because it is the fix order: REQUIRED blocks
+    the build, the advisory tiers do not. So each "By severity" row carries its
+    own findings, grouped by profile layer inside the fold (base → ISA →
+    ISA-Tox, the gate-ordering contract) — one index, not a tier index plus a
+    profile index restating the same counts. A row holding REQUIRED findings is
+    born open (a collapsed fold must never hide a blocking issue); advisory rows
+    start collapsed; a row with nothing to show does not fold at all. A verdict
+    from an older checkpoint (no records) keeps the flat list.
+    """
+
+    @staticmethod
+    def _fold(body: str, tier: str) -> str:
+        """The ``<details>`` markup for one severity row."""
+        start = body.index(f'<span class="st">{tier}</span>')
+        open_at = body.rindex("<details", 0, start)
+        return body[open_at : body.index("</details>", open_at)]
+
+    @staticmethod
+    def _records_report() -> ValidationReport:
+        return ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            required_issues=["[base] ./: root MUST have a name"],
+            should_issues=[
+                "[isa] #study-1: consider adding a license",
+                "[tox] #assay-1: dose units are recommended",
+            ],
+            may_issues=["[isa] #study-1: a DOI would help"],
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=[
+                {
+                    "profile": "base",
+                    "severity": "required",
+                    "entity_id": "./",
+                    "message": "root MUST have a name",
+                },
+                {
+                    "profile": "isa",
+                    "severity": "recommended",
+                    "entity_id": "#study-1",
+                    "message": "consider adding a license",
+                },
+                {
+                    "profile": "tox",
+                    "severity": "recommended",
+                    "entity_id": "#assay-1",
+                    "message": "dose units are recommended",
+                },
+                {
+                    "profile": "isa",
+                    "severity": "optional",
+                    "entity_id": "#study-1",
+                    "message": "a DOI would help",
+                },
+            ],
+        )
+
+    def test_findings_fold_out_of_their_own_severity_row(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        body = _body(build_maturity_html(state, validation=self._records_report()))
+        rec = self._fold(body, "Recommended")
+        # The row keeps its severity summary…
+        assert "2 issues" in rec
+        # …and carries its findings, grouped by profile in fix order.
+        assert rec.index('>ISA<span class="pc">') < rec.index('>ISA-Tox<span class="pc">')
+        assert "consider adding a license" in rec
+        assert "dose units are recommended" in rec
+        # Findings of another tier belong to another row.
+        assert "a DOI would help" not in rec
+        assert "a DOI would help" in self._fold(body, "Optional")
+
+    def test_profile_counts_are_not_restated_outside_the_fold(self) -> None:
+        # The defect this replaces: a per-profile list under the severity block
+        # restating the same counts ("Recommended · 2 issues", then "ISA — 1
+        # recommended · ISA-Tox — 1 recommended").
+        state = vhps_fixture_state("S-VHPS21")
+        body = _body(build_maturity_html(state, validation=self._records_report()))
+        assert "sugg-prof" not in body.replace('class="sugg-prof-h"', "")
+        assert "1 recommended · 1 optional" not in body
+
+    def test_row_with_required_findings_is_open_advisory_rows_collapsed(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        body = _body(build_maturity_html(state, validation=self._records_report()))
+        assert self._fold(body, "Required").startswith('<details class="sev-fold" open>')
+        assert self._fold(body, "Recommended").startswith('<details class="sev-fold">')
+        assert self._fold(body, "Optional").startswith('<details class="sev-fold">')
+
+    def test_rows_with_nothing_to_show_do_not_fold(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            assessed_tiers={"required"},
+            issue_records=[],
+        )
+        body = _body(build_maturity_html(state, validation=val))
+        # A clean REQUIRED tier and two unassessed tiers: nothing to unfold, and
+        # the unassessed ones still say so rather than reading as clean (#306).
+        assert "sev-fold" not in body
+        assert "not assessed" in body.lower()
+
+    def test_items_show_entity_and_message_without_the_string_prefix(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        body = _body(build_maturity_html(state, validation=self._records_report()))
+        assert "<code>./</code>" in body
+        assert "root MUST have a name" in body
+        assert "Must fix" in body
+        assert "Recommended:" in body and "Optional:" in body
+        # The grouped view replaces the flattened "[profile] entity:" prefix.
+        assert "[isa]" not in body and "[base]" not in body
+
+    def test_advisory_caps_apply_per_profile_group(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        records = [
+            {
+                "profile": "isa",
+                "severity": "recommended",
+                "entity_id": f"#e{i}",
+                "message": f"advisory finding {i}",
+            }
+            for i in range(12)
+        ]
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            should_issues=[f"[isa] #e{i}: advisory finding {i}" for i in range(12)],
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=records,
+        )
+        body = _body(build_maturity_html(state, validation=val))
+        assert body.count("Recommended: ") == 10
+        assert "+2 further recommended findings" in body
+
+    def test_records_are_escaped(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            required_issues=['[base] #x: <img src=x onerror=alert(1)>'],
+            assessed_tiers={"required"},
+            issue_records=[
+                {
+                    "profile": "base",
+                    "severity": "required",
+                    "entity_id": "#<b>x</b>",
+                    "message": "<img src=x onerror=alert(1)>",
+                }
+            ],
+        )
+        page = build_maturity_html(state, validation=val)
+        assert "<img src=x" not in page
+        assert "<b>x</b>" not in page
+        assert "&lt;img src=x" in page
+
+    def test_verdict_without_records_falls_back_to_the_flat_list(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            required_issues=["root MUST have a name"],
+            should_issues=["consider adding a license"],
+        )
+        body = _body(build_maturity_html(state, validation=val))
+        assert "sev-fold" not in body
+        assert "root MUST have a name" in body
+        assert "consider adding a license" in body
+
+    def test_a_findings_row_reports_the_count_it_unfolds(self) -> None:
+        # The row's count and its contents come from one list, so the summary
+        # can never promise a number the fold does not hold.
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            should_issues=["[isa] #a: one"],
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=[
+                {"profile": "isa", "severity": "recommended", "entity_id": "#a", "message": "one"},
+                {"profile": "tox", "severity": "recommended", "entity_id": "#b", "message": "two"},
+            ],
+        )
+        body = _body(build_maturity_html(state, validation=val))
+        rec = self._fold(body, "Recommended")
+        assert "2 issues" in rec
+        assert rec.count("Recommended: ") == 2
+
+
 class TestOverviewPanel:
     """The All-entities view: the whole crate as one composition map (#85).
 

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1367,7 +1367,10 @@ class TestGroupedSuggestions:
         assert "<b>x</b>" not in page
         assert "&lt;img src=x" in page
 
-    def test_verdict_without_records_falls_back_to_the_flat_list(self) -> None:
+    def test_verdict_without_records_folds_its_display_strings(self) -> None:
+        # A verdict recorded before issue_records existed carries only the flat
+        # strings. They still belong to a tier, so they still fold out of it —
+        # ungrouped, because such a verdict has no profile attribution to group by.
         state = vhps_fixture_state("S-VHPS21")
         val = ValidationReport(
             base_passed=False,
@@ -1377,9 +1380,109 @@ class TestGroupedSuggestions:
             should_issues=["consider adding a license"],
         )
         body = _body(build_maturity_html(state, validation=val))
-        assert "sev-fold" not in body
-        assert "root MUST have a name" in body
-        assert "consider adding a license" in body
+        assert "root MUST have a name" in self._fold(body, "Required")
+        assert "consider adding a license" in self._fold(body, "Recommended")
+
+    def test_a_tier_whose_records_are_missing_still_shows_its_findings(self) -> None:
+        """The mixed state: records for one tier, display strings for another.
+
+        A pre-records checkpoint that then takes a REQUIRED-gate write-back ends
+        up with required records beside still-fresh advisory strings. Choosing
+        the rendering once, for the whole report, hid those advisory findings
+        while the severity row went on counting them — the report would count
+        findings its own list omits.
+        """
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=False,
+            isa_passed=True,
+            tox_passed=True,
+            required_issues=["[base] ./: root MUST have a name"],
+            should_issues=["[isa] #s: consider a license", "[tox] #a: add dose units"],
+            may_issues=["[isa] #s: a DOI would help"],
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=[
+                {
+                    "profile": "base",
+                    "severity": "required",
+                    "entity_id": "./",
+                    "message": "root MUST have a name",
+                }
+            ],
+        )
+        body = _body(build_maturity_html(state, validation=val))
+        rec = self._fold(body, "Recommended")
+        assert "2 issues" in rec
+        assert "consider a license" in rec and "add dose units" in rec
+        assert "a DOI would help" in self._fold(body, "Optional")
+
+    def test_cap_applies_per_profile_group_not_across_the_tier(self) -> None:
+        # Two layers of 12 findings each: the cap bounds each group at 10, so
+        # both groups keep a listed head and both name what they hid — a global
+        # cap would have shown 10 of 24 and hidden a whole layer.
+        state = vhps_fixture_state("S-VHPS21")
+        records = [
+            {
+                "profile": profile,
+                "severity": "recommended",
+                "entity_id": f"#{profile}{i}",
+                "message": f"{profile} advisory {i}",
+            }
+            for profile in ("isa", "tox")
+            for i in range(12)
+        ]
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            should_issues=[f"{r['profile']} advisory {r['entity_id']}" for r in records],
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=records,
+        )
+        rec = self._fold(_body(build_maturity_html(state, validation=val)), "Recommended")
+        assert rec.count("Recommended: ") == 20
+        assert rec.count("+2 further recommended findings") == 2
+        assert "24 issues" in rec
+
+    def test_unattributed_findings_are_reported_not_dropped(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            should_issues=["one with no layer"],
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=[
+                {
+                    "profile": "",
+                    "severity": "recommended",
+                    "entity_id": "#x",
+                    "message": "one with no layer",
+                }
+            ],
+        )
+        rec = self._fold(_body(build_maturity_html(state, validation=val)), "Recommended")
+        assert "unattributed" in rec
+        assert "one with no layer" in rec
+
+    def test_a_severity_outside_the_three_tiers_grows_its_own_row(self) -> None:
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            assessed_tiers={"required", "recommended", "optional"},
+            issue_records=[
+                {
+                    "profile": "base",
+                    "severity": "info",
+                    "entity_id": "#x",
+                    "message": "an informational note",
+                }
+            ],
+        )
+        body = _body(build_maturity_html(state, validation=val))
+        assert "an informational note" in self._fold(body, "Info")
 
     def test_a_findings_row_reports_the_count_it_unfolds(self) -> None:
         # The row's count and its contents come from one list, so the summary

--- a/tests/test_tools_validation.py
+++ b/tests/test_tools_validation.py
@@ -175,6 +175,110 @@ class TestValidate:
         finally:
             validator_mod.validate_crate = original
 
+    def test_validate_attributes_issue_records_to_profiles(self, tmp_path, monkeypatch):
+        """The disk path knows which profile pass produced each finding — each
+        ``ValidationResult`` is one pass — so ``issue_records`` must carry that
+        attribution (#510). Severity comes from the ``[Required]``-style prefix
+        ``_format_issues`` stamps; the prefix is structure, not message, so the
+        recorded message is the string without it."""
+        import profiles.validator as validator_mod
+        from profiles.validator import ValidationResult
+
+        def patched_validate(crate_dir):
+            return [
+                ValidationResult(
+                    profile="Base RO-Crate 1.1",
+                    passed=False,
+                    issues=[
+                        "[Required] root missing name",
+                        "[Recommended] add a license",
+                    ],
+                    required_issues=["[Required] root missing name"],
+                    passed_required=False,
+                ),
+                ValidationResult(
+                    profile="ISA RO-Crate Profile",
+                    passed=False,
+                    issues=["[Optional] a DOI would help"],
+                    required_issues=[],
+                    passed_required=True,
+                ),
+            ]
+
+        monkeypatch.setattr(validator_mod, "validate_crate", patched_validate)
+
+        crate_dir = tmp_path / "placeholder"
+        crate_dir.mkdir()
+        report = validate(CrateState(), str(crate_dir))
+
+        assert report.issue_records == [
+            {
+                "profile": "base",
+                "severity": "required",
+                "entity_id": "",
+                "message": "root missing name",
+            },
+            {
+                "profile": "base",
+                "severity": "recommended",
+                "entity_id": "",
+                "message": "add a license",
+            },
+            {
+                "profile": "isa",
+                "severity": "optional",
+                "entity_id": "",
+                "message": "a DOI would help",
+            },
+        ]
+        # The display lists keep their historical prefixed shape.
+        assert report.required_issues == ["[Required] root missing name"]
+        assert report.should_issues == ["[Recommended] add a license"]
+        assert report.may_issues == ["[Optional] a DOI would help"]
+
+    def test_isa_failure_does_not_fail_base(self, tmp_path, monkeypatch):
+        """Every pass's display name contains "ro-crate" ("ISA RO-Crate
+        Profile", "ISA-Tox RO-Crate Profile"), so the old ``"ro-crate" in
+        name`` guard classified an ISA or ISA-Tox REQUIRED failure as a BASE
+        failure. The most specific token must win (#510)."""
+        import profiles.validator as validator_mod
+        from profiles.validator import ValidationResult
+
+        def patched_validate(crate_dir):
+            return [
+                ValidationResult(
+                    profile="Base RO-Crate 1.2",
+                    passed=True,
+                    issues=[],
+                    required_issues=[],
+                    passed_required=True,
+                ),
+                ValidationResult(
+                    profile="ISA RO-Crate Profile",
+                    passed=False,
+                    issues=["[Required] root missing identifier"],
+                    required_issues=["[Required] root missing identifier"],
+                    passed_required=False,
+                ),
+                ValidationResult(
+                    profile="ISA-Tox RO-Crate Profile",
+                    passed=False,
+                    issues=["[Required] no dose recorded"],
+                    required_issues=["[Required] no dose recorded"],
+                    passed_required=False,
+                ),
+            ]
+
+        monkeypatch.setattr(validator_mod, "validate_crate", patched_validate)
+
+        crate_dir = tmp_path / "placeholder"
+        crate_dir.mkdir()
+        report = validate(CrateState(), str(crate_dir))
+
+        assert report.base_passed is True
+        assert report.isa_passed is False
+        assert report.tox_passed is False
+
     def test_base_pass_uses_optional_severity(self, tmp_path):
         """Base RO-Crate pass should use Severity.OPTIONAL so that
         RECOMMENDED and OPTIONAL issues are surfaced alongside REQUIRED ones."""

--- a/tests/test_tools_validation.py
+++ b/tests/test_tools_validation.py
@@ -236,6 +236,44 @@ class TestValidate:
         assert report.should_issues == ["[Recommended] add a license"]
         assert report.may_issues == ["[Optional] a DOI would help"]
 
+    def test_a_message_two_profiles_raise_is_recorded_once_per_profile(self, tmp_path, monkeypatch):
+        """The display list dedups identical advisory text; the records do not.
+
+        Two passes can report the same sentence about different layers. Collapsed
+        to one string it reads as one finding, but it is two — and the records
+        are what carry the attribution the report groups by, so each keeps its
+        own profile."""
+        import profiles.validator as validator_mod
+        from profiles.validator import ValidationResult
+
+        same = "[Recommended] add a license"
+
+        def patched_validate(crate_dir):
+            return [
+                ValidationResult(
+                    profile="Base RO-Crate 1.2",
+                    passed=False,
+                    issues=[same],
+                    required_issues=[],
+                    passed_required=True,
+                ),
+                ValidationResult(
+                    profile="ISA RO-Crate Profile",
+                    passed=False,
+                    issues=[same],
+                    required_issues=[],
+                    passed_required=True,
+                ),
+            ]
+
+        monkeypatch.setattr(validator_mod, "validate_crate", patched_validate)
+        crate_dir = tmp_path / "placeholder"
+        crate_dir.mkdir()
+        report = validate(CrateState(), str(crate_dir))
+
+        assert report.should_issues == [same]
+        assert [r["profile"] for r in report.issue_records] == ["base", "isa"]
+
     def test_isa_failure_does_not_fail_base(self, tmp_path, monkeypatch):
         """Every pass's display name contains "ro-crate" ("ISA RO-Crate
         Profile", "ISA-Tox RO-Crate Profile"), so the old ``"ro-crate" in

--- a/tests/test_validation_writeback.py
+++ b/tests/test_validation_writeback.py
@@ -190,6 +190,119 @@ class TestValidationFreshness:
         )
 
 
+class TestIssueRecords:
+    """Write-back preserves the validator's structured attribution (#510).
+
+    ``build_and_validate`` returns issues with ``profile`` / ``severity`` /
+    ``entity_id`` intact, but the write-back used to keep only the flattened
+    display strings — so the maturity report could never say WHICH profile a
+    warning belonged to. ``issue_records`` carries the structure; the display
+    strings stay byte-identical because the ReAct loop parses them.
+    """
+
+    def _state(self):
+        from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+        return vhps_fixture_state("S-VHPS21")
+
+    @staticmethod
+    def _result(issues: list[dict]) -> dict:
+        return {
+            "ok": not issues,
+            "conformance": {"base": True, "isa": False, "tox": True},
+            "issues": issues,
+        }
+
+    def test_writeback_records_structured_issues(self) -> None:
+        from builder.tools.validation import apply_validation_result
+
+        state = self._state()
+        apply_validation_result(
+            state,
+            "build_and_validate",
+            self._result(
+                [
+                    {
+                        "severity": "recommended",
+                        "profile": "tox",
+                        "entity_id": "#m",
+                        "message": "add dose units",
+                    },
+                    {
+                        "severity": "required",
+                        "profile": "isa",
+                        "entity_id": "./",
+                        "message": "missing identifier",
+                    },
+                ]
+            ),
+            severity="optional",
+        )
+        v = state.validation
+        assert v.issue_records == [
+            {
+                "profile": "isa",
+                "severity": "required",
+                "entity_id": "./",
+                "message": "missing identifier",
+            },
+            {
+                "profile": "tox",
+                "severity": "recommended",
+                "entity_id": "#m",
+                "message": "add dose units",
+            },
+        ]
+        # The flattened display strings are a parsed contract (agent_loop's
+        # open-items queue splits on "] " and ": ") — they must not change shape.
+        assert v.required_issues == ["[isa] ./: missing identifier"]
+        assert v.should_issues == ["[tox] #m: add dose units"]
+
+    def test_required_only_refresh_keeps_then_retires_advisory_records(self) -> None:
+        from builder.tools.validation import apply_validation_result
+
+        state = self._state()
+        advisory = {
+            "severity": "recommended",
+            "profile": "isa",
+            "entity_id": "#s",
+            "message": "consider a license",
+        }
+        apply_validation_result(
+            state, "build_and_validate", self._result([advisory]), severity="optional"
+        )
+        assert any(r["severity"] == "recommended" for r in state.validation.issue_records)
+
+        # Same state: a REQUIRED-only refresh must not discard fresh advisory records.
+        apply_validation_result(
+            state, "build_and_validate", self._result([]), severity="required"
+        )
+        assert any(r["severity"] == "recommended" for r in state.validation.issue_records)
+
+        # Crate changed: the advisory records describe an older crate — retire
+        # them alongside the advisory string lists.
+        state.metadata.title = "Edited after validating"
+        apply_validation_result(
+            state, "build_and_validate", self._result([]), severity="required"
+        )
+        assert state.validation.issue_records == []
+        assert state.validation.should_issues == []
+
+    def test_records_round_trip_through_serialisation(self) -> None:
+        record = {
+            "profile": "base",
+            "severity": "required",
+            "entity_id": "./",
+            "message": "root MUST have a name",
+        }
+        report = ValidationReport(issue_records=[record])
+        assert ValidationReport.from_dict(report.to_dict()).issue_records == [record]
+        # …and a checkpoint written before the field existed still loads.
+        legacy = report.to_dict()
+        del legacy["issue_records"]
+        assert ValidationReport.from_dict(legacy).issue_records == []
+
+
 class TestEnsureValidated:
     """``ensure_validated`` re-validates only when the recorded verdict is stale."""
 

--- a/tests/test_validation_writeback.py
+++ b/tests/test_validation_writeback.py
@@ -288,6 +288,54 @@ class TestIssueRecords:
         assert state.validation.issue_records == []
         assert state.validation.should_issues == []
 
+    def test_a_covered_tier_replaces_its_records_rather_than_accumulating(self) -> None:
+        from builder.tools.validation import apply_validation_result
+
+        state = self._state()
+        first = {
+            "severity": "required",
+            "profile": "isa",
+            "entity_id": "./",
+            "message": "missing identifier",
+        }
+        apply_validation_result(state, "build_and_validate", self._result([first]), severity="required")
+        second = {**first, "message": "still missing a name"}
+        apply_validation_result(
+            state, "build_and_validate", self._result([second]), severity="required"
+        )
+        assert [r["message"] for r in state.validation.issue_records] == ["still missing a name"]
+
+    def test_a_severity_outside_the_three_tiers_survives_a_write_back(self) -> None:
+        # No writer emits one today, but a checkpoint or a hand-built report can
+        # carry it — and the report renders such findings rather than dropping
+        # them, so the write-back must not be the thing that loses them.
+        from builder.tools.validation import apply_validation_result
+
+        state = self._state()
+        state.validation = ValidationReport(
+            issue_records=[
+                {"profile": "base", "severity": "info", "entity_id": "#x", "message": "noted"}
+            ],
+            input_fingerprint=state.validation_fingerprint(),
+        )
+        apply_validation_result(
+            state,
+            "build_and_validate",
+            self._result(
+                [
+                    {
+                        "severity": "required",
+                        "profile": "isa",
+                        "entity_id": "./",
+                        "message": "missing identifier",
+                    }
+                ]
+            ),
+            severity="required",
+        )
+        severities = [r["severity"] for r in state.validation.issue_records]
+        assert "info" in severities and "required" in severities
+
     def test_records_round_trip_through_serialisation(self) -> None:
         record = {
             "profile": "base",


### PR DESCRIPTION
Closes #510.

## The problem

The maturity report's improvement list was one flat list of display strings. A reader could not see which profile layer a warning belonged to — even though fix order is layer-ordered by contract — and the per-tier structure showed only as a `[base] ./: …` text prefix.

Attribution was destroyed at write-back. `RoutableIssue` carries `profile` / `severity` / `entity_id` / `message`, but only the flattened strings were recorded. Those strings are a **parsed contract** (the ReAct loop's open-items queue splits on `"] "` and `": "`), so their shape could not change.

## The change

`ValidationReport` gains an additive **`issue_records`** — the same findings with their structure intact — written by both validation paths beside the unchanged string lists, retired and refreshed tier-for-tier with them so neither view can describe a different validation than the other. Old checkpoints load with no records and still render.

The report renders them into the **"By severity"** block: a tier row with findings becomes a `<details>` whose summary is the row itself, the findings grouped by profile layer inside it.

```
BY SEVERITY
✓  Required      3 / 3 profiles   Blocking — every layer must pass to build.
✗  Recommended   69 issues        SHOULD-level quality checks.       ›
✗  Optional      5 issues         MAY-level informational checks.    ›
        └─ unfolds → RO-Crate 1.2 · 49   ISA · 14   ISA-Tox · 6
```

Design decisions worth reviewing:

- **Severity is the primary axis**, profile secondary — that is the fix order (REQUIRED blocks the build; within a tier, base before ISA before ISA-Tox). A per-profile index *alongside* the tier rows would restate the same counts twice, so there is none.
- **The profile cards stay non-interactive.** They assert REQUIRED-gate conformance and nothing else; hanging advisory findings off them would muddy that claim.
- **A row holding REQUIRED findings is born `open`** — a collapsed fold must never hide a blocking issue. A row with nothing to show does not fold, so a caret always means there is something there. Print keeps every row *and* unfolds it.
- **The source is chosen per tier, never once per report.** Records when a tier has them, else that tier's display strings. A verdict can hold records for one tier and only strings for another (a pre-records checkpoint that then takes a REQUIRED-gate write-back); deciding globally hid those findings while the row went on counting them.

The #306 honesty contract is untouched: an unassessed tier still reads "not assessed", never a green zero.

## Also fixed

A pre-existing misclassification in the disk-path `validate()`: every pass's display name contains "ro-crate", so an ISA or ISA-Tox REQUIRED failure was recorded as a **BASE** failure. Now the most-specific token wins, pinned by a test.

## Review

Written test-first throughout. A 17-agent adversarial review found two ways a finding could be counted but never shown — both fixed in `10eb8f4`, both now covered by tests (the per-tier source choice above, and the write-back dropping records whose severity is outside the three tiers). It also surfaced a genuine pre-existing bug unrelated to warnings reporting — crate text containing `__TITLE__` is rewritten to the report title — filed separately as #518.

Full suite: 2534 passed. The 3 failures are pre-existing and verified against a clean tree (#494, the pipeline offline test, and the load-sensitive flake #406).

🤖 Generated with [Claude Code](https://claude.com/claude-code)