### PR TITLE
test: deflake the pair #406 found today, by diagnosis not by tolerance

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,39 @@ def _isolate_session_dir(tmp_path, monkeypatch):
     return root
 
 
+@pytest.fixture(autouse=True)
+def _reset_http_shared_state():
+    """Clear ``lookups._http``'s process-global per-host state around every test.
+
+    ``_http`` deliberately keeps two module-level caches that outlive a single
+    lookup: the circuit breaker (``_breaker_state``) and the politeness throttle
+    (``_host_throttle``). Production wants exactly that — one host's outage is
+    remembered for the rest of the run. A test process is a *very long* run, so
+    without this fixture one test's simulated failures leak into every later
+    test in the same worker that touches the same host.
+
+    Concretely: three tests that drive a timeout/429/5xx at ``api.test`` push
+    the breaker over ``_BREAKER_THRESHOLD``, and for the next 60 seconds
+    ``http_get_json`` raises ``TransientLookupError`` for that host *without
+    issuing a request at all*. A later test then either fails outright (nothing
+    to inspect in ``responses.calls``) or — worse — passes vacuously, because
+    the "transient failure" it thinks it provoked came from the breaker rather
+    than from the response it registered. Which of those happens depends on how
+    xdist packs tests into workers, so it surfaces as load-dependent flakiness
+    instead of a stable red (#406).
+
+    Resetting *after* the test too keeps a test's own failures from reaching
+    fixture teardown or the next module's collection-time code.
+    """
+    from lookups import _http
+
+    _http.reset_circuit_breaker()
+    _http.reset_host_throttle()
+    yield
+    _http.reset_circuit_breaker()
+    _http.reset_host_throttle()
+
+
 @pytest.fixture
 def tmp_files(tmp_path):
     """Fixture that provides a helper to create files in a temporary directory.

--- a/tests/test_http_resilience.py
+++ b/tests/test_http_resilience.py
@@ -78,7 +78,20 @@ class TestHttpGetJson:
             params={"q": "v"},
             headers={"Accept": "application/json"},
         )
-        assert "q=v" in (responses.calls[0].request.url or "")
+        # Assert on the call this test made, not on whatever sits at index 0.
+        # A positional index cannot tell "the request carried no params" from
+        # "no request was sent" — and _http can legitimately send nothing (an
+        # open circuit breaker short-circuits the host), so index 0 is only
+        # this test's request by luck of what ran before it.
+        sent = [
+            call
+            for call in responses.calls
+            if (call.request.url or "").startswith("https://api.test/x")
+        ]
+        assert len(sent) == 1, f"expected exactly one GET to api.test/x, got {len(sent)}"
+        request = sent[0].request
+        assert "q=v" in (request.url or "")
+        assert request.headers.get("Accept") == "application/json"
 
 
 class TestSessionRetryConfig:

--- a/tests/test_tools_session.py
+++ b/tests/test_tools_session.py
@@ -324,7 +324,7 @@ class TestSaveSession:
 class TestSaveSessionForce:
     """Tests for forced save (always_write parameter)."""
 
-    def test_force_always_writes_even_if_unchanged(self, tmp_path):
+    def test_force_always_writes_even_if_unchanged(self, tmp_path, monkeypatch):
         """When always_write=True, the save happens regardless of state changes."""
         from builder.tools import session as sess_mod
 
@@ -345,12 +345,38 @@ class TestSaveSessionForce:
         session_path = tmp_path / "sessions" / "force_test"
         state_path = session_path / "crate_state.json"
 
-        mtime_before = state_path.stat().st_mtime_ns
+        # Count the atomic commit (os.replace of the temp file over
+        # crate_state.json) rather than comparing st_mtime_ns before/after.
+        # File timestamps come from the kernel's *coarse* clock, which only
+        # advances once per tick -- measured at ~4.1ms on the CI filesystem --
+        # so two saves microseconds apart stamp an IDENTICAL mtime and a
+        # strict `>` fails at random (~57% of back-to-back writes collide).
+        # The claim under test is "the write happened", so observe the write.
+        replaced_paths: list[str] = []
+        real_replace = os.replace
+
+        def _counting_replace(src, dst):
+            replaced_paths.append(str(dst))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", _counting_replace)
+
+        # Control: identical content without the flag must skip the write
+        # entirely, otherwise the forced write below would prove nothing.
+        unforced = sess_mod.save_session(state)
+        assert unforced["skipped"] is True
+        assert str(state_path) not in replaced_paths, (
+            "Unchanged state should not be rewritten without always_write"
+        )
+
         result = sess_mod.save_session(state, always_write=True)
-        mtime_after = state_path.stat().st_mtime_ns
 
         assert result["success"] is True
-        assert mtime_after > mtime_before, "File should be modified when always_write=True"
+        assert result["skipped"] is False
+        assert replaced_paths.count(str(state_path)) == 1, (
+            "always_write=True must rewrite crate_state.json even though the "
+            "content hash is unchanged"
+        )
 
 
 # =========================================================================


### PR DESCRIPTION
Refs #406. Both tests failed in today's full `-n auto --maxprocesses=4` run and passed alone. Neither needed a marker, a sleep or a widened threshold — both had a mechanism, and **one was not load-sensitive at all**.

## `test_http_resilience.py` — a leaked circuit breaker, deterministically red

Not the shared `Session`, as I'd guessed. `lookups/_http` keeps a **process-global per-host circuit breaker**: after `_BREAKER_THRESHOLD` consecutive transient failures, `http_get_json` raises `TransientLookupError` *without issuing a request*, for `_BREAKER_COOLDOWN = 60s`. Five tests in `TestHttpGetJson` drive 503 / 429 / timeout / connection-error / malformed-JSON at the same host `api.test`; the third opens the breaker; every later test in that worker is refused. Nothing in the suite ever called `reset_circuit_breaker()`.

It is **red run serially**:

```
$ pytest tests/test_http_resilience.py -q
FAILED …::test_passes_params_and_headers   —  lookups/_http.py:256 TransientLookupError
1 failed, 13 passed
```

So it was never flaky. xdist packing only decided whether the affected test landed in the same process as the three that trip the breaker, which is what made it *look* load-dependent.

**Worse than the red:** a test can also pass **vacuously** this way — the "transient failure" it thinks it provoked came from the breaker rather than from the response it registered. Three sibling tests were in exactly that state; the new fixture de-vacuums them (verified: making `RequestException` return `NOT_FOUND` now reddens `test_timeout_raises_transient` and `test_connection_error_raises_transient`).

The root `conftest.py` now resets the breaker and the politeness throttle around every test. Production wants both to outlive a single lookup — one host's outage *should* be remembered for the rest of the run — and a test process is a very long run.

## `test_tools_session.py` — clock granularity, measured

`save_session` commits via `mkstemp` → `fsync` → `os.replace`, so the mtime is stamped from the kernel's **coarse** clock. Repeating that exact pattern 300× on this host:

```
writes: 300 | consecutive-identical mtime pairs: 177 (59.2%)
smallest nonzero delta (ns): 4125405   ← every delta is one ~4.125 ms quantum
```

Two saves microseconds apart share an `st_mtime_ns`, so `mtime_after > mtime_before` fails. Replaying the test body 400× warm reproduces it at 57%.

**The "under load" signal is the opposite of the obvious reading.** In a full run the module's earlier tests have already warmed `save_session`, so the gap between the two saves *collapses* and the collision rate climbs toward the warm-loop rate. The load makes the hot path faster, not slower — which is why a cold single-test run passes ~92% of the time.

The assertion now **observes the write** instead of inferring it from a clock: count `os.replace` commits onto `crate_state.json`, plus the control arm the old test lacked — the same state saved *without* `always_write` must skip and write nothing. Strictly stronger: the old test could not distinguish "the forced write happened" from "this path always writes".

## Nothing was weakened

| | before | after |
|---|---|---|
| session | `success` + `mtime_after > mtime_before` | `success` + `skipped is False` + **exactly one** `os.replace` onto the state file + a control arm proving the unforced save skips and writes nothing |
| http | `"q=v" in calls[0].request.url` | exactly one GET to the endpoint + params **and** headers asserted on the matching call, not a positional index |

## Verification

- 15/15 clean runs of both modules together here; ~150 runs across configurations in review (`-n 2`, `-n 4` alongside heavy modules, random order, 8-CPU contention) with zero flakes.
- Both originals reproduced by reverting: http deterministically red serially, session red 9/20 module runs.
- **Mutation-checked against production** — dropping `not always_write` from the skip condition, replacing `os.replace` with `os.unlink` (reports success, writes nothing), and dropping `params` from the request each turn the relevant test red. `builder/tools/session.py` and `lookups/_http.py` restored byte-identical; this PR touches only test files and `conftest.py`.

`uvx ruff check` and `uv run ty check` clean.

## Note for the issue

Today's run failed a **different** pair than the two #406 names — three distinct failing sets across three runs of the same tree. Given one of today's two was a deterministic state leak rather than load sensitivity, the issue is probably better shaped around *"shared process-global state leaking between tests"* than around a list of test names. Commented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)