### PR TITLE
fix(mapping): size every File once, wherever it entered the crate

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -758,6 +758,54 @@ def _file_dest(fe: Entity) -> str:
     return _contain_dest(str(path), fallback)
 
 
+def _known_file_size(state: CrateState, fe: Entity, input_path: str | None) -> int | None:
+    """Bytes for a drafted File, from whatever already knows — never a guess.
+
+    Three places may know, in order of authority: the entity's own
+    ``contentSize``, the scan that measured the file, and the file itself. A
+    drafted File that matches none of them has no size stated, which is correct:
+    a synthesized placeholder describes no bytes on disk.
+
+    This exists because the size used to depend on HOW a file entered the crate.
+    The scanned-file loop set it; the drafted-File loop emitted only the entity's
+    own fields; and a file that was BOTH drafted and scanned took the drafted path
+    and was skipped by the scanned one as already covered. So the same file in the
+    same crate carried a size or not depending on which tool created it — two
+    exports of one session differed on exactly this.
+    """
+    existing = fe.fields.get("contentSize")
+    if existing:
+        try:
+            return int(str(existing))
+        except (TypeError, ValueError):
+            pass  # a malformed value is replaced below, not propagated
+
+    dest = _file_dest(fe)
+    for fc in getattr(state, "scanned_files", []) or []:
+        if fc.size and (fc.filename == Path(dest).name or str(fc.path).endswith(dest)):
+            return int(fc.size)
+
+    source = _file_source(fe, input_path)
+    if source:
+        try:
+            return Path(source).stat().st_size
+        except OSError:
+            logger.debug("Could not size %s for contentSize", source, exc_info=True)
+
+    # A provisional table has no file on the in-memory path, but its payload is
+    # the header line `_materialize_provisional_table` is about to write — so its
+    # length is known without writing it. Sizing the CONTENT rather than the file
+    # keeps the validated crate and the written one saying the same thing, which
+    # is the whole reason these tables are described identically on both paths.
+    if fe.fields.get("provisional"):
+        spec = _PROVISIONAL_TABLES.get(str(fe.fields.get("table_kind") or "measurements"))
+        if spec is not None:
+            _name, columns = spec
+            header = ",".join(c["titles"] for c in columns) + "\n"
+            return len(header.encode("utf-8"))
+    return None
+
+
 def _file_source(fe: Entity, input_path: str | None) -> str | None:
     """Resolve the on-disk source for a File data entity, or ``None`` (#128).
 
@@ -1182,6 +1230,12 @@ def _add_leaves(
         # explicit note that it holds no rows, so a consumer can never mistake
         # the template for data.
         props: dict[str, Any] = {"@type": file_type, **_scalar_props(fe)}
+        # Every File gets a size if anything knows one — see `_known_file_size`.
+        # The base profile asks each File Data Entity for a contentSize, and the
+        # answer was already in the scan or on disk.
+        size = _known_file_size(state, fe, state.metadata.input_path)
+        if size is not None:
+            props["contentSize"] = str(size)
         if fe.fields.get("provisional"):
             # Say so in the NAME, on every path. A description explains it, but
             # the name is what a file browser, the preview page and a reader's

--- a/tests/test_file_content_size.py
+++ b/tests/test_file_content_size.py
@@ -1,0 +1,104 @@
+"""Every File states its size if anything in the crate knows it.
+
+The size used to depend on HOW a file entered the crate. The scanned-file loop
+set `contentSize` from the scan; the drafted-File loop emitted only the entity's
+own fields; and a file that was BOTH drafted and scanned took the drafted path and
+was skipped by the scanned one as already covered — so it carried no size at all.
+
+Two exports of one session, two hours apart, disagreed on exactly this: the
+earlier crate had `contentSize` on its input workbooks and the later one did not,
+because the files had been attached a different way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState, FileClassification
+from builder.tools._crate_mapping import _known_file_size
+from builder.tools.drafters import draft_investigation
+
+
+def _file_entity(state, entity_id, **fields):
+    from builder.state import Entity
+
+    ent = Entity(entity_id=entity_id, type="File", fields=fields)
+    state.add_entity(ent)
+    return ent
+
+
+@pytest.fixture
+def state():
+    st = CrateState()
+    draft_investigation(st, {"name": "I", "description": "D"})
+    return st
+
+
+class TestWhereTheSizeComesFrom:
+    def test_the_entity_field_wins(self, state):
+        fe = _file_entity(state, "file_x", dest_path="data/x.csv", contentSize="4242")
+        assert _known_file_size(state, fe, None) == 4242
+
+    def test_the_scan_is_used_when_the_entity_has_none(self, state):
+        """The scan already measured it; the size costs nothing to state."""
+        state.scanned_files.append(
+            FileClassification(path="/in/x.csv", filename="x.csv", size=999, mime_type="text/csv")
+        )
+        fe = _file_entity(state, "file_x", dest_path="data/x.csv")
+        assert _known_file_size(state, fe, None) == 999
+
+    def test_the_file_on_disk_is_used_as_a_last_resort(self, state, tmp_path):
+        src = tmp_path / "real.csv"
+        src.write_text("a,b\n1,2\n", encoding="utf-8")
+        fe = _file_entity(state, "file_real", dest_path="real.csv", path=str(src))
+        assert _known_file_size(state, fe, str(tmp_path)) == src.stat().st_size
+
+    def test_a_malformed_stored_value_is_not_propagated(self, state):
+        state.scanned_files.append(
+            FileClassification(path="/in/x.csv", filename="x.csv", size=77, mime_type="text/csv")
+        )
+        fe = _file_entity(state, "file_x", dest_path="data/x.csv", contentSize="not-a-number")
+        assert _known_file_size(state, fe, None) == 77
+
+    def test_nothing_known_states_nothing(self, state):
+        """A synthesized placeholder describes no bytes; silence is correct."""
+        fe = _file_entity(state, "file_ghost", dest_path="data/ghost.csv")
+        assert _known_file_size(state, fe, None) is None
+
+
+class TestProvisionalTables:
+    def test_a_provisional_table_is_sized_from_its_header(self, state):
+        """It has no file in memory, but its payload is the header about to be
+        written — so the length is known without writing it, and the validated
+        crate says the same thing as the written one."""
+        fe = _file_entity(
+            state, "file_prov", dest_path="data/p.csv", provisional=True, table_kind="measurements"
+        )
+        size = _known_file_size(state, fe, None)
+        assert size is not None and size > 0
+
+    def test_an_unknown_table_kind_states_nothing(self, state):
+        fe = _file_entity(
+            state, "file_prov", dest_path="data/p.csv", provisional=True, table_kind="nonsense"
+        )
+        assert _known_file_size(state, fe, None) is None
+
+
+class TestItReachesTheGraph:
+    def test_a_drafted_and_scanned_file_carries_a_size(self, state):
+        """The regression case: drafted AND scanned, so neither loop set it."""
+        from builder.tools.builder import assemble_crate
+
+        state.scanned_files.append(
+            FileClassification(
+                path="/in/book.xlsx", filename="book.xlsx", size=32959, mime_type="application/xlsx"
+            )
+        )
+        _file_entity(state, "file_book", dest_path="book.xlsx", name="book.xlsx")
+        graph = assemble_crate(
+            state, output_dir=None, materialize_payload=False, include_all_scanned=True
+        ).metadata.generate()["@graph"]
+        node = next(n for n in graph if str(n.get("@id", "")).endswith("book.xlsx"))
+        assert node.get("contentSize") == "32959"


### PR DESCRIPTION
## Reported

```
Recommended: ./data/proc_measure_125i_t4_uptake_..._result.csv   SHOULD have a `contentSize`
Recommended: ./Assay_OATP1C1/raw%20data.../..._Timecourse.xlsx    SHOULD have a `contentSize`
Recommended: ./Assay_OATP1C1/raw%20data.../..._Timecourse.pzfx    SHOULD have a `description`
…
```

## What was actually wrong

`contentSize` depended on **how a file got into the crate**, not on whether anyone knew its size:

| path | sets contentSize? |
|---|---|
| scanned-file loop | yes, from the scan |
| drafted-File loop | only if the entity happened to carry the field |
| **drafted *and* scanned** | **no** — takes the drafted path, and the scanned loop skips it as already covered |

That third row is the bug. It's also why this looked like a regression and isn't: two exports of the same session, two hours apart, disagreed —

```
v59  (20:04)  contentSize present
v61  (22:54)  contentSize absent
```

— because the files had been attached a different way. It was a coin toss that had always been there.

## The change

`_known_file_size` asks whatever knows, in order of authority: the entity's own `contentSize`, then the scan that measured the file, then the file on disk. A drafted File matching none of them still states **nothing** — a synthesized placeholder describes no bytes, and silence is the honest answer there.

**Provisional tables are sized from their header.** They have no file on the in-memory path, but their payload is the line `_materialize_provisional_table` is about to write, so its length is known without writing it. The validated crate then says what the written one will — which is the reason those tables are already described identically on both paths.

## Measured

SVHPS26 crate rebuilt from session `20260811_175613`:

| | before | after |
|---|---:|---:|
| `contentSize` findings | 5 | **0** |
| `description` findings | 2 | 1 |
| total gaps | 70 | **63** |

## Not in this PR

`https://creativecommons.org/licenses/by/4.0/ — License entities SHOULD have a name`, from the same report. That one is a different question: the licence is referenced but never described, and giving it a name means deciding where the name comes from. Deriving it from the URL is fragile, and a hardcoded map is the shape this project has rejected twice. Worth its own discussion rather than a guess bundled in here.

## Tests

8 new, 13 passing with `test_crate_mapping_no_payload`. Covers each source in priority order, a malformed stored value falling through to the scan, nothing-known stating nothing, provisional sizing, an unknown table kind, and the regression case end-to-end — a file both drafted and scanned reaching the graph with a size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)