### PR TITLE
feat(cli): --smoke-test drives the interactive path with nobody at the keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1218,6 +1218,46 @@ FastAPI, CLI) supplies its own adapter without monkeypatching the tool
 functions. The module-level `present_to_human` / `request_input` functions
 remain as thin wrappers over a shared default simulator.
 
+Three implementations ship in `builder/tools/hitl.py`:
+
+| Interface | `is_interactive` | Wired by | Answers with |
+| --- | --- | --- | --- |
+| `SimulatedHumanInterface` | `False` | the headless default (batch, eval, tests) | auto-approve; skip every input; **deny** scan roots |
+| `ConsoleHumanInterface` | `True` | `main.py --interactive` | a real person, on stdin |
+| `SmokeTestHumanInterface` | `True` | `main.py --smoke-test` | itself — see below |
+
+**`SmokeTestHumanInterface` (`--smoke-test`) is a TEST harness, not a frontend.**
+It exists so the interactive path — the guidance tail included — can be driven end
+to end with nobody at the keyboard: every `present` confirms the **pre-selected**
+choice (via the shared `_default_choice_index`, never a re-implemented "first
+option") and every `request_input` returns the literal `SMOKE_TEST_ANSWER`,
+`"yes, continue"`. It reports `is_interactive = True` *because that is the point* —
+the tail is gated on that one signal (§14.6.1), so the simulator cannot exercise
+it. Three properties are load-bearing and tested in `tests/test_smoke_test_mode.py`:
+
+- **Scan roots still fail closed.** `_default_choice_index(..., deny_by_default=True)`
+  pre-selects the refusal for a `purpose="scan_root"` escalation (#197), so
+  "confirm the pre-selection" denies filesystem widening. That correctness is
+  *accidental*, so it is pinned by a test that fails if the pre-selection rule
+  changes — an unattended mode that silently widened filesystem access would be
+  the worst bug here.
+- **The run says the answers are synthesised.** `SYNTHETIC_ANSWER_NOTICE` is
+  printed at the start by `main.py` and again beside the exported crate path by
+  `_export_crate_to_disk` (gated on the fail-closed `answers_are_synthetic(human)`
+  reading an optional `synthesizes_answers` attribute, mirroring `is_interactive`).
+  Nothing is written **into** the crate — a "this was a smoke test" marker in the
+  metadata would be fabricating metadata, which D5 forbids.
+- **`select_many` skips and `is_done()` is always `False`.** A multi-select has no
+  pre-selection to confirm, so picking a subset would be inventing an answer; and a
+  mode that volunteered "done" would return before asking anything, exercising
+  nothing. Termination is left to `run_guidance`'s own guards (report exhausted /
+  no progress / `max_rounds`), which never depend on a cooperating frontend.
+
+`--smoke-test` implies `--interactive` (normalised once, in `parse_args`) and
+**refuses `--legacy-react` with a non-zero exit**: the ReAct loop reads the
+conversation from stdin (`ui.boxed_input`), not through the `HumanInterface`, so a
+synthetic interface cannot answer it and the run would hang.
+
 ## 9. Input & Output Formats
 
 ### Input Formats
@@ -1397,6 +1437,7 @@ The `scan_files` tool is restricted to directories the user has explicitly appro
 - The auto-approve-of-first-scan was removed: the agent's own `scan_files` call can never add a root. Roots enter the allowlist only from a user-provided input path or a real approval.
 - A hard denylist (`scanner._is_forbidden_root`) refuses `/`, the user's home directory itself, `/System`, `/Library`, `/private`, `/var`, `/etc`, `/usr`, bare `/Users`, and `/Volumes` even if explicitly present in `approved_roots`; it is also enforced in `engine._directory_to_approve` so a forbidden directory can never *become* an approved root. Legitimate subdirectories are unaffected.
 - `SimulatedHumanInterface.present(..., purpose="scan_root")` returns a `rejected` action, so the non-interactive default can never approve a new scan root (benign checkpoints still auto-approve).
+- `SmokeTestHumanInterface` (`--smoke-test`) is `is_interactive = True`, so unlike the simulator it *does* reach the `present` escalation — and denies it, because `_default_choice_index(..., deny_by_default=True)` pre-selects the refusal and the mode only ever confirms the pre-selection. The deny is therefore inherited, not re-implemented; `tests/test_smoke_test_mode.py` asserts it directly (including with the *allow* option listed first) so a change to the pre-selection rule cannot hand an unattended test mode the filesystem.
 - The A/B eval is the one bounded exception, and it lives entirely under `eval/`: `eval.hitl.TrustedCorpusHumanInterface` (a `SimulatedHumanInterface` subclass, `is_interactive = True`) **approves** scan-root escalations, but only against the vetted in-repo corpus fixtures. Without it the ReAct arm — which explores — is refused reading a fixture the pipeline arm never has to ask for, so the A/B would measure this security handicap rather than the architectures. It is eval-only and unreachable from any production wiring; the shipped default stays fail-closed.
 
 **Extended to read + write tools (#167).** The approved-roots boundary previously guarded only `scan_files`, so prompt injection could still escape it via the read tools (arbitrary local file read, e.g. `read_file('/etc/passwd')` or a secrets `.env`) and the export writer (a `..` traversal `dest_path`, or a symlinked source escaping the input tree). The fix adds one shared containment primitive, `scanner._contain(candidate, approved_roots) -> Path | None` (resolve realpath, reject when not inside any approved root, apply the `_is_forbidden_root` denylist, fail closed on empty/None roots), applied at three choke points: the read-tool dispatch in `engine.run_tool` (gates `read_file`/`read_excel`/`read_docx`/`read_file_sample`/`read_multiple_files`/`extract_pdf_text`/`preview_archive`/`unzip_file`), `_crate_mapping._file_dest` (contains `dest_path` under the crate output dir, else `data/<slug>`), and `_crate_mapping._file_source` (refuses sources whose realpath escapes `input_path`). The scanner read functions themselves stay unguarded so `scan_files` can still sample files internally; the gate lives at the orchestration layer.
@@ -2346,7 +2387,10 @@ backed by a real user sets it `True`. The default `SimulatedHumanInterface`
 (used by the A/B eval, batch runs, and the test suite) is `is_interactive = False`,
 so behind it `run_interactive_build` degrades to `run_pipeline` + export alone and
 `run_guidance` is **never invoked** — guidance can never block a headless build,
-but the headless build is **still written to disk**. The pipeline, guidance, and
+but the headless build is **still written to disk**. This gate is also why
+`--smoke-test` needs its own `SmokeTestHumanInterface` (§8) rather than reusing the
+simulator: to exercise the tail an interface must report `is_interactive = True`,
+and the simulator reports `False` by design. The pipeline, guidance, and
 exporter runners are all injectable so the wiring is unit-tested with no SHACL /
 no LLM / no disk / no network (`tests/test_agents_build.py`).
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,29 @@ uv run python -m main --interactive --legacy-react -i /path/to/experiment/ \
     --prompt "build the crate"
 ```
 
+**Smoke-testing the interactive path (`--smoke-test`).** For **testing**, not for
+producing a crate you would keep. It runs the same interactive build with nobody at
+the keyboard: every choice prompt confirms its **pre-selected** option and every
+open field is answered with the literal string `"yes, continue"`. That is how the
+HITL path — including the guidance tail, which only runs behind a real interactive
+frontend — can be exercised end to end in CI or a scripted check.
+
+```bash
+uv run python -m main --smoke-test -i /path/to/experiment/
+```
+
+- It **implies `--interactive`** (on its own it would have nothing to answer), and
+  it **refuses `--legacy-react`** with a clear error: the ReAct loop reads your
+  replies straight from stdin rather than through the HITL interface, so nothing
+  can answer it unattended.
+- The run prints a prominent notice that the answers are synthetic — once at the
+  start, and again next to the exported crate path. Nothing is written *into* the
+  crate: `"yes, continue"` lands in prose fields (a name, a description), so the
+  crate **looks** real and is not. Treat its output as a build artifact, never as
+  metadata.
+- Filesystem access is **not** widened: a scan-root escalation pre-selects the
+  refusal, so confirming the pre-selection denies it (see `AGENTS.md` D9).
+
 **Starting the ReAct agent.** The conversational arm greets you and then waits for
 an instruction — on its own it does no work, so a run left at the prompt builds
 nothing. Give it an opening instruction with `--prompt/-P` (or just type one) and
@@ -265,6 +288,11 @@ Options:
                          HITL guidance tail (requires LangChain + API key)
       --legacy-react     With --interactive, use the legacy ReAct agent loop
                          instead of the default pipeline+guidance build
+      --smoke-test       TESTING: drive the interactive build with nobody at the
+                         keyboard — confirm every pre-selected choice, answer
+                         every open field "yes, continue". Implies --interactive;
+                         refuses --legacy-react. The crate it writes holds
+                         synthesised answers, not curated metadata
   -p, --provider STR     LLM provider: 'openai' or 'anthropic' (auto-detected from env)
   -m, --model STR        Model name override (e.g. gpt-4o-mini, llama3.2, claude-sonnet-4)
   -b, --api-base URL     Custom API base URL for OpenAI-compatible providers

--- a/builder/agents/build.py
+++ b/builder/agents/build.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from builder.agents.llm import ModelOverrides
 from builder.agents.progress_spinner import ProgressSpinner
-from builder.tools.hitl import is_interactive
+from builder.tools.hitl import SYNTHETIC_ANSWER_NOTICE, answers_are_synthetic, is_interactive
 from builder.tools.session import save_session
 
 if TYPE_CHECKING:
@@ -443,7 +443,7 @@ def _run_build_body(
         # (#179, Lane 5; #296 — no second full SHACL sweep). Pure observability —
         # it never prompts and never mutates state (D5).
         logger.debug("Non-interactive build: skipping the HITL guidance tail")
-        export_result = _export_crate_to_disk(engine, exporter, emit)
+        export_result = _export_crate_to_disk(engine, exporter, emit, human)
         emit(format_gap_summary(pipeline_result))
         _final_save(engine)
         return {
@@ -473,7 +473,7 @@ def _run_build_body(
         emit(f"  {unresolved}")
 
     # Export LAST so the guidance-enriched crate is what lands on disk (#233).
-    export_result = _export_crate_to_disk(engine, exporter, emit)
+    export_result = _export_crate_to_disk(engine, exporter, emit, human)
     # FINAL persist (#242): always_write guarantees a populated overview + resume.
     _final_save(engine)
 
@@ -546,6 +546,7 @@ def _export_crate_to_disk(
     engine: AgentEngine,
     exporter: Exporter | None,
     emit: OutputChannel,
+    human: HumanInterface | None = None,
 ) -> dict[str, Any]:
     """Write the built crate to disk and surface its absolute path (#233).
 
@@ -555,6 +556,13 @@ def _export_crate_to_disk(
     ``working_crate/`` fallback. On success the resolved ABSOLUTE crate path is
     emitted via *emit*. On failure the error is logged, emitted, and re-raised as
     :class:`CrateExportError` so the failure is never silently swallowed.
+
+    When the answers came from a frontend that makes them up rather than asking a
+    person (``--smoke-test``, :func:`builder.tools.hitl.answers_are_synthetic`), the
+    notice is emitted immediately after the path. It is said HERE, at the one call
+    site that prints the path, so the two lines cannot drift apart: a crate whose
+    prose fields are placeholders must never be read from scrollback as a real one.
+    Nothing is written INTO the crate — that would be fabricating metadata (D5).
     """
     exporter = exporter or _default_exporter()
     state: CrateState = engine.state
@@ -570,6 +578,8 @@ def _export_crate_to_disk(
     abs_path = Path(result["crate_path"]).resolve()
     logger.info("Crate written to %s", abs_path)
     emit(f"Crate written to: {abs_path}")
+    if answers_are_synthetic(human):
+        emit(SYNTHETIC_ANSWER_NOTICE)
     return result
 
 

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -295,6 +295,33 @@ def _default_choice_index(choices: list[str], *, deny_by_default: bool) -> int:
     return len(choices) - 1
 
 
+def _decision_from_choice(answer: str, *, deny_by_default: bool) -> HumanResponse:
+    """Map a SELECTED choice to the response its frontend must return.
+
+    Shared by every interface that resolves a decision to one of the offered
+    choices (the console user arrowing to a row, the smoke-test interface taking
+    the pre-selected one), so the two can never drift apart: "confirm the
+    pre-selection" is only a meaningful contract while both read a selected row
+    the same way — most of all the ``deny_by_default`` line, where anything that
+    is not an explicit affirmative must deny (#197).
+    """
+    stance = _choice_stance(answer)
+    if stance is not None:
+        # A plain yes/no choice is a decision, not a payload: returning "no"
+        # as comments used to read as an APPROVAL carrying the text "no".
+        return {
+            "action": "approved" if stance else "rejected",
+            "comments": None,
+            "edits": None,
+        }
+    if deny_by_default:
+        # Anything that is not an explicit affirmative denies (#197).
+        return {"action": "rejected", "comments": None, "edits": None}
+    # A real menu choice: hand the selected option back so callers can act on
+    # WHICH option was picked (e.g. an ambiguous publication author).
+    return {"action": "approved", "comments": answer, "edits": None}
+
+
 def match_choice(raw: str, choices: list[str], default: int) -> int | None:
     """Resolve a typed answer to a choice index (``None`` = no match).
 
@@ -487,21 +514,7 @@ class ConsoleHumanInterface:
             self._done = True
             return {"action": "skipped", "comments": None, "edits": None}
 
-        stance = _choice_stance(answer)
-        if stance is not None:
-            # A plain yes/no choice is a decision, not a payload: returning "no"
-            # as comments used to read as an APPROVAL carrying the text "no".
-            return {
-                "action": "approved" if stance else "rejected",
-                "comments": None,
-                "edits": None,
-            }
-        if deny_by_default:
-            # Anything that is not an explicit affirmative denies (#197).
-            return {"action": "rejected", "comments": None, "edits": None}
-        # A real menu choice: hand the selected option back so callers can act on
-        # WHICH option was picked (e.g. an ambiguous publication author).
-        return {"action": "approved", "comments": answer, "edits": None}
+        return _decision_from_choice(answer, deny_by_default=deny_by_default)
 
     def select_many(
         self,
@@ -551,6 +564,169 @@ class ConsoleHumanInterface:
         if not value:
             return {"value": None, "skipped": True}
         return {"value": value, "skipped": False}
+
+
+# The single literal every open field gets in smoke-test mode. It is affirmative
+# (an open "shall I go on?" question reads correctly) and it is obviously not a
+# person's name, a study description or a protocol — so the placeholder is
+# recognisable as one in the crate afterwards, without the mode having to write
+# any marker INTO the crate (that would be fabricating metadata, D5).
+SMOKE_TEST_ANSWER = "yes, continue"
+
+# Printed at the start of a smoke-test run and again beside the exported crate
+# path. Both, deliberately: the opening line makes an accidental ``--smoke-test``
+# obvious before the build spends anything, and the closing line means anyone
+# reading scrollback — or a CI log — later sees WHAT the crate next to it is.
+SYNTHETIC_ANSWER_NOTICE = (
+    "SMOKE TEST — THE ANSWERS IN THIS RUN ARE SYNTHETIC, NOT A PERSON'S.\n"
+    "Every choice prompt confirms its pre-selected option and every open field "
+    f'is answered "{SMOKE_TEST_ANSWER}".\n'
+    "Anything this run recorded as prose (a name, a description) is that "
+    "placeholder — the crate proves the interactive path runs, it is not "
+    "curated metadata."
+)
+
+
+class SmokeTestHumanInterface:
+    """Drives the INTERACTIVE build with nobody at the keyboard (``--smoke-test``).
+
+    A test harness, not a curation frontend: it exists so the HITL path — the
+    guidance tail included — can be exercised end to end unattended. The crate it
+    produces is a by-product; its prose fields hold :data:`SMOKE_TEST_ANSWER`.
+
+    * ``is_interactive`` is ``True``, and that is the whole point. The tail is
+      gated on this one signal (AGENTS.md §14.6.1), which is exactly why
+      :class:`SimulatedHumanInterface` — ``is_interactive = False`` — cannot be
+      used to exercise it: behind the simulator ``run_interactive_build`` degrades
+      to ``run_pipeline`` + export and ``run_guidance`` is never called.
+    * ``synthesizes_answers`` is ``True`` so the build can SAY so next to the
+      crate it wrote (see :func:`answers_are_synthetic`). Nothing about the
+      run is marked inside the crate itself — writing "this was a smoke test"
+      into the metadata would be fabricating metadata, which D5 forbids.
+
+    **Scan roots are refused outright**, before any choice is consulted. The
+    pre-selection rule happens to deny them too, but relying on that was wrong:
+    :func:`_default_choice_index` falls back to the LAST option when no choice is
+    recognisably negative, and a caller offering
+    ``["Show me the folder first", "Yes, allow this folder"]`` therefore had this
+    mode approving filesystem access. No production caller passes options today —
+    which is precisely why the bug was invisible. A test harness must never be
+    the approver for filesystem access (#197), so that is stated here directly
+    rather than inherited from a rule written for a human at a keyboard.
+
+    **A real menu is skipped, not answered.** Confirming a pre-selection means
+    taking the answer an Enter would give; picking row 1 of a list of candidate
+    people is *inventing* one. The only such menu in the tree is the ambiguous
+    -author escalation, where answering it would have this mode silently
+    asserting which human wrote a paper — the same line :meth:`select_many`
+    declines to cross.
+    """
+
+    is_interactive: bool = True
+    synthesizes_answers: bool = True
+
+    def present(
+        self,
+        context: str,
+        options: list[str] | None = None,
+        purpose: str | None = None,
+    ) -> HumanResponse:
+        """Confirm the PRE-SELECTED choice — the same row an Enter would take.
+
+        Reuses :func:`_default_choice_index` rather than "the first option" so the
+        mode answers whatever the console frontend would have offered as its
+        default, including the fail-closed refusal on a scan-root escalation. A
+        reimplementation here would quietly grant filesystem access the moment
+        that rule changed.
+        """
+        if purpose == SCAN_ROOT_PURPOSE:
+            # Refused here, not left to the pre-selection: that rule falls back to
+            # the LAST option when nothing reads as a refusal, so a caller passing
+            # ["Show me the folder first", "Yes, allow this folder"] got an
+            # approval out of this mode. Fail-closed for filesystem access is not
+            # something a test harness may inherit by coincidence (#197).
+            logger.warning("smoke-test: refusing a scan-root escalation (fail-closed): %s", context)
+            return {"action": "rejected", "comments": None, "edits": None}
+
+        choices = list(options or []) or list(_APPROVE_CHOICES)
+        answer = choices[_default_choice_index(choices, deny_by_default=False)]
+        if _choice_stance(answer) is None:
+            # Not a yes/no: this is a menu of alternatives (candidate authors,
+            # say), and no row is pre-selected in any meaningful sense. Returning
+            # row 1 would make the harness assert something — which candidate is
+            # the real person — rather than confirm something.
+            logger.info("smoke-test: skipping a menu it cannot confirm: %s", context)
+            return {"action": "skipped", "comments": None, "edits": None}
+        logger.info("smoke-test: confirming the pre-selected choice %r for: %s", answer, context)
+        return _decision_from_choice(answer, deny_by_default=False)
+
+    def request_input(self, prompt: str, field_type: str = "text") -> InputResponse:
+        """Answer every open field with :data:`SMOKE_TEST_ANSWER`.
+
+        A real answer, not a skip: skipping would leave the guidance loop with
+        nothing to commit, so the commit → re-assess → next-gap path this mode
+        exists to exercise would never run.
+
+        An identifier field is safe to answer this way because the value cannot
+        become one: the guidance tail routes every reply through
+        ``_deterministic_decision`` / the interpret leaf, both of which force an
+        identifier-bearing field to a skip (D5), and the citation-author path
+        re-verifies any pasted ORCID against a real lookup before use.
+        """
+        logger.info(
+            "smoke-test: answering %r with the synthetic %r (type=%s)",
+            prompt,
+            SMOKE_TEST_ANSWER,
+            field_type,
+        )
+        return {"value": SMOKE_TEST_ANSWER, "skipped": False}
+
+    def select_many(
+        self,
+        context: str,
+        options: list[str],
+        purpose: str | None = None,
+    ) -> MultiChoiceResponse:
+        """Skip — a multi-select has no pre-selection to confirm.
+
+        Nothing is pre-ticked in a many-of-N box, so there is no "the answer an
+        Enter would give" to stand in for; picking some subset would be this mode
+        inventing an answer rather than taking the offered one, which is the line
+        :class:`SimulatedHumanInterface` also declines to cross. Declared (not
+        left to the degrade path in :func:`select_many`) so the question does not
+        fall through to :meth:`present`, whose pre-selection would look like the
+        user having deliberately ticked the first box.
+        """
+        logger.info(
+            "smoke-test: skipping multi-choice request: %s (%d options)",
+            context,
+            len(options or []),
+        )
+        return {"values": [], "skipped": True}
+
+    def is_done(self) -> bool:
+        """Never end guidance early — the loop's own bounds stop the run.
+
+        Ending at the first opportunity would exercise nothing: the tail would
+        return before asking anything, which is precisely the path this mode is
+        for. So the mode never volunteers "done" and leans on ``run_guidance``'s
+        existing termination guards — the report being exhausted, no gap making
+        progress, and the hard ``max_rounds`` bound — which already guarantee
+        termination without a cooperating frontend.
+        """
+        return False
+
+
+def answers_are_synthetic(human: HumanInterface | None) -> bool:
+    """Whether *human* makes its answers up instead of asking a person.
+
+    Read fail-closed like :func:`is_interactive`: an interface that does not
+    declare ``synthesizes_answers`` is assumed to be relaying a real person, so a
+    build only claims "these answers are synthetic" when the frontend says so.
+    Used by the interactive build to print :data:`SYNTHETIC_ANSWER_NOTICE` beside
+    the exported crate path.
+    """
+    return bool(getattr(human, "synthesizes_answers", False))
 
 
 def supports_multi_choice(human: HumanInterface | None) -> bool:
@@ -650,12 +826,16 @@ def request_input(
 
 __all__ = [
     "SCAN_ROOT_PURPOSE",
+    "SMOKE_TEST_ANSWER",
+    "SYNTHETIC_ANSWER_NOTICE",
     "ConsoleHumanInterface",
     "HumanInterface",
     "HumanResponse",
     "InputResponse",
     "MultiChoiceResponse",
     "SimulatedHumanInterface",
+    "SmokeTestHumanInterface",
+    "answers_are_synthetic",
     "is_interactive",
     "present_to_human",
     "request_input",

--- a/main.py
+++ b/main.py
@@ -191,6 +191,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "see AGENTS.md §14)",
     )
     parser.add_argument(
+        "--smoke-test",
+        action="store_true",
+        help="Drive the interactive build with NOBODY at the keyboard: every "
+        'choice prompt confirms its pre-selected option and every open field is '
+        'answered "yes, continue". Implies --interactive; refuses --legacy-react. '
+        "For TESTING the HITL path end to end — the crate it produces holds "
+        "synthesised answers and is not curated metadata.",
+    )
+    parser.add_argument(
         "--prompt",
         "-P",
         help="With --interactive --legacy-react, an opening instruction (e.g. "
@@ -284,7 +293,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="With --graph --format html, write the file but do not open a browser",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    # --smoke-test IMPLIES --interactive rather than requiring it. Its whole job is
+    # to drive the interactive build unattended, and a batch run never prompts — so
+    # taking the flag without --interactive and doing nothing HITL-shaped would be
+    # the silent misfire the mode exists to make visible. Normalised here, once, so
+    # every downstream reader (the logging bump, the engine wiring, the build
+    # dispatch) sees a single consistent `interactive` fact.
+    if args.smoke_test:
+        args.interactive = True
+    return args
 
 
 def _run_setup_wizard() -> bool:
@@ -459,6 +477,29 @@ def main(argv: list[str] | None = None) -> int:
 
     logger.info("ISA-Tox RO-Crate Builder v0.1.0")
 
+    if args.smoke_test:
+        from builder.tools.hitl import SYNTHETIC_ANSWER_NOTICE
+
+        if args.legacy_react:
+            # The ReAct loop reads the conversation straight from stdin
+            # (builder.agents.ui.boxed_input) rather than through the
+            # HumanInterface, so a synthetic interface cannot answer it and the
+            # run would sit on an empty terminal forever. Refuse loudly instead of
+            # starting a build that can only hang.
+            print(
+                "--smoke-test cannot drive --legacy-react: the ReAct loop reads "
+                "your replies straight from stdin, not through the HITL "
+                "interface, so nothing can answer it unattended. Drop "
+                "--legacy-react to smoke-test the default pipeline + guidance "
+                "build.",
+                file=sys.stderr,
+            )
+            return 1
+        # Say it FIRST, before the build spends a token: if this mode was engaged
+        # by accident, the very first thing on screen must be that nobody is
+        # answering the prompts. It is repeated beside the exported crate path.
+        print(SYNTHETIC_ANSWER_NOTICE)
+
     # --show-config: print and exit
     if args.show_config:
         _show_config()
@@ -493,7 +534,18 @@ def main(argv: list[str] | None = None) -> int:
     # user-named folder instead of fail-closing — without it a conversational
     # legacy scan of an un-approved folder returns no files. Non-interactive
     # (batch) runs keep the headless simulated default.
-    if args.interactive:
+    if args.smoke_test:
+        # --smoke-test: an interface that answers ITSELF (confirm the pre-selected
+        # choice, "yes, continue" into every open field). It reports
+        # is_interactive = True, which is the point — the guidance tail is gated on
+        # that single signal, so the headless SimulatedHumanInterface can never
+        # exercise it. Scan roots stay fail-closed: confirming the pre-selection
+        # denies a scan_root escalation (#197), pinned by
+        # tests/test_smoke_test_mode.py.
+        from builder.tools.hitl import SmokeTestHumanInterface
+
+        engine = AgentEngine(human_interface=SmokeTestHumanInterface())
+    elif args.interactive:
         from builder.agents import ui
         from builder.tools.hitl import ConsoleHumanInterface
 

--- a/tests/test_smoke_test_mode.py
+++ b/tests/test_smoke_test_mode.py
@@ -1,0 +1,443 @@
+"""Tests for ``--smoke-test`` — driving the interactive build with nobody there.
+
+The mode exists to exercise the HITL path (the guidance tail included) unattended:
+every choice prompt confirms its PRE-SELECTED option and every open field is
+answered with the literal ``"yes, continue"``. Three of its properties are
+load-bearing and are pinned here rather than left to inspection:
+
+1. ``is_interactive`` is True — the tail is gated on that single signal, so the
+   headless ``SimulatedHumanInterface`` cannot be used to exercise it;
+2. a scan-root escalation is still DENIED. That is *accidental* correctness (the
+   pre-selection for a ``scan_root`` purpose happens to be the refusal, #197), so
+   these tests fail loudly if the pre-selection rule ever changes — an unattended
+   mode that silently widened filesystem access is the worst bug this could carry;
+3. the run SAYS the answers are synthesised, at the start and beside the exported
+   crate path — and writes no such marker into the crate itself (D5).
+
+No LLM, no network, no SHACL: the build wiring is exercised with injected runners.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools.hitl import (
+    SCAN_ROOT_PURPOSE,
+    SMOKE_TEST_ANSWER,
+    SYNTHETIC_ANSWER_NOTICE,
+    HumanInterface,
+    SmokeTestHumanInterface,
+    answers_are_synthetic,
+    is_interactive,
+)
+from main import main, parse_args
+
+
+class TestProtocolAndInteractiveSignal:
+    """The mode must present as a REAL interactive frontend or it does nothing."""
+
+    def test_satisfies_human_interface_protocol(self):
+        assert isinstance(SmokeTestHumanInterface(), HumanInterface)
+
+    def test_is_interactive_true(self):
+        """The guidance tail is gated on this one signal (AGENTS.md §14.6.1).
+
+        Behind a non-interactive interface ``run_interactive_build`` degrades to
+        the automated pipeline + export and ``run_guidance`` is never called — so
+        a smoke mode reporting False would exercise nothing it was asked to.
+        """
+        assert SmokeTestHumanInterface().is_interactive is True
+        assert is_interactive(SmokeTestHumanInterface()) is True
+
+    def test_declares_its_answers_synthetic(self):
+        assert answers_are_synthetic(SmokeTestHumanInterface()) is True
+
+    def test_console_interface_is_not_marked_synthetic(self):
+        """The marker must be opt-in: a real person's answers are not synthetic."""
+        from builder.tools.hitl import ConsoleHumanInterface, SimulatedHumanInterface
+
+        assert answers_are_synthetic(ConsoleHumanInterface()) is False
+        assert answers_are_synthetic(SimulatedHumanInterface()) is False
+        assert answers_are_synthetic(None) is False
+
+
+class TestConfirmsThePreSelection:
+    """Every choice prompt takes the row an Enter would have taken."""
+
+    def test_default_approval_prompt_approves(self):
+        """With no options the prompt is the yes/no approval, pre-selected yes."""
+        resp = SmokeTestHumanInterface().present("Review the investigation")
+        assert resp["action"] == "approved"
+
+    def test_draft_confirmation_approves(self):
+        """The guidance tail's draft-confirm prompt offers ``["approve", "reject"]``.
+
+        Confirming its pre-selection is what lets a drafted value commit and the
+        loop advance to the next gap — the path the mode exists to walk.
+        """
+        resp = SmokeTestHumanInterface().present(
+            "Approve to commit this drafted value", options=["approve", "reject"]
+        )
+        assert resp["action"] == "approved"
+
+    def test_a_menu_of_alternatives_is_skipped_not_answered(self):
+        """A real menu is not a pre-selection to confirm — it is a claim to make.
+
+        The only such prompt in the tree is the ambiguous-author escalation, whose
+        caller reads ``comments`` to learn which candidate was picked. Returning
+        row 1 would have this harness assert WHICH HUMAN wrote a paper, on the
+        strength of candidate ordering. Confirming means taking the answer an
+        Enter would give; there is no such answer in a list of people, so the mode
+        declines — the same line ``select_many`` refuses to cross.
+        """
+        options = ["Ada Lovelace — 0000-0001", "Ada Byron — 0000-0002", "None of these / skip"]
+        resp = SmokeTestHumanInterface().present("Pick the correct one", options)
+        assert resp["action"] == "skipped"
+        assert resp["comments"] is None, "a skipped menu must not hand back a pick"
+
+    def test_negative_pre_selection_is_a_rejection(self):
+        """When the pre-selected row is a refusal, confirming it REJECTS.
+
+        The mode confirms the pre-selection; it does not approve on principle.
+        """
+        resp = SmokeTestHumanInterface().present(
+            "Proceed?", options=["No, don't do that", "Yes, go ahead"]
+        )
+        assert resp["action"] == "rejected"
+
+
+class TestScanRootStaysFailClosed:
+    def test_refused_even_when_no_option_reads_as_a_refusal(self):
+        """The case that was actually broken (found in review).
+
+        `_default_choice_index` falls back to the LAST option when nothing reads
+        as negative, so a caller offering ["Show me the folder first", "Yes,
+        allow this folder"] got an APPROVAL out of this mode. No production
+        caller passes options today, which is exactly why it was invisible — and
+        exactly why the refusal cannot be inherited from a rule written for a
+        human at a keyboard.
+        """
+        resp = SmokeTestHumanInterface().present(
+            "Approve this folder?",
+            ["Show me the folder first", "Yes, allow this folder"],
+            SCAN_ROOT_PURPOSE,
+        )
+        assert resp["action"] == "rejected"
+
+    """#197: an unattended mode must NEVER widen filesystem access.
+
+    The deny is inherited, not implemented: ``_default_choice_index`` pre-selects
+    the refusal for a ``scan_root`` purpose. These tests exist so a change to that
+    rule breaks HERE instead of silently handing the smoke mode the filesystem.
+    """
+
+    def test_default_scan_root_prompt_is_denied(self):
+        resp = SmokeTestHumanInterface().present(
+            "The agent wants to scan /etc", purpose=SCAN_ROOT_PURPOSE
+        )
+        assert resp["action"] == "rejected"
+
+    def test_denied_even_when_the_allow_option_is_listed_first(self):
+        """The pre-selection must track the REFUSAL, not the ordinal position.
+
+        If ``_default_choice_index`` ever regressed to "the first option" for a
+        scan-root escalation, this is the assertion that catches it: the allowing
+        choice is deliberately offered first.
+        """
+        resp = SmokeTestHumanInterface().present(
+            "Approve scanning /etc?",
+            options=["Yes, allow this folder", "No, keep the current access"],
+            purpose=SCAN_ROOT_PURPOSE,
+        )
+        assert resp["action"] == "rejected"
+
+    def test_denied_when_no_option_is_recognisably_negative(self):
+        """No identifiable refusal => nothing is safe to pre-approve => deny.
+
+        The pre-selection falls to the last option, which is not an explicit
+        affirmative, so the escalation is still refused.
+        """
+        resp = SmokeTestHumanInterface().present(
+            "Approve scanning /etc?",
+            options=["Grant access", "Grant access recursively"],
+            purpose=SCAN_ROOT_PURPOSE,
+        )
+        assert resp["action"] == "rejected"
+
+    def test_engine_refuses_an_unapproved_scan_through_the_real_guard(self, tmp_path):
+        """End-to-end through ``engine.run_tool`` — not just the interface in isolation.
+
+        The engine consults ``present(purpose="scan_root")`` only for an
+        interactive human (a non-interactive one is refused earlier), so the smoke
+        interface genuinely reaches the escalation — and is refused, leaving
+        ``approved_scan_roots`` empty.
+        """
+        secret = tmp_path / "not-approved"
+        secret.mkdir()
+        (secret / "secret.txt").write_text("classified\n")
+
+        engine = AgentEngine(human_interface=SmokeTestHumanInterface())
+        engine.initialize()
+        result = engine.run_tool("scan_files", path=str(secret))
+
+        assert engine.state.approved_scan_roots == set(), "smoke mode must not widen access"
+        assert not (result.get("files") if isinstance(result, dict) else result)
+        # The refusal must come from the ESCALATION the smoke interface answered,
+        # not from an earlier guard — otherwise this test would pass without ever
+        # exercising the pre-selection that does the denying.
+        assert "declined" in str(result.get("message", "") if isinstance(result, dict) else "")
+
+
+class TestOpenFieldsAndOptionalCapabilities:
+    """Open fields get the literal answer; the optional capabilities are deliberate."""
+
+    def test_request_input_answers_with_the_literal_string(self):
+        resp = SmokeTestHumanInterface().request_input("Who ran the study?")
+        assert resp == {"value": SMOKE_TEST_ANSWER, "skipped": False}
+
+    def test_answer_is_a_commit_not_a_skip(self):
+        """A skip would leave guidance nothing to commit, so no gap would resolve
+        and the commit -> re-assess -> next-gap path would never run."""
+        assert SmokeTestHumanInterface().request_input("Describe the assay")["skipped"] is False
+
+    def test_select_many_skips(self):
+        """Nothing is pre-ticked in a many-of-N box, so there is no pre-selection
+        to confirm; picking a subset would be inventing an answer."""
+        resp = SmokeTestHumanInterface().select_many(
+            "Which entities does this apply to?", ["Assay A", "Assay B"]
+        )
+        assert resp == {"values": [], "skipped": True}
+
+    def test_select_many_is_native_so_it_never_degrades_to_present(self):
+        """Routed through the shared helper, the answer must stay a skip.
+
+        Without a native ``select_many`` the helper degrades to ``present``, whose
+        pre-selection would come back looking like a deliberately ticked box.
+        """
+        from builder.tools.hitl import select_many, supports_multi_choice
+
+        human = SmokeTestHumanInterface()
+        assert supports_multi_choice(human) is True
+        assert select_many(human, "Which apply?", ["A", "B"]) == {"values": [], "skipped": True}
+
+    def test_is_done_is_always_false(self):
+        """The mode never ends guidance early — saying "done" would exercise
+        nothing. Termination is left to run_guidance's own bounds."""
+        human = SmokeTestHumanInterface()
+        assert human.is_done() is False
+        assert human.is_done() is False  # and it never flips, however much is asked
+
+
+class TestIdentifiersAreNeverSynthesised:
+    """D5: ``"yes, continue"`` must not be able to become a CAS or an ORCID."""
+
+    def test_guidance_forces_an_identifier_commit_to_a_skip(self):
+        """The guidance interpret fallback skips identifier-bearing fields.
+
+        Confirming the guard still holds for THIS answer rather than assuming it:
+        the same reply commits happily on a descriptive field.
+        """
+        from builder.agents.pipeline.guidance import _deterministic_decision
+        from builder.tools.gap_analysis import Gap
+
+        def _gap(prop: str) -> Gap:
+            return Gap(
+                tier="MUST",
+                source="shacl",
+                entity_id="#compound-1",
+                entity_type="MolecularEntity",
+                property=prop,
+                message="missing",
+                suggestion=None,
+                fix_hint="ask-user",
+                auto_fixable=False,
+            )
+
+        assert _deterministic_decision(_gap("identifier"), SMOKE_TEST_ANSWER) == {"action": "skip"}
+        assert _deterministic_decision(_gap("description"), SMOKE_TEST_ANSWER) == {
+            "action": "commit",
+            "value": SMOKE_TEST_ANSWER,
+        }
+
+    def test_pasted_orcid_prose_is_rejected_by_verification(self):
+        """The citation-author escalation asks for an ORCID as free text.
+
+        The smoke answer is pasted in, but an HITL-supplied ORCID is still resolved
+        and name-matched before use, so the prose resolves to nothing rather than
+        landing on a Person.
+        """
+        from builder.tools.composites import _resolve_via_search
+
+        looked_up: list[str] = []
+
+        def fake_lookup_by_name(given, family, affiliation=None):
+            # Two candidates => ambiguous => the escalation runs.
+            return [
+                {"given": "A.", "family": family, "orcid": "0000-0001-0000-0001"},
+                {"given": "Alice", "family": family, "orcid": "0000-0002-0000-0002"},
+            ]
+
+        def fake_lookup_orcid(orcid_id):
+            looked_up.append(orcid_id)
+            return {"found": False}
+
+        chosen = _resolve_via_search(
+            "Alice",
+            "Smith",
+            None,
+            SmokeTestHumanInterface(),
+            fake_lookup_orcid,
+            fake_lookup_by_name,
+        )
+
+        assert chosen is None
+        # The pick (or the pasted prose) was verified against the lookup, never
+        # trusted on the strength of the answer alone.
+        assert looked_up, "an HITL-chosen identifier must be verified before use"
+
+
+class TestTheRunSaysTheAnswersAreSynthetic:
+    """The notice is printed at the start AND beside the exported crate path."""
+
+    def test_notice_names_the_literal_answer(self):
+        """Whoever reads the scrollback must be able to recognise the placeholder
+        where it landed — in a name, a description — so the notice quotes it."""
+        assert SMOKE_TEST_ANSWER in SYNTHETIC_ANSWER_NOTICE
+        assert "SMOKE TEST" in SYNTHETIC_ANSWER_NOTICE
+
+    def test_export_line_is_followed_by_the_notice(self, tmp_path):
+        """Emitted by the build, immediately after the crate path (#233 line).
+
+        Scrollback read later must not present a crate full of placeholder prose
+        as a real one, so the two lines are adjacent by construction.
+        """
+        from builder.agents.build import run_interactive_build
+
+        out_dir = tmp_path / "smoke-ro-crate"
+        engine = AgentEngine(state=CrateState(), human_interface=SmokeTestHumanInterface())
+        engine.initialize()
+        engine.state.metadata.output_path = str(out_dir)
+        lines: list[str] = []
+
+        def fake_exporter(state: CrateState, **kw: Any) -> dict[str, Any]:
+            return {"success": True, "crate_path": str(out_dir), "error": None}
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: {"ok": True, "conformance": {}, "issues": []},
+            guidance_runner=lambda eng, human, **kw: {"resolved": [], "asked": []},
+            exporter=fake_exporter,
+            output=lines.append,
+        )
+
+        path_index = next(i for i, line in enumerate(lines) if line.startswith("Crate written to:"))
+        assert lines[path_index + 1] == SYNTHETIC_ANSWER_NOTICE
+
+    def test_a_real_frontend_gets_no_notice(self, tmp_path):
+        """A build whose answers came from a person must not be labelled synthetic."""
+        from builder.agents.build import run_interactive_build
+        from builder.tools.hitl import SimulatedHumanInterface
+
+        out_dir = tmp_path / "plain-ro-crate"
+        engine = AgentEngine(state=CrateState(), human_interface=SimulatedHumanInterface())
+        engine.initialize()
+        engine.state.metadata.output_path = str(out_dir)
+        lines: list[str] = []
+
+        run_interactive_build(
+            engine,
+            pipeline_runner=lambda eng: {"ok": True, "conformance": {}, "issues": []},
+            exporter=lambda state, **kw: {
+                "success": True,
+                "crate_path": str(out_dir),
+                "error": None,
+            },
+            output=lines.append,
+        )
+
+        assert not any("SMOKE TEST" in line for line in lines)
+
+
+class TestCli:
+    """``--smoke-test`` implies --interactive, refuses --legacy-react, wires the mode."""
+
+    def _stub_config(self, monkeypatch):
+        """Make the interactive path proceed without a real LLM config check."""
+        import builder.config as cfg
+
+        monkeypatch.setattr(cfg, "is_configured", lambda: True)
+        monkeypatch.setattr(cfg, "load_config", lambda: {})
+        monkeypatch.setattr(cfg, "merge_with_env", lambda c: None)
+
+    def test_flag_defaults_off(self):
+        assert parse_args([]).smoke_test is False
+        assert parse_args([]).interactive is False
+
+    def test_flag_implies_interactive(self):
+        """On its own it would have nothing to answer — a batch run never prompts."""
+        args = parse_args(["--smoke-test"])
+        assert args.smoke_test is True
+        assert args.interactive is True
+
+    def test_legacy_react_combination_is_refused(self, monkeypatch, capsys):
+        """The ReAct loop reads stdin directly, so nothing could answer it — say so
+        and exit non-zero rather than starting a build that can only hang."""
+        calls: list[str] = []
+        import builder.agents.react.agent_loop as agent_loop
+
+        monkeypatch.setattr(
+            agent_loop, "run_interactive_agent", lambda *a, **kw: calls.append("react")
+        )
+
+        assert main(["--smoke-test", "--legacy-react"]) == 1
+        assert calls == [], "the ReAct loop must not be started"
+        assert "--legacy-react" in capsys.readouterr().err
+
+    def test_wires_the_smoke_interface_and_prints_the_opening_notice(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        """The engine handed to the build answers itself and reports interactive."""
+        self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
+        seen: list[Any] = []
+
+        import builder.agents.build as build_mod
+
+        def _capture(engine, **kw):
+            seen.append(engine.human_interface)
+            return {"pipeline": {}, "guidance": None}
+
+        monkeypatch.setattr(build_mod, "run_interactive_build", _capture)
+
+        assert main(["--smoke-test", "--input", str(d)]) == 0
+        assert len(seen) == 1
+        assert isinstance(seen[0], SmokeTestHumanInterface)
+        assert is_interactive(seen[0]) is True
+        # The notice lands BEFORE the build, so an accidental --smoke-test is
+        # obvious immediately rather than only at the end.
+        assert "SMOKE TEST" in capsys.readouterr().out
+
+    def test_plain_interactive_still_gets_the_console_interface(self, monkeypatch, tmp_path):
+        """No --smoke-test => the real stdin frontend, unchanged."""
+        from builder.tools.hitl import ConsoleHumanInterface
+
+        self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
+        seen: list[Any] = []
+
+        import builder.agents.build as build_mod
+
+        monkeypatch.setattr(
+            build_mod,
+            "run_interactive_build",
+            lambda engine, **kw: seen.append(engine.human_interface) or {"pipeline": {}},
+        )
+
+        assert main(["--interactive", "--input", str(d)]) == 0
+        assert isinstance(seen[0], ConsoleHumanInterface)


### PR DESCRIPTION
The HITL path could not be exercised unattended. `SimulatedHumanInterface` reports `is_interactive = False` — precisely the signal the guidance tail is gated on — so behind it `run_interactive_build` degrades to `run_pipeline` + export and `run_guidance` is **never called**. Testing the tail meant a human answering questions.

`--smoke-test` installs a frontend that reports `is_interactive = True`, **confirms the pre-selected choice** on every decision, and answers every open field with the literal `"yes, continue"`. A live run reaches the tail and answers ~10 phrased questions with no terminal input.

## The crate is a by-product, and says so

`"yes, continue"` lands in prose fields — a study description, a person's name — so the artifact looks real and is not. The run prints a notice at the **start** (a misfire is obvious immediately) and again on the line **immediately after `Crate written to:`**, emitted from the one call site that prints the path so the two cannot drift.

Nothing is written *into* the crate. Marking the metadata "this was a smoke test" would be asserting something untrue of the data — the line D5 draws, and the same one we've held all week.

## Two defects found in review

Both are the failure class this mode is most dangerous for, and neither would have shown up in normal use.

**1. Scan roots could be approved.** `present()` had no unconditional refusal for `SCAN_ROOT_PURPOSE` — it inherited fail-closed from `_default_choice_index`, which falls back to the **last** option when nothing reads as a refusal:

```python
present('ctx', ['Show me the folder first', 'Yes, allow this folder'], SCAN_ROOT_PURPOSE)
  →  {'action': 'approved'}          # a test harness granting filesystem access
```

No production caller passes options, which is exactly why it was invisible. Now refused directly, and tested with those adversarial options rather than only the shape production happens to use. I'd flagged fail-closed as the worst available bug here precisely because the correct behaviour was accidental — it turned out not to hold.

**2. A real menu returned row 1 as the pick.** The only such prompt is the ambiguous-author escalation, so an unattended run silently asserted **which human wrote a paper**, on the strength of candidate ordering. Confirming a pre-selection means taking the answer an Enter would give; there is no such answer in a list of people. It now skips — the same line `select_many` declines to cross.

## CLI behaviour

- **implies `--interactive`**, normalised once in `parse_args` so every downstream reader sees one consistent fact. Requiring it would mean the flag alone either errors or silently does nothing HITL-shaped, and "silently does nothing" is the misfire this mode exists to make visible.
- **refused with `--legacy-react`** (exit 1, stderr): that loop reads stdin directly rather than through the `HumanInterface`, so a synthetic frontend cannot answer it and the run would hang on an empty terminal. An error beats a hang.

## D5

Identifier fields are unaffected — guidance forces any identifier-bearing commit to a skip, so `"yes, continue"` cannot become a CAS or an ORCID. Asserted against the real answer with `description` as the contrast case, and the citation-author path re-verified (a pasted string resolves to `None`).

## Verification

`tests/test_smoke_test_mode.py` + `tests/test_tools_hitl.py` — 62 passed. `uvx ruff check` and `uv run ty check` clean. The choice→response mapping was factored out of `ConsoleHumanInterface.present` into a shared `_decision_from_choice` so "confirm the pre-selection" means the same thing on both frontends; Console's behaviour is byte-identical and its tests pass unchanged.

## Known, not fixed here

Nothing marks the **session**. A smoke run's goodbye panel prints `--resume <id> --interactive`, and resuming that way gets a real Console frontend on a crate full of synthesised answers. Worth a follow-up if this mode gets used often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)