### PR TITLE
feat(cli): --smoke-test takes a wall-clock budget in minutes

### DIFF
--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
+import time
 from collections.abc import Callable, Iterator
 from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
 
@@ -586,6 +587,11 @@ CONVERSATION_FIELD_TYPE = "conversation"
 # — reads a turn, acts, comes back for the next — and each extra turn is a real
 # model call spent re-proving it. Three is enough to show the come-back-for-more
 # behaviour that one turn cannot.
+#
+# Superseded by a wall-clock budget when one is given (``--smoke-test 20``): a
+# turn count is a poor stand-in for "run for a while and then export", since turn
+# cost varies by an order of magnitude between a one-tool answer and a full
+# lookup fan-out.
 SMOKE_TEST_CONVERSATION_TURNS = 3
 
 # Printed at the start of a smoke-test run and again beside the exported crate
@@ -640,14 +646,35 @@ class SmokeTestHumanInterface:
     is_interactive: bool = True
     synthesizes_answers: bool = True
 
-    def __init__(self, conversation_turns: int = SMOKE_TEST_CONVERSATION_TURNS) -> None:
+    def __init__(
+        self,
+        conversation_turns: int = SMOKE_TEST_CONVERSATION_TURNS,
+        minutes: float | None = None,
+    ) -> None:
         """Args:
         conversation_turns: How many turns to drive a conversational loop
             (the legacy ReAct arm) before ending the session. Ignored by the
-            default arm, which has no conversational channel. ``<= 0`` ends it
-            at the first prompt.
+            default arm, which has no conversational channel, and superseded
+            entirely when *minutes* is given. ``<= 0`` ends it at the first
+            prompt.
+        minutes: Optional wall-clock budget (``--smoke-test 20``). Once it is
+            spent, both arms wind down at their next question and export what
+            they have. Measured on :func:`time.monotonic` from construction —
+            not a wall date — so a clock adjustment mid-run cannot end a
+            session early or extend one forever.
         """
         self._conversation_budget = int(conversation_turns)
+        self._deadline: float | None = (
+            time.monotonic() + float(minutes) * 60.0 if minutes else None
+        )
+
+    def _time_is_up(self) -> bool:
+        """Whether a wall-clock budget was given and has been spent.
+
+        ``False`` when none was given: an unbudgeted run is bounded by the turn
+        count and by each loop's own guards, exactly as before.
+        """
+        return self._deadline is not None and time.monotonic() >= self._deadline
 
     def present(
         self,
@@ -711,6 +738,15 @@ class SmokeTestHumanInterface:
         re-verifies any pasted ORCID against a real lookup before use.
         """
         if field_type == CONVERSATION_FIELD_TYPE:
+            if self._time_is_up():
+                logger.info("smoke-test: time budget spent — ending the session")
+                return {"value": None, "skipped": True}
+            if self._deadline is not None:
+                # A clock was given, so it is the bound: the turn count would
+                # otherwise stop a `--smoke-test 20` run after three turns, which
+                # is the opposite of what asking for twenty minutes means.
+                logger.info("smoke-test: driving a conversational turn (on the clock)")
+                return {"value": SMOKE_TEST_ANSWER, "skipped": False}
             if self._conversation_budget <= 0:
                 logger.info("smoke-test: conversation budget spent — ending the session")
                 return {"value": None, "skipped": True}
@@ -753,16 +789,24 @@ class SmokeTestHumanInterface:
         return {"values": [], "skipped": True}
 
     def is_done(self) -> bool:
-        """Never end guidance early — the loop's own bounds stop the run.
+        """End guidance only when a wall-clock budget has been spent.
 
-        Ending at the first opportunity would exercise nothing: the tail would
-        return before asking anything, which is precisely the path this mode is
-        for. So the mode never volunteers "done" and leans on ``run_guidance``'s
-        existing termination guards — the report being exhausted, no gap making
-        progress, and the hard ``max_rounds`` bound — which already guarantee
-        termination without a cooperating frontend.
+        Without one this is always ``False``, and deliberately so: ending at the
+        first opportunity would exercise nothing — the tail would return before
+        asking anything, which is precisely the path this mode is for. An
+        unbudgeted run therefore leans on ``run_guidance``'s own termination
+        guards (the report exhausted, no gap making progress, the hard
+        ``max_rounds`` bound), which already guarantee termination without a
+        cooperating frontend.
+
+        A ``--smoke-test 20`` run is the exception, and it is the honest answer
+        to the question this method actually asks — "does the user want to stop
+        now?" — because the user said so up front, in minutes. ``run_guidance``
+        consults this at the TOP of every round, so the deadline lands between
+        gaps and the crate is exported with whatever was answered, never
+        mid-question with a half-applied edit.
         """
-        return False
+        return self._time_is_up()
 
 
 def answers_are_synthetic(human: HumanInterface | None) -> bool:

--- a/main.py
+++ b/main.py
@@ -144,6 +144,26 @@ def setup_logging(verbose: int = 0, interactive: bool = False) -> None:
             logger.debug("Could not install the notice handler", exc_info=True)
 
 
+def _smoke_test_minutes(raw: str) -> float:
+    """Parse ``--smoke-test MINUTES`` into a positive number of minutes.
+
+    Rejects zero and negatives rather than accepting them as "stop immediately".
+    Both would also make ``args.smoke_test`` FALSY, so the mode would silently
+    not engage at all — a `--smoke-test 0` that quietly runs an ordinary
+    interactive build, waiting for a person who is not there, is exactly the
+    silent misfire this flag exists to make impossible.
+    """
+    try:
+        minutes = float(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected a number of minutes, got {raw!r}") from None
+    if minutes <= 0:
+        raise argparse.ArgumentTypeError(
+            f"a smoke test needs a positive number of minutes, got {minutes:g}"
+        )
+    return minutes
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="ISA-Tox RO-Crate Builder")
@@ -192,12 +212,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--smoke-test",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=_smoke_test_minutes,
+        metavar="MINUTES",
         help="Drive the interactive build with NOBODY at the keyboard: every "
         'choice prompt confirms its pre-selected option and every open field is '
-        'answered "yes, continue". Implies --interactive; refuses --legacy-react. '
-        "For TESTING the HITL path end to end — the crate it produces holds "
-        "synthesised answers and is not curated metadata.",
+        'answered "yes, continue". Implies --interactive; works on both arms. '
+        "Takes an OPTIONAL wall-clock budget in minutes (--smoke-test 20): the "
+        "run winds down at its next question once the time is spent and exports "
+        "what it has. Without one it drives a few turns and stops. For TESTING "
+        "the HITL path end to end — the crate it produces holds synthesised "
+        "answers and is not curated metadata.",
     )
     parser.add_argument(
         "--prompt",
@@ -492,6 +519,15 @@ def main(argv: list[str] | None = None) -> int:
         # by accident, the very first thing on screen must be that nobody is
         # answering the prompts. It is repeated beside the exported crate path.
         print(SYNTHETIC_ANSWER_NOTICE)
+        if isinstance(args.smoke_test, float):
+            # Said in minutes because that is what was asked for, and said as
+            # "winds down at its next question" because that is what happens: the
+            # deadline is read between gaps / between turns, never mid-question,
+            # so a long turn overruns it rather than being cut in half.
+            print(
+                f"Running for about {args.smoke_test:g} minute(s), then winding "
+                "down at the next question and exporting."
+            )
 
     # --show-config: print and exit
     if args.show_config:
@@ -537,7 +573,11 @@ def main(argv: list[str] | None = None) -> int:
         # tests/test_smoke_test_mode.py.
         from builder.tools.hitl import SmokeTestHumanInterface
 
-        engine = AgentEngine(human_interface=SmokeTestHumanInterface())
+        # `--smoke-test` alone is True; `--smoke-test 20` is the float 20.0.
+        # `isinstance(True, float)` is False, so the bare flag never reads as a
+        # budget (unlike `isinstance(True, int)`, which would).
+        minutes = args.smoke_test if isinstance(args.smoke_test, float) else None
+        engine = AgentEngine(human_interface=SmokeTestHumanInterface(minutes=minutes))
     elif args.interactive:
         from builder.agents import ui
         from builder.tools.hitl import ConsoleHumanInterface

--- a/tests/test_smoke_test_mode.py
+++ b/tests/test_smoke_test_mode.py
@@ -424,6 +424,78 @@ class TestTheConversationTerminates:
             assert human.request_input("next?", CONVERSATION_FIELD_TYPE)["value"] == expected
 
 
+class TestTheWallClockBudget:
+    """``--smoke-test 20`` — run for a while, then wind down and export.
+
+    Time is exercised with real budgets rather than a patched clock: a budget of
+    an hour cannot expire inside a test, and one of 60 microseconds cannot fail to
+    have expired after a millisecond of sleep. Both directions are decided by
+    margins of several orders of magnitude, so neither depends on scheduling.
+    """
+
+    # Far enough away that nothing in this file can reach it.
+    LIVE = 60.0
+    # Already spent by the time the constructor returns.
+    SPENT = 1e-6
+
+    def _expired(self):
+        """An interface whose budget is definitively spent."""
+        import time
+
+        human = SmokeTestHumanInterface(minutes=self.SPENT)
+        time.sleep(0.001)
+        return human
+
+    def test_the_clock_supersedes_the_turn_cap(self):
+        """The whole point of asking for twenty minutes. A turn count of 3 would
+        otherwise stop the run in under a minute, which is the opposite of what
+        the flag was used for."""
+        from builder.tools.hitl import CONVERSATION_FIELD_TYPE, SMOKE_TEST_CONVERSATION_TURNS
+
+        human = SmokeTestHumanInterface(minutes=self.LIVE)
+        turns = SMOKE_TEST_CONVERSATION_TURNS + 5
+        answers = [human.request_input("next?", CONVERSATION_FIELD_TYPE) for _ in range(turns)]
+        assert all(a["value"] == SMOKE_TEST_ANSWER for a in answers)
+        assert not any(a["skipped"] for a in answers)
+
+    def test_a_spent_clock_ends_the_conversation(self):
+        from builder.tools.hitl import CONVERSATION_FIELD_TYPE
+
+        assert self._expired().request_input("next?", CONVERSATION_FIELD_TYPE) == {
+            "value": None,
+            "skipped": True,
+        }
+
+    def test_a_spent_clock_ends_guidance(self):
+        """run_guidance consults is_done() at the top of every round, so this is
+        what stops the DEFAULT arm — the conversational skip only reaches ReAct."""
+        assert self._expired().is_done() is True
+
+    def test_without_a_budget_guidance_is_never_cut_short(self):
+        """The control, and the pre-existing contract: an unbudgeted smoke test
+        must exercise the tail to exhaustion, not return before asking anything."""
+        assert SmokeTestHumanInterface().is_done() is False
+        assert SmokeTestHumanInterface(minutes=self.LIVE).is_done() is False
+
+    def test_a_question_in_flight_is_still_answered(self):
+        """"Winds down at the next question", not "stops mid-question". The loops
+        read the deadline BETWEEN gaps/turns; a field asked as it lapses is still
+        answered, so nothing lands half-applied."""
+        assert self._expired().request_input("describe the study") == {
+            "value": SMOKE_TEST_ANSWER,
+            "skipped": False,
+        }
+
+    def test_the_deadline_does_not_move_with_the_wall_date(self):
+        """Monotonic, not a wall date: a clock adjustment mid-run must not end a
+        session early or extend one forever."""
+        human = SmokeTestHumanInterface(minutes=self.LIVE)
+        assert human._deadline is not None
+        # A monotonic reading, which is an uptime-relative float — never a POSIX
+        # timestamp (~1.7e9 and climbing).
+        assert human._deadline < 1e9
+
+
 class TestTheLoopReadsTheInterfaceNotStdin:
     """The rewiring itself, driven against the REAL loop.
 
@@ -493,6 +565,54 @@ class TestCli:
     def test_flag_defaults_off(self):
         assert parse_args([]).smoke_test is False
         assert parse_args([]).interactive is False
+
+    def test_minutes_are_optional_and_the_bare_flag_is_not_a_budget(self):
+        """`--smoke-test` stays a boolean; `--smoke-test 20` is a number of
+        minutes. The distinction is `isinstance(x, float)`, which is False for
+        True — unlike `isinstance(x, int)`, which would read the bare flag as a
+        one-minute budget."""
+        assert parse_args(["--smoke-test"]).smoke_test is True
+        assert parse_args(["--smoke-test", "20"]).smoke_test == 20.0
+        assert isinstance(parse_args(["--smoke-test"]).smoke_test, float) is False
+        assert parse_args(["--smoke-test", "0.5"]).smoke_test == 0.5
+
+    def test_a_non_positive_budget_is_refused_not_silently_ignored(self):
+        """0 and -5 are FALSY, so accepting them would leave `args.smoke_test`
+        falsy and quietly run an ordinary interactive build — waiting forever on
+        a person who is not there. Exactly the silent misfire the flag exists to
+        prevent, so argparse rejects them."""
+        for bad in ("0", "-5", "abc"):
+            with pytest.raises(SystemExit):
+                parse_args(["--smoke-test", bad])
+
+    def test_the_budget_reaches_the_interface(self, monkeypatch, capsys, tmp_path):
+        """End to end: the number on the command line becomes the interface's
+        deadline, and the run says so before spending anything."""
+        self._stub_config(monkeypatch)
+        d = tmp_path / "data"
+        d.mkdir()
+        (d / "test.txt").write_text("hello\n")
+        seen: list[Any] = []
+
+        import builder.agents.build as build_mod
+
+        monkeypatch.setattr(
+            build_mod,
+            "run_interactive_build",
+            lambda engine, **kw: seen.append(engine.human_interface) or {"pipeline": {}},
+        )
+
+        assert main(["--smoke-test", "20", "--input", str(d)]) == 0
+        human = seen[0]
+        assert isinstance(human, SmokeTestHumanInterface)
+        assert human._deadline is not None, "the budget never reached the interface"
+        assert human.is_done() is False, "20 minutes must not be spent on arrival"
+        assert "20 minute" in capsys.readouterr().out
+
+    def test_a_bare_smoke_test_sets_no_deadline(self):
+        """The control for the test above — without a number nothing is on a
+        clock, so the turn cap stays the bound."""
+        assert SmokeTestHumanInterface()._deadline is None
 
     def test_flag_implies_interactive(self):
         """On its own it would have nothing to answer — a batch run never prompts."""


### PR DESCRIPTION
`--smoke-test 20` runs for about twenty minutes, then winds down at its next question and exports what it has.

A turn count is a poor stand-in for "run for a while". Turn cost varies by an order of magnitude between a one-tool answer and a full lookup fan-out, so three turns is anywhere from seconds to minutes — not something you can plan an eval around. Minutes are.

```
--smoke-test        # a few turns, then export  (unchanged)
--smoke-test 20     # ~20 minutes, then export
```

## Each arm winds down at its own boundary

- **ReAct** — the conversational read returns a skip, which the loop already treats as end-of-input and finalises on.
- **default arm** — `is_done()` becomes True. `run_guidance` consults it at the **top** of every round, so the deadline lands *between* gaps and the crate exports with whatever was answered, never mid-question with a half-applied edit.

That is why the notice says "winds down at the next question" rather than "stops after 20 minutes": a long turn overruns the deadline rather than being cut in half.

## Decisions worth flagging

- **`is_done()` returning True is a real change of contract for this class.** Until now it was hard-coded False, because ending at the first opportunity would exercise nothing. But the method asks *"does the user want to stop now?"*, and with a budget the user said so up front, in minutes. Without a budget it still always returns False.
- **A non-positive budget is refused, not accepted.** `0` and `-5` are falsy, so `if args.smoke_test:` would skip the mode entirely and quietly run an ordinary interactive build — waiting forever on a person who is not there. Precisely the silent misfire this flag exists to prevent.
- **The discriminator is `isinstance(x, float)`, deliberately not `int`.** `isinstance(True, int)` is True, which would read a bare `--smoke-test` as a one-minute budget.
- **A budget supersedes the turn cap** rather than combining with it — stopping a `--smoke-test 20` run after three turns is the opposite of what asking for twenty minutes means.
- **Monotonic, not a wall date**, so a clock adjustment mid-run cannot end a session early or extend one forever. Pinned by a test.

## Verification

Tests use real budgets (an hour, and 60 microseconds) rather than a patched clock — both directions are decided by several orders of magnitude, so neither depends on scheduling.

Mutation-checked, each failing exactly one test and no others:

| mutation | result |
|---|---|
| `is_done()` ignores the deadline | 1 failed, 42 passed |
| clock does not supersede the turn cap | 1 failed, 42 passed |
| minutes never reach the interface | 1 failed, 42 passed |
| *(restored)* | 43 passed |

`test_smoke_test_mode.py` + `test_main.py` + `test_build_mode.py` 91 passed. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)