### PR TITLE
feat(cli): --smoke-test drives --legacy-react instead of refusing it

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -41,7 +41,7 @@ from builder.agents.progress_spinner import ProgressSpinner
 from builder.agents.react.system_prompt import SYSTEM_PROMPT
 from builder.agents.react.tools_spec import TOOL_SPECS, assert_tool_spec_parity
 from builder.engine import AgentEngine
-from builder.tools.hitl import is_interactive
+from builder.tools.hitl import CONVERSATION_FIELD_TYPE, answers_are_synthetic, is_interactive
 
 if TYPE_CHECKING:
     from typing import cast
@@ -4668,6 +4668,23 @@ def run_interactive_agent(
                     # Echo the seeded line so the transcript shows what drove the
                     # turn, exactly as boxed_input echoes a typed one.
                     user_input, pending_input = pending_input, None
+                    console.print(f"[bold cyan]❯[/bold cyan] {user_input}")
+                elif answers_are_synthetic(engine.human_interface):
+                    # Nobody is at the keyboard (--smoke-test). This ONE read is
+                    # the reason the mode used to refuse this arm: every other
+                    # prompt already goes through the HumanInterface, but the
+                    # conversation was read straight off stdin, so a synthetic
+                    # interface had nothing to answer and the run sat on an empty
+                    # terminal. Ask the interface instead — and let a SKIP end the
+                    # session exactly as Ctrl+D does (below), which is what keeps
+                    # an unattended run from driving turns forever.
+                    reply = engine.human_interface.request_input(
+                        "What would you like to do next?",
+                        CONVERSATION_FIELD_TYPE,
+                    )
+                    if reply.get("skipped") or not str(reply.get("value") or "").strip():
+                        raise EOFError
+                    user_input = str(reply["value"]).strip()
                     console.print(f"[bold cyan]❯[/bold cyan] {user_input}")
                 else:
                     # Rounded input box (Claude Code style); falls back to a plain

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -573,6 +573,21 @@ class ConsoleHumanInterface:
 # any marker INTO the crate (that would be fabricating metadata, D5).
 SMOKE_TEST_ANSWER = "yes, continue"
 
+# The ``field_type`` a frontend is asked with when the question is not a metadata
+# field at all but the CONVERSATION itself — the legacy ReAct loop's "what next?"
+# prompt. A console frontend cannot tell the difference and should not try: it
+# reads a line either way. It exists so an interface that answers ITSELF can,
+# because that channel is the one place where "answer everything affirmatively"
+# does not terminate on its own (see `SmokeTestHumanInterface.request_input`).
+CONVERSATION_FIELD_TYPE = "conversation"
+
+# How many conversational turns a smoke test drives the ReAct loop for before
+# ending the session. Small on purpose: the mode proves the loop RUNS unattended
+# — reads a turn, acts, comes back for the next — and each extra turn is a real
+# model call spent re-proving it. Three is enough to show the come-back-for-more
+# behaviour that one turn cannot.
+SMOKE_TEST_CONVERSATION_TURNS = 3
+
 # Printed at the start of a smoke-test run and again beside the exported crate
 # path. Both, deliberately: the opening line makes an accidental ``--smoke-test``
 # obvious before the build spends anything, and the closing line means anyone
@@ -625,6 +640,15 @@ class SmokeTestHumanInterface:
     is_interactive: bool = True
     synthesizes_answers: bool = True
 
+    def __init__(self, conversation_turns: int = SMOKE_TEST_CONVERSATION_TURNS) -> None:
+        """Args:
+        conversation_turns: How many turns to drive a conversational loop
+            (the legacy ReAct arm) before ending the session. Ignored by the
+            default arm, which has no conversational channel. ``<= 0`` ends it
+            at the first prompt.
+        """
+        self._conversation_budget = int(conversation_turns)
+
     def present(
         self,
         context: str,
@@ -667,12 +691,36 @@ class SmokeTestHumanInterface:
         nothing to commit, so the commit → re-assess → next-gap path this mode
         exists to exercise would never run.
 
+        **:data:`CONVERSATION_FIELD_TYPE` is the exception, and it is why this
+        class needs state at all.** Every other channel terminates on its own:
+        the guidance loop runs out of gaps, the report runs out of findings,
+        ``max_rounds`` bounds the rest. A conversational loop has no such bound —
+        it ends when the person says so, and :data:`SMOKE_TEST_ANSWER` is not a
+        stop word, so answering it affirmatively forever is an infinite run
+        spending a model call per turn. After :data:`SMOKE_TEST_CONVERSATION_TURNS`
+        the answer becomes a skip, which the loop reads as end-of-input and
+        finalises on — the same ending Ctrl+D gives, so the crate is still
+        exported. Budget exhaustion is deliberately NOT ``is_done()``: that
+        answers a different question (may guidance stop early?) whose honest
+        answer here stays "no".
+
         An identifier field is safe to answer this way because the value cannot
         become one: the guidance tail routes every reply through
         ``_deterministic_decision`` / the interpret leaf, both of which force an
         identifier-bearing field to a skip (D5), and the citation-author path
         re-verifies any pasted ORCID against a real lookup before use.
         """
+        if field_type == CONVERSATION_FIELD_TYPE:
+            if self._conversation_budget <= 0:
+                logger.info("smoke-test: conversation budget spent — ending the session")
+                return {"value": None, "skipped": True}
+            self._conversation_budget -= 1
+            logger.info(
+                "smoke-test: driving a conversational turn with %r (%d left after this)",
+                SMOKE_TEST_ANSWER,
+                self._conversation_budget,
+            )
+            return {"value": SMOKE_TEST_ANSWER, "skipped": False}
         logger.info(
             "smoke-test: answering %r with the synthetic %r (type=%s)",
             prompt,
@@ -825,8 +873,10 @@ def request_input(
 
 
 __all__ = [
+    "CONVERSATION_FIELD_TYPE",
     "SCAN_ROOT_PURPOSE",
     "SMOKE_TEST_ANSWER",
+    "SMOKE_TEST_CONVERSATION_TURNS",
     "SYNTHETIC_ANSWER_NOTICE",
     "ConsoleHumanInterface",
     "HumanInterface",

--- a/main.py
+++ b/main.py
@@ -480,21 +480,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.smoke_test:
         from builder.tools.hitl import SYNTHETIC_ANSWER_NOTICE
 
-        if args.legacy_react:
-            # The ReAct loop reads the conversation straight from stdin
-            # (builder.agents.ui.boxed_input) rather than through the
-            # HumanInterface, so a synthetic interface cannot answer it and the
-            # run would sit on an empty terminal forever. Refuse loudly instead of
-            # starting a build that can only hang.
-            print(
-                "--smoke-test cannot drive --legacy-react: the ReAct loop reads "
-                "your replies straight from stdin, not through the HITL "
-                "interface, so nothing can answer it unattended. Drop "
-                "--legacy-react to smoke-test the default pipeline + guidance "
-                "build.",
-                file=sys.stderr,
-            )
-            return 1
+        # NOTE: this used to refuse --legacy-react outright, because the ReAct
+        # loop read its conversation straight off stdin
+        # (builder.agents.ui.boxed_input) with no HumanInterface in the path, so a
+        # synthetic interface had nothing to answer and the run sat on an empty
+        # terminal. That read now goes through the interface when the answers are
+        # synthetic (agent_loop, CONVERSATION_FIELD_TYPE), and a spent budget ends
+        # the session the way Ctrl+D does — so the arm this mode most needs to
+        # exercise unattended is reachable rather than refused.
         # Say it FIRST, before the build spends a token: if this mode was engaged
         # by accident, the very first thing on screen must be that nobody is
         # answering the prompts. It is repeated beside the exported crate path.

--- a/tests/test_smoke_test_mode.py
+++ b/tests/test_smoke_test_mode.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from builder.engine import AgentEngine
 from builder.state import CrateState
 from builder.tools.hitl import (
     SCAN_ROOT_PURPOSE,
     SMOKE_TEST_ANSWER,
     SYNTHETIC_ANSWER_NOTICE,
+    ConsoleHumanInterface,
     HumanInterface,
     SmokeTestHumanInterface,
     answers_are_synthetic,
@@ -360,8 +363,124 @@ class TestTheRunSaysTheAnswersAreSynthetic:
         assert not any("SMOKE TEST" in line for line in lines)
 
 
+class TestTheConversationTerminates:
+    """The bound that makes ``--smoke-test --legacy-react`` finite.
+
+    Every OTHER channel this mode drives stops on its own: guidance runs out of
+    gaps, the report runs out of findings, ``max_rounds`` bounds the rest. A
+    conversational loop has no such bound — it ends when the person says so. And
+    :data:`SMOKE_TEST_ANSWER` is not a stop word, so an unbounded synthetic
+    interface does not hang (the old failure mode) but something worse: it drives
+    turns forever, one model call each. These tests exist for that.
+    """
+
+    def test_the_conversation_channel_runs_out(self):
+        from builder.tools.hitl import (
+            CONVERSATION_FIELD_TYPE,
+            SMOKE_TEST_ANSWER,
+            SMOKE_TEST_CONVERSATION_TURNS,
+            SmokeTestHumanInterface,
+        )
+
+        human = SmokeTestHumanInterface()
+        answers = [
+            human.request_input("next?", CONVERSATION_FIELD_TYPE)
+            for _ in range(SMOKE_TEST_CONVERSATION_TURNS + 3)
+        ]
+        driven = answers[:SMOKE_TEST_CONVERSATION_TURNS]
+        after = answers[SMOKE_TEST_CONVERSATION_TURNS:]
+        assert [a["value"] for a in driven] == [SMOKE_TEST_ANSWER] * len(driven)
+        # A SKIP, which the loop reads as end-of-input — not a "quit" string,
+        # which would be this mode typing a command the user never typed.
+        assert all(a["skipped"] and a["value"] is None for a in after)
+
+    def test_the_budget_does_not_bleed_into_metadata_fields(self):
+        """The two channels are separate. A field is a field however long the
+        conversation ran — bounding open fields would silently stop answering
+        guidance questions, which is the path the mode exists to exercise."""
+        from builder.tools.hitl import (
+            CONVERSATION_FIELD_TYPE,
+            SMOKE_TEST_ANSWER,
+            SmokeTestHumanInterface,
+        )
+
+        human = SmokeTestHumanInterface(conversation_turns=1)
+        human.request_input("next?", CONVERSATION_FIELD_TYPE)
+        assert human.request_input("next?", CONVERSATION_FIELD_TYPE)["skipped"] is True
+        for _ in range(5):
+            assert human.request_input("describe the study") == {
+                "value": SMOKE_TEST_ANSWER,
+                "skipped": False,
+            }
+
+    def test_a_real_frontend_is_not_bounded(self):
+        """The console interface must not inherit any of this: a person is not on
+        a turn budget, and `conversation` is just a text field to them."""
+        from builder.tools.hitl import CONVERSATION_FIELD_TYPE, ConsoleHumanInterface
+
+        typed = ["first", "second", "third", "fourth"]
+        human = ConsoleHumanInterface(prompt_func=lambda _ft: typed.pop(0))
+        for expected in ("first", "second", "third", "fourth"):
+            assert human.request_input("next?", CONVERSATION_FIELD_TYPE)["value"] == expected
+
+
+class TestTheLoopReadsTheInterfaceNotStdin:
+    """The rewiring itself, driven against the REAL loop.
+
+    Everything else in this file stubs ``run_interactive_agent`` out, so nothing
+    there would notice the read site reverting to ``ui.boxed_input``. These drive
+    the actual loop with ``boxed_input`` booby-trapped: if the conversational read
+    ever goes back to stdin, it raises instead of blocking forever, which is the
+    only way a test can catch the old failure mode at all.
+    """
+
+    def _stub_model(self, monkeypatch):
+        """Get the driver as far as the prompt without a provider or a network."""
+        import builder.agents.react.agent_loop as loop_mod
+
+        monkeypatch.setattr(loop_mod, "_build_chat_model", lambda **kw: object())
+        monkeypatch.setattr(
+            loop_mod, "_build_agent_graph", lambda llm, tools, engine=None: object()
+        )
+
+    def _trap_stdin(self, monkeypatch):
+        import builder.agents.ui as ui
+
+        def _boom(*a, **kw):
+            raise AssertionError("the loop read stdin instead of the HumanInterface")
+
+        monkeypatch.setattr(ui, "boxed_input", _boom)
+
+    def test_a_synthetic_interface_drives_and_ends_the_session(self, monkeypatch):
+        """Budget 0 => the first read is a skip, which ends the session the way
+        Ctrl+D does — no model turn is spent proving the wiring."""
+        import builder.agents.react.agent_loop as loop_mod
+
+        self._stub_model(monkeypatch)
+        self._trap_stdin(monkeypatch)
+
+        engine = AgentEngine(human_interface=SmokeTestHumanInterface(conversation_turns=0))
+        engine.initialize()
+        # Returns rather than hanging or raising: the loop asked the interface,
+        # got a skip, finalised and broke.
+        loop_mod.run_interactive_agent(engine)
+
+    def test_a_real_frontend_still_reads_stdin(self, monkeypatch):
+        """The control. Without it the test above passes just as well on a loop
+        that never prompts at all, which would be a different bug entirely."""
+        import builder.agents.react.agent_loop as loop_mod
+
+        self._stub_model(monkeypatch)
+        self._trap_stdin(monkeypatch)
+
+        engine = AgentEngine(human_interface=ConsoleHumanInterface(prompt_func=lambda _ft: "hi"))
+        engine.initialize()
+        with pytest.raises(AssertionError, match="read stdin"):
+            loop_mod.run_interactive_agent(engine)
+
+
 class TestCli:
-    """``--smoke-test`` implies --interactive, refuses --legacy-react, wires the mode."""
+    """``--smoke-test`` implies --interactive and wires the mode on both arms."""
 
     def _stub_config(self, monkeypatch):
         """Make the interactive path proceed without a real LLM config check."""
@@ -381,19 +500,33 @@ class TestCli:
         assert args.smoke_test is True
         assert args.interactive is True
 
-    def test_legacy_react_combination_is_refused(self, monkeypatch, capsys):
-        """The ReAct loop reads stdin directly, so nothing could answer it — say so
-        and exit non-zero rather than starting a build that can only hang."""
-        calls: list[str] = []
+    def test_legacy_react_is_driven_not_refused(self, monkeypatch, capsys, tmp_path):
+        """The combination this mode most needs, and the one it used to refuse.
+
+        The refusal was real while it stood: the ReAct loop read its conversation
+        straight off stdin, so a synthetic interface had nothing to answer and the
+        run sat on an empty terminal. Now that the read goes through the
+        interface, refusing would be turning away the arm a smoke test is FOR.
+        """
+        self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
+        seen: list[Any] = []
+
         import builder.agents.react.agent_loop as agent_loop
 
         monkeypatch.setattr(
-            agent_loop, "run_interactive_agent", lambda *a, **kw: calls.append("react")
+            agent_loop,
+            "run_interactive_agent",
+            lambda engine, *a, **kw: seen.append(engine.human_interface),
         )
 
-        assert main(["--smoke-test", "--legacy-react"]) == 1
-        assert calls == [], "the ReAct loop must not be started"
-        assert "--legacy-react" in capsys.readouterr().err
+        assert main(["--smoke-test", "--legacy-react", "--input", str(d)]) == 0
+        assert len(seen) == 1, "the ReAct loop must actually be started"
+        assert isinstance(seen[0], SmokeTestHumanInterface)
+        # The notice is not skipped just because this is the other arm.
+        assert "SMOKE TEST" in capsys.readouterr().out
 
     def test_wires_the_smoke_interface_and_prints_the_opening_notice(
         self, monkeypatch, capsys, tmp_path


### PR DESCRIPTION
`--smoke-test --legacy-react` exited 1. The reason was real at the time: every HITL prompt on both arms goes through the `HumanInterface` **except one** — the ReAct loop's conversational "what next?", which read stdin directly (`agent_loop.py`, `ui.boxed_input`). A synthetic interface had nothing to answer there, so the run printed the box and sat on an empty terminal. Refusing beat hanging.

But the ReAct arm is one of the two things a smoke test exists to exercise. Closing the gap is the right fix, not keeping the arm turned away.

## The read

That one site now asks the interface when the answers are synthetic, with `field_type="conversation"`. A console frontend cannot tell the difference and should not try — it reads a line either way, so **nothing changes for a real user**.

## The bound (the half that matters more)

`"yes, continue"` is not a stop word, and the ReAct loop has no turn cap. So answering the conversation synthetically doesn't hang — it drives turns forever, one model call each. That is worse than the failure it replaces, and it is what the old refusal was really protecting against.

Every *other* channel this mode drives terminates on its own: guidance runs out of gaps, the report runs out of findings, `max_rounds` bounds the rest. A conversation ends when the person says so. So `SmokeTestHumanInterface` carries a conversational budget (default **3**), after which the answer becomes a **skip** — which the loop reads as end-of-input and finalises on, the same ending Ctrl+D gives. The crate is still exported.

A skip, not the string `"quit"`: typing a command the user never typed is the kind of invention this mode declines everywhere else.

Three decisions worth stating:

- **Scoped to the conversation channel alone.** Bounding open fields would silently stop answering guidance questions partway through — the exact path the mode exists to exercise. A field stays answered however long the conversation ran. Pinned by a test.
- **Not `is_done()`.** That answers a different question (may guidance stop early?) whose honest answer here is still no.
- **Three turns, not one.** One turn cannot show the come-back-for-more behaviour; each extra turn is a real model call spent re-proving the same thing. `SmokeTestHumanInterface(conversation_turns=N)` if you want more.

## Tests

The loop-level pair drives the **real** `run_interactive_agent` with `ui.boxed_input` booby-trapped to raise. That is the only way a test can catch this regressing — a revert to stdin would otherwise just block forever rather than fail. The control asserts a console frontend still reaches stdin, so the pair cannot pass on a loop that stopped prompting altogether.

`tests/test_smoke_test_mode.py` 33 passed, `tests/test_main.py` green, `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)