### PR TITLE
feat(report): a Citations view, so a paper nobody can reach is visible

### DIFF
--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -238,7 +238,8 @@ __CATEGORY_STYLES__
 .mat #mv-prov:checked ~ .tabbar .tab[for="mv-prov"],
 .mat #mv-chem:checked ~ .tabbar .tab[for="mv-chem"],
 .mat #mv-cell:checked ~ .tabbar .tab[for="mv-cell"],
-.mat #mv-people:checked ~ .tabbar .tab[for="mv-people"] {
+.mat #mv-people:checked ~ .tabbar .tab[for="mv-people"],
+.mat #mv-cite:checked ~ .tabbar .tab[for="mv-cite"] {
   background:var(--accent-soft); border-color:color-mix(in srgb,var(--accent) 34%,transparent);
   color:var(--accent); }
 .mat #mv-all:checked ~ .tabbar .tab[for="mv-all"] .tb-c,
@@ -246,21 +247,24 @@ __CATEGORY_STYLES__
 .mat #mv-prov:checked ~ .tabbar .tab[for="mv-prov"] .tb-c,
 .mat #mv-chem:checked ~ .tabbar .tab[for="mv-chem"] .tb-c,
 .mat #mv-cell:checked ~ .tabbar .tab[for="mv-cell"] .tb-c,
-.mat #mv-people:checked ~ .tabbar .tab[for="mv-people"] .tb-c {
+.mat #mv-people:checked ~ .tabbar .tab[for="mv-people"] .tb-c,
+.mat #mv-cite:checked ~ .tabbar .tab[for="mv-cite"] .tb-c {
   background:var(--surface); color:var(--accent); }
 .mat #mv-all:focus-visible ~ .tabbar .tab[for="mv-all"],
 .mat #mv-isa:focus-visible ~ .tabbar .tab[for="mv-isa"],
 .mat #mv-prov:focus-visible ~ .tabbar .tab[for="mv-prov"],
 .mat #mv-chem:focus-visible ~ .tabbar .tab[for="mv-chem"],
 .mat #mv-cell:focus-visible ~ .tabbar .tab[for="mv-cell"],
-.mat #mv-people:focus-visible ~ .tabbar .tab[for="mv-people"] {
+.mat #mv-people:focus-visible ~ .tabbar .tab[for="mv-people"],
+.mat #mv-cite:focus-visible ~ .tabbar .tab[for="mv-cite"] {
   outline:2px solid var(--accent); outline-offset:2px; }
 .mat #mv-all:checked ~ #p-all,
 .mat #mv-isa:checked ~ #p-isa,
 .mat #mv-prov:checked ~ #p-prov,
 .mat #mv-chem:checked ~ #p-chem,
 .mat #mv-cell:checked ~ #p-cell,
-.mat #mv-people:checked ~ #p-people { display:block; }
+.mat #mv-people:checked ~ #p-people,
+.mat #mv-cite:checked ~ #p-cite { display:block; }
 
 /* chemicals — route diagram + identification matrix (#85) */
 /* The derivation chain is wide and fixed, so it stretches and scrolls. The

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1010,6 +1010,14 @@ _LG_CONTAINER = _lg("container")
 _LG_CELLLINE = _lg("material", "Cell line / sample")
 _LG_PERSON = _lg("agent")
 _LG_ORG = _lg("org")
+_LG_ARTICLE = _lg("publication")
+# An `author` @id no node in the crate answers to. Drawn through the same
+# registry with the diagram's own `unwired` variant, so the dashed key can never
+# drift from the dashed node it explains (#532).
+_LG_AUTHOR_UNRESOLVED = (
+    f'<span class="lg">{legend_swatch("agent", "unwired")} '
+    "Author reference that resolves to nothing</span>"
+)
 # The chemicals view draws compounds only (#506), so its legend defines the two
 # states a compound node can be in rather than the route shapes it no longer
 # draws. Drawn through the same registry with the diagram's own `unwired`
@@ -1277,6 +1285,10 @@ _VIEWS: tuple[tuple[str, str, str], ...] = (
     ("mv-chem", "p-chem", "Chemicals"),
     ("mv-cell", "p-cell", "Cell lines"),
     ("mv-people", "p-people", "People &amp; orgs"),
+    # Last, and next to People: the two answer the same kind of question about
+    # credit, and a reader who has just checked who the crate credits is the one
+    # who wants to know whether the papers it cites credit anybody either.
+    ("mv-cite", "p-cite", "Citations"),
 )
 
 
@@ -1285,10 +1297,10 @@ def _render_graph_views_section(
 ) -> str:
     """The graph-views section: one diagram per tab, over a shared topology strip.
 
-    The three views answer different questions about the same ``@graph`` —
-    *how was the result produced* (provenance), *what was tested* (chemicals),
-    *who is credited* (people) — and a reader wants one at a time, not three
-    stacked diagrams. They are therefore tabbed.
+    The views answer different questions about the same ``@graph`` — *how was the
+    result produced* (provenance), *what was tested* (chemicals, cell lines),
+    *who is credited* (people), *what does it cite* (citations) — and a reader
+    wants one at a time, not a stack of diagrams. They are therefore tabbed.
 
     The tabs are pure CSS (radio inputs + ``:checked ~`` sibling rules), because
     the report is a self-contained offline artifact embedded in the crate and
@@ -1302,6 +1314,7 @@ def _render_graph_views_section(
     """
     from builder.writers.provenance_dag import (
         build_cellline_inventory,
+        build_citation_inventory,
         build_crate_graph,
         build_isa_inventory,
         build_people_inventory,
@@ -1315,6 +1328,7 @@ def _render_graph_views_section(
         "p-chem": _render_chemicals_panel(chem_inv),
         "p-cell": _render_celllines_panel(build_cellline_inventory(graph)),
         "p-people": _render_people_panel(build_people_inventory(graph)),
+        "p-cite": _render_citations_panel(build_citation_inventory(graph)),
     }
     live = [(rid, pid, label) for rid, pid, label in _VIEWS if panels[pid][0]]
 
@@ -1671,6 +1685,164 @@ def _render_people_panel(inv: dict[str, Any]) -> tuple[str, str]:
         f"{'person' if counts['people'] == 1 else 'people'} · <b>{counts['orgs']}</b> "
         f"organisation{'' if counts['orgs'] == 1 else 's'} · <b>{pid_backed}</b> "
         "identifier-backed.</p>\n"
+        f"  {diagram}\n"
+        f"  {''.join(notes)}\n"
+        f"  {matrix}"
+    )
+    return panel, str(total)
+
+
+_CITE_STATE_NOTE = {
+    "cited": "something in the crate points at this article",
+    "uncited": "nothing in the crate cites this article",
+}
+
+
+def _render_citations_panel(inv: dict[str, Any]) -> tuple[str, str]:
+    """The Citations view: the literature the crate stands on, and whether the
+    reference goes anywhere.
+
+    The same two questions the other views ask, because a citation fails the same
+    two ways. It is *unreachable* when nothing points at it — the Root Data
+    Entity's ``citation`` is what puts a paper into the deposit's record, and an
+    article no entity cites is described in the crate and referenced by nothing.
+    It is *unidentified* one hop further out than a compound is, because a
+    citation refers to two things: the work, which needs a DOI (a title names a
+    paper, ``10.…`` retrieves it), and the people who wrote it, which have to be
+    entities the crate actually contains. An ``author`` ``@id`` no node answers to
+    — the ``#CitationAuthor_…`` stub minted for a Crossref author with no ORCID —
+    leaves an article that looks fully attributed in the JSON and credits nobody
+    (#532).
+
+    Returns:
+        ``(panel html, tab badge)`` — ``("", "")`` when the crate declares none.
+    """
+    from builder.writers.provenance_dag import CITATION_COVERAGE_FIELDS, render_citations_svg
+
+    articles = inv["articles"]
+    if not articles:
+        return "", ""
+    counts = inv["counts"]
+    total, cited, doi_backed = counts["total"], counts["cited"], counts["doi_backed"]
+    broken = counts["unresolved_authors"]
+    # An article with an EMPTY credit list has no unresolved reference, so `broken`
+    # is 0 and every warning below stays silent — the green note then reports that
+    # "every author resolves" about a paper that credits nobody. Vacuous truth is
+    # the one thing this view must not print: it is the same shape as the "MIT
+    # coverage 0%" claim #311 removed, a confident statement about something never
+    # examined.
+    uncredited = sum(1 for a in inv["articles"] if not a["authors"])
+    pct = (
+        round(counts["fields_met"] / counts["fields_total"] * 100) if counts["fields_total"] else 0
+    )
+
+    svg = render_citations_svg(inv)
+    # The citing entity is drawn in its OWN category's shape — the root Dataset in
+    # a crate this tool builds, but a Study or a File in one it did not — so its
+    # key is looked up from what was actually drawn rather than hard-coded. A
+    # legend that names a shape the figure does not contain teaches the reader to
+    # distrust the legend.
+    sources = sorted(
+        {g["source_cls"] for g in inv["groups"] if g["source"]} & set(CATEGORY_STYLES)
+    )
+    keys = [_LG_ARTICLE, _LG_PERSON, *(_lg(cls) for cls in sources)]
+    if broken:
+        keys.append(_LG_AUTHOR_UNRESOLVED)
+    diagram = (
+        f'<div class="prov-scroll">{svg}</div>\n  ' + _legend(*keys, _LG_LINK, _LG_BREAK)
+        if svg
+        else ""
+    )
+
+    notes = []
+    if total - cited:
+        loose = [a["label"] for a in articles if a["state"] == "uncited"]
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{total - cited} of {total} articles are '
+            "cited by nothing in the crate</b> "
+            f"({', '.join(loose[:4])}{'&hellip;' if len(loose) > 4 else ''}). Point the Root "
+            "Data Entity&rsquo;s <code>citation</code> at the article — or the Study that "
+            "rests on it — otherwise the paper is described in the deposit and referenced "
+            "by nothing.</span></p>"
+        )
+    if total - doi_backed:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{total - doi_backed} of {total} articles '
+            "carry no resolvable DOI.</b> A title names a paper; <code>10.…</code> retrieves "
+            "it, and is the only form a machine can follow.</span></p>"
+        )
+    if broken:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{broken} author reference'
+            f"{'' if broken == 1 else 's'} resolve"
+            f"{'s' if broken == 1 else ''} to no entity in the crate.</b> The article&rsquo;s "
+            "<code>author</code> list points at an <code>@id</code> no node carries — usually a "
+            "<code>#CitationAuthor_&hellip;</code> stub minted for a co-author Crossref gave no "
+            "ORCID for. Add the <code>Person</code> entity or drop the reference: a credit that "
+            "resolves to nothing credits nobody.</span></p>"
+        )
+    if uncredited:
+        notes.append(
+            f'<p class="chem-warn">{_mk("no")}<span><b>{uncredited} of {total} articles '
+            "credit nobody.</b> The work carries no <code>author</code> or "
+            "<code>contributor</code> at all, so the crate says who was cited but not "
+            "who wrote it — and an empty credit list cannot fail the resolution check "
+            "below, which is why it reads as clean.</span></p>"
+        )
+    if not notes:
+        notes.append(
+            '<p class="good-note">Every article is cited, DOI-backed, and every author '
+            "resolves.</p>"
+        )
+
+    ordered = sorted(
+        articles, key=lambda a: (a["state"] == "cited", a["met"], a["name"].casefold(), a["id"])
+    )
+    head = "".join(
+        f'<th scope="col" title="{html.escape(full)}">{html.escape(short)}</th>'
+        for full, short in CITATION_COVERAGE_FIELDS
+    )
+    # Every article is listed — no cap. This is a metadata-checking view, and a
+    # truncated tail is exactly where an uncited paper would hide.
+    rows = []
+    for a in ordered:
+        link = " 🔗" if a["resolvable"] else ""
+        doi = f'<span class="ty">{html.escape(a["doi"])}</span>' if a["doi"] else ""
+        flag = (
+            ""
+            if a["state"] == "cited"
+            else f'<span class="chem-flag" title="{html.escape(_CITE_STATE_NOTE["uncited"])}">'
+            "uncited</span>"
+        )
+        # The credit list is where #532 lives, so the row states how much of it
+        # actually reaches an entity rather than leaving it to the tick alone.
+        dangling = sum(1 for author in a["authors"] if not author["resolved"])
+        credit = (
+            f'<span class="chem-flag" title="author @ids that resolve to no entity">'
+            f"{dangling} of {len(a['authors'])} authors unresolved</span>"
+            if dangling
+            else ""
+        )
+        cells = "".join(
+            f"<td>{_mk(_kind(a['fields'].get(full)))}</td>"
+            for full, _short in CITATION_COVERAGE_FIELDS
+        )
+        rows.append(
+            f'<tr><th scope="row">{_mk("ok" if a["state"] == "cited" else "no")}'
+            f'<span class="cn">{a["label"]}{link}</span>{doi}{flag}{credit}</th>{cells}</tr>'
+        )
+    matrix = (
+        '<div class="chem-tbl-scroll"><table class="chem-tbl">'
+        '<caption class="sr-only">Identification fields carried by each cited article</caption>'
+        f'<thead><tr><th scope="col">Article</th>{head}</tr></thead>'
+        f"<tbody>{''.join(rows)}</tbody></table></div>"
+    )
+
+    panel = (
+        '<p class="prov-cap">The literature the crate stands on — whether each paper is '
+        "actually cited from the record, and whether a reader could retrieve it and reach "
+        f"the people who wrote it. <b>{total}</b> article{'' if total == 1 else 's'} · "
+        f"<b>{cited}</b> cited · <b>{doi_backed}</b> DOI-backed · <b>{pct}%</b> complete.</p>\n"
         f"  {diagram}\n"
         f"  {''.join(notes)}\n"
         f"  {matrix}"

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -3277,9 +3277,494 @@ def render_isa_svg(inventory: dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Citations (#85) — the literature the crate stands on, and whether the
+# reference actually goes anywhere.
+#
+# A ScholarlyArticle fails the same two ways every other entity in these views
+# does. Its ROUTE fails when nothing cites it: the root's ``citation`` — what
+# ``_crate_mapping`` writes — or a Study/Assay reference is the only thing that
+# puts the paper into the deposit's record, and an article no entity points at is
+# a node a reader walking the crate never arrives at.
+#
+# Its IDENTITY fails one hop further out than a compound's, because a citation
+# refers to two things at once: the work, which needs a DOI (a title names a
+# paper, ``10.…`` retrieves it), and the people who wrote it, which have to be
+# entities the crate actually contains. That second half is a currently-shipping
+# defect (#532): a Crossref author with no ORCID is minted as
+# ``#CitationAuthor_Zhongli_Chen`` and the article's ``author`` list points at an
+# ``@id`` no node in the ``@graph`` carries. In the JSON the article looks fully
+# attributed while crediting nobody — invisible in a list of names, and obvious
+# in a picture where the author edge ends on a dashed box.
+# ---------------------------------------------------------------------------
+
+_CITATION_KEYS_FULL: tuple[str, ...] = (
+    "citation",
+    "http://schema.org/citation",
+    "https://schema.org/citation",
+)
+_ISBASEDON_KEYS: tuple[str, ...] = (
+    "isBasedOn",
+    "isBasedOnUrl",
+    "http://schema.org/isBasedOn",
+    "https://schema.org/isBasedOn",
+)
+_HEADLINE_KEYS: tuple[str, ...] = (
+    "headline",
+    "http://schema.org/headline",
+    "https://schema.org/headline",
+)
+_DATEPUBLISHED_KEYS: tuple[str, ...] = (
+    "datePublished",
+    "http://schema.org/datePublished",
+    "https://schema.org/datePublished",
+)
+
+# How something can point AT an article, most canonical first — the order decides
+# which citer is drawn when several apply. ``citation`` is what the builder
+# writes onto the Root Data Entity; ``isBasedOn`` and ``mentions``/``about`` are
+# how an externally-authored crate or a Study/Assay commonly reaches one, and a
+# crate that uses them should see its route rather than be told it has none.
+_CITATION_LINK_RELATIONS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (_CITATION_KEYS_FULL, "citation"),
+    (_ISBASEDON_KEYS, "isBasedOn"),
+    (_MENTIONS_KEYS, "mentions"),
+    (_ABOUT_KEYS, "about"),
+    (_HASPART_KEYS, "hasPart"),
+)
+
+# A DOI: the ``10.`` prefix, the registrant code, then the opaque suffix. Matched
+# rather than read off the tail of the URL the way `_registry_identifiers` reads
+# an ORCID — a DOI *contains* a slash, so splitting on the last one yields
+# "s-vhps22" out of "10.6019/s-vhps22" and would report a truncated identifier
+# that resolves to nothing.
+_DOI_RE = re.compile(r"10\.\d{4,9}/[^\s\"'<>]+")
+
+# Literals that carry no information but are not empty. The publication resolver
+# stringifies a missing Crossref field, so a real crate ships
+# ``"datePublished": "None"`` — and `_literal` cannot tell that from a date.
+# Scoring it as present would paint a green Date column for an article that
+# states no date at all, which is exactly the kind of false green these views
+# exist to remove.
+_PLACEHOLDER_LITERALS = frozenset({"", "none", "null", "nan", "n/a", "na", "unknown", "-"})
+
+# The coverage matrix columns: (full name, column header). The work first (is the
+# paper retrievable), then its credit list (does the reference reach anybody),
+# then the route (does anything cite it at all).
+CITATION_COVERAGE_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Resolvable DOI", "DOI"),
+    ("Title", "Title"),
+    ("Publication date", "Date"),
+    ("Authors listed", "Authors"),
+    ("Every author resolves to an entity", "Resolve"),
+    ("Cited in the crate", "Cited"),
+)
+
+_CITE_MARKER = "cite-ar-link"
+
+
+def _is_article(node: dict[str, Any]) -> bool:
+    """True for a publication entity.
+
+    Asked through :func:`_entity_category` rather than by testing ``@type``
+    directly, so this view draws exactly the entities the rest of the report
+    colours as publications — commit ``ac3fc9b``'s one colour and one shape per
+    entity type only holds if there is one definition of what a publication is.
+    """
+    return _entity_category(node) == "publication"
+
+
+def _meaningful(value: str | None) -> str | None:
+    """*value* when it says something, else ``None`` (see `_PLACEHOLDER_LITERALS`)."""
+    if value is None:
+        return None
+    text = value.strip()
+    return text if text.casefold() not in _PLACEHOLDER_LITERALS else None
+
+
+def _article_doi(node: dict[str, Any], nodes: dict[str, Any]) -> str | None:
+    """The article's DOI, from its ``@id``, ``url``, or an ``identifier``.
+
+    Every carrier is tried because the crate's own writer and an externally
+    authored crate disagree about which one is canonical: the builder mints the
+    DOI URL as the ``@id`` *and* repeats it under ``identifier``/``url``, while a
+    hand-written crate may give the bare ``10.…`` string alone.
+    """
+    candidates: list[str] = []
+    for key in _IDENTIFIER_KEYS:
+        for item in _as_list(node.get(key)):
+            if isinstance(item, str):
+                candidates.append(item)
+            elif isinstance(item, dict):
+                pv = nodes.get(item["@id"], item) if isinstance(item.get("@id"), str) else item
+                candidates.extend(
+                    v for v in (_literal(pv, _VALUE_KEYS), pv.get("@id")) if isinstance(v, str)
+                )
+    candidates.extend(
+        v for v in (_literal(node, _URL_KEYS), node.get("@id")) if isinstance(v, str)
+    )
+    for candidate in candidates:
+        match = _DOI_RE.search(candidate)
+        if match:
+            return match.group(0)
+    return None
+
+
+def _citation_authors(
+    node: dict[str, Any], nodes: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """The article's credit list, resolved and unresolved alike.
+
+    ``contributor`` is read alongside ``author`` and the two deduplicated: the
+    builder writes the same Crossref person into both, and an article credited
+    only through ``contributor`` still has a credit list — reporting it as having
+    none would be a defect this view invented.
+
+    An unresolved reference is KEPT, and that is the point. Dropping it would
+    leave an article whose authors all resolve to nothing looking author-less, or
+    — worse — looking fine because the surviving references happened to resolve.
+    The brief carries the raw ``@id`` as its name, because that string is what a
+    reader has to go and fix.
+    """
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for keys, label in ((_AUTHOR_KEYS, "author"), (_CONTRIBUTOR_KEYS, "contributor")):
+        for ref in _refs(node, keys):
+            if ref in seen:
+                continue
+            seen.add(ref)
+            target = nodes.get(ref)
+            if target is None:
+                out.append(
+                    {
+                        "id": ref,
+                        "name": ref,
+                        "label": _escape(ref),
+                        # Named as the failure, not as a Person: the crate has no
+                        # entity here, and tagging the box "Person" would assert
+                        # the very thing that is missing.
+                        "tag": "Unresolved @id",
+                        "resolved": False,
+                        "pid": None,
+                        "edge": label,
+                    }
+                )
+                continue
+            ids = _registry_identifiers(target, nodes, _AGENT_ID_SCHEMES)
+            out.append(
+                {
+                    **_chem_node_brief(ref, target),
+                    "resolved": True,
+                    "pid": next((ids[s] for s in _PID_FOR_KIND["person"] if s in ids), None),
+                    "edge": label,
+                }
+            )
+    return out
+
+
+def build_citation_inventory(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Model the crate's citations: their route into the record + their identity.
+
+    Resolves, for every ``ScholarlyArticle`` the crate declares, which entity
+    cites it (the Root Data Entity's ``citation`` is preferred when several do,
+    because that is the attribution a reader is looking for), whether it carries
+    a resolvable DOI, a title and a publication date, and whether every ``@id``
+    in its credit list points at an entity the crate actually contains.
+
+    Pure and cheap: one pass over the serialized ``@graph``, no validation and no
+    network. Crate-controlled text is HTML-escaped in ``label`` (#169).
+
+    Args:
+        metadata: Parsed ``ro-crate-metadata.json`` dict, the ``@graph`` list, or
+            the ``crate.metadata.generate()`` document.
+
+    Returns:
+        ``{"articles": [...], "groups": [...], "counts": {...}}``.
+
+        Each article: ``{id, name, label, tag, doi, resolvable, authors, fields,
+        met, total, state, source, edge}`` where ``state`` is ``"cited"``
+        (something in the crate points at it) or ``"uncited"`` (nothing does).
+        Each entry of ``authors`` carries ``resolved`` — ``False`` for an ``@id``
+        no node in the graph answers to (#532).
+
+        ``groups`` are the diagram's bands: a citing entity, the articles it
+        cites, and those articles' authors. Anything nothing cites falls into a
+        trailing band with no source.
+    """
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    nodes = _graph_nodes(metadata)
+    article_ids = {nid for nid, n in nodes.items() if _is_article(n)}
+    empty_counts = {
+        "total": 0,
+        "cited": 0,
+        "uncited": 0,
+        "doi_backed": 0,
+        "authors": 0,
+        "unresolved_authors": 0,
+        "fields_met": 0,
+        "fields_total": 0,
+    }
+    if not article_ids:
+        return {"articles": [], "groups": [], "counts": dict(empty_counts)}
+
+    root_id = _find_root_id(nodes, [n for n in graph if isinstance(n, dict)])
+    citers = _referrers_to(nodes, article_ids, _CITATION_LINK_RELATIONS)
+
+    def _citer(aid: str) -> tuple[str, str] | None:
+        """Best citing entity: the crate root when it cites this article (that is
+        the citation a reader is looking for), else the most canonical other."""
+        found = citers.get(aid)
+        if not found:
+            return None
+        rooted = [p for p in found if p[0] == root_id]
+        return (rooted or found)[0]
+
+    articles: list[dict[str, Any]] = []
+    # The @id tiebreak is load-bearing: `article_ids` is a SET, so two articles
+    # sharing a title would otherwise be ordered by the per-process string hash
+    # seed, and the embedded artifact must be byte-stable across runs.
+    for aid in sorted(article_ids, key=lambda a: (_name(nodes[a]).casefold(), a)):
+        node = nodes[aid]
+        doi = _article_doi(node, nodes)
+        authors = _citation_authors(node, nodes)
+        source = _citer(aid)
+        fields: dict[str, bool | None] = {
+            "Resolvable DOI": doi is not None,
+            "Title": _meaningful(_literal(node, _NAME_KEYS + _HEADLINE_KEYS)) is not None,
+            "Publication date": _meaningful(_literal(node, _DATEPUBLISHED_KEYS)) is not None,
+            "Authors listed": bool(authors),
+            # An article with no credit list has nothing to resolve — n/a, not a
+            # miss, or the same absence would be counted against it twice.
+            "Every author resolves to an entity": (
+                all(a["resolved"] for a in authors) if authors else None
+            ),
+            "Cited in the crate": source is not None,
+        }
+        articles.append(
+            {
+                **_chem_node_brief(aid, node),
+                "doi": doi,
+                "resolvable": _is_uri(aid),
+                "authors": authors,
+                "fields": fields,
+                "met": sum(1 for ok in fields.values() if ok),
+                "total": sum(1 for ok in fields.values() if ok is not None),
+                "state": "cited" if source else "uncited",
+                "source": source[0] if source else None,
+                "edge": source[1] if source else "",
+            }
+        )
+
+    # Bands: one per citing entity, holding the articles it cites. Uncited
+    # articles fall into a trailing band drawn with the ✗ stub on their left,
+    # exactly as an unattached agent does in the people view.
+    banded: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for article in articles:
+        if article["source"] is not None:
+            banded.setdefault((article["source"], article["edge"]), []).append(article)
+    groups: list[dict[str, Any]] = []
+    for (src, edge), band in sorted(
+        banded.items(), key=lambda kv: (kv[0][0] != root_id, kv[0][0], kv[0][1])
+    ):
+        brief = _chem_node_brief(src, nodes[src])
+        groups.append(
+            {
+                "source": brief,
+                # The citing entity's own category, carried out of the builder so
+                # the panel's legend can name the shape that was actually drawn
+                # rather than assume the root Dataset every crate does not have.
+                "source_cls": _node_class_for_brief(brief),
+                "edge": edge,
+                "articles": band,
+                "state": "cited",
+            }
+        )
+    loose = [a for a in articles if a["state"] == "uncited"]
+    if loose:
+        groups.append(
+            {"source": None, "source_cls": "", "edge": "", "articles": loose, "state": "uncited"}
+        )
+
+    # Author references are counted DISTINCTLY across the crate: two papers by the
+    # same unresolvable stub are one broken @id to fix, and reporting it twice
+    # would overstate the work.
+    author_ids = {a["id"] for art in articles for a in art["authors"]}
+    unresolved = {a["id"] for art in articles for a in art["authors"] if not a["resolved"]}
+    counts = {
+        "total": len(articles),
+        "cited": sum(1 for a in articles if a["state"] == "cited"),
+        "uncited": sum(1 for a in articles if a["state"] == "uncited"),
+        "doi_backed": sum(1 for a in articles if a["doi"]),
+        "authors": len(author_ids),
+        "unresolved_authors": len(unresolved),
+        "fields_met": sum(a["met"] for a in articles),
+        "fields_total": sum(a["total"] for a in articles),
+    }
+    return {"articles": articles, "groups": groups, "counts": counts}
+
+
+def render_citations_svg(inventory: dict[str, Any]) -> str:
+    """Draw the citation chain as a self-contained inline ``<svg>``.
+
+    One band per citing entity: ``crate root --citation--> ScholarlyArticle
+    --author--> Person``. The same three-column geometry the people view uses,
+    because it is the same shape of question — something credits something, which
+    in turn names somebody — and drawing them identically is the point: a break in
+    one reads exactly like a break in the other.
+
+    Two failures are drawn rather than omitted. An article nothing cites sits in a
+    trailing band with the ✗ stub on its left. An ``author`` ``@id`` no node in
+    the graph answers to is drawn as a dashed agent with the stub on its *right*:
+    the edge exists — the crate really does state that reference — and it is the
+    trail that ends, which a missing node would not have shown at all (#532).
+
+    Args:
+        inventory: The result of :func:`build_citation_inventory`.
+
+    Returns:
+        The ``<svg>…</svg>`` markup, or ``""`` when the crate cites nothing.
+    """
+    # Peer-aware labels: two entities must never draw as the same text.
+    _label_briefs_uniquely(inventory)
+    groups = inventory.get("groups") or []
+    if not groups:
+        return ""
+
+    has_source = any(g["source"] for g in groups)
+    first_col = 0 if has_source else 1
+    x0 = _CHEM_X0 + (_CHEM_BREAK_DX + 10 if first_col else 0)
+    col_x = [x0 + (i - first_col) * _CHEM_COL_DX for i in range(3)]
+
+    edges: list[str] = []
+    nodes_svg: list[str] = []
+    mid = _SVG_NODE_H // 2
+    band_y = _CHEM_Y0
+    dangling_drawn = False
+
+    def _row_y(row: int) -> int:
+        return band_y + row * _CHEM_ROW_DY
+
+    for group in groups:
+        # Every article and every author is drawn — no "+N more" aggregate. This
+        # view exists so a person can CHECK a citation reference by reference, and
+        # an elided tail is exactly where a dangling author stub would hide.
+        drawn_articles = group["articles"]
+
+        # One node per author, not one per (article, author) pair: a person who
+        # wrote two of the cited papers is ONE person, and drawing them twice
+        # would invent a collaborator the crate does not contain.
+        by_author: dict[str, dict[str, Any]] = {}
+        for article in drawn_articles:
+            for author in article["authors"]:
+                by_author.setdefault(author["id"], author)
+        drawn_authors = list(by_author.values())
+
+        article_rows = {a["id"]: i for i, a in enumerate(drawn_articles)}
+        credits: dict[str, list[int]] = {}
+        for article in drawn_articles:
+            for author in article["authors"]:
+                credits.setdefault(author["id"], []).append(article_rows[article["id"]])
+
+        # An author takes the row of the first article that credits them so the
+        # author edge stays horizontal; collisions step down to the next free row.
+        author_rows: dict[str, int] = {}
+        used: set[int] = set()
+        for author in drawn_authors:
+            row = min(credits.get(author["id"], [0]))
+            while row in used:
+                row += 1
+            author_rows[author["id"]] = row
+            used.add(row)
+
+        rows = max(len(drawn_articles), max(used, default=-1) + 1, 1)
+        centre = _row_y(0) + ((rows - 1) * _CHEM_ROW_DY) // 2
+
+        if group["source"] is not None:
+            _svg_place(
+                nodes_svg, group["source"], group["source_cls"], col_x[0], centre
+            )
+
+        for i, article in enumerate(drawn_articles):
+            y = _row_y(i)
+            uncited = article["state"] == "uncited"
+            _svg_place(
+                nodes_svg,
+                # The inventory's own brief, not a copy: it carries the `display`
+                # label just written onto it, and a copy would silently lose it.
+                article,
+                "publication",
+                col_x[1],
+                y,
+                "unwired" if uncited else "",
+            )
+            if group["source"] is not None:
+                _svg_link(
+                    edges,
+                    col_x[0] + _SVG_NODE_W,
+                    centre + mid,
+                    col_x[1],
+                    y + mid,
+                    group["edge"] if i == 0 else "",
+                    marker=_CITE_MARKER,
+                )
+            elif uncited:
+                _svg_break(edges, col_x[1], y + mid)
+            for j, author in enumerate(article["authors"]):
+                _svg_link(
+                    edges,
+                    col_x[1] + _SVG_NODE_W,
+                    y + mid,
+                    col_x[2],
+                    _row_y(author_rows[author["id"]]) + mid,
+                    author["edge"] if i == 0 and j == 0 else "",
+                    marker=_CITE_MARKER,
+                )
+            if not article["authors"]:
+                # Cited, but the paper credits nobody at all.
+                _svg_break(edges, col_x[1] + _SVG_NODE_W, y + mid, leading=False)
+
+        for author in drawn_authors:
+            y = _row_y(author_rows[author["id"]])
+            _svg_place(
+                nodes_svg,
+                author,
+                # The credit list is not all Persons: a Crossref affiliation
+                # resolves to an Organization, and painting it with the agent
+                # block would give one entity two shapes across the report —
+                # the exact rule ac3fc9b exists to hold. An UNRESOLVED id keeps
+                # the agent block because there is no entity to ask; its box is
+                # already tagged "Unresolved @id" and drawn `unwired`, so the
+                # shape is not the thing carrying the claim.
+                _node_class_for_brief(author) if author["resolved"] else "agent",
+                col_x[2],
+                y,
+                "" if author["resolved"] else "unwired",
+            )
+            if not author["resolved"]:
+                dangling_drawn = True
+                _svg_break(edges, col_x[2] + _SVG_NODE_W, y + mid, leading=False)
+
+        band_y += (rows - 1) * _CHEM_ROW_DY + _SVG_NODE_H + _CHEM_BAND_GAP
+
+    counts = inventory.get("counts", {})
+    return _svg_document(
+        edges,
+        nodes_svg,
+        # The trailing stub after a dangling author hangs past the last column, so
+        # the canvas has to make room for it or the ✗ is clipped off the page.
+        col_x[2] + _SVG_NODE_W + (_CHEM_BREAK_DX + 16 if dangling_drawn else 16),
+        band_y - _CHEM_BAND_GAP + 18,
+        f"Citations: {counts.get('cited', 0)} of {counts.get('total', 0)} articles cited "
+        f"in the crate, {counts.get('doi_backed', 0)} DOI-backed",
+        marker=_CITE_MARKER,
+    )
+
+
+# ---------------------------------------------------------------------------
 # All-entities overview (#85) — the whole crate on one screen.
 #
-# The other five views each answer a question by drawing EDGES. This one answers
+# The other six views each answer a question by drawing EDGES. This one answers
 # a different question — "what is actually in here, and how much of it is
 # connected?" — for which a node-link diagram is the wrong instrument: 188 nodes
 # and 79 edges render as a hairball that hides exactly the composition it is

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -815,10 +815,17 @@ class TestGraphViewTabs:
                     "@type": "Organization",
                     "name": "Brown University",
                 },
+                {
+                    "@id": "https://doi.org/10.1007/s00204-024-03787-2",
+                    "@type": "ScholarlyArticle",
+                    "name": "Two novel in vitro assays for OATP1C1",
+                    "datePublished": "2024",
+                    "author": [{"@id": "https://orcid.org/0000-0002-1825-0097"}],
+                },
             ]
         }
 
-    def test_all_three_views_are_tabbed(self) -> None:
+    def test_every_view_is_tabbed(self) -> None:
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
         assert "<h2>Graph views</h2>" in page
         for label in (
@@ -828,9 +835,10 @@ class TestGraphViewTabs:
             "Chemicals",
             "Cell lines",
             "People &amp; orgs",
+            "Citations",
         ):
             assert f'<span class="tb-n">{label}</span>' in page, f"missing tab: {label}"
-        for pid in ("p-all", "p-isa", "p-prov", "p-chem", "p-cell", "p-people"):
+        for pid in ("p-all", "p-isa", "p-prov", "p-chem", "p-cell", "p-people", "p-cite"):
             assert f'<div class="panel" id="{pid}">' in page, f"missing panel: {pid}"
 
     def test_inputs_precede_the_tabbar_and_panels(self) -> None:
@@ -843,7 +851,7 @@ class TestGraphViewTabs:
 
     def test_exactly_one_tab_starts_selected(self) -> None:
         body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph()))
-        assert body.count('name="mat-view"') == 6
+        assert body.count('name="mat-view"') == 7
         assert body.count(" checked>") == 1
         # ISA is first: the structural backbone every other view hangs off.
         assert 'id="mv-all" checked>' in body
@@ -854,9 +862,10 @@ class TestGraphViewTabs:
         assert "onclick" not in page.lower()
 
     def test_absent_views_drop_their_tab_and_first_survivor_is_selected(self) -> None:
-        # No compounds, no cell lines and nobody credited. The root Dataset is
-        # still an Investigation, so ISA survives alongside Provenance — and the
-        # first surviving tab must be the selected one, never a dead tab bar.
+        # No compounds, no cell lines, nobody credited and nothing cited. The
+        # root Dataset is still an Investigation, so ISA survives alongside
+        # Provenance — and the first surviving tab must be the selected one,
+        # never a dead tab bar.
         graph = {
             "@graph": [
                 {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
@@ -873,7 +882,10 @@ class TestGraphViewTabs:
             ]
         }
         body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph))
-        for absent in ("mv-chem", "p-chem", "mv-cell", "p-cell", "mv-people", "p-people"):
+        for absent in (
+            "mv-chem", "p-chem", "mv-cell", "p-cell",
+            "mv-people", "p-people", "mv-cite", "p-cite",
+        ):
             assert f'"{absent}"' not in body, f"{absent} should have been dropped"
         assert 'id="mv-all" checked>' in body
         assert body.count(" checked>") == 1
@@ -910,6 +922,22 @@ class TestGraphViewTabs:
         # …and the rule must actually match the class the renderer emits.
         assert 'class="prov view"' in _body(page)
 
+    def test_every_registered_view_is_styled(self) -> None:
+        # The tabs are pure CSS, and the stylesheet names each id by hand. A view
+        # added to `_VIEWS` without its four selectors renders a tab that cannot
+        # be selected and a panel that never shows — with no error anywhere.
+        from builder.writers.maturity_report import _VIEWS, _load_css
+
+        css = _load_css()
+        for rid, pid, _label in _VIEWS:
+            for selector in (
+                f'#{rid}:checked ~ .tabbar .tab[for="{rid}"]',
+                f'#{rid}:checked ~ .tabbar .tab[for="{rid}"] .tb-c',
+                f'#{rid}:focus-visible ~ .tabbar .tab[for="{rid}"]',
+                f"#{rid}:checked ~ #{pid}",
+            ):
+                assert selector in css, f"unstyled view selector: {selector}"
+
     def test_print_styles_expand_every_panel(self) -> None:
         # Tabs are a screen affordance; a printed report must not silently lose
         # two of the three views.
@@ -921,7 +949,7 @@ class TestGraphViewTabs:
         # The strip describes the whole graph, not one view — it must not be
         # trapped inside a panel that a reader has to select to see.
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph())
-        assert page.index('<div class="panel" id="p-people">') < page.index("Graph topology")
+        assert page.index('<div class="panel" id="p-cite">') < page.index("Graph topology")
 
 
 class TestCellLinesPanel:
@@ -1143,6 +1171,116 @@ class TestPeoplePanel:
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
         assert "<script>alert(1)</script>" not in page
         assert "&lt;script&gt;" in page
+
+
+class TestCitationsPanel:
+    """The Citations view (#85): the literature the crate stands on.
+
+    A citation refers to two things at once, and each can fail on its own. The
+    work needs a DOI and something in the crate has to point at it; the credit
+    list has to reach entities the crate contains. The second is a shipping
+    defect — a Crossref author with no ORCID is minted as ``#CitationAuthor_…``
+    and nothing in the ``@graph`` answers to that ``@id`` (#532), leaving an
+    article that looks fully attributed in the JSON and credits nobody.
+    """
+
+    def _graph(self, *, cite: bool = True, doi: bool = True, dangling: bool = False) -> dict:
+        article_id = "https://doi.org/10.1007/s00204-024-03787-2" if doi else "#Publication_oatp"
+        root: dict = {"@id": "./", "@type": "Dataset", "name": "Crate"}
+        if cite:
+            root["citation"] = [{"@id": article_id}]
+        authors: list[dict] = [{"@id": "https://orcid.org/0000-0002-1825-0097"}]
+        if dangling:
+            authors.append({"@id": "#CitationAuthor_Zhongli_Chen"})
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                root,
+                {
+                    "@id": article_id,
+                    "@type": "ScholarlyArticle",
+                    "name": "Two novel in vitro assays for OATP1C1",
+                    "datePublished": "2024",
+                    "author": authors,
+                },
+                {
+                    "@id": "https://orcid.org/0000-0002-1825-0097",
+                    "@type": "Person",
+                    "name": "Josiah Carberry",
+                },
+            ]
+        }
+
+    def _page(self, **kw: bool) -> str:
+        return build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=self._graph(**kw))
+
+    def test_renders_diagram_and_matrix(self) -> None:
+        page = self._page()
+        assert '<div class="panel" id="p-cite">' in page
+        assert '<span class="tb-n">Citations</span>' in page
+        assert "Two novel in vitro assays for OATP1C1" in page
+        assert "10.1007/s00204-024-03787-2" in page
+        for column in ("DOI", "Title", "Date", "Authors", "Resolve", "Cited"):
+            assert f">{column}</th>" in page, f"missing citation column: {column}"
+
+    def test_uncited_article_is_called_out_with_the_fix(self) -> None:
+        page = self._page(cite=False)
+        assert "1 of 1 articles are cited by nothing in the crate" in page
+        assert "<code>citation</code>" in page
+
+    def test_missing_doi_is_called_out_separately_from_the_route(self) -> None:
+        # Correctly cited but unretrievable: the two defects are independent, and
+        # collapsing them would hide whichever the crate actually has.
+        page = self._page(doi=False)
+        assert "cited by nothing in the crate" not in page
+        assert "1 of 1 articles carry no resolvable DOI." in page
+
+    def test_author_that_resolves_to_nothing_is_reported(self) -> None:
+        page = self._page(dangling=True)
+        assert "1 author reference resolves to no entity in the crate." in page
+        assert "#CitationAuthor_&hellip;" in page
+        assert "1 of 2 authors unresolved" in page
+
+    def test_clean_citation_reports_no_defect(self) -> None:
+        page = self._page()
+        assert "Every article is cited, DOI-backed, and every author resolves." in page
+        assert "resolve to no entity" not in page
+
+    def test_legend_names_the_dashed_author_only_when_one_is_drawn(self) -> None:
+        # A key for a shape the reader cannot find teaches them to distrust the
+        # legend — and here it would also misdescribe the crate.
+        assert "Author reference that resolves to nothing" in self._page(dangling=True)
+        assert "Author reference that resolves to nothing" not in self._page()
+
+    def test_crate_without_articles_omits_the_view(self) -> None:
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {"@id": "./", "@type": "Dataset", "hasPart": [{"@id": "#f"}]},
+                {"@id": "#f", "@type": "File", "name": "result.csv"},
+            ]
+        }
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph))
+        assert 'id="p-cite"' not in body
+        assert 'for="mv-cite"' not in body
+
+    def test_escapes_article_names(self) -> None:
+        graph = self._graph()
+        graph["@graph"][2]["name"] = "<script>alert(1)</script>"
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "<script>alert(1)</script>" not in page
+        assert "&lt;script&gt;" in page
+
+    def test_escapes_a_crate_controlled_doi(self) -> None:
+        # The DOI reaches the matrix as a chip of its own, outside the `label`
+        # the inventory pre-escapes — a second path from crate text to the page.
+        # A DOI suffix is opaque and may legally carry `&`, so the chip cannot
+        # rely on the pattern alone to keep markup out.
+        graph = self._graph(doi=False)
+        graph["@graph"][2]["identifier"] = "10.1000/a&b<script>alert(1)</script>"
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        assert "<script>alert(1)</script>" not in page
+        assert "10.1000/a&amp;b" in page
 
 
 class TestSeverityTiers:

--- a/tests/test_provenance_dag.py
+++ b/tests/test_provenance_dag.py
@@ -32,6 +32,7 @@ from builder.writers.provenance_dag import (
     _svg_node_shape,
     build_cellline_inventory,
     build_chemical_inventory,
+    build_citation_inventory,
     build_crate_graph,
     build_isa_inventory,
     build_people_inventory,
@@ -39,6 +40,7 @@ from builder.writers.provenance_dag import (
     legend_swatch,
     render_celllines_svg,
     render_chemicals_svg,
+    render_citations_svg,
     render_crate_graph,
     render_isa_svg,
     render_mermaid_html,
@@ -1253,6 +1255,227 @@ class TestRenderIsaSvg:
         assert "&lt;script&gt;" in svg
 
 
+def _citation_graph(
+    *,
+    cite: bool = True,
+    doi: bool = True,
+    dangling_author: bool = False,
+    authors: bool = True,
+) -> dict:
+    """A crate citing one paper, optionally broken the ways real crates are.
+
+    ``cite=False`` drops the root's ``citation`` (the paper is in the crate and
+    nothing points at it); ``doi=False`` gives the article a local ``@id`` and no
+    identifier; ``dangling_author`` adds the ``#CitationAuthor_…`` stub the
+    publication resolver mints for a Crossref author with no ORCID, which no node
+    in the ``@graph`` answers to (#532).
+    """
+    article_id = "https://doi.org/10.1007/s00204-024-03787-2" if doi else "#Publication_oatp"
+    article: dict = {
+        "@id": article_id,
+        "@type": "ScholarlyArticle",
+        "name": "Two novel in vitro assays for OATP1C1",
+        "datePublished": "2024",
+    }
+    if authors:
+        article["author"] = [{"@id": "https://orcid.org/0000-0002-1825-0097"}] + (
+            [{"@id": "#CitationAuthor_Zhongli_Chen"}] if dangling_author else []
+        )
+    root: dict = {"@id": "./", "@type": "Dataset", "name": "Crate"}
+    if cite:
+        root["citation"] = [{"@id": article_id}]
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            root,
+            article,
+            {
+                "@id": "https://orcid.org/0000-0002-1825-0097",
+                "@type": "Person",
+                "name": "Josiah Carberry",
+            },
+        ]
+    }
+
+
+class TestBuildCitationInventory:
+    """``build_citation_inventory`` models the crate's citations.
+
+    A citation fails two ways: its ROUTE fails when nothing points at the
+    article, and its IDENTITY fails when the work carries no DOI or its credit
+    list points at ``@id``\\ s the crate does not contain (#532).
+    """
+
+    def _article(self, graph: dict) -> dict:
+        articles = build_citation_inventory(graph)["articles"]
+        assert len(articles) == 1
+        return articles[0]
+
+    def test_resolves_the_citing_entity_and_the_doi(self) -> None:
+        article = self._article(_citation_graph())
+        assert article["state"] == "cited"
+        assert article["source"] == "./"
+        assert article["edge"] == "citation"
+        assert article["doi"] == "10.1007/s00204-024-03787-2"
+
+    def test_doi_keeps_the_slash_in_its_suffix(self) -> None:
+        # The ORCID/ROR fallback reads the tail after the LAST slash; a DOI
+        # contains one, so that route would report "s00204-024-03787-2" — an
+        # identifier that resolves to nothing.
+        assert "/" in self._article(_citation_graph())["doi"]
+
+    def test_article_nothing_points_at_is_uncited(self) -> None:
+        article = self._article(_citation_graph(cite=False))
+        assert article["state"] == "uncited"
+        assert article["source"] is None
+        assert article["fields"]["Cited in the crate"] is False
+
+    def test_article_without_a_doi_is_not_identified(self) -> None:
+        article = self._article(_citation_graph(doi=False))
+        assert article["doi"] is None
+        assert article["fields"]["Resolvable DOI"] is False
+
+    def test_author_id_no_node_answers_to_is_kept_and_marked(self) -> None:
+        # Dropping it would leave the article looking fully attributed — which is
+        # exactly how #532 stayed invisible in the JSON.
+        article = self._article(_citation_graph(dangling_author=True))
+        by_id = {a["id"]: a for a in article["authors"]}
+        assert by_id["https://orcid.org/0000-0002-1825-0097"]["resolved"] is True
+        assert by_id["#CitationAuthor_Zhongli_Chen"]["resolved"] is False
+        assert article["fields"]["Every author resolves to an entity"] is False
+
+    def test_resolved_author_carries_its_orcid(self) -> None:
+        article = self._article(_citation_graph())
+        assert article["authors"][0]["pid"] == "0000-0002-1825-0097"
+
+    def test_article_with_no_credit_list_scores_resolution_as_not_applicable(self) -> None:
+        # No authors is one absence, not two; scoring "every author resolves" as
+        # a miss would count the same gap twice.
+        article = self._article(_citation_graph(authors=False))
+        assert article["fields"]["Authors listed"] is False
+        assert article["fields"]["Every author resolves to an entity"] is None
+
+    def test_contributor_only_credit_list_still_counts_as_authors(self) -> None:
+        graph = _citation_graph()
+        graph["@graph"][2]["contributor"] = graph["@graph"][2].pop("author")
+        assert self._article(graph)["fields"]["Authors listed"] is True
+
+    def test_author_repeated_as_contributor_is_one_person(self) -> None:
+        graph = _citation_graph()
+        graph["@graph"][2]["contributor"] = list(graph["@graph"][2]["author"])
+        assert len(self._article(graph)["authors"]) == 1
+
+    def test_placeholder_date_is_not_a_publication_date(self) -> None:
+        # The resolver stringifies a missing Crossref field, so a shipped crate
+        # carries `"datePublished": "None"`. Scoring that as present would paint
+        # a green column for an article that states no date at all.
+        graph = _citation_graph()
+        graph["@graph"][2]["datePublished"] = "None"
+        assert self._article(graph)["fields"]["Publication date"] is False
+
+    def test_counts_summarise_route_identity_and_credit(self) -> None:
+        counts = build_citation_inventory(_citation_graph(dangling_author=True))["counts"]
+        assert counts["total"] == 1
+        assert counts["cited"] == 1
+        assert counts["uncited"] == 0
+        assert counts["doi_backed"] == 1
+        assert counts["authors"] == 2
+        assert counts["unresolved_authors"] == 1
+
+    def test_the_same_broken_author_id_on_two_papers_is_one_fix(self) -> None:
+        graph = _citation_graph(dangling_author=True)
+        second = dict(graph["@graph"][2], **{"@id": "#Publication_second", "name": "Second paper"})
+        graph["@graph"].append(second)
+        graph["@graph"][1]["citation"].append({"@id": "#Publication_second"})
+        counts = build_citation_inventory(graph)["counts"]
+        assert counts["total"] == 2
+        assert counts["unresolved_authors"] == 1
+
+    def test_crate_without_articles_is_empty(self) -> None:
+        inv = build_citation_inventory({"@graph": [{"@id": "#f", "@type": "File", "name": "a"}]})
+        assert inv["articles"] == []
+        assert inv["groups"] == []
+        assert inv["counts"]["total"] == 0
+
+
+class TestRenderCitationsSvg:
+    """The citation diagram: ``citer → article → author``, nothing elided."""
+
+    def test_draws_the_chain_with_its_edge_labels(self) -> None:
+        svg = render_citations_svg(build_citation_inventory(_citation_graph()))
+        assert "Josiah Carberry" in svg
+        assert ">citation<" in svg
+        assert ">author<" in svg
+
+    def test_article_uses_the_registry_publication_shape(self) -> None:
+        # One colour and one shape per entity type, in every view (ac3fc9b): the
+        # article must draw as the registry's publication, never as a new shape.
+        svg = render_citations_svg(build_citation_inventory(_citation_graph()))
+        assert 'class="n n-publication"' in svg
+        assert 'class="n n-agent"' in svg  # …and an author is the people view's agent
+
+    def test_uncited_article_is_marked_and_still_drawn(self) -> None:
+        svg = render_citations_svg(build_citation_inventory(_citation_graph(cite=False)))
+        assert "Two novel in vitro assays for OATP1C1" in svg  # never dropped
+        assert "e-break" in svg and "unwired" in svg
+
+    def test_unresolved_author_is_drawn_with_the_edge_that_reaches_it(self) -> None:
+        # The crate really does state the reference, so the edge is drawn and it
+        # is the TRAIL that ends — a node simply left out would have shown
+        # nothing at all.
+        svg = render_citations_svg(
+            build_citation_inventory(_citation_graph(dangling_author=True))
+        )
+        assert "#CitationAuthor_Zhongli_Chen" in svg
+        assert 'class="n n-agent unwired"' in svg
+        assert "e-break" in svg
+
+    def test_every_drawn_node_stays_inside_the_canvas(self) -> None:
+        # The stub after a dangling author hangs past the last column; without
+        # room for it the ✗ is clipped off the page.
+        svg = render_citations_svg(
+            build_citation_inventory(_citation_graph(dangling_author=True))
+        )
+        box = re.search(r'viewBox="0 0 (\d+) (\d+)"', svg)
+        assert box is not None
+        width = int(box.group(1))
+        starts = [int(x) for x in re.findall(r'<text class="brk start" x="(\d+)"', svg)]
+        assert starts, "no trailing stub was drawn"
+        assert max(starts) < width
+
+    def test_shared_author_is_drawn_once(self) -> None:
+        # Two papers by one person is one person; drawing them twice would invent
+        # a collaborator the crate does not contain.
+        graph = _citation_graph()
+        graph["@graph"].append(
+            {
+                "@id": "#Publication_second",
+                "@type": "ScholarlyArticle",
+                "name": "Second paper",
+                "author": [{"@id": "https://orcid.org/0000-0002-1825-0097"}],
+            }
+        )
+        graph["@graph"][1]["citation"].append({"@id": "#Publication_second"})
+        svg = render_citations_svg(build_citation_inventory(graph))
+        assert svg.count('class="n n-agent"') == 1
+
+    def test_empty_inventory_returns_empty(self) -> None:
+        assert render_citations_svg(build_citation_inventory({"@graph": []})) == ""
+
+    def test_escapes_crate_controlled_names(self) -> None:
+        graph = _citation_graph()
+        graph["@graph"][2]["name"] = "<script>alert(1)</script>"
+        svg = render_citations_svg(build_citation_inventory(graph))
+        assert "<script>alert(1)</script>" not in svg
+        assert "&lt;script&gt;" in svg
+
+    def test_is_well_formed_xml(self) -> None:
+        svg = render_citations_svg(
+            build_citation_inventory(_citation_graph(dangling_author=True))
+        )
+        ET.fromstring(svg)
+
+
 class TestIdentifierFallbackIsNotFabricated:
     """The registry-URL fallback must identify, not merely match a hostname."""
 
@@ -2127,3 +2350,73 @@ class TestCategoryRegistry:
 
         assert f"{category_label('org')} · 1" in svg
         assert category_label("org") == "Organisation"
+
+
+class TestCitationCreditListIsDrawnHonestly:
+    """Two ways the Citations view could flatter a crate it should be reporting on."""
+
+    @staticmethod
+    def _graph(author: list[dict] | None) -> dict:
+        article: dict = {
+            "@id": "#a1",
+            "@type": "ScholarlyArticle",
+            "name": "A paper",
+            "identifier": "10.6019/s-vhps22",
+        }
+        if author is not None:
+            article["author"] = author
+        return {
+            "@graph": [
+                {"@id": "./", "@type": "Dataset", "citation": [{"@id": "#a1"}]},
+                article,
+                {"@id": "https://ror.org/02catss52", "@type": "Organization", "name": "Brown"},
+                {"@id": "#p1", "@type": "Person", "name": "A Person"},
+            ]
+        }
+
+    def test_an_organization_author_keeps_the_organization_shape(self) -> None:
+        """One entity, one colour and one shape, in EVERY view (ac3fc9b).
+
+        A credit list is not all Persons — a Crossref affiliation resolves to an
+        Organization — so painting the whole list with the agent block gives one
+        entity two shapes across the report, which is the rule's whole point.
+        """
+        from builder.writers.provenance_dag import build_citation_inventory, render_citations_svg
+
+        svg = render_citations_svg(
+            build_citation_inventory(
+                self._graph([{"@id": "https://ror.org/02catss52"}, {"@id": "#p1"}])
+            )
+        )
+
+        assert svg.count("n-org") == 1, "the Organization author was repainted as a Person"
+        assert svg.count("n-agent") == 1
+
+    def test_an_article_crediting_nobody_is_not_reported_as_fully_resolved(self) -> None:
+        """The vacuous-truth guard.
+
+        An empty credit list has no unresolved reference, so every warning stays
+        silent and the green note would report that "every author resolves" about
+        a paper that credits nobody. That is the same shape as the "MIT coverage
+        0%" claim #311 removed: a confident statement about something never
+        examined.
+        """
+        from builder.writers.maturity_report import _render_citations_panel
+        from builder.writers.provenance_dag import build_citation_inventory
+
+        panel, _badge = _render_citations_panel(build_citation_inventory(self._graph(None)))
+
+        assert "every author resolves" not in panel
+        assert "credit nobody" in panel
+
+    def test_a_real_credit_list_still_earns_the_clean_note(self) -> None:
+        """The control: the warning above must not fire on a crate that is fine."""
+        from builder.writers.maturity_report import _render_citations_panel
+        from builder.writers.provenance_dag import build_citation_inventory
+
+        panel, _badge = _render_citations_panel(
+            build_citation_inventory(self._graph([{"@id": "#p1"}]))
+        )
+
+        assert "every author resolves" in panel
+        assert "credit nobody" not in panel


### PR DESCRIPTION
Adds a **Citations** tab to `ro-crate-metadata-maturity.html` — the sixth per-type graph view, for `ScholarlyArticle`.

The report drew the crate five ways and never showed what it cites. An article fails two ways that are both invisible in the JSON:

- **Route** — is anything pointing at it (the root's `citation`, or a Study via `isBasedOn`/`mentions`/`about`), or is it described in the deposit and referenced by nothing?
- **Identity** — does it carry a resolvable DOI, and does its credit list reach entities the crate actually contains?

## The second half draws a live defect

`#CitationAuthor_Zhongli_Chen` is a dangling `@id` on the DOI article of a shipped crate (**#532**) — an article that looks fully attributed in the JSON and credits nobody. The view draws that author **with the edge that reaches it** and a ✗ stub beyond. Omitting the node would have shown nothing at all, which is how the defect stayed invisible.

## Built like its siblings

`build_citation_inventory` → `render_citations_svg` → `_render_citations_panel`, registered in `_VIEWS`, returning `("", "")` so the tab drops out of the strip on a crate that cites nothing. Geometry is the people view's, because it's the same shape of question: `citer → article → author`, authors deduplicated across the band. Colour and shape come from the existing `CATEGORY_STYLES["publication"]` — no new colour, shape or spelling (`ac3fc9b`).

## Two things the real data forced

- **The DOI is matched with `_DOI_RE`**, not read through `_registry_identifiers`' URL fallback — that takes the tail after the last slash, and a DOI *contains* one, so `10.6019/s-vhps22` would have been reported as `s-vhps22`.
- **`"None"` is refused as a publication date.** Scoring the resolver's stringified missing field as present paints a green column for an article that states no date.

## Two defects found in review, both fixed

1. **Every credit-list node was painted `agent`**, so an Organization author (a ROR-resolved affiliation) drew with the Person colour and shape — one entity, two shapes, which is the rule `ac3fc9b` exists to hold. The class now comes from the entity. An *unresolved* id keeps the agent block because there is no entity to ask, and its box already carries the claim as a tag.
2. **The green "every author resolves" note fired for an article with an empty credit list** — nothing unresolved means nothing to warn about, so the panel reported a paper that credits nobody as clean. Reproduced on a shipped crate (`svhps26_real_input_crate_v30`: 1 article, cited, DOI-backed, **0** authors). Vacuous truth is the one thing this view must not print — the same shape as the "MIT coverage 0%" claim #311 removed.

Both are pinned by regression tests, plus a control proving the clean note still fires on a healthy crate.

## Also

Ties `_VIEWS` to the stylesheet. The CSS-only tabs name every view id by hand in four selector lists, so a view added to `_VIEWS` without them renders a tab that **cannot be selected**, with no error anywhere — a trap I walked into building this.

## Verification

`tests/test_provenance_dag.py` 164 passed, `tests/test_maturity_report.py` 114 passed; `uvx ruff check` and `uv run ty check` clean. Reviewers separately confirmed: escaping holds (XSS payloads pushed through the article name, `@type`, DOI, citer name and author `@id` — nothing reached the SVG or panel), output is byte-stable across `PYTHONHASHSEED` 1/2/3/12345, and the citation-free crate genuinely drops both `mv-cite` and `p-cite` from the rendered page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)