### PR TITLE
fix(validation): verify the payload where it exists, and say so where it does not (#530)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,11 @@ CrateState {
         # are their display projection and stay byte-stable (the ReAct loop
         # parses them); empty on a verdict recorded before the field existed
         issue_records: [{ profile, severity, entity_id, message }],
-        assessed_tiers: set[str], input_fingerprint: str,
+        assessed_tiers: set[str],
+        # whether anything actually looked at the crate's FILES (#530) — the
+        # in-memory gate validates a document, where payload checks emit nothing
+        payload_checked: bool,
+        input_fingerprint: str,
     },
     mit_assessment: { module_scores: { m: { completed, total } }, overall_score },
     fair_assessment: { indicator_results, dsm_level },
@@ -1516,6 +1520,19 @@ renders as an explicit **"not assessed"** neutral state (glyph + label, never co
 a green zero; REQUIRED/RECOMMENDED issue text is still surfaced as `Must fix` / `Recommended`
 suggestions. Rendering this from `state.validation` alone (no new validation machinery) keeps the
 pure/cheap contract.
+
+**A verdict states the ground it stands on (#530).** "Is every declared Data Entity part of the
+payload?" is REQUIRED by the base profile and answerable only where the payload exists — the
+in-memory gate validates a document, so that check emits *nothing* there, and its silence must never
+be read as a pass. `verify_payload` states the invariant the crate itself must satisfy instead of
+naming a check id (ids move between upstream releases, and skipping a check that emits nothing
+suppresses nothing): every local data entity is backed by a source `crate.write()` will
+materialise, since ro-crate-py writes the metadata for a source-less entity and no bytes. Export
+runs it against the assembled crate **before** the report is embedded — a verdict reached after the
+write could never reach the report shipping inside the crate — and files what it finds as REQUIRED
+issues, so the existing rendering flips the header verdict without knowing this check exists.
+`payload_checked` records that something looked; a verdict where nothing did says so rather than
+implying a clean sheet it did not earn.
 
 **Every finding folds out of the severity row it belongs to** (#510). Severity is the primary axis
 because it is the fix order — REQUIRED blocks the build, the advisory tiers do not — so a tier row

--- a/builder/state.py
+++ b/builder/state.py
@@ -633,6 +633,11 @@ class ValidationReport:
             renderers (the maturity report's per-profile fold-outs, #510) never
             have to re-parse that display format. Empty on a verdict recorded
             before the field existed — consumers must fall back, not infer.
+        payload_checked: Whether anything actually looked at the crate's files.
+            The in-memory gate validates a document, so checks that need a
+            payload — "is every declared Data Entity present?" — emit nothing
+            there, and their silence must not be read as a pass (#530). False on
+            a verdict that only ever saw the metadata.
         input_fingerprint: :meth:`CrateState.validation_fingerprint` as it was
             when this verdict was recorded — the answer to "does this verdict
             still describe the crate?". Empty means unknown (a report restored
@@ -647,6 +652,7 @@ class ValidationReport:
     may_issues: list[str] = field(default_factory=list)
     assessed_tiers: set[str] = field(default_factory=set)
     issue_records: list[dict[str, str]] = field(default_factory=list)
+    payload_checked: bool = False
     input_fingerprint: str = ""
 
     def is_stale_for(self, state: CrateState) -> bool:
@@ -670,6 +676,7 @@ class ValidationReport:
             "may_issues": list(self.may_issues),
             "assessed_tiers": sorted(self.assessed_tiers),
             "issue_records": [dict(r) for r in self.issue_records],
+            "payload_checked": self.payload_checked,
             "input_fingerprint": self.input_fingerprint,
         }
 
@@ -684,6 +691,7 @@ class ValidationReport:
             may_issues=data.get("may_issues", []),
             assessed_tiers=set(data.get("assessed_tiers", [])),
             issue_records=data.get("issue_records", []),
+            payload_checked=data.get("payload_checked", False),
             input_fingerprint=data.get("input_fingerprint", ""),
         )
 

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -603,6 +603,22 @@ def export_crate(
             logger.warning("Could not record generator provenance: %s", gen_err)
 
         crate = assemble_crate(state, output_dir, materialize_payload=True)
+
+        # Answer the one REQUIRED question the in-memory gate cannot: does the
+        # crate carry the files it describes (#530)? `ensure_validated` above
+        # validates a document, where a payload check has nothing to look at and
+        # so emits nothing — and silence there was being read as a pass, shipping
+        # a crate that fails the base profile on disk under a green "Conformant".
+        # Runs here because the maturity report is rendered from `state.validation`
+        # a few lines below, while the crate is still in memory: a verdict reached
+        # after `crate.write()` could never reach the report that ships inside it.
+        try:
+            from builder.tools.validation import record_payload_check
+
+            record_payload_check(state, crate)
+        except Exception as payload_err:  # noqa: BLE001 — never fail the write
+            logger.warning("Could not verify the crate payload: %s", payload_err)
+
         # Embed the standard ro-crate-py preview (ro-crate-preview.html, a
         # CreativeWork about ./) so the written crate is browsable without
         # tooling (#86) — rendered through an autoescaping template so

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -133,6 +133,9 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
         should_issues=should_issues,
         may_issues=may_issues,
         issue_records=issue_records,
+        # This path validated a directory, so the payload checks the in-memory
+        # gate cannot run did run here — the verdict covers the files too (#530).
+        payload_checked=True,
     )
 
 
@@ -154,6 +157,103 @@ def _profile_key(profile_name: str) -> str:
     if "base" in name or "ro-crate" in name:
         return "base"
     return ""
+
+
+# ---------------------------------------------------------------------------
+# Payload verification (#530)
+# ---------------------------------------------------------------------------
+# The SHACL profiles ask whether every declared Data Entity is part of the
+# payload, but only the on-disk path can answer it: the in-memory document the
+# build/fix loop and `export_crate` validate has no payload to inspect, so the
+# check emits nothing at all — and a caller reading "no issues" as "passed"
+# ships a crate whose base profile fails on disk under a green "Conformant".
+#
+# The fix is deliberately NOT a list of check ids to skip. Ids move between
+# upstream releases (see the two namespaces tracked in #525), a list needs an
+# edit per release, and skipping a check that emits nothing suppresses nothing.
+# Instead this states the invariant the crate itself must satisfy — every local
+# data entity is backed by a source `write()` will materialise — and answers it
+# from the assembled crate, which is available wherever a crate is built, for
+# any deposit.
+
+
+def verify_payload(crate: Any) -> list[dict[str, Any]]:
+    """Report every data entity the crate declares but will not write.
+
+    ``ROCrate.write()`` materialises a data entity from its ``source``. An entity
+    whose source is ``None`` is written to the metadata and never to disk (
+    ro-crate-py warns "No source for …" and continues), leaving a crate that
+    describes a file it does not contain — a REQUIRED failure of the base
+    profile, and invisible to every in-memory validation.
+
+    Checked before the write rather than after, because the maturity report is
+    rendered and embedded while the crate is still in memory; a verdict reached
+    afterwards could not reach the report that ships inside the crate. The two
+    are equivalent for this class: ``write()`` materialises exactly the sources
+    it holds.
+
+    Entities identified by an absolute URI are remote by design and are not this
+    crate's to materialise, so they are not reported.
+
+    Args:
+        crate: The assembled :class:`rocrate.rocrate.ROCrate`.
+
+    Returns:
+        Routable issue dicts in the shape :func:`build_and_validate` returns, so
+        the existing write-back and the maturity report render them unchanged.
+    """
+    issues: list[dict[str, Any]] = []
+    for entity in crate.data_entities:
+        entity_id = str(getattr(entity, "id", "") or "")
+        if not entity_id or entity_id.startswith(("#", "http://", "https://")):
+            continue
+        if getattr(entity, "source", None) is not None:
+            continue
+        issues.append(
+            {
+                "entity_id": entity_id,
+                "property": "contentUrl",
+                "message": (
+                    f"The crate describes {entity_id!r} but carries no content for it, "
+                    "so the written crate would not contain the file"
+                ),
+                "fix": (
+                    f"Attach the real file for `{entity_id}`, or drop the entity so the "
+                    "crate stops claiming a file it does not have."
+                ),
+                "severity": "required",
+                "profile": "base",
+            }
+        )
+    return issues
+
+
+def record_payload_check(state: CrateState, crate: Any) -> list[dict[str, Any]]:
+    """Fold :func:`verify_payload` into ``state.validation`` (#530).
+
+    Files the crate cannot write are REQUIRED failures of the base profile, so
+    they are filed as REQUIRED issues through the same shape every other finding
+    uses: the maturity report renders them, and the header verdict flips off
+    "Conformant" without the report needing to know this check exists.
+
+    Marks the verdict ``payload_checked`` either way — a clean payload is a
+    result, and the distinction that matters downstream is "looked and found
+    nothing" versus "never looked".
+
+    Returns the issues found, for the caller to log or report.
+    """
+    issues = verify_payload(crate)
+    report = state.validation
+    existing = set(report.required_issues)
+    for issue, text in zip(issues, order_issues(issues, "required"), strict=True):
+        if text not in existing:
+            report.required_issues.append(text)
+            report.issue_records.extend(_issue_records([issue], "required"))
+    if issues:
+        report.base_passed = False
+    report.assessed_tiers.add("required")
+    report.payload_checked = True
+    return issues
 
 
 # ---------------------------------------------------------------------------

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -127,6 +127,10 @@
 .mat .prof-card span { font-weight:600; font-size:.9rem; } .mat .prof-card em { margin-left:auto;
   font-style:normal; font-size:.62rem; letter-spacing:.05em; color:var(--muted); }
 .mat .good-note { color:var(--good-ink); font-size:.86rem; margin:.8rem 0 0; font-weight:550; }
+/* What this verdict did NOT look at (#530) — a caveat, not a failure, so it is
+   set apart from the findings rather than coloured like one. */
+.mat .payload-note { margin:.8rem 0 0; padding-left:.7rem; border-left:2px solid var(--hairline);
+  color:var(--muted); font-size:.8rem; }
 .mat ul.sugg { margin:.8rem 0 0; padding-left:1.1rem; font-size:.85rem; } .mat ul.sugg li.must { color:var(--low-ink); }
 .mat ul.sugg li.opt { color:var(--muted); } .mat ul.sugg li.more { color:var(--muted); font-style:italic;
   list-style:none; margin-left:-1.1rem; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -655,6 +655,30 @@ def _clean_note(val: ValidationReport) -> str:
     return "No outstanding REQUIRED issues."
 
 
+def _payload_caveat(val: ValidationReport) -> str:
+    """Name the one question a metadata-only verdict cannot answer (#530).
+
+    Whether the crate contains the files it describes is REQUIRED by the base
+    profile and answerable only where the payload exists. A verdict computed
+    from the assembled document alone never looked, and the checks that would
+    have asked emit nothing there — so its verdict is about the metadata, not
+    about the crate.
+
+    Rendered independently of whether the crate has findings: a verdict can be
+    clean at REQUIRED, carry advisory findings, and still head the report with
+    "Conformant" — so hanging this off the no-findings note would drop it in
+    exactly the case where the green pill is doing the over-claiming. Export
+    verifies the payload and clears it.
+    """
+    if val.payload_checked:
+        return ""
+    return (
+        '<p class="lead payload-note">The crate\'s files were not checked against the '
+        "metadata — this verdict covers the metadata document only, so it cannot say "
+        "whether the crate contains the files it describes.</p>"
+    )
+
+
 def _render_profile_section(
     val: ValidationReport, tiers: list[dict[str, str]] | None, *, stale: bool = False
 ) -> str:
@@ -702,6 +726,7 @@ def _render_profile_section(
         f'  <div class="prof-grid">{cards}</div>\n'
         f"  {severity_detail}\n"
         f"  {sugg}\n"
+        f"  {_payload_caveat(val)}\n"
         "</section>\n"
     )
 

--- a/tests/test_payload_verification.py
+++ b/tests/test_payload_verification.py
@@ -1,0 +1,243 @@
+"""The crate must not describe a file it does not contain (#530).
+
+The SHACL validator asks this question — "is every declared Data Entity part of
+the payload?" — but it can only answer it when there is a payload to look at.
+Export validates the assembled *document*, where no file exists, so the check
+emits nothing and silence reads as a pass: a crate whose base profile fails on
+disk ships with a report headlining "Conformant".
+
+The fix does not enumerate the check: check ids move between upstream releases
+and a hardcoded list needs an edit per release. It states the invariant the
+crate itself must satisfy — every local data entity is backed by a source the
+write will materialise — and checks that where it is answerable, which is
+everywhere a crate is assembled, for any deposit.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from rocrate.model.file import File
+from rocrate.rocrate import ROCrate
+
+from builder.state import CrateState, Entity, ValidationReport
+from builder.tools.builder import export_crate
+from builder.tools.validation import verify_payload
+from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+pytestmark = pytest.mark.timeout(120)
+
+
+class TestVerifyPayload:
+    """The invariant, stated over the assembled crate rather than a check id."""
+
+    def test_a_data_entity_with_no_source_is_reported(self) -> None:
+        # Exactly what ro-crate-py does with a source-less file: it warns, writes
+        # the metadata, and writes no bytes — leaving the crate describing a file
+        # that is not there.
+        crate = ROCrate()
+        crate.add_file(source=None, dest_path="data/ghost.csv", properties={"name": "ghost"})
+
+        issues = verify_payload(crate)
+
+        assert [i["entity_id"] for i in issues] == ["data/ghost.csv"]
+        assert issues[0]["severity"] == "required"
+        assert issues[0]["profile"] == "base"
+        assert "data/ghost.csv" in issues[0]["message"]
+
+    def test_a_backed_data_entity_is_not_reported(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.csv"
+        real.write_text("well_id,value\nA1,1\n", encoding="utf-8")
+        crate = ROCrate()
+        crate.add_file(source=str(real), dest_path="data/real.csv")
+
+        assert verify_payload(crate) == []
+
+    def test_in_memory_sources_are_not_reported(self) -> None:
+        # The crate's own generated artifacts (preview, graph, maturity report)
+        # carry their content as an in-memory source. They are materialised by
+        # write() and must never be flagged.
+        crate = ROCrate()
+        crate.add(File(crate, StringIO("<html></html>"), dest_path="ro-crate-preview.html"))
+
+        assert verify_payload(crate) == []
+
+    def test_remote_data_entities_are_not_reported(self) -> None:
+        # A data entity identified by an absolute URI lives elsewhere by design;
+        # there is nothing for this crate to materialise.
+        crate = ROCrate()
+        crate.add_file(
+            source="https://example.org/remote.csv",
+            fetch_remote=False,
+            validate_url=False,
+        )
+
+        assert verify_payload(crate) == []
+
+
+class TestExportRefusesToClaimAPayloadItLacks:
+    """The end-to-end regression: the shipped report must not say Conformant."""
+
+    @staticmethod
+    def _state_declaring_a_missing_file(tmp_path: Path) -> CrateState:
+        """A crate that declares a data file whose path does not resolve.
+
+        This is the generic shape of the defect, not one deposit's: assembly maps
+        a declared file to ``source=None`` whenever its path is not an existing
+        file (``_crate_mapping.py``), so any lost, renamed, or never-written
+        output produces it.
+        """
+        state = vhps_fixture_state("S-VHPS21")
+        state.metadata.output_path = str(tmp_path / "crate")
+        state.add_entity(
+            Entity(
+                entity_id="file_vanished",
+                type="File",
+                fields={
+                    "path": str(tmp_path / "never_written.csv"),
+                    "filename": "never_written.csv",
+                    "name": "never_written.csv",
+                },
+            )
+        )
+        return state
+
+    def test_export_records_the_missing_file_as_a_required_issue(self, tmp_path: Path) -> None:
+        state = self._state_declaring_a_missing_file(tmp_path)
+
+        result = export_crate(state, str(tmp_path / "crate"))
+
+        assert result["success"], result["error"]
+        assert any("never_written.csv" in issue for issue in state.validation.required_issues), (
+            state.validation.required_issues
+        )
+
+    def test_the_embedded_report_does_not_headline_conformant(self, tmp_path: Path) -> None:
+        state = self._state_declaring_a_missing_file(tmp_path)
+
+        export_crate(state, str(tmp_path / "crate"))
+
+        page = (tmp_path / "crate" / "ro-crate-metadata-maturity.html").read_text(encoding="utf-8")
+        body = page.split("</style>", 1)[-1]
+        assert "Not conformant" in body
+        assert '<span class="vpill good">' not in body
+
+    def test_a_crate_whose_payload_is_whole_still_passes(self, tmp_path: Path) -> None:
+        """The same fixture, whole, keeps its green verdict.
+
+        Paired with the test above: without this, "Not conformant appears" would
+        pass just as well on a fixture that was never conformant to begin with,
+        and the assertion would be pinning nothing.
+        """
+        state = vhps_fixture_state("S-VHPS21")
+        state.metadata.output_path = str(tmp_path / "crate")
+
+        export_crate(state, str(tmp_path / "crate"))
+
+        assert verify_payload_of(tmp_path / "crate") == []
+        assert state.validation.payload_checked is True
+        assert state.validation.required_issues == []
+        body = (
+            (tmp_path / "crate" / "ro-crate-metadata-maturity.html")
+            .read_text(encoding="utf-8")
+            .split("</style>", 1)[-1]
+        )
+        assert '<span class="vpill good">' in body
+        assert "Not conformant" not in body
+
+
+def verify_payload_of(crate_dir: Path) -> list[str]:
+    """Every data entity in the written crate resolves on disk (test helper)."""
+    import json
+    import urllib.parse
+
+    graph = json.loads((crate_dir / "ro-crate-metadata.json").read_text())["@graph"]
+    missing = []
+    for entity in graph:
+        eid = str(entity.get("@id", ""))
+        types = entity.get("@type")
+        types = types if isinstance(types, list) else [types]
+        if "File" not in types or eid.startswith(("#", "http://", "https://")):
+            continue
+        if not (crate_dir / urllib.parse.unquote(eid)).exists():
+            missing.append(eid)
+    return missing
+
+
+class TestVerdictRecordsWhetherThePayloadWasSeen:
+    """A verdict that never observed the payload must not be read as one that did."""
+
+    def test_defaults_to_unchecked_and_round_trips(self) -> None:
+        assert ValidationReport().payload_checked is False
+        report = ValidationReport(payload_checked=True)
+        assert ValidationReport.from_dict(report.to_dict()).payload_checked is True
+        # A checkpoint written before the field existed still loads.
+        legacy = report.to_dict()
+        del legacy["payload_checked"]
+        assert ValidationReport.from_dict(legacy).payload_checked is False
+
+    def test_a_clean_metadata_only_verdict_says_the_files_were_not_checked(self) -> None:
+        from builder.writers.maturity_report import build_maturity_html
+
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            assessed_tiers={"required", "recommended", "optional"},
+        )
+        page = build_maturity_html(state, validation=val)
+        assert "covers the metadata document only" in page
+
+        val.payload_checked = True
+        assert "covers the metadata document only" not in build_maturity_html(state, validation=val)
+
+    def test_the_caveat_survives_a_crate_that_has_advisory_findings(self) -> None:
+        """The green pill over-claims hardest exactly here.
+
+        A verdict clean at REQUIRED but carrying advisory findings still heads
+        the report with "Conformant" — and renders no empty-state note. Hanging
+        the caveat off that note would drop it in the one case where it matters
+        most, so it is rendered independently of whether findings exist.
+        """
+        from builder.writers.maturity_report import build_maturity_html
+
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            should_issues=["[base] ./: add a license"],
+            assessed_tiers={"required", "recommended", "optional"},
+        )
+        page = build_maturity_html(state, validation=val)
+        assert '<span class="vpill good">' in page, "precondition: the pill still reads Conformant"
+        assert "covers the metadata document only" in page
+
+    def test_the_on_disk_validator_records_that_it_saw_the_payload(self, tmp_path: Path) -> None:
+        # validate() runs over a directory, so the payload checks the in-memory
+        # gate cannot run did run — its verdict must not carry the caveat.
+        from builder.tools.validation import validate
+
+        crate_dir = tmp_path / "crate"
+        crate_dir.mkdir()
+        (crate_dir / "ro-crate-metadata.json").write_text(
+            '{"@context": "https://w3id.org/ro/crate/1.1/context", "@graph": []}'
+        )
+
+        assert validate(CrateState(), str(crate_dir)).payload_checked is True
+
+    def test_the_in_memory_gate_leaves_it_unchecked(self) -> None:
+        # build_and_validate cannot see a payload, so it must not claim to have.
+        from builder.tools.validation import apply_validation_result
+
+        state = vhps_fixture_state("S-VHPS21")
+        apply_validation_result(
+            state,
+            "build_and_validate",
+            {"ok": True, "conformance": {"base": True, "isa": True, "tox": True}, "issues": []},
+            severity="required",
+        )
+        assert state.validation.payload_checked is False


### PR DESCRIPTION
Closes #530.

## The bug

`output/svhps26_real_input_crate` ships a maturity report headlining **"Conformant — all required profile layers pass"**. On disk:

```
Base RO-Crate 1.2   passed_required=False
  [Required] The RO-Crate does not include the Data Entity
             'data/exposure_conditions.csv' as part of its payload
```

Export validates the assembled *document*, not the written directory. The base profile asks whether every declared Data Entity is part of the payload — and on the dict path there is no payload to look at, so that check emits **nothing at all**. Silence was read as a pass.

## Why this is not a list of check ids

The obvious fix — add the check to `_DICT_PATH_NA_CHECKS` — is both fragile and **ineffective**:

```
dict path, base, required:  passed_required=True | issues: 0
```

There is no finding to suppress. Skipping a check that emits nothing changes nothing. And a hardcoded id list needs an edit per upstream release (#525 already tracks two namespaces for the base 1.2 shapes).

So the fix states the invariant **the crate itself** must satisfy, and answers it from the assembled crate — no check ids, no filenames, no deposit knowledge:

> every local data entity is backed by a source `crate.write()` will materialise

That is grounded in observed library behaviour: `add_file(source=None)` makes ro-crate-py warn `No source for …`, write the metadata, and write no bytes.

**Evidence it generalises:** run across the existing crates, it finds the same defect in a *second* crate under a different filename — `data/oatp1c1_exposure_conditions.csv` in the S-VHPS26 v2 build. Any check keyed to a filename, or to the crate the bug was found in, would have missed it.

## Where it runs, and why there

The maturity report is rendered from `state.validation` while the crate is still in memory; files only reach disk at `crate.write()` four lines later. A verdict reached after the write could never reach the report that ships **inside** the crate. So the check runs against the assembled crate just before the report is embedded, and files findings as ordinary REQUIRED issues — the header verdict flips off "Conformant" through the existing rendering, with no report changes on that path.

## The honesty half

`payload_checked` records whether anything actually looked. The on-disk validator sets it (it validated a directory); the in-memory gate leaves it false, and a verdict that never looked now says so instead of implying a clean sheet it did not earn.

It is rendered **independently of whether findings exist**. A verdict clean at REQUIRED but carrying advisory findings still shows the green pill and renders no empty-state note — hanging the caveat off that note would have dropped it in exactly the case where the pill over-claims. There is a test pinning that.

## Tests

12 new tests, written first, all red for the right reason. The end-to-end pair is deliberately non-tautological: one asserts a crate with a missing file renders "Not conformant"; its partner asserts the **same fixture, whole**, still renders the green pill with zero required issues — without it, the first would pass just as well on a fixture that was never conformant.

Full suite on the committed HEAD: **2626 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)