### PR TITLE
fix(metadata): read the licence the deposit declares (#535)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,11 @@ CrateState {
     session_id: str, created_at: datetime, updated_at: datetime,
     metadata: {
         title: str | None, description: str | None, accession: str | None,
+        license: str | None,
+        # the licence was READ from the deposit descriptor, not drafted (#535):
+        # a depositor's statement is a fact and outranks a drafted guess, so
+        # `set_crate_metadata` will not overwrite it
+        license_from_deposit: bool,
         input_type: "directory" | "conversation",
         input_path: str | None, output_path: str | None,
     },

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -336,6 +336,43 @@ def _run_document_discovery(engine: AgentEngine) -> None:
         )
 
 
+def _read_declared_licence(engine: AgentEngine) -> None:
+    """Read the licence the deposit declares, before anyone drafts one (#535).
+
+    Nothing used to read it: ``set_metadata`` — an LLM-callable tool — was the
+    only writer, so the licence on the Root Data Entity was whatever the model
+    supplied, and assembly asserted all-rights-reserved when it supplied
+    nothing. On a real deposit the guess inverted the depositor's: S-VHPS26
+    declares CC-BY-4.0 and its crate claimed all rights reserved — wrong in the
+    one direction that suppresses reuse of openly-licensed data.
+
+    Runs beside document discovery, for the same reason: it is deterministic,
+    bounded, and independent of which arm is driving, so both get the fact. Only
+    a licence nobody has set yet is filled — a resumed session that already
+    carries one is left alone — and the value is marked as read from the deposit
+    so a later draft cannot overwrite it.
+    """
+    from builder.tools.file_readers import extract_deposit_licence, read_file
+
+    metadata = engine.state.metadata
+    if metadata.license:
+        return
+    for candidate in engine.state.scanned_files:
+        path = str(getattr(candidate, "path", "") or "")
+        if not path.lower().endswith(".json"):
+            continue
+        try:
+            text = read_file(path)
+        except Exception:  # noqa: BLE001 — an unreadable file is simply not the one
+            continue
+        licence = extract_deposit_licence(text or "")
+        if licence:
+            metadata.license = licence
+            metadata.license_from_deposit = True
+            logger.info("Read the licence the deposit declares: %s", licence)
+            return
+
+
 class AgentEngine:
     """Orchestrator for the LLM agent toolbox loop.
 
@@ -430,6 +467,10 @@ class AgentEngine:
                         _run_document_discovery(self)
                     except Exception as exc:  # noqa: BLE001 — discovery is best-effort
                         logger.warning("Document discovery failed (continuing): %s", exc)
+                    try:
+                        _read_declared_licence(self)
+                    except Exception as exc:  # noqa: BLE001 — best-effort, like discovery
+                        logger.warning("Reading the declared licence failed: %s", exc)
             else:
                 logger.warning(
                     "Refusing to initialize scan on forbidden input path: %s", input_path

--- a/builder/state.py
+++ b/builder/state.py
@@ -560,6 +560,11 @@ class CrateMetadata:
     creator: str | None = None
     contact: str | None = None
     license: str | None = None
+    # True when `license` was READ from the deposit rather than drafted (#535).
+    # A depositor's statement is a fact and a drafter's is a guess, so the guess
+    # does not get to overwrite it — a wrong licence is wrong in the one
+    # direction that suppresses reuse of openly-licensed data.
+    license_from_deposit: bool = False
     input_type: InputType = "directory"
     input_path: str | None = None
     output_path: str | None = None
@@ -584,6 +589,8 @@ class CrateMetadata:
             value = getattr(self, key)
             if value is not None:
                 d[key] = value
+        if self.license_from_deposit:
+            d["license_from_deposit"] = True
         if self.input_path is not None:
             d["input_path"] = self.input_path
         if self.output_path is not None:
@@ -606,6 +613,7 @@ class CrateMetadata:
             creator=data.get("creator"),
             contact=data.get("contact"),
             license=data.get("license"),
+            license_from_deposit=bool(data.get("license_from_deposit", False)),
             input_type=data.get("input_type", "directory"),  # type: ignore[arg-type]
             input_path=data.get("input_path"),
             output_path=data.get("output_path"),

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -986,6 +986,60 @@ def compact_attribute_json(text: str) -> str:
     return "\n".join(out).strip()
 
 
+_LICENCE_NAMES = {"license", "licence"}
+
+
+def extract_deposit_licence(text: str) -> str | None:
+    """The licence a BioStudies descriptor declares, as the deposit states it (#535).
+
+    Reading this is not guessing: the descriptor carries it as an attribute, and
+    usually qualifies it with a canonical URL —
+
+    .. code-block:: json
+
+        {"name": "License", "value": "CC-BY",
+         "valqual": [{"name": "URL",
+                      "value": "https://creativecommons.org/licenses/by/4.0/legalcode"}]}
+
+    A URL is preferred because it is machine-actionable and the depositor chose
+    it. Without one the declared value is returned **verbatim**: "CC-BY" does
+    not say which version, and mapping it onto a 4.0 URI would state something
+    the depositor did not (D5).
+
+    Applied blindly to any scanned file, so anything that is not a BioStudies
+    attribute tree — or carries no licence — yields ``None`` rather than raising.
+    """
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict) or not ("attributes" in parsed or "section" in parsed):
+        return None
+
+    found: list[str] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if str(node.get("name") or "").strip().casefold() in _LICENCE_NAMES:
+                for qualifier in node.get("valqual") or []:
+                    url = str((qualifier or {}).get("value") or "").strip()
+                    if url.startswith(("http://", "https://")):
+                        found.append(url)
+                        return
+                value = str(node.get("value") or "").strip()
+                if value:
+                    found.append(value)
+                return
+            for child in node.values():
+                _walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                _walk(child)
+
+    _walk(parsed)
+    return found[0] if found else None
+
+
 def read_file(
     path: str,
     *,

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -772,9 +772,21 @@ def set_crate_metadata(
                 "tool": "set_crate_metadata",
             }
         setattr(m, attr, value)
+    licence_note: str | None = None
     if license not in (None, ""):
-        m.license = license
-    return {
+        # A licence READ from the deposit is a fact about someone else's data;
+        # this setter's caller is guessing. The guess does not get to replace it
+        # — the crate that prompted this asserted "all rights reserved" over a
+        # deposit that declared CC-BY (#535).
+        if m.license_from_deposit and license != m.license:
+            licence_note = (
+                f"license unchanged: the deposit declares {m.license!r}, which is a "
+                "stated fact and outranks a drafted value. Correct the deposit "
+                "descriptor if it is wrong."
+            )
+        else:
+            m.license = license
+    result = {
         "title": m.title,
         "description": m.description,
         "accession": m.accession,
@@ -785,6 +797,9 @@ def set_crate_metadata(
         "contact": m.contact,
         "license": m.license,
     }
+    if licence_note:
+        result["note"] = licence_note
+    return result
 
 
 def set_validation_preference(

--- a/tests/test_deposit_licence.py
+++ b/tests/test_deposit_licence.py
@@ -1,0 +1,175 @@
+"""The depositor's declared licence is read, not guessed (#535).
+
+Nothing in the builder ever read the licence: `set_metadata` — an LLM-callable
+tool — was its only writer, and assembly hardcoded "ALL RIGHTS RESERVED BY THE
+AUTHORS" when no one had set one. Both branches assert a licence nobody
+declared, and on a real deposit the guessed one inverted the depositor's:
+S-VHPS26 declares CC-BY-4.0, the crate claimed all rights reserved.
+
+Reading it is not a guess: a BioStudies descriptor states the licence as an
+attribute and usually qualifies it with a canonical URL, so the extractor
+prefers what the deposit says and never invents a version number.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from builder.state import CrateMetadata, CrateState
+from builder.tools.file_readers import extract_deposit_licence
+
+
+def _descriptor(licence: dict | None) -> str:
+    """A BioStudies descriptor, optionally carrying a licence attribute."""
+    attributes = [{"name": "Title", "value": "A study"}]
+    if licence is not None:
+        attributes.append(licence)
+    return json.dumps({"accno": "S-TEST1", "section": {"attributes": attributes}})
+
+
+class TestExtractDepositLicence:
+    def test_prefers_the_canonical_url_the_deposit_qualifies_it_with(self) -> None:
+        # The real S-VHPS26 shape: a short form plus a URL value qualifier.
+        text = _descriptor(
+            {
+                "name": "License",
+                "value": "CC-BY",
+                "valqual": [
+                    {
+                        "name": "URL",
+                        "value": "https://creativecommons.org/licenses/by/4.0/legalcode",
+                    }
+                ],
+            }
+        )
+        assert (
+            extract_deposit_licence(text)
+            == "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )
+
+    def test_returns_the_declared_value_verbatim_when_no_url_is_given(self) -> None:
+        # "CC-BY" alone does not say which version; mapping it to a 4.0 URI would
+        # state something the depositor did not (D5).
+        assert extract_deposit_licence(_descriptor({"name": "License", "value": "CC-BY"})) == (
+            "CC-BY"
+        )
+
+    def test_matches_the_attribute_name_case_and_spelling_insensitively(self) -> None:
+        for name in ("license", "LICENSE", "Licence"):
+            text = _descriptor({"name": name, "value": "CC0"})
+            assert extract_deposit_licence(text) == "CC0", name
+
+    def test_a_descriptor_without_a_licence_yields_nothing(self) -> None:
+        assert extract_deposit_licence(_descriptor(None)) is None
+
+    def test_non_biostudies_input_yields_nothing(self) -> None:
+        # Applied blindly to any scanned file, so it must be quiet on the rest.
+        assert extract_deposit_licence("not json at all") is None
+        assert extract_deposit_licence(json.dumps({"unrelated": True})) is None
+        assert extract_deposit_licence("") is None
+
+    def test_the_real_deposit_descriptor(self) -> None:
+        # The file that exposed the bug, read as the tool would read it.
+        descriptor = Path("output/svhps26_real_input_crate/S-VHPS26.json")
+        if not descriptor.exists():  # pragma: no cover - crate not checked in
+            return
+        assert (
+            extract_deposit_licence(descriptor.read_text(encoding="utf-8"))
+            == "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )
+
+
+class TestDeclaredLicenceWins:
+    """A depositor's statement is a fact; a drafter's is a guess."""
+
+    def test_set_metadata_does_not_overwrite_a_licence_read_from_the_deposit(self) -> None:
+        from builder.tools.management import set_crate_metadata as set_metadata
+
+        state = CrateState()
+        state.metadata.license = "https://creativecommons.org/licenses/by/4.0/legalcode"
+        state.metadata.license_from_deposit = True
+
+        result = set_metadata(state, license="https://en.wikipedia.org/wiki/All_rights_reserved")
+
+        assert state.metadata.license == (
+            "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )
+        assert "license" in str(result).lower()
+
+    def test_set_metadata_still_sets_a_licence_nobody_declared(self) -> None:
+        from builder.tools.management import set_crate_metadata as set_metadata
+
+        state = CrateState()
+        set_metadata(state, license="https://creativecommons.org/publicdomain/zero/1.0/")
+        assert state.metadata.license == "https://creativecommons.org/publicdomain/zero/1.0/"
+
+    def test_the_marker_round_trips(self) -> None:
+        meta = CrateMetadata(license="CC-BY", license_from_deposit=True)
+        assert CrateMetadata.from_dict(meta.to_dict()).license_from_deposit is True
+        # A checkpoint written before the field existed still loads.
+        legacy = meta.to_dict()
+        legacy.pop("license_from_deposit", None)
+        assert CrateMetadata.from_dict(legacy).license_from_deposit is False
+
+
+class TestBothArmsGetTheDeclaredLicence:
+    """Wired where discovery is, so neither arm has to remember to ask."""
+
+    def test_initializing_over_a_deposit_reads_its_licence(self, tmp_path: Path) -> None:
+        from builder.engine import AgentEngine
+
+        (tmp_path / "S-TEST1.json").write_text(
+            _descriptor(
+                {
+                    "name": "License",
+                    "value": "CC-BY",
+                    "valqual": [
+                        {
+                            "name": "URL",
+                            "value": "https://creativecommons.org/licenses/by/4.0/legalcode",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        engine = AgentEngine()
+        engine.initialize(input_path=str(tmp_path))
+
+        assert engine.state.metadata.license == (
+            "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )
+        assert engine.state.metadata.license_from_deposit is True
+
+    def test_a_deposit_without_a_licence_leaves_it_unset(self, tmp_path: Path) -> None:
+        # Never invent one: absent stays absent, and the drafter may still set it.
+        from builder.engine import AgentEngine
+
+        (tmp_path / "S-TEST1.json").write_text(_descriptor(None), encoding="utf-8")
+
+        engine = AgentEngine()
+        engine.initialize(input_path=str(tmp_path))
+
+        assert engine.state.metadata.license is None
+        assert engine.state.metadata.license_from_deposit is False
+
+
+class TestTheDeclaredLicenceReachesTheCrate:
+    """Reading it is only worth anything if it lands on the Root Data Entity."""
+
+    def test_a_declared_licence_still_reaches_the_root(self) -> None:
+        from rocrate.rocrate import ROCrate
+
+        from builder.tools._crate_mapping import populate_crate
+
+        state = CrateState()
+        state.metadata.title = "Licensed"
+        state.metadata.license = "https://creativecommons.org/licenses/by/4.0/legalcode"
+        crate = ROCrate()
+        populate_crate(state, crate, None, materialize_payload=False)
+
+        assert crate.root_dataset["license"] == (
+            "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )


### PR DESCRIPTION
Addresses #535. The remaining half is split out as #540 — see below.

## The bug

| | value |
|---|---|
| deposit declares | `License = CC-BY` → `https://creativecommons.org/licenses/by/4.0/legalcode` |
| crate asserted | `https://en.wikipedia.org/wiki/All_rights_reserved` |

Nothing ever read the licence. `set_crate_metadata` — an LLM-callable tool — was the **only** writer of `state.metadata.license`, so the value on the Root Data Entity was whatever the model supplied. The build session confirms the model wrote that URL itself.

The crate contradicted the depositor in the one direction that suppresses reuse of openly-licensed data, and the value is not a licence URI at all — it points at a Wikipedia *article*, so the FAIR R1.1 indicator is answered with something no machine can act on.

## Reading it is not guessing

A BioStudies descriptor states the licence, usually qualified with a canonical URL:

```json
{"name": "License", "value": "CC-BY",
 "valqual": [{"name": "URL", "value": "https://creativecommons.org/licenses/by/4.0/legalcode"}]}
```

`extract_deposit_licence` prefers that URL because the depositor chose it, and otherwise returns the declared value **verbatim**. `"CC-BY"` alone does not say which version — mapping it onto a 4.0 URI would state something the depositor did not (D5). Anything that is not a BioStudies attribute tree yields `None`, so it is safe to apply to any scanned file.

## Where it runs

Beside document discovery, for the same reason discovery lives there: deterministic, bounded, and **independent of which arm is driving**, so both get the fact before anyone drafts. Only an unset licence is filled, so a resumed session keeps what it had.

## A statement outranks a guess

`license_from_deposit` marks the value as read rather than drafted, and `set_crate_metadata` refuses to overwrite one so marked — reporting the refusal rather than silently ignoring the call. Without this the model could still overwrite the fact it was given, which is exactly how the original crate went wrong.

## Tests

12, written first. Two of them caught mistakes in my own test code (the tool is `set_crate_metadata`, and `initialize` takes no `approved_scan_roots`). The end-to-end pair drives real `AgentEngine.initialize` over a temp deposit — one asserting the licence is read, one asserting a deposit *without* a licence leaves it unset rather than inventing one.

Full suite: **2638 passed, 0 failed.**

## Deliberately not in this PR — #540

Assembly still asserts `"ALL RIGHTS RESERVED BY THE AUTHORS"` when nobody stated a licence. I verified licence is a **base REQUIRED** property, so simply deleting that placeholder flips every licence-less crate to non-conformant. That is arguably the honest outcome, but it is a behavioural fork worth deciding deliberately — #540 lays out three options with a recommendation. Note `mit_assessment.py:148` already lists the placeholder in `_PLACEHOLDER_CACHE` so our own scorer refuses to credit it: it fools external consumers while not fooling us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)