### PR TITLE
fix(mapping): keep payload files on the root's hasPart, not only under their Assay (#532)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1469,12 +1469,16 @@ of the root via `StudyMustBeReferencedFromInvestigation`, so the root cannot its
   (`FAB-2026` → `FAB-2026/study-<id>` → `…/assay-<id>`). The `@id` (the path) is the true unique
   key; the `identifier` *property* is the ISA descriptor and must not collide across levels.
 - Attaches each **result `File` to its producing Assay's `hasPart`** (de-duped via `_append_unique`)
-  and removes it from the root's auto-added `hasPart` (`_remove_child`) — raw/processed data are the
-  data of an assay. Files stay reachable from the root transitively (File → Assay → Study → `./`).
+  **in addition to** the root's reference, never instead of it (#532) — raw/processed data are the
+  data of an assay, and RO-Crate lets a data entity be `hasPart` of more than one `Dataset`. The
+  root's reference is what keeps the file in the crate's **file tree**: that tree is walked from
+  `./` through *directory* Datasets, and an ISA container is a contextual `#Study_…` / `#Assay_…`
+  node, not a directory. Re-parenting therefore stranded every payload file — ro-crate-py refuses to
+  open such a crate, while all three SHACL profiles pass it, because none of them asks.
 - Re-emits the Assay's **`dataFiles` / `resources` PageTab aliases** (both expand to `schema:hasPart`
   via `profiles/context.py`) as resolved File references *and* nests those Files under the Assay's
-  `hasPart`, un-parenting them from the root — same move as result Files, so the gold-crate JSON keys
-  round-trip without breaking reachability (`_wire_dataset_aliases`, #180 Lane C).
+  `hasPart` — same move as result Files, so the gold-crate JSON keys round-trip (`_wire_dataset_aliases`,
+  #180 Lane C).
 
 Round-trip is symmetric: `read_existing_crate` (`builder/readers/existing_crate.py`) recovers the
 **bare** entity_id (stripping the type-qualifier so `#Study_study_1` → `study_1`, not the unbounded

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1423,15 +1423,19 @@ def _attach_explicit_parts(node: Any, entity: Entity, idx: dict[str, Any], root:
     """Move a Study/Assay entity's explicit ``hasPart`` File members under its node.
 
     ``attach_files`` (#177) records placement by appending File entity_ids to the
-    dataset entity's ``hasPart`` field. Resolve those to their built File nodes,
-    attach them under the dataset, and un-parent them from the root's auto-added
-    ``hasPart`` — the same move D13 makes for a process's result Files.
+    dataset entity's ``hasPart`` field. Resolve those to their built File nodes
+    and attach them under the dataset — **in addition to** the root's reference,
+    never instead of it (#532). RO-Crate lets a data entity be ``hasPart`` of
+    more than one Dataset, and the root's copy is what makes the file reachable
+    at all: the file tree is walked from ``./`` through *directory* Datasets, and
+    an ISA container is a contextual ``#Study_…`` / ``#Assay_…`` node, not a
+    directory. Re-parenting therefore stranded every payload file — ro-crate-py
+    refuses to load such a crate, while all three SHACL profiles pass it.
     """
     for key in ("hasPart", "has_part"):
         for child in _resolve_many(idx, entity.fields.get(key)):
             if child is node:
                 continue
-            _remove_child(root, "hasPart", child.id)
             _append_unique(node, "hasPart", child)
 
 
@@ -2312,12 +2316,12 @@ def _add_processes(
         if assay is not None:
             assay.append_to("about", node)
             # Result Files are the data of this assay → attach them to the Assay's
-            # hasPart (ISA), de-duped, and remove them from the root's hasPart
-            # where crate.add auto-placed them. They stay reachable from the root
-            # transitively (File → Assay → Study → ./).
+            # hasPart (ISA), de-duped, while KEEPING the root's reference (#532).
+            # "Reachable transitively via File → Assay → Study → ./" was the
+            # premise for dropping it, and it is false: the file tree runs
+            # through directory Datasets, and an Assay is a contextual node.
             for file_node in _result_file_nodes(node):
                 _append_unique(assay, "hasPart", file_node)
-                _remove_child(crate.root_dataset, "hasPart", file_node.id)
 
 
 def _build_process(
@@ -2616,10 +2620,10 @@ def _wire_dataset_aliases(state: CrateState, crate: ROCrate, idx: dict[str, Any]
       ``about``->LabProcess wiring, for the Investigation/root).
     * Assay ``measurementMethod`` -> a single DefinedTerm reference.
     * Assay ``dataFiles`` / ``resources`` -> File references, also attached to the
-      assay's ``hasPart`` and un-parented from the root (they expand to
-      schema:hasPart, so reachability and containment are preserved).
+      assay's ``hasPart`` while KEEPING the root's reference (#532) — both expand
+      to schema:hasPart, and the root's copy is what keeps the file in the file
+      tree, which is walked through directory Datasets rather than ISA nodes.
     """
-    root = crate.root_dataset
 
     # Agent/organisation references on the ISA datasets. These were emitted
     # straight out of `_scalar_props`, i.e. as the raw STATE id — which happens
@@ -2654,9 +2658,8 @@ def _wire_dataset_aliases(state: CrateState, crate: ROCrate, idx: dict[str, Any]
                     continue
                 # Emit under the PageTab alias key …
                 _append_unique(node, alias, child)
-                # … and keep it reachable: nest under the assay's hasPart, removing
-                # the root's auto-added top-level reference (it stays reachable
-                # transitively File -> Assay -> Study -> ./). Both expand to
-                # schema:hasPart, so the RDF containment is a single edge.
-                _remove_child(root, "hasPart", child.id)
+                # … and nest under the assay's hasPart, keeping the root's
+                # reference alongside it (#532). Both alias and hasPart expand to
+                # schema:hasPart, so the RDF containment is a single edge; the
+                # root's copy is what keeps the file inside the crate's file tree.
                 _append_unique(node, "hasPart", child)

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -138,8 +138,9 @@ class TestISAHierarchy:
 
         # The raw file is hasPart of its producing Assay …
         assert "data/raw.csv" in _ids(by_id["#Assay_assay_1"].get("hasPart"))
-        # … and no longer dumped directly on the root.
-        assert "data/raw.csv" not in _ids(by_id["./"].get("hasPart"))
+        # … and stays on the root too, which is what keeps it in the file tree
+        # (#532 — an ISA container is a contextual node, not a directory).
+        assert "data/raw.csv" in _ids(by_id["./"].get("hasPart"))
 
     def test_assay_haspart_is_deduped(self, tmp_path):
         state = CrateState()

--- a/tests/test_crate_mapping_references.py
+++ b/tests/test_crate_mapping_references.py
@@ -231,9 +231,9 @@ class TestAssayDataFilesAndResources:
         )
         assert "assays/a/dataset/raw.prism" in assay_parts
         assert "assays/a/resources/README.txt" in assay_parts
-        # not orphaned loose on the root's hasPart
-        assert "assays/a/dataset/raw.prism" not in _ids(root.get("hasPart"))
-        assert "assays/a/resources/README.txt" not in _ids(root.get("hasPart"))
+        # …and still listed by the root, so the file tree reaches them (#532)
+        assert "assays/a/dataset/raw.prism" in _ids(root.get("hasPart"))
+        assert "assays/a/resources/README.txt" in _ids(root.get("hasPart"))
 
 
 class TestAssaysReverseAlias:

--- a/tests/test_crate_reads_back.py
+++ b/tests/test_crate_reads_back.py
@@ -1,0 +1,132 @@
+"""A crate this tool writes must load in the reference implementation (#532).
+
+Every crate in ``output/`` failed ``ROCrate(path)`` with the same complaint —
+a data entity not linked from the root's ``hasPart``. The cause was deliberate:
+D13 nests result files and PageTab-alias files under their Assay and then
+*removes* them from the root, on the stated grounds that they "stay reachable
+from the root transitively (File → Assay → Study → ./)".
+
+They do not. RO-Crate's file tree is walked from the root through **directory**
+Datasets, and the ISA Study/Assay are contextual entities identified by
+``#Study_…`` / ``#Assay_…`` — logical containers, not directories. ro-crate-py
+does not traverse them, so a file parented only there is unreachable and the
+canonical consumer refuses the whole crate. It passed all three SHACL profiles
+the entire time, because none of them asks this question.
+
+RO-Crate permits a data entity to be ``hasPart`` of more than one Dataset, so
+the ISA nesting is kept and the root reference is kept with it.
+
+The oracle here is ro-crate-py rather than a hand-written rule: it is the
+implementation real consumers use, so it cannot drift from the thing we care
+about.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from builder.tools.builder import export_crate
+from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+pytestmark = pytest.mark.timeout(180)
+
+
+def _ids(value: object) -> list[str]:
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [str(v.get("@id")) if isinstance(v, dict) else str(v) for v in items]
+
+
+@pytest.fixture(scope="module")
+def written_crate(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    out = tmp_path_factory.mktemp("readback") / "crate"
+    state = vhps_fixture_state("S-VHPS21")
+    state.metadata.output_path = str(out)
+    result = export_crate(state, str(out))
+    assert result["success"], result["error"]
+    return out
+
+
+class TestTheReferenceImplementationCanReadIt:
+    def test_a_receiving_lab_can_open_the_crate(self, written_crate: Path) -> None:
+        """``ROCrate(path)`` in a process that knows nothing about this repo.
+
+        Deliberately a subprocess: ro-crate-py builds its read-time class map
+        from every imported subclass of ``ContextEntity`` and matches by class
+        *name*, so importing ``profiles.models`` changes how a crate is read.
+        A receiving lab has only vanilla ro-crate-py, and that is the claim
+        worth pinning — reading it in-process would test our import graph as
+        much as the crate.
+
+        (In-process reading is separately broken and tracked; the models'
+        constructors are incompatible with ro-crate-py's positional read call.
+        That bug masks this one but is not this one.)
+        """
+        script = (
+            "from rocrate.rocrate import ROCrate;"
+            f"c = ROCrate({str(written_crate)!r});"
+            "assert list(c.data_entities), 'no data entities'"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=120
+        )
+        assert proc.returncode == 0, (
+            f"a plain ro-crate-py consumer cannot open the crate:\n{proc.stderr[-800:]}"
+        )
+
+    def test_every_local_data_entity_is_reachable_from_the_root(
+        self, written_crate: Path
+    ) -> None:
+        """The rule ro-crate-py enforces, asserted directly.
+
+        Stated separately from the load test so a future ro-crate-py that
+        loosens (or tightens) its check still leaves the invariant pinned.
+        """
+        import json
+
+        graph = json.loads(
+            (written_crate / "ro-crate-metadata.json").read_text(encoding="utf-8")
+        )["@graph"]
+        root = next(e for e in graph if e.get("@id") == "./")
+        root_parts = set(_ids(root.get("hasPart")))
+
+        unreachable = [
+            e["@id"]
+            for e in graph
+            if "File" in str(e.get("@type"))
+            and not str(e["@id"]).startswith(("#", "http://", "https://"))
+            and e["@id"] not in root_parts
+        ]
+        assert unreachable == [], f"files unreachable from the root: {unreachable}"
+
+
+class TestTheIsaNestingSurvives:
+    """Dual-parenting, not re-parenting: the ISA hierarchy is the point of D13."""
+
+    def test_files_stay_nested_under_their_isa_container(self, written_crate: Path) -> None:
+        import json
+
+        graph = json.loads(
+            (written_crate / "ro-crate-metadata.json").read_text(encoding="utf-8")
+        )["@graph"]
+        containers = [
+            e
+            for e in graph
+            if str(e.get("additionalType")) in ("Assay", "Study")
+            and _ids(e.get("hasPart"))
+        ]
+        assert containers, "no ISA container carries hasPart — the nesting was lost"
+
+        nested = {cid for c in containers for cid in _ids(c.get("hasPart"))}
+        root = next(e for e in graph if e.get("@id") == "./")
+        root_parts = set(_ids(root.get("hasPart")))
+        both = nested & root_parts
+        assert both, (
+            "no entity is listed by both an ISA container and the root — "
+            "re-parented rather than dual-parented"
+        )

--- a/tests/test_provenance_tools.py
+++ b/tests/test_provenance_tools.py
@@ -63,7 +63,7 @@ class TestAttachFiles:
         # The assay now references the file via hasPart.
         assert files[0].entity_id in (state.get_entity("assay_1").fields.get("hasPart") or [])
 
-    def test_build_places_file_under_assay_not_root(self, tmp_path):
+    def test_build_places_file_under_assay_and_root(self, tmp_path):
         state = self._state(tmp_path)
         attach_files(state, to="assay_1", mime_contains="csv", role="raw_data")
         graph = assemble_crate(
@@ -71,8 +71,11 @@ class TestAttachFiles:
         ).metadata.generate()["@graph"]
         assay = next(n for n in graph if n.get("additionalType") == "Assay")
         root = next(n for n in graph if n.get("@id") == "./")
+        # Under the Assay (ISA placement) AND under the root (#532): the root's
+        # reference is what keeps the file in the crate's file tree, which is
+        # walked through directory Datasets, not through contextual ISA nodes.
         assert any("raw.csv" in str(p) for p in _haspart_ids(assay)), assay
-        assert not any("raw.csv" in str(p) for p in _haspart_ids(root)), root
+        assert any("raw.csv" in str(p) for p in _haspart_ids(root)), root
 
     def test_dedups_already_drafted_file(self, tmp_path):
         state = self._state(tmp_path)

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -92,9 +92,12 @@ class TestRoundTrip:
         build_crate(restored, str(tmp_path / "c2"))
         by2 = _graph(tmp_path / "c2")
 
-        # The raw file stays attached to its Assay, not orphaned onto the root.
+        # The raw file is attached to its Assay AND to the root (#532): the ISA
+        # nesting is what makes it the assay's data, the root reference is what
+        # keeps it inside the crate's file tree. Dropping the latter stranded it —
+        # ro-crate-py refuses to open such a crate.
         assert "data/raw.csv" in _ids(by2["#Assay_assay_1"].get("hasPart"))
-        assert "data/raw.csv" not in _ids(by2["./"].get("hasPart"))
+        assert "data/raw.csv" in _ids(by2["./"].get("hasPart"))
 
     def test_single_investigation_not_duplicated_after_roundtrip(self, tmp_path):
         build_crate(self._state(), str(tmp_path / "c1"))
@@ -145,9 +148,9 @@ class TestRoundTrip:
         # The File's @id (path) is STABLE — no drift to data/raw.prism.
         assert nested in by2
         assert "data/raw.prism" not in by2
-        # And it stays nested under its Assay, not orphaned onto the root.
+        # Nested under its Assay, and still reachable from the root (#532).
         assert nested in _ids(by2["#Assay_assay_1"].get("hasPart"))
-        assert nested not in _ids(by2["./"].get("hasPart"))
+        assert nested in _ids(by2["./"].get("hasPart"))
 
 
 class TestReaderFileDestPath:


### PR DESCRIPTION
Addresses the read-blocking half of #532. The dangling-agent-references half (Part A) is **not** in this PR.

## Every crate we have written fails to open

```bash
uv run python -c "
from rocrate.rocrate import ROCrate; import glob
for p in sorted(glob.glob('output/*/')):
    try: ROCrate(p); print('OK  ', p)
    except Exception as e: print('FAIL', p, e)"
```

All five crates in `output/` fail identically:

```
ValueError: 'Assay_OATP1C1/Assay-metadata-CHO-K1_OATP1C1-v1.1.xlsx' is a data entity
            but it's not linked to from the root dataset's hasPart
```

## The cause was deliberate, and its premise is false

D13 nests result files and PageTab-alias files under their Assay and then **removes them from the root**, on the stated grounds that they

> stay reachable from the root transitively (File → Assay → Study → `./`)

They do not. RO-Crate's file tree is walked from the root through **directory** Datasets. The ISA Study and Assay are contextual entities — `#Study_…`, `#Assay_…` — logical containers, not directories. Nothing traverses them, so a file parented only there sits outside the crate's file tree. Minimal repro:

```python
st = c.add(ContextEntity(c, '#Study_s', properties={'@type': 'Dataset', 'name': 'S'}))
f  = c.add_file(source=..., dest_path='payload/f.txt')
st.append_to('hasPart', f)
c.root_dataset['hasPart'] = [...]              # drop the root's reference
# -> ValueError: 'payload/f.txt' is a data entity but it's not linked to from the root
```

**All three SHACL profiles pass such a crate**, because none of them asks this question. That is why it survived this long.

## The fix

RO-Crate permits a data entity to be `hasPart` of more than one Dataset, so both edges are kept: the ISA nesting says whose data the file is, the root reference keeps it in the crate. Three call sites stop un-parenting. The fourth is left alone — it nests an Assay **node** under its Study, which is the ISA hierarchy, not a file-tree question.

D13 is updated to state the corrected contract.

## About the test changes — please look at these

**Five existing tests asserted the un-parenting** (`assert "data/raw.csv" not in root hasPart`). Their assertions are inverted here. That is changing tests to match new behaviour, so it deserves scrutiny; the justification is that the contract they pinned **is** the defect. Each one's *nesting* assertion is untouched and still passes, so the ISA placement they were really protecting is still pinned.

## Why the regression test uses a subprocess

ro-crate-py builds its read-time class map from every imported subclass of `ContextEntity`, matched by class **name** — so importing `profiles.models` changes how a crate is read. Our models' constructors are separately incompatible with the reader's positional call, which **masks** this bug in-process; that is filed as **#544** (14 of 15 classes). A receiving lab has neither our models nor that problem, so the test drives `ROCrate(path)` in a clean subprocess — the claim external consumers actually care about. Two further tests assert the reachability rule and the surviving dual-parenting directly, so the invariant stays pinned if ro-crate-py's own check ever changes.

## Verification status

- New tests (3) and the five updated contract tests: **green**.
- Full suite before the last fix: **2659 passed, 1 failed** — that one failure was a *fifth* instance of the same contract assertion (`test_provenance_tools.py`), now fixed, and its module passes (31 passed).
- A full-suite run against this exact commit is still in flight; I will report it here. Please hold the merge until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)