### PR TITLE
fix(validation): tell citations apart from gaps, from the crate's own structure

### DIFF
--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -195,6 +195,126 @@ def _assemble_and_validate(
     return metadata_doc, validate_crate_dict(metadata_doc, severity=severity, profile=profile)
 
 
+# Properties whose value is a term the crate POINTS AT rather than describes.
+# `propertyID` says which scheme an identifier belongs to, `propertyUrl` which
+# term a column means, `conformsTo` which spec a thing follows. None of them
+# assert anything about the IRI itself.
+#
+# Kept in step with `builder.tools.builder._TERM_REFERENCE_PROPERTIES`, which is
+# the same idea for the same reason on the writing side.
+_CITATION_PROPERTIES: frozenset[str] = frozenset(
+    {"propertyID", "propertyUrl", "inDefinedTermSet", "conformsTo"}
+)
+
+
+def _context_vocabulary(metadata_doc: dict[str, Any]) -> set[str]:
+    """Every IRI the crate's own ``@context`` defines a term for.
+
+    A context maps names to classes and properties — `"KeyEvent"` to
+    `https://aopwiki.org/ontology/KeyEvent`, `"has_key_event"` to
+    `…/hasKeyEvent`. Those IRIs reach the validator as types and predicates, never
+    as reference objects, so scanning the graph for `{"@id": …}` values misses
+    every one of them: on a real crate that was 47 findings asking a *property*
+    for a human-readable name.
+
+    Vocabulary by construction. A predicate is not an entity a crate can describe,
+    whoever publishes it — which is why this needs no namespace list either.
+    """
+    context = metadata_doc.get("@context")
+    entries = context if isinstance(context, list) else [context]
+    defined: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue  # a remote context reference; its terms are not ours to judge
+        for term, target in entry.items():
+            if term.startswith("@"):
+                continue  # @vocab and friends are namespaces, not terms
+            iri = target.get("@id") if isinstance(target, dict) else target
+            if isinstance(iri, str) and "://" in iri:
+                defined.add(iri)
+    return defined
+
+
+def _cited_iris(metadata_doc: dict[str, Any]) -> set[str]:
+    """External IRIs the crate CITES — points at without asserting anything about.
+
+    An RO-Crate is expected to describe what it asserts. It is not expected to
+    describe the vocabularies it references: the upstream shapes say so
+    themselves, excluding schema.org, w3.org, purl.org, bioschemas.org and urn:
+    from these very checks. That list is the one a workflow crate needs, so a
+    crate citing any other vocabulary gets findings for terms it does not own —
+    "no name", "no schema.org type", "not described in the graph" — none of which
+    can be fixed without copying data that belongs to, and is versioned by,
+    somebody else.
+
+    The obvious fix is to add the missing namespaces, and it is wrong. It fits
+    whichever crate prompted it, needs an edit for every new ontology, and cannot
+    express the case that actually matters: `https://orcid.org` is a scheme this
+    crate cites, while `https://orcid.org/0009-0000-5074-6239` is an author it
+    describes. Same prefix, opposite answers. No host list can separate them.
+
+    So this asks the crate instead. An IRI is a citation when all three hold:
+
+    * it is external — a crate-local id is always ours;
+    * the crate does not describe it — nothing in the graph gives it properties;
+    * nothing references it through a property that asserts something. Referenced
+      only via `propertyID`/`propertyUrl`/`conformsTo`, or only as a type, it is
+      vocabulary. Referenced via `author`, `hasPart` or `has_key_event`, it is an
+      entity the crate is genuinely missing, and it stays reported.
+
+    That last clause is the safety property: an author we linked but never drafted
+    is referenced via `author`, so it is NOT a citation and the finding survives.
+    Nothing the crate asserts can be silenced by this.
+
+    No namespace list, no configuration, and an ontology nobody has seen before
+    classifies correctly on first contact.
+    """
+    graph = metadata_doc.get("@graph")
+    if not isinstance(graph, list):
+        return set()
+
+    described: set[str] = set()
+    asserted: set[str] = set()  # referenced through a property that means something
+    mentioned: set[str] = set()  # referenced at all
+
+    for node in graph:
+        if not isinstance(node, dict):
+            continue
+        node_id = node.get("@id")
+        # A node carrying anything beyond its identity is described. `@type`
+        # alone is not description — a bare {"@id", "@type"} stub is exactly what
+        # these findings are about.
+        if isinstance(node_id, str) and set(node) - {"@id", "@type"}:
+            described.add(node_id)
+        for prop, value in node.items():
+            if prop in ("@id", "@type"):
+                continue
+            for item in value if isinstance(value, list) else [value]:
+                iri = item.get("@id") if isinstance(item, dict) else item
+                if not isinstance(iri, str) or "://" not in iri:
+                    continue
+                mentioned.add(iri)
+                if prop not in _CITATION_PROPERTIES:
+                    asserted.add(iri)
+
+    # The classes and properties the crate's own context defines are vocabulary
+    # too, and they never appear as reference objects — see `_context_vocabulary`.
+    return (mentioned | _context_vocabulary(metadata_doc)) - asserted - described
+
+
+def _partition_citations(
+    issues: list[dict[str, Any]], cited: set[str]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split findings into real gaps and findings about cited vocabulary."""
+    if not cited:
+        return issues, []
+    gaps, citations = [], []
+    for issue in issues:
+        entity = issue.get("entity_id") or ""
+        (citations if entity in cited else gaps).append(issue)
+    return gaps, citations
+
+
 def build_and_validate(
     state: CrateState,
     severity: str | None = "required",
@@ -247,7 +367,7 @@ def build_and_validate(
             cached[0],
             cached[1],
         )
-        return _sweep_scoped(cached[2], cached[3], profile, severity)
+        return _sweep_scoped(cached[2], cached[3], profile, severity, cached[4])
 
     try:
         # include_all_scanned=False: the auto-included scanned-file leaves (#175)
@@ -260,16 +380,16 @@ def build_and_validate(
         return {"ok": False, "conformance": {}, "issues": [], "error": str(e)}
 
     conformance = {r.profile: r.passed_required for r in results}
-    # Every finding the validator reports is reported here. We used to set aside
-    # findings whose subject was an IRI in a vocabulary namespace the crate only
-    # CITES (OBO, BAO, EFO, AOP-Wiki) — the upstream validator exempts the same
-    # category for schema.org/w3.org/Dublin Core but its list stops at the
-    # vocabularies a *workflow* crate is built from. That was a hardcoded host
-    # list: it needed an edit for every new ontology, and the need only ever
-    # surfaced as findings appearing for no visible reason. Modelling propertyID
-    # as a string rather than a node removed most of what it was compensating
-    # for; the rest is reported, consistent with showing users what is still
-    # missing rather than deciding for them that it does not count.
+    # Findings about vocabulary the crate CITES are separated from findings about
+    # what the crate ASSERTS — see `_cited_iris` for how that line is drawn, and
+    # why it is drawn from the crate's own structure rather than from a list of
+    # ontology hosts. A previous attempt at this WAS such a list, deleted in
+    # 00ca43b for needing an edit per ontology; the objection was right and it
+    # applies to any list, including one written today.
+    #
+    # Separated, not dropped: they come back under `citations`, counted, so a
+    # finding never disappears without a trace. What changes is that `issues`
+    # holds the things somebody can actually act on.
     issues: list[dict[str, Any]] = [
         {
             "entity_id": issue.entity_id,
@@ -283,13 +403,20 @@ def build_and_validate(
         for issue in result.issues
     ]
 
+    issues, citations = _partition_citations(issues, _cited_iris(metadata_doc))
+    if citations:
+        logger.info(
+            "%d finding(s) are about vocabulary this crate cites, not about the crate",
+            len(citations),
+        )
+
     if memo_key:
-        _remember_sweep(memo_key, profile, severity, conformance, issues)
+        _remember_sweep(memo_key, profile, severity, conformance, issues, citations)
 
     # Keep the original routable tool shape stable. The engine receives the
     # requested severity/profile as call arguments and routes writeback from
     # those arguments rather than expanding this public result contract.
-    return _sweep_scoped(conformance, issues, profile, severity)
+    return _sweep_scoped(conformance, issues, profile, severity, citations)
 
 
 # ---------------------------------------------------------------------------
@@ -299,7 +426,9 @@ def build_and_validate(
 # computed for that state. Bounded and in-process: a crate the agent has moved on
 # from is never asked about again, so a handful of entries covers the loop's
 # back-and-forth without holding whole issue lists for a long session.
-_SWEEP_MEMO: dict[str, tuple[str, str, dict[str, bool], list[dict[str, Any]]]] = {}
+_SWEEP_MEMO: dict[
+    str, tuple[str, str, dict[str, bool], list[dict[str, Any]], list[dict[str, Any]]]
+] = {}
 _SWEEP_MEMO_MAX = 4
 
 # Which passes each `profile` argument actually runs. Mirrors the dispatch in
@@ -353,6 +482,7 @@ def _remember_sweep(
     severity: str,
     conformance: dict[str, bool],
     issues: list[dict[str, Any]],
+    citations: list[dict[str, Any]],
 ) -> None:
     """Record a sweep, keeping the widest (profile, gate) seen for this state."""
     existing = _SWEEP_MEMO.get(key)
@@ -364,7 +494,7 @@ def _remember_sweep(
         return  # what we already hold answers strictly more
     if len(_SWEEP_MEMO) >= _SWEEP_MEMO_MAX and key not in _SWEEP_MEMO:
         _SWEEP_MEMO.pop(next(iter(_SWEEP_MEMO)))
-    _SWEEP_MEMO[key] = (profile, severity, conformance, issues)
+    _SWEEP_MEMO[key] = (profile, severity, conformance, issues, citations)
 
 
 def _sweep_covers(
@@ -381,6 +511,7 @@ def _sweep_scoped(
     issues: list[dict[str, Any]],
     profile: str,
     severity: str,
+    citations: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Narrow a sweep to the passes and tiers this call actually asked for.
 
@@ -405,10 +536,21 @@ def _sweep_scoped(
         if issue.get("profile") in passes
         and (issue.get("severity") not in _TIER_ORDER or issue.get("severity") in tiers)
     ]
-    gated_conformance = {
-        layer: passed for layer, passed in conformance.items() if layer in passes
+    gated_conformance = {layer: passed for layer, passed in conformance.items() if layer in passes}
+    scoped_citations = [
+        issue
+        for issue in (citations or [])
+        if issue.get("profile") in passes
+        and (issue.get("severity") not in _TIER_ORDER or issue.get("severity") in tiers)
+    ]
+    return {
+        "ok": not scoped,
+        "conformance": gated_conformance,
+        "issues": scoped,
+        # Scoped and gated exactly like `issues`, so a narrowed result is
+        # indistinguishable from a real run at that scope — citations included.
+        "citations": scoped_citations,
     }
-    return {"ok": not scoped, "conformance": gated_conformance, "issues": scoped}
 
 
 def clear_sweep_memo() -> None:

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -502,7 +502,7 @@ def _remember_sweep(
 
 
 def _sweep_covers(
-    cached: tuple[str, str, dict[str, bool], list[dict[str, Any]]],
+    cached: tuple[str, str, dict[str, bool], list[dict[str, Any]], list[dict[str, Any]]],
     profile: str,
     severity: str,
 ) -> bool:

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -267,7 +267,11 @@ def _cited_iris(metadata_doc: dict[str, Any]) -> set[str]:
     Nothing the crate asserts can be silenced by this.
 
     No namespace list, no configuration, and an ontology nobody has seen before
-    classifies correctly on first contact.
+    classifies correctly on first contact. It replaces an open-ended list of hosts
+    with a closed list of four properties, which is the part worth keeping.
+
+    Proposed upstream too, since the same rule would subsume the namespace list
+    their shapes carry — see docs/upstream/rocrate-validator-cited-vocabulary.md.
     """
     graph = metadata_doc.get("@graph")
     if not isinstance(graph, list):

--- a/docs/upstream/rocrate-validator-cited-vocabulary.md
+++ b/docs/upstream/rocrate-validator-cited-vocabulary.md
@@ -1,0 +1,123 @@
+# Upstream request (draft)
+
+**Target:** [crs4/rocrate-validator](https://github.com/crs4/rocrate-validator)
+**Status:** to file
+**Related local work:** `builder/tools/validation.py::_cited_iris` implements the rule below on our side, so the behaviour and the measurements are real rather than hypothetical.
+
+Everything below the line is the issue text.
+
+---
+
+## Decide the excluded namespaces from the graph instead of listing them
+
+The entity checks exclude a fixed set of namespaces. From
+`profiles/ro-crate/1.2/should/0_entity_metadata.ttl`:
+
+```sparql
+# Exclude entities with non-IRI identifiers or those from specific namespaces
+FILTER(!STRSTARTS(STR(?this), "http://www.w3.org/"))
+FILTER(!STRSTARTS(STR(?this), "https://w3id.org/ro/crate/"))
+FILTER(!STRSTARTS(STR(?this), "http://schema.org/"))
+FILTER(!STRSTARTS(STR(?this), "http://purl.org/"))
+FILTER(!STRSTARTS(STR(?this), "https://bioschemas.org/"))
+FILTER(!STRSTARTS(STR(?this), "urn:"))
+```
+
+The same block appears in seven shape files, 34 filters in all, at both SHOULD
+and MUST severity:
+
+| file | filters |
+|---|---:|
+| `profiles/ro-crate/1.2/must/6_contextual_entity_metadata.ttl` | 18 |
+| `profiles/ro-crate/1.2/should/0_entity_metadata.ttl` | 8 |
+| `profiles/ro-crate/1.2/must/4_data_entity_metadata.ttl` | 2 |
+| `profiles/ro-crate/1.2/should/6_organization_metadata.ttl` | 2 |
+| `profiles/ro-crate/1.2/should/4_data_entity_metadata.ttl` | 1 |
+| `profiles/ro-crate/1.2/should/4_dataset_data_entity.ttl` | 1 |
+| `profiles/ro-crate/1.1/must/4_data_entity_metadata.ttl` | 2 |
+
+The intent is clearly right: an IRI a crate only cites is not an entity the crate
+has to describe.
+
+### What the list cannot express
+
+`http://purl.org/` is excluded, so Dublin Core passes. `http://purl.obolibrary.org/`
+is a different host and is not, so every OBO term a crate cites is reported as
+missing a type, a name and a description. The same is true for any registry the
+list does not name — and every field has its own.
+
+Adding entries one at a time means a release each time, in several files, in two
+profile versions. But the harder problem is that some cases cannot be written as
+a namespace at all:
+
+```
+https://orcid.org                        a scheme, cited by propertyID
+https://orcid.org/0009-0000-5074-6239    an author, described in the crate
+```
+
+Same prefix, opposite answers. Excluding the prefix silences the authors;
+excluding neither reports the scheme. We hit exactly this and could not resolve it
+with any list.
+
+### The rule the list is approximating
+
+Whether an IRI is cited or described is visible in the graph. An IRI is a
+citation when all of:
+
+- it is not the subject of any triple other than `rdf:type` — the crate says
+  nothing about it;
+- every triple with it as object uses a property that *references* rather than
+  *asserts*: `schema:propertyID`, `csvw:propertyUrl`, `schema:inDefinedTermSet`,
+  `dcterms:conformsTo`;
+- which, in RDF, also covers IRIs used only as predicates or as types: they have
+  no asserting references by construction.
+
+Anything referenced through `schema:author`, `schema:hasPart`, or a domain
+property is an entity the crate is talking about, and stays checked — including
+an entity the crate references but forgot to describe, which is a real finding
+that must survive.
+
+This subsumes the current list. `http://schema.org/name` is only ever a
+predicate; `https://bioschemas.org/Sample` is only ever a type; both fall out
+without being named. And it needs no addition for a registry nobody has seen.
+
+It replaces an open-ended list of hosts with a closed list of four properties —
+spec-defined, and not something each deployment has to extend.
+
+### Measured
+
+We implemented this on our side, over a 293-entity crate, at the RECOMMENDED
+gate:
+
+| | |
+|---|---:|
+| findings before | 211 |
+| entity findings kept | **112** |
+| citation findings separated | **99** |
+
+The 99 are OBO, EFO and AOP-Wiki terms, plus three identifier schemes
+(`https://orcid.org`, `https://pubchem.ncbi.nlm.nih.gov/compound`,
+`https://comptox.epa.gov/dashboard/chemical/details`) — none of which the crate
+could describe without copying data maintained elsewhere.
+
+Everything that stays reported is a genuine gap: authors missing an email or job
+title, organizations, cell lines, the licence, the publication. The eight authors
+under `https://orcid.org/…` keep all their findings while the scheme root is
+excluded, which is the case no list could handle.
+
+### Two notes
+
+`profiles/ro-crate/1.2/should/6_contextual_entity_metadata.ttl` has no namespace
+filters at all, so today a cited IRI is excluded from "must have a name" but still
+reported by "should be described in the same @graph". A rule applied once covers
+both, where a list has to be copied into each file.
+
+We have not measured the cost of the `NOT EXISTS` over incoming edges on a large
+graph. Ours is small. That seems the main thing worth checking before adopting it.
+
+### If the rule is too large a change
+
+A way to extend the existing list from the caller — a `ValidationSettings` field —
+would let each deployment name the namespaces its domain cites, without a release
+per registry. It would not solve the `orcid.org` case above, but it would solve
+most of them.

--- a/docs/upstream/rocrate-validator-cited-vocabulary.md
+++ b/docs/upstream/rocrate-validator-cited-vocabulary.md
@@ -2,15 +2,16 @@
 
 **Target:** [crs4/rocrate-validator](https://github.com/crs4/rocrate-validator)
 **Status:** to file
-**Related local work:** `builder/tools/validation.py::_cited_iris` implements the rule below on our side, so the behaviour and the measurements are real rather than hypothetical.
 
 Everything below the line is the issue text.
 
 ---
 
-## Decide the excluded namespaces from the graph instead of listing them
+## Work out the excluded namespaces from the graph instead of listing them
 
-The entity checks exclude a fixed set of namespaces. From
+### What happens today
+
+The entity checks skip a fixed set of namespaces. From
 `profiles/ro-crate/1.2/should/0_entity_metadata.ttl`:
 
 ```sparql
@@ -23,8 +24,7 @@ FILTER(!STRSTARTS(STR(?this), "https://bioschemas.org/"))
 FILTER(!STRSTARTS(STR(?this), "urn:"))
 ```
 
-The same block appears in seven shape files, 34 filters in all, at both SHOULD
-and MUST severity:
+The same block appears in seven files, 34 filters in total:
 
 | file | filters |
 |---|---:|
@@ -36,88 +36,102 @@ and MUST severity:
 | `profiles/ro-crate/1.2/should/4_dataset_data_entity.ttl` | 1 |
 | `profiles/ro-crate/1.1/must/4_data_entity_metadata.ttl` | 2 |
 
-The intent is clearly right: an IRI a crate only cites is not an entity the crate
-has to describe.
+The idea is right. A crate points at terms from other vocabularies, and it should
+not have to describe them.
 
-### What the list cannot express
+### The problem
 
-`http://purl.org/` is excluded, so Dublin Core passes. `http://purl.obolibrary.org/`
-is a different host and is not, so every OBO term a crate cites is reported as
-missing a type, a name and a description. The same is true for any registry the
-list does not name — and every field has its own.
+The list names the vocabularies the authors had in mind. Any other one is
+reported as an entity with no type, no name and no description. Those findings
+cannot be fixed. The terms belong to someone else, and copying their labels into
+the crate duplicates data that goes stale on the ontology's next release.
 
-Adding entries one at a time means a release each time, in several files, in two
-profile versions. But the harder problem is that some cases cannot be written as
-a namespace at all:
+`http://purl.org/` is on the list, so Dublin Core terms pass. Ontology registries
+on other hosts are not, so their terms are all reported. Every field has its own
+registries, so adding entries means a release each time, in seven files, in two
+profile versions.
+
+And some cases cannot be written as a namespace at all. Take these two:
 
 ```
-https://orcid.org                        a scheme, cited by propertyID
-https://orcid.org/0009-0000-5074-6239    an author, described in the crate
+https://orcid.org                        an identifier scheme, only pointed at
+https://orcid.org/0009-0000-5074-6239    a person, described in the crate
 ```
 
-Same prefix, opposite answers. Excluding the prefix silences the authors;
-excluding neither reports the scheme. We hit exactly this and could not resolve it
-with any list.
+Excluding the prefix hides the people. Excluding neither reports the scheme.
+There is no prefix that separates them.
 
-### The rule the list is approximating
+### What could replace it
 
-Whether an IRI is cited or described is visible in the graph. An IRI is a
-citation when all of:
+Whether a crate cites an IRI or describes it is already visible in the graph. An
+IRI is only cited when both of these hold:
 
-- it is not the subject of any triple other than `rdf:type` — the crate says
-  nothing about it;
-- every triple with it as object uses a property that *references* rather than
-  *asserts*: `schema:propertyID`, `csvw:propertyUrl`, `schema:inDefinedTermSet`,
-  `dcterms:conformsTo`;
-- which, in RDF, also covers IRIs used only as predicates or as types: they have
-  no asserting references by construction.
+1. The crate says nothing about it — it is the subject of no triple except
+   `rdf:type`.
+2. Nothing points at it in a way that claims something. Every triple with it as
+   the object uses a property that references rather than asserts:
+   `schema:propertyID`, `csvw:propertyUrl`, `schema:inDefinedTermSet`,
+   `dcterms:conformsTo`.
 
-Anything referenced through `schema:author`, `schema:hasPart`, or a domain
-property is an entity the crate is talking about, and stays checked — including
-an entity the crate references but forgot to describe, which is a real finding
-that must survive.
+An IRI used only as a predicate or a type passes both without a special case,
+because it is never the object of anything.
 
-This subsumes the current list. `http://schema.org/name` is only ever a
-predicate; `https://bioschemas.org/Sample` is only ever a type; both fall out
-without being named. And it needs no addition for a registry nobody has seen.
+This covers the current list. `http://schema.org/name` is only ever a predicate.
+`https://bioschemas.org/Sample` is only ever a type. Neither has to be named.
 
-It replaces an open-ended list of hosts with a closed list of four properties —
-spec-defined, and not something each deployment has to extend.
+It also keeps the findings that matter. An entity referenced by
+`schema:author` or `schema:hasPart` and never described is still reported,
+because something claimed it exists. That is a real gap in the crate.
 
-### Measured
+And it separates the two ORCID IRIs above without anyone deciding anything.
 
-We implemented this on our side, over a 293-entity crate, at the RECOMMENDED
-gate:
+### How involved is it
 
-| | |
-|---|---:|
-| findings before | 211 |
-| entity findings kept | **112** |
-| citation findings separated | **99** |
+Small. It changes the SPARQL targets that already exist, and nothing else — no
+Python, no API, no new settings.
 
-The 99 are OBO, EFO and AOP-Wiki terms, plus three identifier schemes
-(`https://orcid.org`, `https://pubchem.ncbi.nlm.nih.gov/compound`,
-`https://comptox.epa.gov/dashboard/chemical/details`) — none of which the crate
-could describe without copying data maintained elsewhere.
+In each place the namespace filters appear now, this goes in their place:
 
-Everything that stays reported is a genuine gap: authors missing an email or job
-title, organizations, cell lines, the licence, the publication. The eight authors
-under `https://orcid.org/…` keep all their findings while the scheme root is
-excluded, which is the case no list could handle.
+```sparql
+# Skip IRIs the crate only cites. Nothing is said about them, and every
+# reference to them points rather than claims.
+FILTER NOT EXISTS {
+    $this ?p ?o .
+    FILTER(?p != rdf:type)
+}
+FILTER NOT EXISTS {
+    ?subject ?ref $this .
+    FILTER(?ref NOT IN (schema:propertyID, csvw:propertyUrl,
+                        schema:inDefinedTermSet, dcterms:conformsTo))
+}
+```
 
-### Two notes
+Roughly:
 
-`profiles/ro-crate/1.2/should/6_contextual_entity_metadata.ttl` has no namespace
-filters at all, so today a cited IRI is excluded from "must have a name" but still
-reported by "should be described in the same @graph". A rule applied once covers
-both, where a list has to be copied into each file.
+- seven files to edit, replacing 34 lines with about ten;
+- `csvw:` needs adding to the shared prefixes if it is not there;
+- the four properties are the only judgement call, and they are spec-defined
+  rather than open-ended;
+- `should/6_contextual_entity_metadata.ttl` has no filters today, so it would
+  gain the exclusion and stop disagreeing with its neighbours;
+- worth measuring the cost of the second `NOT EXISTS` on a large graph. It scans
+  incoming edges per focus node, which is the one part that could be slow.
 
-We have not measured the cost of the `NOT EXISTS` over incoming edges on a large
-graph. Ours is small. That seems the main thing worth checking before adopting it.
+An implementation of this rule outside SHACL, over the same JSON-LD, took about
+40 lines and behaved as described: on a 293-entity crate, 211 findings at the
+RECOMMENDED gate separated into 112 about the crate and 99 about vocabulary it
+cites. Everything kept was a real gap: people missing an email or a job title,
+organizations, cell lines, a licence, a publication. The people under
+`https://orcid.org/…` kept all their findings while the scheme root was excluded.
 
-### If the rule is too large a change
+### A smaller option
 
-A way to extend the existing list from the caller — a `ValidationSettings` field —
-would let each deployment name the namespaces its domain cites, without a release
-per registry. It would not solve the `orcid.org` case above, but it would solve
-most of them.
+If the rule is more than you want to take on, a setting that lets a caller add
+namespaces to the current list would help a lot on its own:
+
+```python
+ValidationSettings(rocrate_uri=..., excluded_namespaces=[...])
+```
+
+It would not separate the two ORCID IRIs, but it would stop each field needing a
+release.

--- a/tests/test_citations_are_not_gaps.py
+++ b/tests/test_citations_are_not_gaps.py
@@ -1,0 +1,180 @@
+"""Findings about vocabulary a crate CITES are separated from findings about it.
+
+An RO-Crate describes what it asserts and links what it cites. The validator
+agrees — its base shapes exclude schema.org, w3.org, purl.org, bioschemas.org and
+urn: from these very checks — but that exclusion list is the one a workflow crate
+needs, so any other vocabulary is reported as an entity with no name, no
+schema.org type and no description. Nothing can be done about those: the terms
+belong to, and are versioned by, someone else.
+
+The tempting fix is to add the missing namespaces. It is wrong twice over: it
+fits whichever crate prompted it and needs an edit per ontology (the reason
+00ca43b deleted exactly such a list), and it cannot express the case that decides
+the question —
+
+    https://orcid.org                      a scheme the crate cites
+    https://orcid.org/0009-0000-5074-6239  an author the crate describes
+
+Same prefix, opposite answers. So the crate is asked instead of a list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.tools.validation import (
+    _cited_iris,
+    _context_vocabulary,
+    _partition_citations,
+)
+
+OBO = "http://purl.obolibrary.org/obo/PATO_0000033"
+ORCID_SCHEME = "https://orcid.org"
+ORCID_PERSON = "https://orcid.org/0009-0000-5074-6239"
+
+
+def _doc(graph, context=None):
+    return {"@context": context or ["https://w3id.org/ro/crate/1.2/context"], "@graph": graph}
+
+
+class TestWhatCountsAsACitation:
+    def test_a_term_referenced_only_as_vocabulary_is_a_citation(self):
+        doc = _doc([{"@id": "#col", "@type": "csvw:Column", "propertyUrl": {"@id": OBO}}])
+        assert OBO in _cited_iris(doc)
+
+    def test_an_identifier_scheme_is_a_citation(self):
+        """`propertyID` says which scheme an id belongs to. That is a citation."""
+        doc = _doc([{"@id": "#pv", "@type": "PropertyValue", "propertyID": ORCID_SCHEME}])
+        assert ORCID_SCHEME in _cited_iris(doc)
+
+    def test_a_described_entity_is_never_a_citation(self):
+        doc = _doc(
+            [
+                {"@id": "./", "author": {"@id": ORCID_PERSON}},
+                {"@id": ORCID_PERSON, "@type": "Person", "name": "Nathalie Dierichs"},
+            ]
+        )
+        assert ORCID_PERSON not in _cited_iris(doc)
+
+    def test_the_scheme_and_a_person_under_it_are_told_apart(self):
+        """The case no namespace list can express — same prefix, opposite answers."""
+        doc = _doc(
+            [
+                {"@id": "./", "author": {"@id": ORCID_PERSON}},
+                {"@id": ORCID_PERSON, "@type": "Person", "name": "Someone"},
+                {"@id": "#pv", "@type": "PropertyValue", "propertyID": ORCID_SCHEME},
+            ]
+        )
+        cited = _cited_iris(doc)
+        assert ORCID_SCHEME in cited
+        assert ORCID_PERSON not in cited
+
+    def test_a_crate_local_id_is_never_a_citation(self):
+        doc = _doc([{"@id": "./", "hasPart": {"@id": "#thing"}}])
+        assert _cited_iris(doc) == set()
+
+
+class TestTheSafetyProperty:
+    """Nothing the crate ASSERTS may be silenced by this."""
+
+    def test_an_undescribed_entity_referenced_by_a_real_property_stays_reported(self):
+        """An author we linked but never drafted is a genuine gap, not a citation."""
+        doc = _doc([{"@id": "./", "author": {"@id": "https://example.org/person/1"}}])
+        assert "https://example.org/person/1" not in _cited_iris(doc)
+
+    def test_one_asserting_reference_is_enough(self):
+        """Cited in one place and asserted in another, it is still an entity."""
+        target = "https://example.org/thing"
+        doc = _doc(
+            [
+                {"@id": "#col", "propertyUrl": {"@id": target}},
+                {"@id": "./", "hasPart": {"@id": target}},
+            ]
+        )
+        assert target not in _cited_iris(doc)
+
+    def test_a_type_only_stub_is_not_treated_as_described(self):
+        """`{"@id", "@type"}` with nothing else is the shape the findings are about."""
+        doc = _doc(
+            [
+                {"@id": "#col", "propertyUrl": {"@id": OBO}},
+                {"@id": OBO, "@type": "DefinedTerm"},
+            ]
+        )
+        assert OBO in _cited_iris(doc)
+
+
+class TestContextVocabulary:
+    def test_classes_and_properties_from_the_context_are_citations(self):
+        """These reach the validator as types and predicates, never as {"@id"}.
+
+        A real crate produced 47 findings asking a *property* IRI for a
+        human-readable name.
+        """
+        ctx = {
+            "KeyEvent": "https://aopwiki.org/ontology/KeyEvent",
+            "has_key_event": "https://aopwiki.org/ontology/hasKeyEvent",
+            "@vocab": "http://schema.org/",
+        }
+        doc = _doc([{"@id": "#e", "@type": "KeyEvent"}], context=[ctx])
+        cited = _cited_iris(doc)
+        assert "https://aopwiki.org/ontology/KeyEvent" in cited
+        assert "https://aopwiki.org/ontology/hasKeyEvent" in cited
+
+    def test_namespace_keys_are_not_terms(self):
+        assert _context_vocabulary({"@context": [{"@vocab": "http://schema.org/"}]}) == set()
+
+    def test_a_remote_context_reference_is_left_alone(self):
+        assert _context_vocabulary({"@context": "https://w3id.org/ro/crate/1.2/context"}) == set()
+
+    def test_expanded_term_definitions_are_read(self):
+        ctx = {"thing": {"@id": "https://example.org/vocab/thing", "@type": "@id"}}
+        assert "https://example.org/vocab/thing" in _context_vocabulary({"@context": [ctx]})
+
+
+class TestPartitioning:
+    def _issue(self, entity_id):
+        return {"entity_id": entity_id, "severity": "recommended", "profile": "base"}
+
+    def test_citations_are_separated_not_dropped(self):
+        issues = [self._issue(OBO), self._issue("./#Study_x")]
+        gaps, citations = _partition_citations(issues, {OBO})
+        assert [i["entity_id"] for i in gaps] == ["./#Study_x"]
+        assert [i["entity_id"] for i in citations] == [OBO]
+        assert len(gaps) + len(citations) == len(issues), "a finding must never vanish"
+
+    def test_nothing_cited_leaves_the_list_untouched(self):
+        issues = [self._issue("./#Study_x")]
+        gaps, citations = _partition_citations(issues, set())
+        assert gaps is issues
+        assert citations == []
+
+
+class TestTheToolResult:
+    @pytest.fixture
+    def state(self):
+        from builder.state import CrateState
+        from builder.tools.drafters import draft_investigation
+
+        st = CrateState()
+        draft_investigation(st, {"name": "I", "description": "D"})
+        return st
+
+    def test_the_result_carries_both(self, state):
+        from builder.tools import validation as V
+
+        V.clear_sweep_memo()
+        out = V.build_and_validate(state, severity="recommended", profile="all")
+        assert "issues" in out
+        assert "citations" in out
+        V.clear_sweep_memo()
+
+    def test_a_memo_hit_still_carries_citations(self, state, monkeypatch):
+        """A cached answer must be indistinguishable from a fresh one."""
+        from builder.tools import validation as V
+
+        V.clear_sweep_memo()
+        first = V.build_and_validate(state, severity="optional", profile="all")
+        second = V.build_and_validate(state, severity="optional", profile="all")
+        assert second["citations"] == first["citations"]
+        V.clear_sweep_memo()

--- a/tests/test_tools_build_and_validate.py
+++ b/tests/test_tools_build_and_validate.py
@@ -28,7 +28,11 @@ def _exposure_state() -> CrateState:
 class TestBuildAndValidateShape:
     def test_returns_routable_shape(self):
         report = build_and_validate(CrateState())
-        assert set(report.keys()) == {"ok", "conformance", "issues"}
+        # `citations` joined the contract: findings about vocabulary the crate
+        # CITES are reported separately from findings about the crate itself, so
+        # `issues` is what somebody can act on and nothing is dropped silently.
+        assert set(report.keys()) == {"ok", "conformance", "issues", "citations"}
+        assert isinstance(report["citations"], list)
         assert isinstance(report["ok"], bool)
         assert isinstance(report["conformance"], dict)
         assert set(report["conformance"]) == {"base", "isa", "tox"}


### PR DESCRIPTION
Replaces #520, which I'd close.

## The problem

A crate describes what it asserts and links what it cites. The validator agrees — its base shapes exclude schema.org, w3.org, purl.org, bioschemas.org and `urn:` from these very checks. But that list is the one a *workflow* crate needs, so any other vocabulary is reported as an entity with no name, no schema.org type and not described in the graph.

Nothing can be done about those findings. The terms belong to, and are versioned by, someone else.

## Why adding namespaces is the wrong fix

That was #520, and it's wrong twice over.

**It overfits.** The three namespaces it added are what one crate happens to cite. Next crate, new ontology, edit the agent. `00ca43b` deleted exactly such a list for exactly that reason.

**It cannot express the case that decides the question:**

```
https://orcid.org                      a scheme the crate cites
https://orcid.org/0009-0000-5074-6239  an author the crate describes
```

Same prefix, opposite answers. No host list separates them — and #520 consequently **did not fix the finding that prompted this work** (`https://orcid.org: SHOULD include at least one Schema.org type` was still reported with it applied).

## The rule

An IRI is a citation when all three hold:

- it is **external** — a crate-local id is always ours;
- the crate **describes it nowhere** — no node gives it properties (`{"@id", "@type"}` alone is the stub these findings are about, not a description);
- **nothing references it through a property that asserts something** — only `propertyID` / `propertyUrl` / `inDefinedTermSet` / `conformsTo`, or only as a class or predicate the crate's own `@context` defines.

That last source matters independently: context-defined IRIs reach the validator as **types and predicates**, never as `{"@id"}` objects, so scanning the graph misses them. On a real crate that was 47 findings asking a *property* for a human-readable name.

**The safety property is the reverse clause.** An author linked but never drafted is referenced via `author`, so it is not a citation and its finding survives. Nothing the crate asserts can be silenced. There are tests on exactly that, including the one-asserting-reference-is-enough case.

## Separated, not dropped

Citations come back under a `citations` key, counted, scoped and gated exactly like `issues` — including through the sweep memo, so a cached answer is indistinguishable from a fresh one. Nothing disappears without a trace; what changes is that `issues` holds only what somebody can act on.

## Measured

SVHPS22 crate rebuilt from session `20260811_105646`, RECOMMENDED gate:

| | |
|---|---:|
| before | 211 findings |
| real gaps | **112** |
| citations | **99** |

What stays reported is what should:

| still reported | why |
|---|---|
| `orcid.org/0000-…` × 18 | described Persons missing an email or job title |
| `ror.org` × 4 | Organizations the crate describes |
| `cellosaurus.org` × 3 | cell lines the crate describes |
| `creativecommons.org` × 2, `doi.org` × 1 | licence and publication |

And the two findings that prompted this, both now citations with nothing left reported:

```
https://pubchem.ncbi.nlm.nih.gov/compound   4 findings → citations
https://orcid.org                           4 findings → citations
```

## What this costs

Nothing external. No namespace list, no configuration, no monkey-patching of anyone else's shapes — #520's loader patch is gone. An ontology nobody has seen before classifies correctly on first contact, because the answer comes from the crate rather than from a list somebody has to maintain.

## Tests

16 new, `90 passed` exit 0 across `test_citations_are_not_gaps` / `test_validation_sweep_memo` / `test_tools_build_and_validate` / `test_validation_writeback` / `test_validation_escalation` / `test_tools_validation` / `test_validate_dict` / `test_pipeline_e2e`.

`test_returns_routable_shape` was updated: `citations` joins the result contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)