### PR TITLE
fix(report): fill the shell in one pass, so crate text is never re-scanned

### DIFF
--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -42,6 +42,7 @@ row — the "not assessed" state remains for reports rendered from a partial ver
 from __future__ import annotations
 
 import html
+import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -287,6 +288,12 @@ def _load_css() -> str:
             "report would render with no entity colours at all."
         )
     return css.replace(_CSS_CATEGORY_TOKEN, category_css())
+
+
+# The shell's placeholders, matched in ONE pass (see build_maturity_html). Kept
+# module-level so the pattern is compiled once and the set of sentinels has a
+# single definition rather than one per call site.
+_SHELL_PLACEHOLDER_RE = re.compile(r"__(?:STYLE|BODY|TITLE)__")
 
 
 @lru_cache(maxsize=1)
@@ -1752,12 +1759,13 @@ def build_maturity_html(
         + footer
     )
 
-    # Fill the shell placeholders. STYLE and BODY first (neither can contain a
-    # sentinel), TITLE last so crate-controlled text can never re-trigger a
-    # replacement.
-    return (
-        _load_shell()
-        .replace("__STYLE__", _load_css())
-        .replace("__BODY__", body)
-        .replace("__TITLE__", esc(title))
-    )
+    # ONE pass over the shell, so nothing a substitution inserts is ever scanned
+    # again. Chained `.replace()` calls cannot give that guarantee in any order:
+    # BODY carries crate-controlled entity ids and validation messages, and
+    # `html.escape` leaves underscores alone, so a finding on an entity whose
+    # `@id` is `#__TITLE__` came out as `#My Crate` — naming an entity that does
+    # not exist. Reversing the order only moves the hole to a crate titled
+    # `__BODY__`, which would paste the whole body into `<title>`. Both strings
+    # come from the crate, so neither can be the trusted one.
+    filling = {"__STYLE__": _load_css(), "__BODY__": body, "__TITLE__": esc(title)}
+    return _SHELL_PLACEHOLDER_RE.sub(lambda m: filling[m.group(0)], _load_shell())

--- a/tests/test_html_xss.py
+++ b/tests/test_html_xss.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import pytest
 
-from builder.state import CrateState, Entity, EntityProvenance
+from builder.state import CrateState, Entity, EntityProvenance, ValidationReport
 from builder.tools.builder import build_crate
 from builder.writers.maturity_report import build_maturity_html
 from builder.writers.provenance_dag import (
@@ -157,6 +157,47 @@ def test_maturity_report_escapes_title() -> None:
     out = build_maturity_html(_malicious_state())
     assert SCRIPT_PAYLOAD not in out
     assert "&lt;script&gt;" in out
+
+
+def test_maturity_report_does_not_rewrite_crate_text_that_looks_like_a_sentinel() -> None:
+    """A crate string spelled like a shell placeholder must survive verbatim (#518).
+
+    The shell is filled by substituting ``__STYLE__`` / ``__BODY__`` / ``__TITLE__``.
+    ``html.escape`` leaves underscores alone, so an entity id of ``#__TITLE__``
+    reaches the body still spelled as the sentinel; a second substitution pass
+    then rewrote it to the crate title, and a finding about that entity named an
+    entity that does not exist. Not an injection — the title is escaped — but the
+    report quietly says something false about the crate.
+
+    Both strings are crate-controlled, so no ordering of chained replacements is
+    safe: putting TITLE last protects the body and exposes the title to a crate
+    named ``__BODY__``. Only a single pass is.
+    """
+    state = CrateState()
+    state.metadata.title = "My Crate"
+    state.add_entity(
+        Entity(
+            entity_id="#__TITLE__",
+            type="Investigation",
+            fields={"title": "An investigation"},
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    # A finding is what puts the entity id into the BODY verbatim — which is the
+    # only place the second substitution pass could reach it.
+    state.validation = ValidationReport(
+        base_passed=False,
+        required_issues=["entity #__TITLE__ needs a name"],
+    )
+
+    out = build_maturity_html(state)
+
+    assert "__TITLE__" in out, "the crate's own text was rewritten by the shell fill"
+    assert "#My Crate" not in out
+    # …and the real title still reached the slot it was meant for.
+    assert "My Crate" in out
+    # No placeholder is left unfilled by the single pass.
+    assert "__STYLE__" not in out and "__BODY__" not in out
 
 
 # --- bundled ro-crate-preview.html (export) --------------------------------


### PR DESCRIPTION
Closes #518.

`build_maturity_html` filled the document shell with chained `.replace()` calls, and the comment claimed STYLE and BODY *"can contain no sentinel"*. That is false for BODY — `html.escape` preserves underscores, so an entity id of `#__TITLE__` reaches the body still spelled as the sentinel, and the next replacement rewrites it to the crate title:

```
REQUIRED finding on  #__TITLE__   →  rendered as  #My Crate
```

The report then names an entity that does not exist, and the quoted text is corrupted.

**Not an injection** — the title is escaped before insertion. It is the report quietly saying something false about the crate, which is the worse failure in a document whose whole job is to be believed.

## Why reordering isn't the fix

Putting TITLE last protects the body and exposes the title: a crate named `__BODY__` would paste the entire body into `<title>`. Both strings come from the crate, so neither can be the trusted one. Only a **single pass** guarantees that nothing a substitution inserts is ever scanned again — one `re.sub` over `__(?:STYLE|BODY|TITLE)__` with a callback, with the pattern compiled once at module level so the set of sentinels has a single definition rather than one per call site.

## Verification

Driven through the real `build_maturity_html` over a crate carrying the hostile id, with a REQUIRED finding quoting it (the finding is what puts the id into the body verbatim, which is the only place the second pass could reach it):

- `#__TITLE__` survives verbatim
- `#My Crate` does not appear
- the real title still reaches `<title>`
- no `__STYLE__` / `__BODY__` left unfilled

**Mutation-checked:** restoring the chained `.replace()` calls turns the new test red — so it pins the fix, not just the current output. `tests/test_html_xss.py` is 8/8 green; `uvx ruff check` and `uv run ty check` clean.

The test lives beside `test_maturity_report_escapes_title` in `tests/test_html_xss.py`, since it is the same class of "crate-controlled string reaching a template slot" — but distinguished in its docstring from the escaping tests, because this one is not about safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)