### PR TITLE
fix(types): satisfy the ty that came with the version bump

### DIFF
--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -1083,7 +1083,10 @@ def assert_tool_spec_parity() -> None:
     Called when the ReAct arm builds its LangChain tools, so a mismatch fails fast
     at build time rather than silently advertising the wrong toolbox to the LLM.
     """
-    spec_names = {spec["name"] for spec in TOOL_SPECS}
+    # `str(...)`: a spec's values are heterogeneous (name, description, nested
+    # parameter schemas), so the inferred element type is a wide union and
+    # `sorted` has nothing to order it by. A tool name is always a string.
+    spec_names = {str(spec["name"]) for spec in TOOL_SPECS}
     expected = expected_tool_spec_names()
     missing = expected - spec_names
     extra = spec_names - expected

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -349,7 +349,7 @@ def _install_offline_context_loader() -> None:
             return _wrapped
         return _original_getattr(self, name)
 
-    requester_cls.__getattr__ = _offline_getattr  # ty: ignore[invalid-assignment]
+    requester_cls.__getattr__ = _offline_getattr
 
     # ``fetch_fresh`` is a real method (not proxied through ``__getattr__``); the
     # cache warm-up uses it. Wrap it too so a bundled context is served from disk
@@ -362,7 +362,7 @@ def _install_offline_context_loader() -> None:
             return local
         return _blocked_remote_response(url)
 
-    requester_cls.fetch_fresh = _offline_fetch_fresh  # ty: ignore[invalid-assignment]
+    requester_cls.fetch_fresh = _offline_fetch_fresh
     requester_cls._vitro_offline_loader_installed = True  # ty: ignore[unresolved-attribute]
 
     # Also wire the rdflib JSON-LD document loader so context expansion goes

--- a/tests/test_offline_validation.py
+++ b/tests/test_offline_validation.py
@@ -75,7 +75,7 @@ def _network_down() -> Iterator[list[str]]:
         attempted.append(request.url)
         raise requests.exceptions.ConnectionError(_FLAKE_MESSAGE)
 
-    HTTPAdapter.send = blocked_send  # ty: ignore[invalid-assignment]
+    HTTPAdapter.send = blocked_send
     try:
         yield attempted
     finally:
@@ -105,7 +105,7 @@ def _requester_raises() -> Iterator[None]:
             return _blocked
         return original_getattr(self, name)
 
-    rv_http.HttpRequester.__getattr__ = patched_getattr  # ty: ignore[invalid-assignment]
+    rv_http.HttpRequester.__getattr__ = patched_getattr
     try:
         yield
     finally:

--- a/tests/test_validation_ssrf.py
+++ b/tests/test_validation_ssrf.py
@@ -59,7 +59,7 @@ def _record_outbound() -> Iterator[list[str]]:
             f"network hard-blocked in test: {request.url}"
         )
 
-    HTTPAdapter.send = recording_send  # ty: ignore[invalid-assignment]
+    HTTPAdapter.send = recording_send
     try:
         yield attempted
     finally:


### PR DESCRIPTION
`main` has been red since `chore: bump versions` (744a442) — six `ty` diagnostics, none of them from a behaviour change, and every PR branched after it inherits the failure.

**Five are stale suppressions.** The newer `ty` accepts the monkey-patched assignments that `# ty: ignore[invalid-assignment]` was covering, and an unused directive is itself an error. Removed. The `unresolved-attribute` ignore sitting beside one of them is still needed and stays.

**One is real.** A spec's values are heterogeneous — name, description, nested parameter schemas — so `{spec["name"] for spec in TOOL_SPECS}` infers a wide union and `sorted` has nothing to order it by. A tool name is always a string, so the comprehension now says so.

No behaviour change. `ruff` and `ty` clean; the tool-spec parity guard (15), offline-validation and SSRF tests pass.

Worth a look separately: the bump also dropped two pins that carried their reasons —
```
- "cryptography>=41,<49",  # pinned below 46 to avoid missing DeprecatedIn46 in google-auth
- "openai>=2.0,<2.43",     # pinned due to breaking OAuthErrorCode/WebSocketConnectionOptions changes in 2.20+
```
This PR doesn't touch them, since whether the unpinning was intended is your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)