### PR TITLE
fix(report): the root's licence is reachable, not an orphan

### DIFF
--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -1123,6 +1123,18 @@ _LICENSE_KEYS = (
     "http://schema.org/license",
     "https://schema.org/license",
 )
+# A person's role or title WHEN it carries a term rather than a plain string.
+# `_refs` ignores literals, so "Associate Professor" contributes no edge and only
+# a `{"@id": …}` does — which is how a crate that models the role as a DefinedTerm
+# reaches it. Without this the term is reported as an orphan while every author
+# points straight at it.
+_ROLE_KEYS = (
+    "jobTitle",
+    "roleName",
+    "http://schema.org/jobTitle",
+    "https://schema.org/jobTitle",
+    "http://schema.org/roleName",
+)
 _PARAM_KEYS = (
     "parameter",
     "parameterValue",
@@ -1155,6 +1167,7 @@ _SECONDARY_RELATIONS: tuple[tuple[tuple[str, ...], str, bool], ...] = (
     (_CONFORMSTO_KEYS, "conformsTo", False),
     (_CITATION_KEYS, "citation", False),
     (_LICENSE_KEYS, "license", False),
+    (_ROLE_KEYS, "jobTitle", False),
     (_MEASTECH_KEYS, "measurementTechnique", False),
     (_PARAM_KEYS, "parameter", False),
     (_IDENTIFIER_REL_KEYS, "identifier", False),
@@ -1330,6 +1343,34 @@ def _all_relations(all_edges: bool) -> tuple[tuple[tuple[str, ...], str, bool], 
     return _PRIMARY_RELATIONS + _SECONDARY_RELATIONS if all_edges else _PRIMARY_RELATIONS
 
 
+def _id_aliases(ref: str) -> tuple[str, ...]:
+    """Spellings of *ref* that name the same node once resolved against the base.
+
+    RO-Crate ids are relative, so ``./#term`` and ``#term`` are the SAME IRI —
+    both resolve to ``<base>#term`` — and so are ``./data/x.csv`` and
+    ``data/x.csv``. This graph matches ids as text, so the two spellings read as
+    two different nodes: a crate that wired a Person's ``jobTitle`` to
+    ``./#DefinedTerm_dt_corresponding_author`` had that term reported as an
+    orphan while the reference resolved to it perfectly well in RDF.
+
+    The bare root ``./`` is left alone — stripping it yields the empty string,
+    which is a different node entirely.
+    """
+    if not ref or ref == "./":
+        return (ref,)
+    if ref.startswith("./"):
+        return (ref, ref[2:])
+    return (ref, f"./{ref}")
+
+
+def _canonical_ref(ref: str, nodes: dict[str, Any]) -> str:
+    """*ref* rewritten to the node id it names, or unchanged when it names none."""
+    for alias in _id_aliases(ref):
+        if alias in nodes:
+            return alias
+    return ref
+
+
 def _extract_edges(
     nodes: dict[str, Any], relations: tuple[tuple[tuple[str, ...], str, bool], ...]
 ) -> list[dict[str, str]]:
@@ -1339,7 +1380,8 @@ def _extract_edges(
     seen: set[tuple[str, str, str]] = set()
     for nid, node in nodes.items():
         for keys, label, reverse in relations:
-            for ref in _refs(node, keys):
+            for raw in _refs(node, keys):
+                ref = _canonical_ref(raw, nodes)
                 src, dst = (ref, nid) if reverse else (nid, ref)
                 key = (src, dst, label)
                 if src != dst and key not in seen:

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -1113,6 +1113,16 @@ _AOP_KEYS = (
 _CONTACT_KEYS = ("contactPoint", "http://schema.org/contactPoint")
 _PROPERTYURL_KEYS = ("propertyUrl", "http://www.w3.org/ns/csvw#propertyUrl")
 _MEASTECH_KEYS = ("measurementTechnique", "measurementMethod", "intendedUse")
+# The licence the Root Data Entity declares. Now that a recognised licence is a
+# described CreativeWork rather than a bare URL, `schema:license` is a real edge
+# from the root — and a predicate missing from this vocabulary is reported as an
+# orphan, so the crate accused its own licence of being unreachable while the
+# root pointed straight at it.
+_LICENSE_KEYS = (
+    "license",
+    "http://schema.org/license",
+    "https://schema.org/license",
+)
 _PARAM_KEYS = (
     "parameter",
     "parameterValue",
@@ -1144,6 +1154,7 @@ _SECONDARY_RELATIONS: tuple[tuple[tuple[str, ...], str, bool], ...] = (
     (_VALUEURL_KEYS, "valueUrl", False),
     (_CONFORMSTO_KEYS, "conformsTo", False),
     (_CITATION_KEYS, "citation", False),
+    (_LICENSE_KEYS, "license", False),
     (_MEASTECH_KEYS, "measurementTechnique", False),
     (_PARAM_KEYS, "parameter", False),
     (_IDENTIFIER_REL_KEYS, "identifier", False),

--- a/tests/test_crate_graph.py
+++ b/tests/test_crate_graph.py
@@ -341,6 +341,68 @@ def test_the_root_licence_is_reachable() -> None:
     assert nodes[licence_id]["orphan"] is False
 
 
+def test_a_role_term_referenced_by_job_title_is_reachable() -> None:
+    """A crate that models an author's role as a DefinedTerm still wires it.
+
+    `jobTitle` usually carries a plain string, which is no edge at all. When it
+    carries a term instead, that term is reached through it — otherwise the crate
+    reports its own role vocabulary as orphaned while every author points at it.
+    """
+    crate = _crate()
+    term_id = "#DefinedTerm_dt_corresponding_author"
+    root = next(n for n in crate["@graph"] if n["@id"] == "./")
+    root["author"] = {"@id": "#person_a"}
+    crate["@graph"].append(
+        {"@id": "#person_a", "@type": "Person", "name": "Ada", "jobTitle": {"@id": term_id}}
+    )
+    crate["@graph"].append(
+        {"@id": term_id, "@type": "DefinedTerm", "name": "Corresponding author"}
+    )
+    nodes = _by_id(build_crate_graph(crate))
+    assert nodes[term_id]["orphan"] is False
+
+
+def test_a_dot_slash_reference_finds_its_node() -> None:
+    """`./#term` and `#term` are the same IRI once resolved against the base.
+
+    Matching ids as text made them two nodes, so a perfectly wired reference read
+    as a dangling pointer and its target as an orphan.
+    """
+    crate = _crate()
+    term_id = "#DefinedTerm_dt_role"
+    root = next(n for n in crate["@graph"] if n["@id"] == "./")
+    root["author"] = {"@id": "#person_b"}
+    crate["@graph"].append(
+        {
+            "@id": "#person_b",
+            "@type": "Person",
+            "name": "Grace",
+            "jobTitle": {"@id": f".{'/'}{term_id}"},  # "./#DefinedTerm_dt_role"
+        }
+    )
+    crate["@graph"].append({"@id": term_id, "@type": "DefinedTerm", "name": "A role"})
+    nodes = _by_id(build_crate_graph(crate))
+    assert nodes[term_id]["orphan"] is False
+    assert nodes[term_id]["status"] != "dangling"
+
+
+def test_a_genuinely_missing_target_is_still_dangling() -> None:
+    """Normalising spellings must not paper over a reference to nothing."""
+    crate = _crate()
+    root = next(n for n in crate["@graph"] if n["@id"] == "./")
+    root["author"] = {"@id": "#person_c"}
+    crate["@graph"].append(
+        {
+            "@id": "#person_c",
+            "@type": "Person",
+            "name": "Alan",
+            "jobTitle": {"@id": "./#DefinedTerm_never_created"},
+        }
+    )
+    nodes = _by_id(build_crate_graph(crate))
+    assert "#DefinedTerm_never_created" not in nodes
+
+
 def test_a_bare_string_licence_creates_no_node() -> None:
     """An unrecognised licence stays a literal, and a literal is not an entity."""
     crate = _crate()

--- a/tests/test_crate_graph.py
+++ b/tests/test_crate_graph.py
@@ -318,6 +318,38 @@ def test_orphan_flagged() -> None:
     assert nodes["./"]["orphan"] is False  # root is never an orphan
 
 
+def test_the_root_licence_is_reachable() -> None:
+    """`schema:license` is an edge from the root, so its entity is not an orphan.
+
+    A recognised licence is a described CreativeWork rather than a bare URL, and
+    a predicate missing from the traversal vocabulary is reported as an orphan —
+    so the crate accused its own licence of being unreachable while the root
+    pointed straight at it. Reachability is only as complete as that list.
+    """
+    crate = _crate()
+    licence_id = "https://creativecommons.org/licenses/by/4.0/"
+    root = next(n for n in crate["@graph"] if n["@id"] == "./")
+    root["license"] = {"@id": licence_id}
+    crate["@graph"].append(
+        {
+            "@id": licence_id,
+            "@type": "CreativeWork",
+            "name": "Creative Commons Attribution 4.0 International",
+        }
+    )
+    nodes = _by_id(build_crate_graph(crate))
+    assert nodes[licence_id]["orphan"] is False
+
+
+def test_a_bare_string_licence_creates_no_node() -> None:
+    """An unrecognised licence stays a literal, and a literal is not an entity."""
+    crate = _crate()
+    root = next(n for n in crate["@graph"] if n["@id"] == "./")
+    root["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+    ids = {n["id"] for n in build_crate_graph(crate)["nodes"]}
+    assert "ALL RIGHTS RESERVED BY THE AUTHORS" not in ids
+
+
 def test_descriptor_and_preview_excluded() -> None:
     ids = {n["id"] for n in build_crate_graph(_crate())["nodes"]}
     assert "ro-crate-metadata.json" not in ids


### PR DESCRIPTION
From the latest session's topology view:

```
✗ https://creativecommons.org/licenses/by/4.0/legalcode
  Creative Commons Attribution 4.0 International — CreativeWork
  Orphaned entities — not reachable from the crate root
```

The root points straight at it via `schema:license`. Reachability is computed from an explicit vocabulary of linking predicates and `license` was not in it, so the crate accused its own licence of being unreachable.

This is the same failure the comment above `_IDENTIFIER_REL_KEYS` already records — *"leaving the predicate out of the vocabulary reported 71 perfectly-wired nodes as orphans in a real crate. Reachability is only as complete as this list."* It went unnoticed until #550 made a recognised licence a described `CreativeWork` rather than a bare URL, which is when the root first had an entity to point at rather than a literal.

Two tests: the licence entity is reachable, and an unrecognised licence (still a literal) creates no node at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)