### PR TITLE
feat(report): the graph view's orphan list folds out the rest, like the tiers do

### DIFF
--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -379,8 +379,12 @@ __CATEGORY_STYLES__
   .mat .panel > .panel-h{display:block; font-size:.95rem; font-weight:660; margin:0 0 .6rem;}
 }
 
-/* The overflow fold inside a findings list: same muted voice as the
-   '+N further' line it replaces, but reachable. */
-.mat ul.sugg li.more > details.more-fold > summary { cursor:pointer; font-style:italic; }
-.mat ul.sugg li.more > details.more-fold > summary:hover { color:var(--ink); }
-.mat ul.sugg li.more > details.more-fold > ul.sugg { margin:.35rem 0 0; font-style:normal; }
+/* The overflow fold inside a capped list: same muted voice as the '+N further'
+   line it replaces, but reachable. Selectors are on li.more rather than on the
+   list class, because the same fold now serves the profile tiers (ul.sugg) and
+   the graph view's orphan / dangling lists (ul.ind) — keying it to one list
+   class is what left the second one unstyled. */
+.mat li.more > details.more-fold > summary { cursor:pointer; font-style:italic; }
+.mat li.more > details.more-fold > summary:hover { color:var(--ink); }
+.mat li.more > details.more-fold > ul.sugg,
+.mat li.more > details.more-fold > ul.ind { margin:.35rem 0 0; font-style:normal; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -901,33 +901,63 @@ def _render_topology_detail(nodes: list[dict[str, Any]]) -> str:
     if not orphans and not dangling:
         return ""
 
-    def _rows(items: list[dict[str, Any]], *, with_type: bool) -> str:
-        # Node labels are pre-escaped by build_crate_graph; ids/types are raw.
-        rows = []
-        for n in items[:_TOPO_LIST_CAP]:
+    def _rows(items: list[dict[str, Any]], *, with_type: bool, one: str, many: str) -> str:
+        """The list, with anything past the cap behind a second fold-out.
+
+        The cap bounds the page; it is not a decision about what the reader may
+        see. It used to end at "+7 more", which named a number and then offered
+        no way to reach it — and this report is the ONLY place those ids are
+        written down, so a reader who wanted the eighth orphan had nowhere else
+        to look. Same fix as the profile-adherence tiers (:func:`_apply_cap`):
+        the remainder sits in a nested ``<details>``, closed by default, so the
+        page stays the length it was and is one click from complete.
+        """
+
+        def _row(n: dict[str, Any]) -> str:
+            # Node labels are pre-escaped by build_crate_graph; ids/types are raw.
             ty = str(n.get("type") or "")
             tail = f' <span class="ty">{esc(ty)}</span>' if with_type and ty else ""
-            rows.append(
+            return (
                 f"<li>{_mk('no')} <code>{esc(str(n['id']))}</code>"
                 f"<span>{n.get('label') or ''}{tail}</span></li>"
             )
-        extra = len(items) - _TOPO_LIST_CAP
-        if extra > 0:
-            rows.append(f'<li class="more">+{extra} more</li>')
-        return "".join(rows)
+
+        shown = [_row(n) for n in items[:_TOPO_LIST_CAP]]
+        rest = [_row(n) for n in items[_TOPO_LIST_CAP:]]
+        if not rest:
+            return "".join(shown)
+        # Spelled out rather than "+s": the nouns here are "orphaned entity" and
+        # "dangling reference", and a naive rule renders the first as "entitys".
+        plural = one if len(rest) == 1 else many
+        return "".join(
+            [
+                *shown,
+                '<li class="more">'
+                f'<details class="more-fold"><summary>+{len(rest)} further {plural}</summary>'
+                f'<ul class="ind">{"".join(rest)}</ul>'
+                "</details>"
+                "</li>",
+            ]
+        )
+
+    _orphan_rows = _rows(orphans, with_type=True, one="orphaned entity", many="orphaned entities")
+    _dangling_rows = _rows(
+        dangling, with_type=False, one="dangling reference", many="dangling references"
+    )
 
     groups = []
     if orphans:
         groups.append(
             '<p class="topo-detail-h">Orphaned entities — not reachable from the '
             "crate root; link each via <code>hasPart</code>, <code>result</code>, "
-            f'or <code>about</code></p><ul class="ind">{_rows(orphans, with_type=True)}</ul>'
+            "or <code>about</code></p>"
+            f'<ul class="ind">{_orphan_rows}</ul>'
         )
     if dangling:
         groups.append(
             '<p class="topo-detail-h">Dangling references — a referenced '
             "<code>@id</code> with no matching entity; add the entity or drop the "
-            f'reference</p><ul class="ind">{_rows(dangling, with_type=False)}</ul>'
+            f'reference</p><ul class="ind">{_dangling_rows}</ul>'
         )
 
     def _n(count: int, one: str) -> str:

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -567,8 +567,9 @@ class TestActionableTopology:
         assert 'class="disc topo-detail"' not in page
 
     def test_orphan_list_is_bounded_with_more_marker(self) -> None:
-        # 12 orphaned files → only the first 10 listed, then "+2 more" (nothing
-        # silently dropped).
+        # 12 orphaned files → the first 10 listed inline, the rest behind a
+        # fold-out. The cap bounds the PAGE, not what the reader may see: this
+        # report is the only place those ids are written down.
         graph = {
             "@graph": [
                 {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
@@ -580,11 +581,14 @@ class TestActionableTopology:
             graph["@graph"].append({"@id": f"#loose{i}", "@type": "File", "name": f"loose{i}.csv"})
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
         assert "12 orphans" in page
-        assert "+2 more" in page
-        # First 10 are listed; the 11th/12th are folded into the "+N more".
+        assert "+2 further orphaned entities" in page
         assert "#loose0" in page
         assert "#loose9" in page
-        assert "#loose11" not in page
+        # The 11th and 12th are BEHIND the fold, not absent from it. This
+        # assertion was previously `not in page` — a capped list that named a
+        # number and gave the reader no way to reach it.
+        assert "#loose10" in page
+        assert "#loose11" in page
 
 
 class TestChemicalsSection:
@@ -1953,3 +1957,60 @@ class TestUnreachableRepairEstimate:
 
         assert "Every entity is reachable from the crate root." in page
         assert "would reconnect" not in page
+
+
+class TestTheOrphanListIsReachable:
+    """The graph view's capped lists must not name a number and stop.
+
+    The profile-adherence tiers already put their overflow behind a fold
+    (`_apply_cap`) for a stated reason: this report is the ONLY place those
+    findings are written down, so "+9 further" with no way to reach them sent the
+    reader nowhere. The topology lists had the same dead end.
+    """
+
+    @staticmethod
+    def _nodes(orphans: int = 0, dangling: int = 0) -> list[dict]:
+        out = [
+            {"id": f"#orphan_{i}", "label": f"Thing {i}", "type": "Sample", "orphan": True}
+            for i in range(orphans)
+        ]
+        out += [{"id": f"#dangle_{i}", "label": "", "status": "dangling"} for i in range(dangling)]
+        return out
+
+    def test_every_orphan_is_reachable_however_many_there_are(self) -> None:
+        from builder.writers.maturity_report import _render_topology_detail
+
+        html = _render_topology_detail(self._nodes(orphans=14))
+
+        assert "+4 further orphaned entities" in html
+        assert 'details class="more-fold"' in html
+        # The point of the fold: the ids past the cap are still IN the document.
+        for i in range(14):
+            assert f"#orphan_{i}" in html, f"orphan {i} is named nowhere in the report"
+
+    def test_dangling_references_fold_the_same_way(self) -> None:
+        from builder.writers.maturity_report import _render_topology_detail
+
+        html = _render_topology_detail(self._nodes(dangling=13))
+
+        assert "+3 further dangling references" in html
+        for i in range(13):
+            assert f"#dangle_{i}" in html
+
+    def test_a_single_overflow_row_reads_singular(self) -> None:
+        """"+1 further orphaned entitys" is the naive-pluralisation tell."""
+        from builder.writers.maturity_report import _render_topology_detail
+
+        html = _render_topology_detail(self._nodes(orphans=11))
+
+        assert "+1 further orphaned entity<" in html
+        assert "entitys" not in html
+
+    def test_a_list_inside_the_cap_gets_no_fold(self) -> None:
+        """The control — a short list must not grow a pointless disclosure."""
+        from builder.writers.maturity_report import _render_topology_detail
+
+        html = _render_topology_detail(self._nodes(orphans=3, dangling=2))
+
+        assert "more-fold" not in html
+        assert "further" not in html


### PR DESCRIPTION
The Profile adherence tiers already stagger their overflow behind a `<details>` (`_apply_cap`), and that function states why:

> It used to end at "+9 further recommended findings not listed here", which named a number and then offered no way to reach it — the crate's own report was the one place those findings existed, so a reader who wanted them had nowhere else to look.

**The Graph view's topology lists had the identical dead end** — `+2 more` — and the identical justification for fixing it. `ro-crate-metadata.json` holds the graph; it does not hold a list of which nodes are unreachable from the root. If the report caps at ten, the eleventh orphan is named nowhere.

Both lists now behave like the tiers: ten inline, the remainder in a nested fold, closed by default so the page stays the length it was and is one click from complete.

```
+4 further orphaned entities     ← folds out
+3 further dangling references   ← folds out
```

## Details

- **The overflow noun is spelled out, not `+"s"`.** The nouns are "orphaned entity" and "dangling reference"; a naive rule renders the first as *"orphaned entitys"*. Pinned by a test.
- **The fold's CSS moves from `ul.sugg li.more` to `li.more`.** The same disclosure now serves the profile tiers (`ul.sugg`) and the graph view's lists (`ul.ind`) — keying it to one list class is precisely what would have left the new one unstyled while looking correct in the HTML.
- **A short list gets no fold at all** — a control test asserts a 3-orphan crate grows no pointless disclosure.

## One assertion inverted, deliberately

`test_orphan_list_is_bounded_with_more_marker` asserted `"#loose11" not in page`. That was pinning the dead end — the test existed to prove the eleventh orphan was *hidden*. It now asserts the id **is** present, behind the fold. That is a change of expectation to match the requested behaviour, not a weakened assertion: the test got stricter, since it now requires the overflow ids to actually be in the document rather than merely counted.

## Verification

`tests/test_maturity_report.py` 118 passed (4 new). `uvx ruff check` and `uv run ty check` clean. Verified against a 14-orphan / 13-dangling graph that every id is present in the output, and that the singular case reads "+1 further orphaned entity".

🤖 Generated with [Claude Code](https://claude.com/claude-code)