### PR TITLE
docs: the base pass dominates a real sweep, not tox (#115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1007,9 +1007,12 @@ a fix to a specific field:
 
 `severity` (`required`|`recommended`|`optional`) is the gate that decides which
 SHACL checks run — `required` (the default) is fastest. `profile`
-(`all`|`base`|`isa`|`tox`) scopes the passes; since the tox pass dominates
-wall-clock, the inner loop can validate a single profile at REQUIRED severity
-and run the full 3-pass sweep only as a gate. The three passes mirror
+(`all`|`base`|`isa`|`tox`) scopes the passes, so the inner loop can validate a
+single profile at REQUIRED severity and run the full 3-pass sweep only as a gate.
+Which pass costs most is crate-dependent and NOT tox by default: on a real
+293-entity crate the BASE pass is 22.9s of a 36.9s optional sweep (62%) against
+9.2s for tox — measured in `builder/tools/validation.py`. Scoping to `tox` to
+save time is therefore backwards on a large crate. The three passes mirror
 `profiles/validator.validate_crate`, fed the metadata dict instead of a path.
 
 `fix_required_issues` is the **deterministic repair loop** — the keystone of the
@@ -2329,7 +2332,7 @@ renders the count of open **MUST** issues plus base/isa/tox conformance.
 **It REUSES the validation result the pipeline already computed** (`run_pipeline`
 returns `{conformance, issues, …}` from its required-severity fix loop) rather
 than calling `assess_gaps` afresh: a fresh `assess_gaps` re-runs the heaviest
-`severity="optional"` SHACL + MIT + FAIR sweep (the #115 tox-pass bottleneck),
+`severity="optional"` SHACL + MIT + FAIR sweep (the #115 validation bottleneck),
 which on every headless build is both a real per-build UX regression and a CI
 timeout (#296). Because the pipeline validates only at REQUIRED severity, SHOULD/MAY
 gaps are not computed on this fast path — the line reports them as *not assessed*

--- a/docs/validator-profiling-115.md
+++ b/docs/validator-profiling-115.md
@@ -50,12 +50,21 @@ speedup factors below are the portable result**.
 | **tox** | **required** | **2868 ms** | **220 ms** | **222 ms** | **2425 ms** | 0 |
 | **tox** | **optional** | **3588 ms** | **294 ms** | **212 ms** | **3082 ms** | 6 |
 
-The tox pass dominates the sweep, exactly as the issue said — but the split is the
-opposite of the assumption:
+On THIS fixture the tox pass dominates the sweep, as the issue assumed — but the
+split within it is the opposite of the assumption:
 
 - **owlrl inference: ~0.29 s (~8%)**
 - **SHACL evaluation: ~0.21 s (~6%)**
 - **composition + routing: ~3.08 s (~86%)**
+
+> **Superseded on a real crate — the ORDERING flips.** These numbers are from a
+> 29-node fixture. On a real 293-entity crate the **base** pass dominates: 22.9s
+> of a 36.9s optional sweep (62%), against 9.2s for tox (25%) and 4.8s for isa
+> (see `builder/tools/validation.py`). What survives is the finding *inside* a
+> pass — inference is ~14% and composition/routing ~86% — which is why the
+> upstream ask (crs4/rocrate-validator#184) targets graph reuse rather than
+> faster inference. What does NOT survive is "scope to tox to save time": on a
+> large crate that leaves the expensive pass running.
 
 Caching the parsed SHACL `.ttl` (the lever already rejected in #63/#111) would
 touch only the small ontology-parse slice inside composition — it cannot reach the

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -150,6 +150,17 @@ def _patch_in_memory_descriptor_id() -> None:
     the in-memory dict path — so the on-disk ``validate_crate`` (which legitimately
     discovers a descriptor in a real crate directory) is untouched. The patch is
     idempotent so repeated imports don't re-wrap it.
+
+    **Delete this when upstream fixes it.** Reported as
+    https://github.com/crs4/rocrate-validator/issues/192 — filed against the
+    *symptom* (the walk finds nothing, ``get_file_content`` raises
+    ``FileNotFoundError``, and the check's ``except Exception`` relabels it as a
+    false "not UTF-8 encoded" finding), but the cause is the same walk this patch
+    skips. Their fix is ours: in metadata-only mode there is no folder, so the
+    descriptor id should be the canonical constant instead of something searched
+    for. When a released roc-validator no longer walks the CWD on the dict path,
+    this whole function goes — check by removing it and timing
+    ``validate_crate_dict`` from a large checkout.
     """
     try:
         from rocrate_validator.rocrate.base import ROCrate as _RVROCrate


### PR DESCRIPTION
Refs #115. Docs only.

Three places still advised scoping validation to `tox` to save time. That was measured on a 29-node fixture and is **backwards on a real crate** — `builder/tools/validation.py` records, for a 293-entity crate:

| pass | time | share |
|---|---|---|
| **base** | **22.9s** | **62%** |
| tox | 9.2s | 25% |
| isa | 4.8s | 13% |

Acting on the old advice leaves the expensive pass running.

- `AGENTS.md` (`build_and_validate`) no longer claims tox dominates wall-clock, and names the real numbers plus where they're measured.
- `AGENTS.md` (`assess_gaps`) says "the #115 validation bottleneck" rather than "tox-pass bottleneck".
- `docs/validator-profiling-115.md` scopes its headline to the fixture it was measured on, and carries a superseding note.

**What survives** from the original profiling is the finding *inside* a pass — inference ~14%, composition/routing ~86%. That is why the upstream ask ([crs4/rocrate-validator#184](https://github.com/crs4/rocrate-validator/issues/184)) targets graph reuse rather than faster inference, and it's the reason to correct the wrapper claim instead of deleting the document.

With this, #115's exploration is fully answered and both upstream asks are filed (#184 for graph reuse, #192 for the metadata-only `rglob`), so the issue can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)