### PR TITLE
docs: CONTRIBUTING said ty is advisory and the matrix is 4-way; neither is true

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,13 @@ Three mechanisms enforce this:
 ## CI
 
 A GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push/PR to `main`:
-1. `lint` job — `uvx ruff check` and `uv run ty check` (ty is continue-on-error).
-2. `test` job — a **4-way matrix** that shards the suite across four independent
+1. `lint` job — `uvx ruff check` and `uv run ty check`. **Both gate**: `ty` has been
+   enforcing since the ty-clean sweep, so a type error reddens the PR before any test
+   shard runs. Run it locally before pushing — it is cheap, and it catches things a
+   passing test suite will not (a stub whose signature no longer matches what it
+   replaces, a `dict` literal ty narrows more tightly than you meant).
+   `ruff format` is **not** a gate.
+2. `test` job — a **16-way matrix** that shards the suite across sixteen independent
    `ubuntu-latest` runners with [`pytest-split`](https://github.com/jerry-git/pytest-split).
    Each shard runs serially (no `pytest-xdist`), and the shards run concurrently
    as separate jobs.
@@ -90,7 +95,7 @@ runner's RAM and provides real wall-clock parallelism without OOM risk.
 
 Shards are balanced by recorded test timings in the committed `.test_durations`
 file (`--splitting-algorithm least_duration`), so the heavy SHACL-validation and
-e2e build tail is spread evenly (~162s per shard) rather than piling into one
+e2e build tail is spread evenly (a few minutes per shard) rather than piling into one
 group. Regenerate `.test_durations` after large test-suite changes with:
 
 ```bash


### PR DESCRIPTION
Two stale CI claims in CONTRIBUTING.md, both of which cost real time today.

## 1. `ty` is not continue-on-error — it gates

> `lint` job — `uvx ruff check` and `uv run ty check` (ty is continue-on-error).

`.github/workflows/ci.yml` runs it as a plain step, and that step's own comment says *"Enforcing as of the ty-clean sweep"*.

**Four PRs went red on `ty` today and none on tests** — #495, #498, #509, #520. Every one was a change a passing local test run would never have caught:

- a helper annotated with the concrete `AgentEngine` rather than the duck-type it actually reads — so the test double written to *prove* the duck-typing was what ty rejected;
- a `dict` literal ty narrowed to `str | int | bool`, making every `**kwargs` field of another type an error (22 diagnostics from one test helper);
- a shim function whose signature no longer matched the attribute it replaces.

A contributor who believes the current doc runs the tests, sees green, and pushes into a red PR.

Also stated: **`ruff format` is not a gate.** It fails on ~25 pre-existing files, which looks alarming to anyone who runs it on spec, and CI never invokes it.

## 2. The matrix is 16-way, not 4-way

> a **4-way matrix** that shards the suite across four independent runners

`ci.yml` has `group: [1..16]`, passes `--splits 16`, and names the job `shard N/16`.

The accompanying **"~162s per shard"** figure is from the 4-way era and no longer describes anything, so it's replaced with a qualitative statement rather than a number that will go stale again.

Everything else in the section — the rationale for matrix sharding over in-process `pytest-xdist`, the OOM argument, the `.test_durations` regeneration command — I checked against `ci.yml` and left as is; it's all still accurate.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)