### PR TITLE
fix(mapping): the Exposure's condition table is appended, never substituted (#531)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -2376,7 +2376,14 @@ def _build_process(
         # intake/condition_table.py.
         cells = samples or obj
         chems = _resolve_many(idx, f.get("chemicals"))
-        out = result or [
+        # APPENDED, never substituted — the same contract the EndpointReadout
+        # branch below states for its raw_measurements table (#531). The table is
+        # the compound's only route to the process (a MolecularEntity cannot be
+        # the object), so letting a drafter-declared `result` stand in for it
+        # severed that route silently: the crate kept its compounds and lost
+        # every link to them, and the declared file — never synthesized, so
+        # never materialised — left the crate describing a file it lacks.
+        out = list(result) + [
             _synth_condition_table(
                 crate,
                 output_dir,

--- a/tests/test_csvw_payload.py
+++ b/tests/test_csvw_payload.py
@@ -148,6 +148,54 @@ def test_condition_table_value_urls_resolve_to_entities():
     assert "#Sample_sample_cult" in str(cols["cell_line"].get("valueUrl"))
 
 
+def test_a_declared_exposure_result_does_not_displace_the_condition_table():
+    """A drafter-supplied result is added to, never swapped for, the table (#531).
+
+    The condition table is not decoration: ISA forbids a MolecularEntity as a
+    LabProcess object, so a compound reaches the experiment only *through* the
+    table (table --about--> compound). Substituting a declared result for it
+    severs that route silently — the crate keeps its compounds and loses every
+    link to them.
+
+    The EndpointReadout branch already appends rather than substitutes and says
+    so in its own comment; this pins the Exposure branch to the same contract.
+    """
+    state = _exposure_state()
+    exposure = next(e for e in state.list_entities("LabProcess") if e.entity_id == "proc_exp")
+    exposure.fields["result"] = "file_declared"
+    state.add_entity(
+        _ent("file_declared", "File", name="declared.csv", path="data/declared.csv")
+    )
+
+    graph = _assemble(state)
+    by_id = _by_id(graph)
+    process = next(
+        e for e in graph if str(e.get("@id", "")).endswith("LabProcess_proc_exp")
+    )
+    results = _ids(process.get("output"))
+
+    assert any(r.endswith("condition_table.csv") for r in results), (
+        f"the condition table was displaced by the declared result: {results}"
+    )
+    assert any("declared" in r for r in results), (
+        f"the declared result was dropped: {results}"
+    )
+    # …and the table still routes the compound to the process.
+    table = by_id[next(r for r in results if r.endswith("condition_table.csv"))]
+    schema = by_id[[s for s in _ids(table.get("conformsTo")) if "schema" in str(s)][0]]
+    cols = {by_id[cid]["titles"]: by_id[cid] for cid in _ids(schema.get("columns"))}
+    assert "#MolecularEntity_chem_1" in str(cols["compound"].get("valueUrl"))
+
+
+def test_an_exposure_without_a_declared_result_still_gets_the_table():
+    # The pre-existing path, pinned so the fix cannot regress it.
+    graph = _assemble(_exposure_state())
+    process = next(
+        e for e in graph if str(e.get("@id", "")).endswith("LabProcess_proc_exp")
+    )
+    assert [r for r in _ids(process.get("output")) if r.endswith("condition_table.csv")]
+
+
 # --- (b) raw_measurements typed csvw:Table ----------------------------------
 
 


### PR DESCRIPTION
Closes #531.

## One `or`

`builder/tools/_crate_mapping.py`, the Exposure branch:

```python
out = result or [_synth_condition_table(...)]   # substitutes
```

Any result the drafting model supplied replaced the synthesized CSVW condition table. The EndpointReadout branch thirty lines below does the opposite, and states the contract in its own comment:

```python
# … It is appended, never substituted, so a resultless readout still fires the
# "MUST have a result" issue for the deterministic repair loop (#179).
```

## Why the table is not optional

ISA forbids a `MolecularEntity` as a LabProcess object, so a compound reaches the experiment **only through the condition table** (`table --about--> compound`). Substituting it away severs that route in silence: the crate keeps its compounds and loses every link to them. And the declared file, never synthesized, is never materialised — so the crate also ends up describing a file it does not contain.

On `output/svhps26_real_input_crate` that produced zero condition tables, a dangling `data/exposure_conditions.csv`, and nowhere for the deposit's 20-compound × 8-concentration screen to land — 19 of 21 chemicals dropped.

## After

```
process outputs: ['data/declared.csv', 'data/LabProcess_proc_condition_table.csv']
table --about--> : [Sample, MolecularEntity Bisphenol-A, MolecularEntity TBBPA]
```

Both survive, and the compounds are reachable again.

## Tests

Two, written first:

- the declared result and the table coexist, and the table still carries the compound `valueUrl`;
- **a control** asserting the no-declared-result path still emits the table, so the fix cannot regress it. That control earned its place immediately — it caught that I had asserted on `result` when the ISA-Tox context serialises a process result as `output`.

Full suite: **2628 passed, 0 failed.**

## Composes with #530

They meet on the same crate without overlapping: this restores the condition table, and the merged #530 payload check now reports the drafter's declared-but-unwritten file as a REQUIRED issue instead of shipping it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)