### PR TITLE
fix(mapping): declare the CSVW columns we generate, on both paths

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1212,7 +1212,19 @@ def _add_leaves(
                 )
             ),
         )
-        if provisional_rel is not None:
+        if fe.fields.get("provisional"):
+            # Keyed on the FLAG, not on materialisation — the same correction the
+            # name, the co-type and the description above already carry.
+            #
+            # These columns are OURS: the build generates them from
+            # `_PROVISIONAL_TABLES`, so the crate can declare them whether or not
+            # a payload was written. Keyed on `provisional_rel`, the schema and
+            # its columns existed only in the EXPORTED crate — nine nodes the
+            # in-loop validation never saw, carrying what has historically been
+            # this project's largest finding bucket. The agent iterated against a
+            # graph with no CSVW schema at all, and those findings appeared for
+            # the first time after export, when the loop that could have fixed
+            # them had already finished.
             _attach_provisional_schema(crate, node, fe)
 
     for proto in state.list_entities("LabProtocol"):

--- a/tests/test_metadata_is_write_independent.py
+++ b/tests/test_metadata_is_write_independent.py
@@ -1,0 +1,126 @@
+"""What the agent validates must be what the crate ships.
+
+`build_and_validate` assembles with `materialize_payload=False` and validates the
+result; `export_crate` assembles with True and writes it. Whenever a leaf site
+decided what METADATA to emit based on that flag, the agent spent its whole loop
+validating a graph that differed from the crate it would produce — and the
+difference only appeared after export, when the loop that could have acted on it
+had finished.
+
+Three landed that way before this was pinned: the provisional tables' description
+and co-type, `contentSize`, and the CSVW schemas — nine nodes the in-loop
+validation never saw, carrying what was historically the project's largest
+finding bucket.
+
+The flag means "resolve a source path so ro-crate-py copies the payload". It does
+not mean "should this metadata exist". This test is what keeps those apart.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools.builder import assemble_crate
+from builder.tools.drafters import draft_investigation
+
+
+def _graph(state_factory, materialize, output_dir):
+    crate = assemble_crate(
+        state_factory(),
+        output_dir=output_dir,
+        materialize_payload=materialize,
+        include_all_scanned=True,
+    )
+    return {
+        node["@id"]: {k: v for k, v in node.items() if k != "@id"}
+        for node in crate.metadata.generate()["@graph"]
+    }
+
+
+@pytest.fixture(scope="module")
+def graphs():
+    """The same state assembled both ways."""
+
+    def factory():
+        from builder.state import Entity
+
+        state = CrateState()
+        draft_investigation(state, {"name": "T", "description": "D"})
+        # A provisional table, because that is where every divergence so far has
+        # lived. Without one the comparison below passes vacuously — there is
+        # nothing in the crate whose metadata the write flag could have changed.
+        state.add_entity(
+            Entity(
+                entity_id="file_prov",
+                type="File",
+                fields={
+                    "dest_path": "data/p.csv",
+                    "name": "p.csv",
+                    "provisional": True,
+                    "table_kind": "measurements",
+                },
+            )
+        )
+        return state
+
+    with tempfile.TemporaryDirectory() as td:
+        written = _graph(factory, True, Path(td))
+        in_memory = _graph(factory, False, None)
+    return written, in_memory
+
+
+class TestTheGraphsAgree:
+    def test_no_node_is_missing_from_the_validated_graph(self, graphs):
+        """The failure that hid nine CSVW nodes: memory was a strict SUBSET."""
+        written, in_memory = graphs
+        missing = sorted(set(written) - set(in_memory))
+        assert not missing, f"only in the written crate, so never validated: {missing}"
+
+    def test_no_node_is_invented_by_the_validated_graph(self, graphs):
+        written, in_memory = graphs
+        extra = sorted(set(in_memory) - set(written))
+        assert not extra, f"validated but never written: {extra}"
+
+    def test_every_shared_node_carries_the_same_properties(self, graphs):
+        """`contentSize` and the provisional description both failed here."""
+        written, in_memory = graphs
+        differing = {
+            nid: sorted(set(written[nid]) ^ set(in_memory[nid]))
+            for nid in set(written) & set(in_memory)
+            if set(written[nid]) ^ set(in_memory[nid])
+        }
+        assert not differing, f"property sets differ between the two paths: {differing}"
+
+
+class TestTheColumnsAreDeclared:
+    def test_a_provisional_table_declares_its_schema_in_memory(self):
+        """We generate these columns, so the crate can declare them either way."""
+        state = CrateState()
+        draft_investigation(state, {"name": "T", "description": "D"})
+        from builder.state import Entity
+
+        state.add_entity(
+            Entity(
+                entity_id="file_prov",
+                type="File",
+                fields={
+                    "dest_path": "data/p.csv",
+                    "name": "p.csv",
+                    "provisional": True,
+                    "table_kind": "measurements",
+                },
+            )
+        )
+        graph = assemble_crate(
+            state, output_dir=None, materialize_payload=False
+        ).metadata.generate()["@graph"]
+        schemas = [n for n in graph if "csvw:Schema" in str(n.get("@type"))]
+        columns = [n for n in graph if "csvw:Column" in str(n.get("@type"))]
+        assert schemas, "no CSVW schema without writing the payload"
+        assert columns, "no CSVW columns without writing the payload"
+        table = next(n for n in graph if str(n.get("@id", "")).endswith("p.csv"))
+        assert table.get("tableSchema"), "the table does not point at its schema"


### PR DESCRIPTION
## The bug, in one line

```python
if provisional_rel is not None:      # set only when materialize_payload=True
    _attach_provisional_schema(crate, node, fe)
```

A provisional table's `csvw:Schema` and its columns were attached **only when the payload had been written**. So nine nodes existed in the exported crate and never in the graph the agent validates.

The agent iterated against a crate with **no CSVW schema at all**, and findings on those columns appeared for the first time *after* export — when the loop that could have fixed them had already finished. CSVW columns have historically been this project's largest finding bucket (161 findings at one point).

## Why it's a one-line fix

We generate those columns ourselves from `_PROVISIONAL_TABLES`, and `_attach_provisional_schema` reads that spec and touches no file. So the crate can declare them whether or not a payload was written. Keyed on the `provisional` flag now — exactly as the name, the co-type and the description beside it already are.

## It closes the divergence completely

Assembling one state both ways:

```
nodes: written=138   in-memory=138
  only in written : 0
  only in memory  : 0
  differing props : 0
```

## The guard matters more than the fix

`materialize_payload` means *"resolve a source path so ro-crate-py copies the payload"*. It does **not** mean *"should this metadata exist"* — and three bugs have now landed from the second meaning leaking in:

| | |
|---|---|
| provisional tables undescribed and un-co-typed in memory | #512 |
| `contentSize` absent depending on how the file was attached | #546 |
| CSVW schemas invisible to the agent | **this** |

Each was found in production, by the user, reading a report. `tests/test_metadata_is_write_independent.py` asserts the two graphs carry the same nodes and the same properties — it fails **3 of 4** without this change, so the next leak fails a test instead of reaching a report.

**One thing worth flagging about that test:** its fixture carries a provisional table on purpose. Without one the comparison passes vacuously — nothing in the crate has metadata the flag could alter — and the first version of this test did exactly that on `origin/main` and I nearly shipped it. A guard that cannot fail is worse than no guard, because it reads like coverage.

## Tests

4 new, 9 passing with `test_crate_mapping_no_payload`. Lint and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)