### PR TITLE
test(profiles): pin that the strict-Investigation shape selects the root

### DIFF
--- a/tests/test_root_shape_fires.py
+++ b/tests/test_root_shape_fires.py
@@ -1,0 +1,67 @@
+"""The strict-Investigation shape must actually select the root data entity.
+
+`9_investigation_strict.ttl` targets `ro-crate:RootDataEntity`, and its prefix
+resolves to `…/profiles/ro-crate/` while the class is defined by the base profile
+under `…/profiles/ro-crate/1.2/`. It works — SHACL resolves it through the
+profile's ontology rather than by string concatenation — but nothing proved it,
+and a `sh:targetClass` that matches nothing is not an error in SHACL: the shape
+simply never runs, and every crate passes.
+
+That failure mode is live upstream right now. crs4/rocrate-validator#193 reports
+the base profile declaring two different namespaces for its own 1.2 shapes and
+says validation outcomes become "kind of random" when a profile picks the wrong
+one. If that churn ever moves the class out from under us, this test is what says
+so, instead of a REQUIRED gate quietly passing everything.
+
+Deliberately built from a bare root rather than from a drafted one: the drafters
+fill name, description, license and datePublished with defaults, so a crate built
+the normal way has nothing for this shape to find and cannot tell a working shape
+from a dead one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BARE_ROOT = {
+    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@graph": [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+            "about": {"@id": "./"},
+        },
+        {"@id": "./", "@type": "Dataset", "additionalType": "Investigation"},
+    ],
+}
+
+REQUIRED_ON_THE_ROOT = (
+    "schema:name",
+    "schema:description",
+    "schema:license",
+    "schema:datePublished",
+)
+
+
+@pytest.fixture(scope="module")
+def messages() -> list[str]:
+    from profiles.validator import validate_crate_dict
+
+    results = validate_crate_dict(BARE_ROOT, severity="required", profile="tox")
+    return [issue.message for result in results for issue in result.issues]
+
+
+def test_the_shape_selects_the_root_at_all(messages):
+    assert messages, (
+        "the strict-Investigation shape found nothing on a root with no name, "
+        "description, licence or date — its target is selecting no node, so the "
+        "REQUIRED gate is passing every crate"
+    )
+
+
+@pytest.mark.parametrize("field", REQUIRED_ON_THE_ROOT)
+def test_each_required_descriptor_is_enforced(messages, field):
+    assert any(field in message for message in messages), (
+        f"nothing required {field} of the root data entity"
+    )


### PR DESCRIPTION
Closes nothing; guards #525.

## What this is not

I thought I'd found a dead MUST-level check and I hadn't. Recording that, because the wrong test is instructive.

`9_investigation_strict.ttl` targets `ro-crate:RootDataEntity` via a prefix resolving to `…/profiles/ro-crate/`, while the base profile defines the class under `…/profiles/ro-crate/1.2/`. I built a crate with `draft_investigation`, got **0 REQUIRED findings**, and concluded the shape never fired.

It fires. The drafters fill `name`, `description`, `license` and `datePublished` with defaults, so that crate had nothing missing — zero was the right answer. SHACL resolves the prefix through the profile ontology, not by concatenating strings.

## What this is

The shape works and nothing proved it. **A `sh:targetClass` matching nothing is not an error in SHACL** — the shape just never runs, and every crate passes.

That failure mode is live upstream. [crs4/rocrate-validator#193](https://github.com/crs4/rocrate-validator/issues/193) reports the base profile declaring two namespaces for its own 1.2 shapes, and says outcomes become *"kind of random"* when a profile picks the wrong one. Our prefix is a third spelling. It resolves today; it is one upstream decision away from not.

So: validate a deliberately **bare** root and assert all four descriptors are demanded. If that class moves out from under us, this fails loudly instead of a REQUIRED gate quietly passing everything.

The bare root is the point. A crate built the normal way cannot distinguish a working shape from a dead one — which is exactly how I misread it.

`isa-ro-crate:` matches upstream exactly, so this is the only prefix of ours at risk.

## Not done

Retargeting the shape structurally (`sh:SPARQLTarget` selecting what `ro-crate-metadata.json` is `schema:about`, as the base profile's own targets do). Version-independent and immune to #193, but it is hardening against a hypothetical on a shape that works. Noted in #525 for when #193 resolves.

## Tests

5 new, all passing. No production code changes.