### PR TITLE
perf(composites): verify a paper's authors against ORCID together, not in turn

### DIFF
--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -626,7 +626,6 @@ def materialize_aop_subgraph(
     }
 
 
-
 # ---------------------------------------------------------------------------
 # Assay -> AOP Key Event (#382)
 # ---------------------------------------------------------------------------
@@ -694,9 +693,7 @@ def link_assay_to_key_event(state: CrateState, assay_id: str, event_name: str) -
             if alias
         )
     ]
-    candidates = [
-        {"@id": e.entity_id, "name": e.fields.get("name")} for e in events
-    ]
+    candidates = [{"@id": e.entity_id, "name": e.fields.get("name")} for e in events]
     if len(matches) != 1:
         return {
             "ok": False,
@@ -715,6 +712,7 @@ def link_assay_to_key_event(state: CrateState, assay_id: str, event_name: str) -
         "key_event_id": event.entity_id,
         "matched_name": event.fields.get("name"),
     }
+
 
 # ---------------------------------------------------------------------------
 # Publication authors + ORCID harmonization (Issue #180, deferred item)
@@ -789,6 +787,70 @@ def _verify_orcid(orcid_id: str, family: str, lookup_orcid_fn: Any) -> dict | No
     if _norm(resolved_family) and _norm(resolved_family) == _norm(family):
         return data
     return None
+
+
+# Authors are verified against ORCID one network round-trip at a time, and a paper
+# has as many of those as it has authors. `_prefetch_orcid_verifications` runs
+# that step for every author at once instead, under the same bounded gate
+# `resolve_compound` uses so ORCID is not hammered.
+#
+# Only step (a) of the cascade moves. Everything else stays exactly where it was,
+# in order, on the calling thread: the in-crate match and the person entities
+# touch CrateState, and the name-search branch can ask the human. Neither belongs
+# on a worker thread, and interleaving prompts from several at once would be
+# worse than the wait.
+_AUTHOR_VERIFY_TIMEOUT = 25.0
+
+
+def _prefetch_orcid_verifications(
+    authors: list[dict[str, Any]], lookup_orcid_fn: Any
+) -> dict[int, dict | None]:
+    """Verify every author's Crossref ORCID up front, concurrently.
+
+    Returns ``{author index: verified record or None}``. An index missing from
+    the mapping was never attempted (no Crossref ORCID to check).
+
+    A verification that runs past :data:`_AUTHOR_VERIFY_TIMEOUT` yields ``None``,
+    which the cascade already understands as "not verified" and handles by moving
+    to its next step. That is the point: one ORCID sitting on the retry ladder
+    used to hold up every author behind it. A profiled run spent 405 seconds in a
+    single `draft_publication_with_authors` call — 22% of that session's machine
+    time — resolving one DOI.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    pending = {
+        index: str(author.get("identifier"))
+        for index, author in enumerate(authors)
+        if author.get("identifier")
+    }
+    if not pending:
+        return {}
+
+    def verify(index: int, orcid_id: str) -> tuple[int, dict | None]:
+        family = str(authors[index].get("familyName", ""))
+        with resolve_concurrency.slot():
+            ok, value = run_with_timeout(
+                lambda: _verify_orcid(orcid_id, family, lookup_orcid_fn),
+                _AUTHOR_VERIFY_TIMEOUT,
+            )
+        if not ok:
+            logger.info(
+                "ORCID verification for author %d ran past %.0fs; falling through "
+                "to the rest of the cascade",
+                index,
+                _AUTHOR_VERIFY_TIMEOUT,
+            )
+            return index, None
+        return index, value
+
+    verified: dict[int, dict | None] = {}
+    # Bounded by the gate inside `verify`, so the pool only has to be wide enough
+    # not to be the narrower limit.
+    with ThreadPoolExecutor(max_workers=min(8, len(pending))) as pool:
+        for index, value in pool.map(lambda kv: verify(*kv), list(pending.items())):
+            verified[index] = value
+    return verified
 
 
 def _find_in_crate_person(
@@ -1095,17 +1157,23 @@ def draft_publication_with_authors(
 
     authors_out: list[dict[str, Any]] = []
     hitl_count = 0
-    for author in data.get("author", []):
+    # Step (a) for every author at once, before the loop — see
+    # `_prefetch_orcid_verifications`. The loop below is otherwise unchanged: the
+    # cascade, its order, the HITL prompts and every write to CrateState still
+    # happen here, one author at a time, on this thread.
+    author_list = list(data.get("author", []))
+    prefetched = _prefetch_orcid_verifications(author_list, lookup_orcid)
+    for index, author in enumerate(author_list):
         given = author.get("givenName", "")
         family = author.get("familyName", "")
         affiliation = author.get("affiliation")
         resolution = "synthesized"
         person: Entity | None = None
 
-        # (a) Crossref ORCID on the author.
+        # (a) Crossref ORCID on the author, verified before the loop started.
         crossref_orcid = author.get("identifier")
         if crossref_orcid:
-            verified = _verify_orcid(crossref_orcid, family, lookup_orcid)
+            verified = prefetched.get(index)
             if verified is not None:
                 person = _ensure_person_for_orcid(state, crossref_orcid, verified)
                 resolution = "crossref_orcid"
@@ -1872,11 +1940,7 @@ def wire_unreferenced_domain_entities(state: CrateState) -> dict[str, Any]:
         else:
             # No process to attach to — say what IS true: the Study mentions it.
             container = next(
-                (
-                    c
-                    for kind in _CONTAINER_FALLBACK
-                    for c in state.list_entities(kind)
-                ),
+                (c for kind in _CONTAINER_FALLBACK for c in state.list_entities(kind)),
                 None,
             )
             if container is None:

--- a/tests/test_author_resolution_concurrency.py
+++ b/tests/test_author_resolution_concurrency.py
@@ -1,0 +1,152 @@
+"""Authors are verified against ORCID together, not one after another.
+
+`draft_publication_with_authors` walks each author through a cascade, and its
+first step is a network verification of the ORCID Crossref supplied. Done in the
+loop, that is one round-trip per author, strictly in series — and any one of them
+landing on the HTTP retry ladder (10s timeout, up to four attempts) stalls every
+author behind it. A profiled run spent **405 seconds inside a single call** for one
+DOI: 22% of that whole session's machine time.
+
+Only that step moves. The in-crate match and the person entities write to
+CrateState, and the name-search branch can ask the human; both stay on the calling
+thread, in author order. These tests pin that split.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from builder.tools.composites import (
+    _AUTHOR_VERIFY_TIMEOUT,
+    _prefetch_orcid_verifications,
+)
+
+
+def _author(family, orcid=None):
+    out = {"givenName": "A", "familyName": family}
+    if orcid:
+        out["identifier"] = orcid
+    return out
+
+
+def _orcid_ok(family):
+    return {"found": True, "data": {"familyName": family, "givenName": "A"}}
+
+
+class TestItRunsThemTogether:
+    def test_slow_lookups_overlap(self):
+        """Six 0.4s lookups in series would be 2.4s. Concurrently, far less."""
+        authors = [_author(f"Name{i}", f"0000-0000-0000-000{i}") for i in range(6)]
+
+        def slow(orcid_id):
+            time.sleep(0.4)
+            return _orcid_ok(f"Name{orcid_id[-1]}")
+
+        started = time.monotonic()
+        out = _prefetch_orcid_verifications(authors, slow)
+        elapsed = time.monotonic() - started
+
+        assert len(out) == 6
+        assert all(v is not None for v in out.values())
+        assert elapsed < 1.6, f"{elapsed:.2f}s — looks serial"
+
+    def test_the_concurrency_gate_is_respected(self):
+        """Shared with resolve_compound, so ORCID is not hammered either."""
+        from builder.tools._resolve_cache import resolve_concurrency
+
+        peak = 0
+        live = 0
+        lock = threading.Lock()
+
+        def watched(orcid_id):
+            nonlocal peak, live
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.05)
+            with lock:
+                live -= 1
+            return _orcid_ok("X")
+
+        authors = [_author("X", f"0000-0000-0000-{i:04d}") for i in range(12)]
+        _prefetch_orcid_verifications(authors, watched)
+        assert peak <= resolve_concurrency.limit
+
+
+class TestItKeepsTheCascadeHonest:
+    def test_results_are_keyed_by_author_index(self):
+        authors = [_author("Alpha", "0000-0000-0000-0001"), _author("Beta", "0000-0000-0000-0002")]
+        out = _prefetch_orcid_verifications(
+            authors, lambda oid: _orcid_ok("Alpha" if oid.endswith("1") else "Beta")
+        )
+        assert out[0]["familyName"] == "Alpha"
+        assert out[1]["familyName"] == "Beta"
+
+    def test_an_author_without_a_crossref_orcid_is_not_attempted(self):
+        authors = [_author("Alpha"), _author("Beta", "0000-0000-0000-0002")]
+        out = _prefetch_orcid_verifications(authors, lambda oid: _orcid_ok("Beta"))
+        assert 0 not in out, "nothing to verify, so nothing should be recorded"
+        assert out[1] is not None
+
+    def test_a_mismatched_family_name_is_not_verified(self):
+        """D5 — an ORCID is only trusted when the resolved name matches."""
+        authors = [_author("Alpha", "0000-0000-0000-0001")]
+        out = _prefetch_orcid_verifications(authors, lambda oid: _orcid_ok("Somebody Else"))
+        assert out[0] is None
+
+    def test_nothing_to_do_costs_nothing(self):
+        assert _prefetch_orcid_verifications([], lambda oid: _orcid_ok("X")) == {}
+        assert _prefetch_orcid_verifications([_author("Alpha")], None) == {}
+
+
+class TestOneSlowLookupCannotHoldThePaper:
+    def test_a_hung_verification_times_out_to_none(self):
+        """None is what the cascade already reads as "not verified"."""
+        authors = [_author("Alpha", "0000-0000-0000-0001")]
+
+        def hangs(orcid_id):
+            time.sleep(_AUTHOR_VERIFY_TIMEOUT + 5)
+            return _orcid_ok("Alpha")
+
+        import builder.tools.composites as composites
+
+        original = composites._AUTHOR_VERIFY_TIMEOUT
+        composites._AUTHOR_VERIFY_TIMEOUT = 0.2
+        try:
+            started = time.monotonic()
+            out = _prefetch_orcid_verifications(authors, hangs)
+            elapsed = time.monotonic() - started
+        finally:
+            composites._AUTHOR_VERIFY_TIMEOUT = original
+
+        assert out[0] is None
+        assert elapsed < 2, f"{elapsed:.2f}s — the timeout did not bound it"
+
+    def test_one_slow_author_does_not_block_the_others(self):
+        authors = [_author(f"N{i}", f"0000-0000-0000-000{i}") for i in range(4)]
+
+        def mixed(orcid_id):
+            if orcid_id.endswith("0"):
+                time.sleep(0.6)
+            return _orcid_ok(f"N{orcid_id[-1]}")
+
+        started = time.monotonic()
+        out = _prefetch_orcid_verifications(authors, mixed)
+        elapsed = time.monotonic() - started
+        assert len(out) == 4
+        assert elapsed < 1.2, f"{elapsed:.2f}s — the fast three waited on the slow one"
+
+
+class TestAnErrorIsNotSwallowed:
+    def test_a_lookup_that_raises_propagates(self):
+        """A bug in the lookup layer must not be reported as an unverified author."""
+        authors = [_author("Alpha", "0000-0000-0000-0001")]
+
+        def boom(orcid_id):
+            raise RuntimeError("lookup layer is broken")
+
+        with pytest.raises(RuntimeError):
+            _prefetch_orcid_verifications(authors, boom)

--- a/tests/test_author_resolution_concurrency.py
+++ b/tests/test_author_resolution_concurrency.py
@@ -82,8 +82,10 @@ class TestItKeepsTheCascadeHonest:
         out = _prefetch_orcid_verifications(
             authors, lambda oid: _orcid_ok("Alpha" if oid.endswith("1") else "Beta")
         )
-        assert out[0]["familyName"] == "Alpha"
-        assert out[1]["familyName"] == "Beta"
+        first, second = out[0], out[1]
+        assert first is not None and second is not None
+        assert first["familyName"] == "Alpha"
+        assert second["familyName"] == "Beta"
 
     def test_an_author_without_a_crossref_orcid_is_not_attempted(self):
         authors = [_author("Alpha"), _author("Beta", "0000-0000-0000-0002")]


### PR DESCRIPTION
## The cost

Session `20260811_175613` spent **405 seconds inside a single `draft_publication_with_authors` call** resolving one DOI — **22% of that session's entire machine time**.

```
draft_publication_with_authors    1 call     405.4s
resolve_compound                 20 calls    118.9s   (5.9s avg)
build_and_validate               25 calls    141.1s   (5.6s avg)
```

Twenty compound resolutions cost less than a third of one publication. `resolve_compound` is fast because it already runs under a bounded gate with a shared cache (`_resolve_cache.py`). The author cascade had neither.

## Why

The loop at `composites.py:1098` walks each author through a cascade whose first step is a network verification of the ORCID Crossref supplied. In the loop, that's one round-trip per author, strictly serial — and any one landing on the HTTP retry ladder (10s timeout × up to 4 attempts ≈ 33–40s) stalls every author behind it. Same ceiling I've now seen across four sessions on `resolve_compound`.

## The change

Step (a) runs for every author at once, under the **same `resolve_concurrency` gate** `resolve_compound` uses, so ORCID sees no more parallelism than PubChem does. Plus a 25s deadline per author: an overrun yields `None`, which the cascade already reads as "not verified" and handles by moving to its next step — so a slow lookup degrades into the existing path instead of holding the paper.

**Only step (a) moves.** The in-crate match, the public-name search, the HITL prompts and every write to `CrateState` stay exactly where they were — on the calling thread, one author at a time, in order. Those touch state or ask the human, and interleaving prompts from several workers would be worse than the wait.

A lookup that **raises** still propagates rather than being quietly recorded as an unverified author: a broken lookup layer is not the same fact as an author without an ORCID.

## Tests

9 new, plus the 29 in the existing author suites:

- concurrency actually overlaps — 6 × 0.4s lookups finish in under 1.6s
- the shared gate is respected — peak in-flight never exceeds `resolve_concurrency.limit`
- one hung lookup times out to `None` and does not hold the others
- results stay keyed by author index; an author without a Crossref ORCID is never attempted
- a mismatched family name still fails verification (D5)
- a raising lookup propagates

## A pre-existing hang, not from this

A broader local run including `test_agents_guidance.py` timed out. Checked against `origin/main`: **it hangs there too**, at `test_auto_fixable_must_fixed_without_prompt`, with a `ProcessPoolExecutor` in the stack — the parallel SHACL validation from #492, unrelated to this change. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)