### PR TITLE
feat(report): every finding is reachable, not just the first ten

### DIFF
--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -374,3 +374,9 @@ __CATEGORY_STYLES__
   .mat .panel + .panel{margin-top:1.2rem; padding-top:1rem; border-top:1px solid #ccc;}
   .mat .panel > .panel-h{display:block; font-size:.95rem; font-weight:660; margin:0 0 .6rem;}
 }
+
+/* The overflow fold inside a findings list: same muted voice as the
+   '+N further' line it replaces, but reachable. */
+.mat ul.sugg li.more > details.more-fold > summary { cursor:pointer; font-style:italic; }
+.mat ul.sugg li.more > details.more-fold > summary:hover { color:var(--ink); }
+.mat ul.sugg li.more > details.more-fold > ul.sugg { margin:.35rem 0 0; font-style:normal; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -452,7 +452,7 @@ def _render_kpis(
         chem_tile = (
             '<article class="kpi">'
             '<div class="kpi-h"><span class="eyebrow">Chemicals</span>'
-            f'{_mk("ok" if wired == total else "no")}</div>'
+            f"{_mk('ok' if wired == total else 'no')}</div>"
             f'<div class="kpi-v"><b>{wired}</b><span class="den">/ {total}</span> '
             '<span class="tag-inline">wired</span></div>'
             f'<div class="kpi-sub">{id_pct}% of identification fields filled</div>'
@@ -495,17 +495,31 @@ _TIER_RENDER_ORDER: tuple[str, ...] = ("required", "recommended", "optional")
 
 
 def _capped_tier_items(tier: str, rendered: list[str]) -> list[str]:
-    """Apply the tier's cap to already-rendered ``<li>`` items, naming the rest."""
+    """Apply the tier's cap, putting the remainder behind a second fold-out.
+
+    The cap bounds the page; it is not a decision about what the reader may see.
+    It used to end at "+9 further recommended findings not listed here", which
+    named a number and then offered no way to reach it — the crate's own report
+    was the one place those findings existed, so a reader who wanted them had
+    nowhere else to look.
+
+    The overflow now sits in a nested ``<details>``: closed by default, so the
+    page stays the length it was, and one click from complete.
+    """
     cap = _SUGGESTION_CAPS.get(tier)
     shown = rendered if cap is None else rendered[:cap]
-    hidden = len(rendered) - len(shown)
-    if hidden:
-        shown = [
-            *shown,
-            f'<li class="more">+{hidden} further {tier} '
-            f"{'finding' if hidden == 1 else 'findings'} not listed here</li>",
-        ]
-    return shown
+    rest = rendered[len(shown) :]
+    if not rest:
+        return shown
+    noun = "finding" if len(rest) == 1 else "findings"
+    return [
+        *shown,
+        '<li class="more">'
+        f'<details class="more-fold"><summary>+{len(rest)} further {tier} {noun}</summary>'
+        f'<ul class="sugg">{"".join(rest)}</ul>'
+        "</details>"
+        "</li>",
+    ]
 
 
 def _tier_findings_html(records: list[dict[str, str]], tier: str) -> str:
@@ -636,7 +650,7 @@ def _render_severity_detail(val: ValidationReport, tiers: list[dict[str, str]]) 
         )
     return (
         '<div class="sev-detail"><span class="sev-detail-label">By severity</span>'
-        f'{"".join(rows)}</div>'
+        f"{''.join(rows)}</div>"
     )
 
 
@@ -713,9 +727,7 @@ def _render_profile_section(
     # left to say underneath is that there were none — and that line stays
     # honest about how much of the crate was actually checked (#306).
     has_findings = any(_tier_body(val, tier["key"])[1] for tier in tiers) or any(
-        records
-        for key, records in _tier_records(val).items()
-        if key not in _TIER_RENDER_ORDER
+        records for key, records in _tier_records(val).items() if key not in _TIER_RENDER_ORDER
     )
     sugg = "" if has_findings else f'<p class="good-note">{_clean_note(val)}</p>'
 
@@ -830,9 +842,7 @@ def _render_mit_section(mit: MITReport) -> str:
         # label map doesn't know — rendered raw rather than dropped.
         ordered = [k for k in MIT_STANDARD_LABELS if k in mit.standard_scores]
         ordered += sorted(k for k in mit.standard_scores if k not in MIT_STANDARD_LABELS)
-        srows = "".join(
-            row(MIT_STANDARD_LABELS.get(k, k), mit.standard_scores[k]) for k in ordered
-        )
+        srows = "".join(row(MIT_STANDARD_LABELS.get(k, k), mit.standard_scores[k]) for k in ordered)
         body += (
             '\n  <h3 class="mit-sub">Per guidance document</h3>\n'
             '  <p class="lead">One parameter can be required by several documents — '
@@ -1113,9 +1123,7 @@ def _reach_repair(counts: dict[str, Any]) -> str:
 
     parts = []
     if stranded:
-        parts.append(
-            f"<b>{stranded}</b> are linked to each other but not to the root"
-        )
+        parts.append(f"<b>{stranded}</b> are linked to each other but not to the root")
     if isolated:
         parts.append(f"<b>{isolated}</b> stand entirely alone")
     detail = f" ({'; '.join(parts)})" if parts else ""
@@ -1148,15 +1156,12 @@ def _render_isa_panel(inv: dict[str, Any]) -> tuple[str, str]:
     counts = inv["counts"]
     detached = counts["detached"]
     pct = (
-        round(counts["fields_met"] / counts["fields_total"] * 100)
-        if counts["fields_total"]
-        else 0
+        round(counts["fields_met"] / counts["fields_total"] * 100) if counts["fields_total"] else 0
     )
 
     svg = render_isa_svg(inv)
     diagram = (
-        f'<div class="prov-scroll">{svg}</div>\n  '
-        + _legend(_LG_CONTAINER, _LG_LINK, _LG_BREAK)
+        f'<div class="prov-scroll">{svg}</div>\n  ' + _legend(_LG_CONTAINER, _LG_LINK, _LG_BREAK)
         if svg
         else ""
     )
@@ -1166,8 +1171,8 @@ def _render_isa_panel(inv: dict[str, Any]) -> tuple[str, str]:
         loose = [n["label"] for n in nodes if n["state"] == "detached"]
         notes.append(
             f'<p class="chem-warn">{_mk("no")}<span><b>{detached} ISA container'
-            f'{"" if detached == 1 else "s"} sit outside the hierarchy</b> '
-            f'({", ".join(loose[:4])}{"&hellip;" if len(loose) > 4 else ""}). '
+            f"{'' if detached == 1 else 's'} sit outside the hierarchy</b> "
+            f"({', '.join(loose[:4])}{'&hellip;' if len(loose) > 4 else ''}). "
             "Nothing lists them under <code>hasPart</code>, so a reader walking the "
             "Investigation never reaches them.</span></p>"
         )
@@ -1175,8 +1180,8 @@ def _render_isa_panel(inv: dict[str, Any]) -> tuple[str, str]:
     if hollow:
         notes.append(
             f'<p class="chem-warn">{_mk("no")}<span><b>{len(hollow)} container'
-            f'{"" if len(hollow) == 1 else "s"} contain nothing below them</b> '
-            f'({", ".join(n["label"] for n in hollow[:4])}). An Assay needs a '
+            f"{'' if len(hollow) == 1 else 's'} contain nothing below them</b> "
+            f"({', '.join(n['label'] for n in hollow[:4])}). An Assay needs a "
             "<code>LabProcess</code>, a Study an Assay, an Investigation a Study — "
             "otherwise the level is a label with no work under it.</span></p>"
         )
@@ -1199,7 +1204,7 @@ def _render_isa_panel(inv: dict[str, Any]) -> tuple[str, str]:
         )
         extra = (
             f'<span class="ty">{len(n["processes"])} process'
-            f'{"" if len(n["processes"]) == 1 else "es"}</span>'
+            f"{'' if len(n['processes']) == 1 else 'es'}</span>"
             if n["level"] == "Assay"
             else ""
         )
@@ -1210,13 +1215,13 @@ def _render_isa_panel(inv: dict[str, Any]) -> tuple[str, str]:
             f'<tr><th scope="row">{_mk("ok" if n["state"] == "linked" else "no")}'
             f'<span class="cn">{n["label"]}</span>'
             f'<span class="ty" title="{html.escape(_ISA_LEVEL_NOTE[n["level"]])}">'
-            f'{n["level"]}</span>{extra}{flag}</th>{cells}</tr>'
+            f"{n['level']}</span>{extra}{flag}</th>{cells}</tr>"
         )
     matrix = (
         '<div class="chem-tbl-scroll"><table class="chem-tbl">'
         '<caption class="sr-only">Structural fields carried by each ISA container</caption>'
         f'<thead><tr><th scope="col">Container</th>{head}</tr></thead>'
-        f'<tbody>{"".join(rows)}</tbody></table></div>'
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
     panel = (
@@ -1315,7 +1320,7 @@ def _render_graph_views_section(
 
     inputs = "".join(
         f'<input class="tab-in" type="radio" name="mat-view" id="{rid}"'
-        f'{" checked" if i == 0 else ""}>'
+        f"{' checked' if i == 0 else ''}>"
         for i, (rid, _pid, _label) in enumerate(live)
     )
     tabs = "".join(
@@ -1325,8 +1330,7 @@ def _render_graph_views_section(
         for rid, pid, label in live
     )
     bodies = "".join(
-        f'<div class="panel" id="{pid}">'
-        f'<h3 class="panel-h">{label}</h3>{panels[pid][0]}</div>'
+        f'<div class="panel" id="{pid}"><h3 class="panel-h">{label}</h3>{panels[pid][0]}</div>'
         for _rid, pid, label in live
     )
 
@@ -1379,9 +1383,7 @@ def _render_chemicals_panel(inv: dict[str, Any]) -> tuple[str, str]:
     counts = inv["counts"]
     total, wired = counts["total"], counts["wired"]
     id_pct = (
-        round(counts["fields_met"] / counts["fields_total"] * 100)
-        if counts["fields_total"]
-        else 0
+        round(counts["fields_met"] / counts["fields_total"] * 100) if counts["fields_total"] else 0
     )
 
     svg = render_chemicals_svg(inv)
@@ -1421,7 +1423,7 @@ def _render_chemicals_panel(inv: dict[str, Any]) -> tuple[str, str]:
             f"{'not linked' if c['state'] == 'unlinked' else 'no process'}</span>"
         )
         cells = "".join(
-            f'<td>{_mk("ok" if c["fields"].get(full) else "no")}</td>'
+            f"<td>{_mk('ok' if c['fields'].get(full) else 'no')}</td>"
             for full, _short in CHEM_COVERAGE_FIELDS
         )
         rows.append(
@@ -1432,14 +1434,13 @@ def _render_chemicals_panel(inv: dict[str, Any]) -> tuple[str, str]:
         '<div class="chem-tbl-scroll"><table class="chem-tbl">'
         f'<caption class="sr-only">Identification fields carried by each compound</caption>'
         f'<thead><tr><th scope="col">Compound</th>{head}</tr></thead>'
-        f'<tbody>{"".join(rows)}</tbody></table></div>'
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
     # Compounds only (#506) — the legend defines the two states a compound node
     # can be in, not the route shapes this view no longer draws.
     diagram = (
-        f'<div class="prov-scroll">{svg}</div>\n  '
-        + _legend(_LG_COMPOUND, _LG_COMPOUND_UNWIRED)
+        f'<div class="prov-scroll">{svg}</div>\n  ' + _legend(_LG_COMPOUND, _LG_COMPOUND_UNWIRED)
         if svg
         else ""
     )
@@ -1489,9 +1490,7 @@ def _render_celllines_panel(inv: dict[str, Any]) -> tuple[str, str]:
     total, wired = counts["total"], counts["wired"]
     rrid_backed = sum(1 for c in lines if c["rrid"])
     pct = (
-        round(counts["fields_met"] / counts["fields_total"] * 100)
-        if counts["fields_total"]
-        else 0
+        round(counts["fields_met"] / counts["fields_total"] * 100) if counts["fields_total"] else 0
     )
 
     svg = render_celllines_svg(inv)
@@ -1541,7 +1540,7 @@ def _render_celllines_panel(inv: dict[str, Any]) -> tuple[str, str]:
             f"{'not linked' if c['state'] == 'unlinked' else 'no process'}</span>"
         )
         cells = "".join(
-            f'<td>{_mk("ok" if c["fields"].get(full) else "no")}</td>'
+            f"<td>{_mk('ok' if c['fields'].get(full) else 'no')}</td>"
             for full, _short in CELLLINE_COVERAGE_FIELDS
         )
         rows.append(
@@ -1552,7 +1551,7 @@ def _render_celllines_panel(inv: dict[str, Any]) -> tuple[str, str]:
         '<div class="chem-tbl-scroll"><table class="chem-tbl">'
         '<caption class="sr-only">Identification fields carried by each cell line</caption>'
         f'<thead><tr><th scope="col">Cell line</th>{head}</tr></thead>'
-        f'<tbody>{"".join(rows)}</tbody></table></div>'
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
     panel = (
@@ -1574,6 +1573,8 @@ _AGENT_STATE_NOTE = {
     "unattached": "nothing in the crate references this agent",
 }
 _AGENT_STATE_CHIP = {"affiliated": ("muted", "via affiliation"), "unattached": ("", "unattached")}
+
+
 def _render_people_panel(inv: dict[str, Any]) -> tuple[str, str]:
     """The People & organisations view: who the crate credits, how resolvably.
 
@@ -1625,9 +1626,7 @@ def _render_people_panel(inv: dict[str, Any]) -> tuple[str, str]:
             "ROR — a name string credits nobody a machine can resolve.</span></p>"
         )
     if not notes:
-        notes.append(
-            '<p class="good-note">Every agent is credited and identifier-backed.</p>'
-        )
+        notes.append('<p class="good-note">Every agent is credited and identifier-backed.</p>')
 
     ordered = sorted(
         agents, key=lambda a: (a["state"] == "credited", a["met"], a["name"].casefold(), a["id"])
@@ -1663,7 +1662,7 @@ def _render_people_panel(inv: dict[str, Any]) -> tuple[str, str]:
         '<div class="chem-tbl-scroll"><table class="chem-tbl">'
         '<caption class="sr-only">Attribution fields carried by each agent</caption>'
         f'<thead><tr><th scope="col">Agent</th>{head}</tr></thead>'
-        f'<tbody>{"".join(rows)}</tbody></table></div>'
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 
     panel = (

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import json
 from pathlib import Path
 from typing import Any
@@ -21,6 +23,7 @@ from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 # (test_export_smoke, test_readers, test_path_traversal, test_html_xss).
 # Headroom, not a licence to grow: no test in this module is changed.
 pytestmark = pytest.mark.timeout(120)
+
 
 def _body(page: str) -> str:
     """The rendered markup without the inlined stylesheet.
@@ -147,12 +150,8 @@ class TestBuildMaturityHtml:
             page,
         )
         assert head, "aggregate headline fraction not found"
-        assert int(head.group(1)) == sum(
-            sc["completed"] for sc in mit.module_scores.values()
-        )
-        assert int(head.group(2)) == sum(
-            sc["total"] for sc in mit.module_scores.values()
-        )
+        assert int(head.group(1)) == sum(sc["completed"] for sc in mit.module_scores.values())
+        assert int(head.group(2)) == sum(sc["total"] for sc in mit.module_scores.values())
         # Documents overlap — one parameter can serve several — so the note
         # that rows don't sum is part of the contract, not decoration.
         assert "do not sum" in page
@@ -340,9 +339,7 @@ class TestExportCoupledToValidation:
         assert "Not conformant" in page
         assert "root MUST have a name" in page
 
-    def test_validator_failure_does_not_fail_the_export(
-        self, monkeypatch, tmp_path: Path
-    ) -> None:
+    def test_validator_failure_does_not_fail_the_export(self, monkeypatch, tmp_path: Path) -> None:
         import builder.tools.validation as validation
 
         def _boom(state, severity="required", profile="all"):
@@ -358,9 +355,7 @@ class TestExportCoupledToValidation:
     def test_validate_false_skips_entirely(self, monkeypatch, tmp_path: Path) -> None:
         calls: list = []
         self._stub(monkeypatch, calls)
-        res = export_crate(
-            vhps_fixture_state("S-VHPS21"), str(tmp_path / "c"), validate=False
-        )
+        res = export_crate(vhps_fixture_state("S-VHPS21"), str(tmp_path / "c"), validate=False)
         assert res["success"] is True
         assert "validation" not in res
         assert calls == []
@@ -487,9 +482,7 @@ class TestUnassessedMITIsNotRenderedAsZero:
         # asserts a coverage figure just as loudly as the tile did.
         assert "fields · 0%" not in body
 
-    def test_the_rest_of_the_report_still_renders(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_the_rest_of_the_report_still_renders(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The assessor must not raise: three other axes depend on this page."""
         body = _body(self._unscoreable_page(monkeypatch))
         assert "FAIR" in body
@@ -584,9 +577,7 @@ class TestActionableTopology:
             ]
         }
         for i in range(12):
-            graph["@graph"].append(
-                {"@id": f"#loose{i}", "@type": "File", "name": f"loose{i}.csv"}
-            )
+            graph["@graph"].append({"@id": f"#loose{i}", "@type": "File", "name": f"loose{i}.csv"})
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
         assert "12 orphans" in page
         assert "+2 more" in page
@@ -830,8 +821,14 @@ class TestGraphViewTabs:
     def test_all_three_views_are_tabbed(self) -> None:
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
         assert "<h2>Graph views</h2>" in page
-        for label in ("All entities", "ISA structure", "Provenance", "Chemicals",
-                      "Cell lines", "People &amp; orgs"):
+        for label in (
+            "All entities",
+            "ISA structure",
+            "Provenance",
+            "Chemicals",
+            "Cell lines",
+            "People &amp; orgs",
+        ):
             assert f'<span class="tb-n">{label}</span>' in page, f"missing tab: {label}"
         for pid in ("p-all", "p-isa", "p-prov", "p-chem", "p-cell", "p-people"):
             assert f'<div class="panel" id="{pid}">' in page, f"missing panel: {pid}"
@@ -1206,6 +1203,22 @@ class TestSeverityTiers:
         assert "3 / 3 profiles" not in page
 
 
+def _visible_before_the_fold(html: str) -> str:
+    """The part of a findings list a reader sees without opening the overflow.
+
+    The cap bounds what is shown, not what exists: the remainder now sits in a
+    nested `<details class="more-fold">`. Counting occurrences across the whole
+    string used to measure the cap and no longer does, because the hidden items
+    are in the markup too — closed, but present.
+    """
+    # Strip each fold whole, keeping what surrounds it. Two earlier attempts got
+    # this wrong in opposite directions: a non-greedy match to `</li>` ends INSIDE
+    # the fold (it contains <li> items) and leaks the remainder; splitting on the
+    # opening tag drops every later profile group, which is exactly what the cap
+    # is meant to be measured across. `</details></li>` closes it unambiguously.
+    return re.sub(r'<li class="more">.*?</details></li>', "", html, flags=re.S)
+
+
 class TestGroupedSuggestions:
     """Warnings fold out of the severity row they belong to (#510).
 
@@ -1221,10 +1234,30 @@ class TestGroupedSuggestions:
 
     @staticmethod
     def _fold(body: str, tier: str) -> str:
-        """The ``<details>`` markup for one severity row."""
+        """The ``<details>`` markup for one severity row.
+
+        Balances the tags rather than slicing to the first ``</details>``: the
+        advisory overflow is itself a ``<details>`` nested inside this one, so the
+        first closer belongs to the inner fold and cutting there truncated the
+        section — dropping every later profile group with it.
+        """
         start = body.index(f'<span class="st">{tier}</span>')
         open_at = body.rindex("<details", 0, start)
-        return body[open_at : body.index("</details>", open_at)]
+        depth, i = 0, open_at
+        while i < len(body):
+            nxt_open = body.find("<details", i)
+            nxt_close = body.find("</details>", i)
+            if nxt_close == -1:
+                break
+            if nxt_open != -1 and nxt_open < nxt_close:
+                depth += 1
+                i = nxt_open + len("<details")
+                continue
+            depth -= 1
+            if depth == 0:
+                return body[open_at:nxt_close]
+            i = nxt_close + len("</details>")
+        return body[open_at:]
 
     @staticmethod
     def _records_report() -> ValidationReport:
@@ -1342,7 +1375,7 @@ class TestGroupedSuggestions:
             issue_records=records,
         )
         body = _body(build_maturity_html(state, validation=val))
-        assert body.count("Recommended: ") == 10
+        assert _visible_before_the_fold(body).count("Recommended: ") == 10
         assert "+2 further recommended findings" in body
 
     def test_records_are_escaped(self) -> None:
@@ -1351,7 +1384,7 @@ class TestGroupedSuggestions:
             base_passed=False,
             isa_passed=True,
             tox_passed=True,
-            required_issues=['[base] #x: <img src=x onerror=alert(1)>'],
+            required_issues=["[base] #x: <img src=x onerror=alert(1)>"],
             assessed_tiers={"required"},
             issue_records=[
                 {
@@ -1440,7 +1473,7 @@ class TestGroupedSuggestions:
             issue_records=records,
         )
         rec = self._fold(_body(build_maturity_html(state, validation=val)), "Recommended")
-        assert rec.count("Recommended: ") == 20
+        assert _visible_before_the_fold(rec).count("Recommended: ") == 20
         assert rec.count("+2 further recommended findings") == 2
         assert "24 issues" in rec
 
@@ -1557,9 +1590,7 @@ class TestOverviewPanel:
         assert "are unreachable from the crate root" in page
 
     def test_clean_crate_reports_no_unreachable(self) -> None:
-        page = build_maturity_html(
-            vhps_fixture_state("S-VHPS21"), graph=self._graph(orphan=False)
-        )
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph(orphan=False))
         assert "Every entity is reachable from the crate root." in page
         # Pinned to the exact phrase the orphan branch emits, so this stays a
         # real guard rather than passing because the wording moved on.

--- a/tests/test_report_shows_every_finding.py
+++ b/tests/test_report_shows_every_finding.py
@@ -1,0 +1,76 @@
+"""The report caps what it shows, never what a reader can reach.
+
+The advisory tiers are capped per profile group so the page stays a page. That
+cap used to end at "+9 further recommended findings not listed here" — a number
+with no way to reach it. The crate's own report is the one place those findings
+exist, so a reader who wanted them had nowhere else to look.
+
+The overflow now sits in a nested `<details>`: closed by default, so the page is
+the length it was, and one click from complete.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import cast
+
+import pytest
+
+from builder.writers.maturity_report import _SUGGESTION_CAPS, _capped_tier_items
+
+# `_SUGGESTION_CAPS` is `int | None` — REQUIRED is deliberately uncapped. These
+# tests are about the capped tiers, so narrow once here rather than at every use.
+REC_CAP = cast(int, _SUGGESTION_CAPS["recommended"])
+assert REC_CAP is not None, "the recommended tier is expected to have a cap"
+
+
+def _items(n):
+    return [f"<li>Recommended: finding {i}</li>" for i in range(n)]
+
+
+class TestTheOverflowIsReachable:
+    def test_everything_over_the_cap_is_still_in_the_html(self):
+        cap = REC_CAP
+        html = "".join(_capped_tier_items("recommended", _items(cap + 7)))
+        for i in range(cap + 7):
+            assert f"finding {i}</li>" in html, f"finding {i} is unreachable"
+
+    def test_the_remainder_is_behind_a_fold(self):
+        cap = REC_CAP
+        html = "".join(_capped_tier_items("recommended", _items(cap + 7)))
+        assert 'details class="more-fold"' in html
+        assert "<summary>+7 further recommended findings</summary>" in html
+
+    def test_no_dead_end_text_remains(self):
+        html = "".join(_capped_tier_items("recommended", _items(30)))
+        assert "not listed here" not in html
+
+    def test_the_visible_list_is_still_capped(self):
+        """The page stays bounded — that is what the cap is for."""
+        cap = REC_CAP
+        items = _capped_tier_items("recommended", _items(cap + 7))
+        before_fold = "".join(items).split('<li class="more">')[0]
+        assert before_fold.count("<li>") == cap
+
+
+class TestItStaysOutOfTheWayOtherwise:
+    def test_nothing_over_the_cap_adds_no_fold(self):
+        cap = REC_CAP
+        html = "".join(_capped_tier_items("recommended", _items(cap)))
+        assert "more-fold" not in html
+
+    def test_a_single_extra_reads_as_singular(self):
+        cap = REC_CAP
+        html = "".join(_capped_tier_items("recommended", _items(cap + 1)))
+        assert "+1 further recommended finding<" in html
+
+    def test_required_is_never_capped(self):
+        """Those block conformance, so every one is named up front."""
+        assert _SUGGESTION_CAPS["required"] is None
+        html = "".join(_capped_tier_items("required", _items(40)))
+        assert "more-fold" not in html
+        assert html.count("<li>") == 40
+
+    @pytest.mark.parametrize("tier", ["recommended", "optional"])
+    def test_an_empty_tier_renders_nothing(self, tier):
+        assert _capped_tier_items(tier, []) == []


### PR DESCRIPTION
## The dead end

```
Recommended: ./data/… File Data Entities SHOULD have a `contentSize` property
… 10 shown …
+9 further recommended findings not listed here
```

The advisory tiers are capped per profile group so the page stays a page. That's fine — but the cap named a number and offered no way to reach it. The crate's own report is the **one place those findings exist**, so a reader who wanted them had nowhere else to look.

## The change

The remainder moves into a nested `<details>`, closed by default. The page is the length it was, and one click from complete.

On a real crate that turns three dead-end counts into three fold-outs:

```
+4 further recommended findings
+33 further recommended findings
+37 further optional findings
```

All **63** recommended findings reachable, where 30 were.

REQUIRED stays uncapped and unfolded — those block conformance and are named up front.

## Two test helpers had to learn about the nesting

Both were wrong in ways worth recording, because they're the kind of thing that reads as passing.

**`_fold`** sliced a severity section to the first `</details>` — which is now the *inner* fold's closer. It truncated the section and dropped every later profile group, so the very test asserting "the cap applies per group, not across the tier" was measuring one group. It balances the tags now.

**The cap assertions** counted occurrences across the whole string as a proxy for "how many are shown". Everything is in the markup now — closed, but present — so that proxy stopped measuring the cap. They count what precedes the fold instead.

My first two attempts at that second helper were both wrong in opposite directions: a non-greedy match to `</li>` ends *inside* the fold (it contains `<li>` items) and leaks the remainder; splitting on the opening tag drops every later group. `</details></li>` closes it unambiguously.

## Tests

9 new; **113 passing** with `test_maturity_report`. Lint and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)