### PR TITLE
feat(tools): resolve_cell_line — the Cellosaurus accession is minted, not discarded

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,6 +631,7 @@ scaffold_isa_backbone(investigation=None, study=None, assay=None, validate_base=
 materialize_aop_subgraph(aop_id: str, study_id: str | None = None) → dict  # composite: one AOP-Wiki id → AdverseOutcomePathway + KeyEvent[] + KeyEventRelationship[] subgraph, cross-linked deterministically; optionally wired onto a Study
 link_assay_to_key_event(assay_id: str, event_name: str) → {ok, assay_id, key_event_id, matched_name} | {ok: False, error, candidates}  # composite: link an Assay to the AOP Key Event it MEASURES (schema:mentions via keyEvent), matched by name against the KeyEvents already in state; commits the in-state AOP-Wiki id, never one built from the name, and writes NOTHING on a zero/ambiguous match because which Key Event an assay measures is a scientific claim (D5)
 resolve_compound(name: str, hints: dict | None = None, verify=None) → {entity_id, name, identifiers, verifications, verified, source}  # composite: chemical name → lookup_compound → draft_molecular_entity → verify_identifier (+ best-effort CompTox DTXSID), in one idempotent call; carries the looked-up CAS + PubChem CID + EPA DTXSID and never keeps an unverified id (D5)
+resolve_cell_line(name: str, hints: dict | None = None, catalog_name: str | None = None, verify=None) → {entity_id, name, accession, match, query, verifications, verified, source}  # composite: cell-line name → lookup_cell_line_by_name (full name, then catalog_name) → draft_cell_line_sample → lookup_cell_line (which IS the verification), in one idempotent call; a miss is NOT a failure (no `ok` key) — the Sample is always minted and the accession is enrichment
 resolve_publication(title: str, verify=None) → {ok, doi, entity_id, title, score} | {ok: False, reason, title}  # composite: publication title → Crossref title-search → confidence gate → draft_publication_with_authors(doi=…), in one idempotent call; commits a DOI only on a high-confidence match (score floor AND near-exact title) and never fabricates one (D5)
 draft_publication_with_authors(doi: str) → {publication_id, doi, authors:[{name, person_id, orcid, resolution}], hitl}  # composite (engine-routed, HITL-capable): publication + every author wired as a Person, each author's @id harmonized to their ORCID via a verify-first cascade
 draft_investigation(hints: dict) → Entity
@@ -704,6 +705,48 @@ names resolving to the same `pubchem_cid` can no longer mint the same `@id` (whi
 ro-crate-py silently overwrites — data loss). When the record carries no identity
 field, it falls back to name-keyed reuse so re-running the same name still reuses
 the entity rather than duplicating it.
+
+`resolve_cell_line` (Issue #372) is the cell-line counterpart of
+`resolve_compound`, and the deterministic arm's **only** name→Cellosaurus path.
+Before it, `_materialize_plan` minted every cell line through
+`draft_cell_line_sample(name=…, hints={})` — no lookup — so
+`lookup_cell_line_by_name` had no caller outside the ReAct arm (its
+`PIPELINE_UNREACHED` waiver named exactly this gap) and no default-arm crate ever
+carried an accession. Two steps, both Cellosaurus: (1)
+`lookup_cell_line_by_name` on the full normalized name and then on
+`catalog_name`, each gated by that lookup's **unmodified** exact+unique D5 rule —
+first unique-exact hit wins, and the tier is reported as `match`; (2)
+`lookup_cell_line` on the accession, which **is** the verification —
+`_select_verifier("CellLineSample", "accession")` already resolves to exactly
+that function, so a following `verify_identifier` would re-issue the same
+`lru_cache`d call, and the status is set directly (mirroring
+`_verify_compound_identifier`). A *transient* step-2 failure keeps the accession
+unverified; a *definitive* step-2 miss clears it.
+
+**A miss is NOT a failure** — the one deliberate divergence from
+`resolve_compound`, which returns `{ok: False}` and mints nothing. A
+`CellLineSample` with only a name is a valid ISA Sample and is what the arm
+produced before this composite, so returning `{ok: False}` would delete the cell
+line from every crate whose line is not catalogued, taking the
+`CellCulture.cell_line` input and the Study's `cell_lines` mention with it.
+**Always mint; the accession is enrichment** — hence no `ok` key: read
+`accession` / `match`. `name` stays the name **as the source documents word it**;
+the Cellosaurus label goes to `alternateName`. The plan's short `catalog_name`
+(a catalogue *name* is a name, so it is D5-clean and `_strip_plan_identifiers`
+leaves it) is what lets a descriptive phrase such as "FRTL-5 TPO-overexpressing
+rat thyroid follicular cells" reach CVCL_0265 at all; one shaped like an
+accession is **refused**, as is any identifier-bearing `hints` key, so every id
+it commits came back from Cellosaurus inside the call. Idempotency lives in the
+composite, not the drafter: reuse is tried by accession first — one line often
+appears under two names in one submission, and once the accession drives the
+`@id` (`_crate_mapping._mint_id`) two such entities would collide onto one node
+— then by the deterministic name-derived id. Only `accession` /
+`alternateName` / `url` / `sameAs` are persisted; `_CELL_LINE_DROPPED_FIELDS`
+records what else the record offers and the failure each would cause (the
+record's own `identifier` is a full URL that `verify_all_identifiers` would
+re-query percent-encoded, miss, and pop; `taxonomicRange`/`disease`/
+`anatomicalSite` are `DefinedTerm` node objects that `_scalar_props` emits
+un-flattened, failing base conformance).
 
 `resolve_publication` (Issue #179) is the citation counterpart of
 `resolve_compound`, closing the gap PR #217 deferred: a plan carries a

--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -254,6 +254,14 @@ _PLAN_SYSTEM_PROMPT = (
     "exactly as the source documents word it. Leave it empty unless the "
     "documents say which event is measured — never infer it from the assay's "
     "name and never assume an assay measures the initiating event. "
+    # #372: a descriptive phrase never clears the Cellosaurus exact-match gate,
+    # so without the short catalogue NAME the cell line resolves to nothing and
+    # the crate ships a Sample with no accession.
+    "For each cell line, also report its SHORT catalogue name in 'catalog_name' "
+    "when the documents give one — the name a cell collection or catalogue lists "
+    "it under, e.g. 'FRTL-5' for 'FRTL-5 TPO-overexpressing rat thyroid "
+    "follicular cells', or 'HepG2'. It is a NAME, never an accession or catalogue "
+    "number; leave it empty if the documents do not support one. "
     "Refer to compounds, cell lines, people and "
     "publications BY NAME ONLY, and key events by their NAME only. NEVER "
     "include identifiers of any kind: no CAS, "
@@ -317,7 +325,28 @@ def _plan_schema() -> dict[str, Any]:
                 required=["name"],
             ),
             "cell_lines": _array_of(
-                {"name": {**str_field, "description": "Cell-line name only (no accession)."}},
+                {
+                    "name": {
+                        **str_field,
+                        "description": (
+                            "Cell-line name as the documents word it, no accession."
+                        ),
+                    },
+                    # #372: the ONLY route from a descriptive phrase to a
+                    # Cellosaurus record. `resolve_cell_line`'s exact+unique D5
+                    # gate matches against primary identifiers and synonyms, so
+                    # "FRTL-5 TPO-overexpressing rat thyroid follicular cells"
+                    # misses while "FRTL-5" hits. A catalogue NAME is a name, not
+                    # an identifier — it is absent from _PLAN_IDENTIFIER_FIELDS on
+                    # purpose, and a hallucinated one simply fails the gate.
+                    "catalog_name": {
+                        **str_field,
+                        "description": (
+                            "Short catalogue/collection NAME for the same line, "
+                            "e.g. 'FRTL-5' or 'HepG2'. A name, never an accession."
+                        ),
+                    },
+                },
                 required=["name"],
             ),
             "protocols": _array_of(

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1545,9 +1545,10 @@ def _materialize_plan(
     * each ``compounds[]`` → :func:`resolve_compound` (mints the
       ``MolecularEntity`` and its **verified** identifiers; the plan supplies the
       NAME only — D5).
-    * each ``cell_lines[]`` → ``draft_cell_line_sample`` (a ``CellLineSample``
-      from the name only; the Cellosaurus accession is a later lookup, not the
-      plan).
+    * each ``cell_lines[]`` → :func:`resolve_cell_line` (mints the
+      ``CellLineSample`` and looks its Cellosaurus accession up from the plan's
+      NAME plus optional short ``catalog_name`` — D5). Unlike ``resolve_compound``
+      a miss still mints: a name-only cell line is a valid ISA Sample.
     * **entity→provenance wiring (#273).** Resolving a compound / cell line MINTS
       the entity but leaves it a graph ORPHAN unless something references it, so the
       collected ids are wired deterministically via ``set_fields`` (never
@@ -1752,22 +1753,34 @@ def _materialize_plan(
         if cid:
             compound_ids.append(str(cid))
 
-    # --- cell lines: a CellLineSample from the name only (accession is a lookup) ---
-    # Collect each minted CellLineSample id so the cell line can be wired into the
-    # CellCulture (and Study) below (#273) rather than left orphaned.
+    # --- cell lines: resolve_cell_line mints the CellLineSample + its accession ---
+    # This used to call `draft_cell_line_sample(name=name, hints={})` — no lookup at
+    # all — so `lookup_cell_line_by_name` had no caller on this arm and every
+    # default-arm cell line shipped without an accession (#372). Collect each id so
+    # the cell line can be wired into the CellCulture (and Study) below (#273)
+    # rather than left orphaned.
     cell_line_ids: list[str] = []
     for cell_line in plan.get("cell_lines") or []:
         name = str((cell_line or {}).get("name") or "").strip()
         if not name:
             continue
+        # The plan's short catalogue NAME (never an accession — the composite
+        # refuses a CVCL-shaped one). Without it a descriptive phrase like "FRTL-5
+        # TPO-overexpressing rat thyroid follicular cells" can never clear the
+        # exact-match gate, because Cellosaurus knows the line as "FRTL-5".
+        catalog_name = str((cell_line or {}).get("catalog_name") or "").strip()
         try:
-            cell = engine.run_tool("draft_cell_line_sample", name=name, hints={})
+            # D5: only NAMES are passed; the accession comes from the lookup.
+            resolved = engine.run_tool(
+                "resolve_cell_line", name=name, catalog_name=catalog_name or None
+            )
             result["cell_lines"] += 1
         except Exception as exc:  # noqa: BLE001
-            logger.warning("draft_cell_line_sample failed for %r: %s", name, exc)
+            logger.warning("resolve_cell_line failed for %r: %s", name, exc)
             continue
-        # draft_cell_line_sample returns the Entity it created/reused.
-        cid = getattr(cell, "entity_id", None)
+        # resolve_cell_line ALWAYS mints (a miss is not a failure — a name-only
+        # CellLineSample is a valid ISA Sample), so there is always an id to wire.
+        cid = resolved.get("entity_id") if isinstance(resolved, dict) else None
         if cid:
             cell_line_ids.append(str(cid))
 

--- a/builder/agents/react/system_prompt.py
+++ b/builder/agents/react/system_prompt.py
@@ -34,6 +34,7 @@ Entity drafting:
 - materialize_aop_subgraph: Turn one AOP-Wiki id into the full subgraph (AdverseOutcomePathway + KeyEvents + KeyEventRelationships, cross-linked) and optionally wire it onto a Study
 - link_assay_to_key_event: Link an Assay to the AOP Key Event it measures, by the event's name (refuses to guess when the name is ambiguous)
 - resolve_compound: Resolve a chemical name to a verified MolecularEntity in one call (lookup_compound -> draft_molecular_entity -> verify_identifier), carrying the looked-up CAS + PubChem CID; idempotent and never keeps an unverified identifier (D5)
+- resolve_cell_line: Resolve a cell-line name to a CellLineSample carrying its Cellosaurus accession in one call (lookup_cell_line_by_name -> draft_cell_line_sample -> lookup_cell_line, which IS the verification); pass the short catalogue name as catalog_name when the documents' name is a descriptive phrase; unlike resolve_compound a miss is NOT a failure — the Sample is always minted and the accession is enrichment; never pass an accession yourself (D5)
 - resolve_publication: Resolve a publication title to a DOI-backed ScholarlyArticle in one call (Crossref title-search -> confidence gate -> draft_publication_with_authors); commits a DOI ONLY on a high-confidence match (score floor AND near-exact title) and never fabricates one (D5); idempotent (keyed by the resolved DOI)
 - draft_investigation: Create an Investigation entity
 - draft_study: Create a Study entity

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -11,6 +11,30 @@ scalar and reference keys an entity accepts.
 
 from builder.tools._crate_mapping import draft_hints_schema
 
+
+def _cell_line_resolve_hints_schema() -> dict:
+    """``draft_hints_schema("CellLineSample")`` minus the keys the composite refuses.
+
+    The drafter's schema advertises ``accession`` — correct there, since
+    ``draft_cell_line_sample`` is the primitive an agent uses when it already
+    holds a looked-up id. It is exactly wrong for ``resolve_cell_line``, whose
+    whole point is that the accession comes back from Cellosaurus inside the
+    call: advertising a slot the composite silently drops invites the model to
+    fill it with the nearest CVCL id in its context (#383). Derived from
+    ``_CELL_LINE_REFUSED_HINTS`` rather than restated, so the advertised schema
+    and the enforced one cannot drift.
+    """
+    from builder.tools.composites import _CELL_LINE_REFUSED_HINTS
+
+    schema = draft_hints_schema("CellLineSample")
+    schema["properties"] = {
+        key: spec
+        for key, spec in schema.get("properties", {}).items()
+        if key not in _CELL_LINE_REFUSED_HINTS
+    }
+    return schema
+
+
 TOOL_SPECS = [
     {
         "name": "draft_investigation",
@@ -125,6 +149,29 @@ TOOL_SPECS = [
                 "verify": {
                     "type": "boolean",
                     "description": "Verify the minted identifiers against source (default true). Pass false only when you will verify later — never to attach an unverified id.",
+                },
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "resolve_cell_line",
+        "description": "Resolve a cell-line NAME to a CellLineSample carrying its Cellosaurus accession in ONE call (the cell-line counterpart of resolve_compound). Two steps, both against Cellosaurus: lookup_cell_line_by_name on the name (and then on catalog_name) commits an accession ONLY on its exact+unique D5 gate, and lookup_cell_line on that accession IS the verification (a definitive miss clears the accession; a transient outage keeps it unverified). Prefer this over lookup_cell_line_by_name + draft_cell_line_sample + verify_identifier. UNLIKE resolve_compound a miss is NOT a failure and there is no 'ok' key: a name-only CellLineSample is a valid ISA Sample, so the entity is ALWAYS minted and the accession is enrichment — read 'accession'/'match' to see whether one was found. 'name' is kept exactly as the source documents word it; the Cellosaurus label lands on alternateName. Idempotent (reused by accession, then by name). NEVER pass an accession — not as a hint and not as catalog_name (a CVCL_*-shaped catalog_name is refused); every id must come back from the lookup. Example: resolve_cell_line(name='FRTL-5 TPO-overexpressing rat thyroid follicular cells', catalog_name='FRTL-5').",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Cell-line name as the source documents word it, e.g. 'FRTL-5 TPO-overexpressing rat thyroid follicular cells'.",
+                },
+                "hints": _cell_line_resolve_hints_schema(),
+                "catalog_name": {
+                    "type": "string",
+                    "description": "Optional SHORT catalogue name for the same line, e.g. 'FRTL-5' or 'HepG2' — a name, never an accession. Tried after the full name so a descriptive phrase can still reach its record.",
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "Confirm the accession against its Cellosaurus record (default true). Passing false also skips the record fetch, so no enrichment lands — use only when you will verify later.",
                 },
             },
             "required": ["name"],

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -15,6 +15,7 @@ consistent with the "Toolbox, Not Graph" design (AGENTS.md §1).
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any
 
@@ -30,6 +31,7 @@ from builder.tools.drafters import (
     VALID_PROCESS_TYPES,
     _make_entity_id,
     draft_assay,
+    draft_cell_line_sample,
     draft_investigation,
     draft_molecular_entity,
     draft_organization,
@@ -40,6 +42,8 @@ from builder.tools.drafters import (
 )
 from builder.tools.hitl import HumanInterface
 from builder.tools.lookups import (
+    lookup_cell_line,
+    lookup_cell_line_by_name,
     lookup_compound,
     lookup_doi,
     lookup_dtxsid,
@@ -1488,11 +1492,14 @@ def _find_entity_by_identity(state: CrateState, key: tuple[str, str]) -> Entity 
 
 
 def _append_alternate_name(entity: Entity, name: str) -> None:
-    """Record ``name`` as a ``schema:alternateName`` on a reused MolecularEntity.
+    """Record ``name`` as a ``schema:alternateName`` on a reused entity.
 
     A no-op when ``name`` is empty, already the entity's primary ``name``, or
-    already present in ``alternateName`` (deduped). Keeps the field a list so a
-    molecule resolved under several synonyms accumulates them.
+    already present in ``alternateName`` (deduped). Keeps the field a list so an
+    entity resolved under several synonyms accumulates them — a molecule reused
+    across two chemical names (:func:`resolve_compound`) and a cell line reused
+    across two source spellings or its Cellosaurus label
+    (:func:`resolve_cell_line`) both rely on that.
     """
     candidate = " ".join(str(name).split())
     if not candidate or candidate == str(entity.fields.get("name") or ""):
@@ -1800,6 +1807,373 @@ def resolve_compound(
 
 
 # ---------------------------------------------------------------------------
+# resolve_cell_line (#372)
+# ---------------------------------------------------------------------------
+
+# A catalogue NAME is a name, not an identifier, which is what makes the plan's
+# `catalog_name` D5-clean. This refuses the one thing that is NOT a name: a
+# Cellosaurus accession smuggled through a field the plan's identifier strip
+# deliberately leaves alone. Case-insensitive and tolerant of the `CVCL-`
+# spelling, because a model routing an id around the strip would not be expected
+# to use the canonical form.
+_ACCESSION_SHAPED = re.compile(r"^CVCL[_-]?\w+$", re.IGNORECASE)
+
+# Hint keys refused outright before anything is written (D5). A caller — the
+# ReAct model, or a plan field that slipped the strip — must never be able to
+# hand this composite an accession: every id it commits has to come back from
+# Cellosaurus in THIS call. `rrid` and `identifier` are in here because
+# `_crate_mapping._mint_id` reads `accession`/`rrid` to build the cell line's
+# resolvable `@id`, so a hint on either would fabricate the node's identity, and
+# the profile model promotes the accession to `schema:identifier` itself.
+_CELL_LINE_REFUSED_HINTS: frozenset[str] = frozenset(
+    {"accession", "identifier", "rrid", "cellosaurus", "cellosaurus_accession", "@id", "id"}
+)
+
+# Fields copied from the `lookup_cell_line` record onto the CellLineSample.
+# Deliberately short — see `_CELL_LINE_DROPPED_FIELDS` for what the record also
+# offers and why each of those stays off the entity.
+_CELL_LINE_DATA_FIELDS: tuple[str, ...] = ("alternateName", "url", "sameAs")
+
+# Everything the Cellosaurus record carries that must NOT be persisted, each with
+# the failure it causes. Written out rather than left implicit because every one
+# of these looks harmless and two of them are silently destructive.
+_CELL_LINE_DROPPED_FIELDS: tuple[tuple[str, str], ...] = (
+    (
+        "identifier",
+        "lookup_cellosaurus sets `identifier` to the record's full URL, not the "
+        "bare accession. Persisting it would make verify_all_identifiers re-query "
+        "Cellosaurus with that URL percent-encoded into the cell-line path, miss, "
+        "and POP the field — D5 destroying a value the authority actually gave us. "
+        "The profile model derives schema:identifier from `accession` anyway.",
+    ),
+    (
+        "name",
+        "The entity's `name` is the name as the SOURCE DOCUMENTS word it. The "
+        "Cellosaurus label is a different string for the same line and belongs on "
+        "alternateName; clobbering `name` would rewrite the study's own wording.",
+    ),
+    (
+        "taxonomicRange",
+        "A DefinedTerm NODE object. _scalar_props emits it inline, producing an "
+        "un-flattened nested entity that fails base conformance. Promoting these "
+        "to real DefinedTerm entities is its own lane.",
+    ),
+    ("disease", "A list of DefinedTerm node objects — same un-flattening failure."),
+    ("anatomicalSite", "A DefinedTerm node object — same un-flattening failure."),
+    (
+        "donorSex",
+        "Not a term in the crate's JSON-LD context, so emitting it fails base "
+        "conformance ('not allowed in the compacted JSON-LD context'). It belongs "
+        "in a Sample characteristic, which needs the additionalProperty lane.",
+    ),
+    ("donorAge", "Not a context term — same base-conformance failure as donorSex."),
+    (
+        "category",
+        "Cellosaurus's own line-category vocabulary ('Cancer cell line', …), not a "
+        "schema.org value. Same characteristic lane as donorSex/donorAge.",
+    ),
+)
+
+
+def _cell_line_candidates(display_name: str, catalog_name: str | None) -> list[tuple[str, str]]:
+    """The ``(tier, query)`` name candidates to try against Cellosaurus, in order.
+
+    The full normalized display name first — it is what the documents call the
+    line, so a hit on it is the strongest claim available. Then ``catalog_name``,
+    the short catalogue name the extract plan may report ("FRTL-5" for "FRTL-5
+    TPO-overexpressing rat thyroid follicular cells"), which is the ONLY way a
+    descriptive phrase ever reaches its record: the D5 gate in
+    :func:`~builder.tools.lookups.lookup_cell_line_by_name` requires an exact
+    match against a primary identifier or synonym and is not relaxed here.
+
+    Two candidates are refused rather than queried: one shaped like an accession
+    (see :data:`_ACCESSION_SHAPED`), and one that merely re-spells the display
+    name, which would spend a second network round-trip to ask the same question.
+    """
+    candidates: list[tuple[str, str]] = []
+    if display_name.strip():
+        candidates.append(("exact", display_name))
+    catalog = " ".join(str(catalog_name or "").split())
+    if not catalog or _ACCESSION_SHAPED.match(catalog):
+        return candidates
+    if any(catalog.casefold() == query.casefold() for _tier, query in candidates):
+        return candidates
+    candidates.append(("catalog", catalog))
+    return candidates
+
+
+def _find_cell_line_by_accession(state: CrateState, accession: str) -> Entity | None:
+    """An existing ``CellLineSample`` already carrying ``accession``, or ``None``.
+
+    The cell-line counterpart of :func:`_find_entity_by_identity` (Issue #179).
+    One line routinely appears under two names in one submission — the shipped
+    S-VHPS22 fixture calls it "…rat thyroid follicular cells" in the README and
+    "…overexpressing cells" in both CSVs — and each name mints its own
+    ``cell_<name>`` id. Once the accession drives the ``@id``
+    (``_crate_mapping._mint_id``), two such entities collide onto ONE node at
+    build time and ro-crate-py silently keeps whichever was written last.
+    """
+    target = accession.strip()
+    for entity in state.list_entities("CellLineSample"):
+        existing = entity.fields.get("accession")
+        if existing not in (None, "") and str(existing).strip() == target:
+            return entity
+    return None
+
+
+def _search_cell_line_accession(
+    candidates: list[tuple[str, str]], budget: float
+) -> tuple[str, str, str]:
+    """Step 1: the first candidate name with a confident Cellosaurus accession.
+
+    Returns ``(accession, match_tier, query)`` — all empty strings when no
+    candidate resolved. Each candidate goes through the UNMODIFIED exact+unique
+    gate, so a "catalog"-tier hit is not a weaker claim about the record, only a
+    weaker claim that the record is the line the documents mean.
+
+    A transient outage or a timeout **stops the walk** rather than falling
+    through to the next candidate: the remaining candidates are weaker, and
+    committing one because the strongest could not be asked would turn an outage
+    into a quietly different answer.
+    """
+    for tier, query in candidates:
+
+        def _do_lookup(query: str = query) -> dict[str, Any]:
+            with resolve_concurrency.slot():
+                return lookup_cell_line_by_name(query)
+
+        try:
+            completed, hit = run_with_timeout(_do_lookup, budget)
+        except Exception:  # a lookup that raised — enrichment, never fatal
+            logger.exception("resolve_cell_line name search failed for %r", query)
+            break
+        if not completed:
+            logger.warning(
+                "resolve_cell_line name search for %r exceeded its %gs timeout; "
+                "continuing without an accession",
+                query,
+                budget,
+            )
+            break
+        if hit.get("found"):
+            accession = str((hit.get("data") or {}).get("accession") or "").strip()
+            if accession:
+                return accession, tier, query
+        elif hit.get("transient"):
+            break
+    return "", "", ""
+
+
+def resolve_cell_line(
+    state: CrateState,
+    name: str,
+    hints: dict[str, Any] | None = None,
+    catalog_name: str | None = None,
+    verify: bool | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    """Resolve a cell-line name to a ``CellLineSample`` + Cellosaurus accession.
+
+    The cell-line counterpart of :func:`resolve_compound`, and the deterministic
+    arm's ONLY name→Cellosaurus path: before this existed the arm minted every
+    cell line through ``draft_cell_line_sample`` with empty hints, so
+    ``lookup_cell_line_by_name`` had no caller outside the ReAct arm and no
+    default-arm crate ever carried an accession (#372, #386).
+
+    Two steps, both against Cellosaurus:
+
+    1. :func:`~builder.tools.lookups.lookup_cell_line_by_name` on each candidate
+       name in turn (see :func:`_cell_line_candidates`) → a bare ``CVCL_*``
+       accession, committed only on that lookup's exact+unique D5 gate.
+    2. :func:`~builder.tools.lookups.lookup_cell_line` on that accession → the
+       record. **Step 2 IS the verification.**
+       ``_select_verifier("CellLineSample", "accession")`` already resolves to
+       exactly this function, so following it with ``verify_identifier`` would
+       re-issue the same ``lru_cache``d call to reach the same verdict; the
+       status is set directly instead, mirroring
+       :func:`_verify_compound_identifier`. A *transient* step-2 failure keeps
+       the accession unverified; a *definitive* step-2 miss clears it, because a
+       search that produced an accession the record endpoint denies is not
+       evidence of anything.
+
+    **A miss is NOT a failure.** The one deliberate divergence from
+    :func:`resolve_compound`, which returns ``{"ok": False}`` and mints nothing.
+    A ``CellLineSample`` carrying only a name is a valid ISA Sample and is
+    exactly what the arm produced before this composite existed, so refusing to
+    mint would delete the cell line from every crate whose line is not
+    catalogued — taking the ``CellCulture.cell_line`` input and the Study's
+    ``cell_lines`` mention with it. **Always mint; the accession is enrichment.**
+    There is therefore no ``ok`` key: read ``accession``/``match`` instead.
+
+    Idempotency is handled HERE, not in the drafter (which stays the plain
+    ReAct-callable primitive): ``draft_cell_line_sample`` is not idempotent and
+    ``state.add_entity`` silently *replaces* under ``CellLineSample:<eid>``,
+    which would wipe the accession, its verified status and its provenance on a
+    re-resolve. Reuse is tried by accession first (:func:`_find_cell_line_by_accession`)
+    and then by the deterministic name-derived id.
+
+    Args:
+        state: The crate state to resolve into.
+        name: The cell-line name **as the source documents word it** — kept
+            verbatim as the entity's ``name``. The Cellosaurus label, when it
+            differs, is recorded as an ``alternateName``, never as the name.
+        hints: Optional extra descriptive field values (e.g. ``passage``).
+            Identifier-bearing keys are refused (:data:`_CELL_LINE_REFUSED_HINTS`)
+            — an accession may only come back from Cellosaurus in this call.
+        catalog_name: Optional short catalogue name for the same line, e.g.
+            ``"FRTL-5"`` for a descriptive phrase naming it. A catalogue *name*
+            is a name, so it is D5-clean; one shaped like an accession is refused.
+        verify: When ``None``/``True`` (the default), run step 2. Passing
+            ``False`` skips it — and with it the record, since step 2 is the only
+            fetch: the accession is then kept unverified and no enrichment
+            fields land. ``verified`` is reported as ``None``.
+        timeout: Per-request wall-clock budget (seconds). ``None`` uses
+            :data:`~builder.tools._resolve_cache.DEFAULT_RESOLVE_TIMEOUT`;
+            ``<= 0`` disables the bound. On expiry the cell line is still minted,
+            without an accession.
+
+    Returns:
+        ``{"entity_id", "name", "accession", "match": "exact"|"catalog"|"none",
+        "query", "verifications": [{field, verified, message}], "verified":
+        bool | None, "source"}``. ``match`` is the tier of the candidate that
+        hit and ``query`` the string that hit it, so a caller (interactive build)
+        can surface a ``catalog``-tier commit for confirmation — that prompt is
+        deliberately NOT here and NOT in ``run_pipeline``, whose contract is to
+        stay non-blocking so ``--arch pipeline`` and the corpus eval run headless.
+    """
+    budget = DEFAULT_RESOLVE_TIMEOUT if timeout is None else timeout
+
+    # Canonical display name: strip + collapse internal whitespace. Casing is
+    # preserved for display; `_make_entity_id` lowercases for the id. Keeps
+    # "Hep G2" and "Hep  G2" one entity, and is what gets searched.
+    display_name = " ".join(str(name).split()) or name
+
+    accession, match, query = _search_cell_line_accession(
+        _cell_line_candidates(display_name, catalog_name), budget
+    )
+
+    # --- step 2: the record IS the verification -----------------------------
+    record: dict[str, Any] = {}
+    verifications: list[dict[str, Any]] = []
+    do_verify = verify is None or verify
+    verified: bool | None = None
+    denied_accession = ""
+    if accession and do_verify:
+
+        def _do_record() -> dict[str, Any]:
+            with resolve_concurrency.slot():
+                return lookup_cell_line(accession)
+
+        # A raised lookup and an expired budget are both "could not ask", which
+        # is a transient verdict — the accession stays, unverified. Only a
+        # definitive answer from the endpoint may clear it.
+        confirmation: dict[str, Any] = {"found": False, "transient": True}
+        try:
+            completed, fetched = run_with_timeout(_do_record, budget)
+            if completed and isinstance(fetched, dict):
+                confirmation = fetched
+        except Exception:
+            logger.exception("resolve_cell_line record fetch failed for %r", accession)
+
+        if confirmation.get("found"):
+            record = confirmation.get("data") or {}
+            verified = True
+            message = f"Verified accession for CellLineSample via cellosaurus ({accession})"
+        elif confirmation.get("transient"):
+            verified = False
+            message = (
+                f"accession {accession} could not be confirmed right now — cellosaurus "
+                "is temporarily unavailable; value kept."
+            )
+        else:
+            # The name search handed us an accession the record endpoint denies.
+            # Nothing about that pair is trustworthy, so drop it rather than
+            # publish a CVCL id that does not dereference (D5).
+            message = (
+                f"accession {accession} did not resolve at cellosaurus; cleared "
+                "rather than published as an unresolvable id."
+            )
+            denied_accession = accession
+            accession, match, query = "", "none", ""
+            verified = False
+        verifications.append({"field": "accession", "verified": bool(verified), "message": message})
+
+    # --- fields -------------------------------------------------------------
+    merged_hints: dict[str, Any] = {
+        key: value for key, value in (hints or {}).items() if key not in _CELL_LINE_REFUSED_HINTS
+    }
+    # Tracked separately so the AUTHORITY's values can be recorded as such; the
+    # rest of `merged_hints` is the caller's and keeps that origin.
+    looked_up: dict[str, Any] = {}
+    for key in _CELL_LINE_DATA_FIELDS:
+        value = record.get(key)
+        if value not in (None, ""):
+            looked_up[key] = value
+    if accession:
+        looked_up["accession"] = accession
+    merged_hints.update(looked_up)
+
+    # --- mint or reuse ------------------------------------------------------
+    by_accession = _find_cell_line_by_accession(state, accession) if accession else None
+    if by_accession is not None:
+        entity = by_accession
+        # Keep the name the line was first minted under and record this call's
+        # name as an alias, so the second spelling in the submission is not lost.
+        refreshed = dict(merged_hints)
+        refreshed.pop("name", None)
+        entity.set_fields_from_dict(refreshed, source="lookup")
+        _append_alternate_name(entity, display_name)
+    else:
+        entity_id = _make_entity_id("cell", display_name, merged_hints)
+        existing = state.get_entity(entity_id)
+        if existing is not None and existing.type == "CellLineSample":
+            entity = existing
+            entity.set_fields_from_dict({**merged_hints, "name": display_name}, source="lookup")
+        else:
+            entity = draft_cell_line_sample(state, display_name, merged_hints)
+            # The drafter stamps every hint it is handed `source="llm"` — right
+            # for a drafted hint, wrong for the Cellosaurus record. Re-record
+            # that subset as looked-up so a D5 audit reading `_completion` does
+            # not see a fabricated accession on every cell line (#424).
+            if looked_up:
+                entity.set_fields_from_dict(looked_up, source="lookup")
+
+    # The Cellosaurus label is an alias for the same line, never the entity's
+    # name (which stays the documents' wording). Skipped when the record carried
+    # no name-list: `lookup_cellosaurus` then echoes the accession back as the
+    # name, and publishing "CVCL_0265" as an alternateName would read as a name
+    # the line is actually known by.
+    label = str(record.get("name") or "")
+    if label != accession:
+        _append_alternate_name(entity, label)
+
+    if accession:
+        if verified:
+            entity.set_field_status("accession", "verified", "lookup")
+        if "cellosaurus" not in entity._provenance.lookups_used:
+            entity._provenance.lookups_used.append("cellosaurus")
+    elif denied_accession and str(entity.fields.get("accession") or "") == denied_accession:
+        # A re-resolve whose step 2 came back definitively 404: an id the record
+        # endpoint denies must not survive on the entity just because an earlier
+        # call wrote it. Mirrors `verify_identifier`'s pop-on-definitive-miss —
+        # the return would otherwise report no accession while the crate still
+        # published one, and `_mint_id` would still key the node on it.
+        entity.fields.pop("accession", None)
+        entity.set_field_status("accession", "missing", "lookup")
+
+    return {
+        "entity_id": entity.entity_id,
+        "name": display_name,
+        "accession": accession,
+        "match": match or "none",
+        "query": query,
+        "verifications": verifications,
+        "verified": verified,
+        "source": "cellosaurus",
+    }
+
+
+# ---------------------------------------------------------------------------
 # Tool registration
 # ---------------------------------------------------------------------------
 from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
@@ -1807,6 +2181,7 @@ from builder.tools.registry import TOOL_REGISTRY  # noqa: E402
 TOOL_REGISTRY.register("scaffold_isa_backbone", scaffold_isa_backbone, takes_state=True)
 TOOL_REGISTRY.register("draft_process_chain", draft_process_chain, takes_state=True)
 TOOL_REGISTRY.register("resolve_compound", resolve_compound, takes_state=True)
+TOOL_REGISTRY.register("resolve_cell_line", resolve_cell_line, takes_state=True)
 TOOL_REGISTRY.register("resolve_publication", resolve_publication, takes_state=True)
 TOOL_REGISTRY.register("materialize_aop_subgraph", materialize_aop_subgraph, takes_state=True)
 TOOL_REGISTRY.register("link_assay_to_key_event", link_assay_to_key_event, takes_state=True)

--- a/builder/tools/reachability.py
+++ b/builder/tools/reachability.py
@@ -93,11 +93,6 @@ class ToolReachabilityError(RuntimeError):
 # fails on a waiver naming a now-reachable tool, so wiring one forces its row out.
 PIPELINE_UNREACHED: Mapping[str, str] = {
     # --- should be wired; each names the lane that owns it -------------------
-    "lookup_cell_line_by_name": (
-        "Owned by #372 — the only name->Cellosaurus resolver, while the arm "
-        "materialises cell lines through draft_cell_line_sample, which does no "
-        "lookup; default-arm CellLineSamples therefore carry no accession."
-    ),
     "lookup_ror": (
         "No caller. composites._find_or_draft_organization sets `ror` only when "
         "a caller supplies one, and nothing on the arm does, so default-arm "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,47 @@ def _stub_composites_dtxsid(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_composites_cellosaurus(monkeypatch):
+    """Keep ``resolve_cell_line``'s Cellosaurus calls offline (#372).
+
+    Wiring ``resolve_cell_line`` into ``_materialize_plan`` gave three modules a
+    live network path they never had: ``test_agents_pipeline``,
+    ``test_pipeline_e2e`` and ``test_pipeline_real_input`` all drive the real
+    pipeline over a plan carrying a cell line, and nothing stubbed Cellosaurus.
+    Default both primitives to a MISS so a forgotten stub surfaces as "no
+    accession" rather than as a request to api.cellosaurus.org.
+
+    **Scoped to the symbols bound in the ``composites`` namespace**, exactly like
+    ``_stub_composites_dtxsid`` above — NOT to ``builder.tools.lookups``, which
+    the issue's plan proposed. Patching there is measurably wrong: nine tests in
+    ``test_lookups_cellosaurus_recall`` drive the REAL
+    ``builder.tools.lookups.lookup_cell_line_by_name`` with its HTTP replayed by
+    ``responses``, and stubbing the search it calls short-circuits the very
+    recall/D5-gate behaviour they pin. "Do not reach the network" and "do not
+    resolve" are different claims, and only the first one is this fixture's job.
+
+    Tests that need a hit re-patch these two names (a later ``monkeypatch.setattr``
+    wins); ``tests/test_composites_resolve_cell_line.py`` instead restores the real
+    primitives and stubs one layer down, so the D5 gate stays under test.
+    ``raising=False`` tolerates any import order.
+    """
+    from builder.tools import composites
+
+    monkeypatch.setattr(
+        composites,
+        "lookup_cell_line_by_name",
+        lambda name: {"found": False, "data": {}, "error": "offline stub (conftest)"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        composites,
+        "lookup_cell_line",
+        lambda accession: {"found": False, "data": {}, "error": "offline stub (conftest)"},
+        raising=False,
+    )
+
+
 @pytest.fixture
 def minimal_state() -> CrateState:
     """Return a CrateState with one Investigation entity."""

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -869,9 +869,39 @@ class TestMaterializePlan:
         def fake_search_works_by_title(title):
             return []
 
+        # resolve_cell_line -> the two Cellosaurus primitives (#372). The suite-wide
+        # conftest stub defaults both to a MISS so no test reaches the network; here
+        # they answer for the plan's FRTL-5 so the accession assertions have a value
+        # to check. Step 2 (the record) IS the verification, hence no verify stub.
+        def fake_lookup_cell_line_by_name(name):
+            if str(name).strip().casefold() == "frtl-5":
+                return {
+                    "found": True,
+                    "data": {"accession": "CVCL_0265", "name": "FRTL-5", "synonyms": ["FRTL5"]},
+                    "error": None,
+                }
+            return {"found": False, "data": {}, "error": "no confident match"}
+
+        def fake_lookup_cell_line(accession):
+            if accession == "CVCL_0265":
+                return {
+                    "found": True,
+                    "data": {
+                        "name": "FRTL-5",
+                        "url": "https://www.cellosaurus.org/CVCL_0265",
+                        "alternateName": ["FRTL 5", "FRTL5"],
+                    },
+                    "error": None,
+                }
+            return {"found": False, "data": {}, "error": "not found"}
+
         monkeypatch.setattr(composites_mod, "lookup_compound", fake_lookup_compound)
         monkeypatch.setattr(composites_mod, "verify_identifier", fake_verify_identifier)
         monkeypatch.setattr(composites_mod, "search_works_by_title", fake_search_works_by_title)
+        monkeypatch.setattr(
+            composites_mod, "lookup_cell_line_by_name", fake_lookup_cell_line_by_name
+        )
+        monkeypatch.setattr(composites_mod, "lookup_cell_line", fake_lookup_cell_line)
         monkeypatch.setattr(tool_lookups, "lookup_aop", fake_lookup_aop)
 
     def _by_type(self, engine: AgentEngine, type_name: str) -> list[Entity]:
@@ -896,9 +926,14 @@ class TestMaterializePlan:
         chems = self._by_type(engine, "MolecularEntity")
         assert {c.fields.get("name") for c in chems} == {"Methimazole", "Sodium iodide"}
 
-        # Cell line → CellLineSample.
+        # Cell line → CellLineSample, carrying the LOOKED-UP accession (#372).
+        # Asserting the name alone passed for as long as the arm called
+        # `draft_cell_line_sample(name=…, hints={})` and never looked anything up,
+        # which is exactly the defect: the accession is the assertion with teeth.
         cells = self._by_type(engine, "CellLineSample")
         assert [c.fields.get("name") for c in cells] == ["FRTL-5"]
+        assert cells[0].fields.get("accession") == "CVCL_0265"
+        assert cells[0]._completion["CellLineSample:accession"].status == "verified"
 
         # Process chain → 4 LabProcess steps wired to the assay.
         procs = self._by_type(engine, "LabProcess")
@@ -1841,6 +1876,190 @@ class TestMaterializeCompoundsFromFilenames:
         # The CAS on each entity is the name's LOOKED-UP value, not a fabrication.
         for name, expected in self._LOOKUP_BY_NAME.items():
             assert chems[name].fields.get("cas") == expected["cas"]
+
+
+class TestMaterializeCellLineAccessionFromThePlan:
+    """#372 — the DEFAULT pipeline path must turn a plan cell line into a
+    ``CellLineSample`` carrying its LOOKED-UP Cellosaurus accession.
+
+    Before ``resolve_cell_line``, ``_materialize_plan`` called
+    ``draft_cell_line_sample(name=name, hints={})`` — empty hints, no lookup —
+    so ``lookup_cell_line_by_name`` had zero callers under
+    ``builder/agents/pipeline/`` and every default-arm cell line shipped without
+    an accession.
+
+    Drives the REAL ``extract_plan`` leaf (only its chat model faked) so the
+    whole documents → plan → ``resolve_cell_line`` → CellLineSample chain runs
+    offline, including the ``catalog_name`` slot the leaf now offers: the
+    documents' descriptive phrase cannot clear Cellosaurus's exact-match gate,
+    and the short catalogue name is the only thing that can.
+    """
+
+    _DESCRIPTIVE = "FRTL-5 TPO-overexpressing rat thyroid follicular cells"
+    _CATALOG = "FRTL-5"
+
+    def _enable_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        monkeypatch.setattr(pipeline_mod, "get_provider", lambda: "openai")
+
+    def _titled_state(self) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "FRTL-5 thyroid TPO inhibition screen"
+        state.metadata.description = (
+            "Rat thyroid follicular FRTL-5 cells overexpressing TPO, dosed in vitro."
+        )
+        return state
+
+    def _fake_leaf_chat_model(self, monkeypatch: pytest.MonkeyPatch, plan_item: dict) -> list[str]:
+        """Fake the REAL leaf's chat model, recording the prompt it was shown.
+
+        The genuine ``extract_plan`` code path runs — its schema is built, its
+        system prompt assembled and fed the gathered context — and the model
+        deterministically answers with the cell line a correctly-steered model
+        would propose. Names only (D5).
+        """
+        import builder.agents.pipeline.leaves as leaves_mod
+
+        seen_prompts: list[str] = []
+
+        class _Runnable:
+            def invoke(self, messages, *a, **k):
+                for msg in messages:
+                    content = getattr(msg, "content", "")
+                    if isinstance(content, str):
+                        seen_prompts.append(content)
+                return {"cell_lines": [dict(plan_item)]}
+
+        class _Model:
+            def with_structured_output(self, schema, *, include_raw=False, **k):
+                return _Runnable()
+
+        monkeypatch.setattr(leaves_mod, "_build_chat_model", lambda *a, **k: _Model())
+        return seen_prompts
+
+    def _stub_cellosaurus(
+        self, monkeypatch: pytest.MonkeyPatch, *, known: bool = True
+    ) -> list[str]:
+        """Stub the two Cellosaurus primitives, recording every name queried.
+
+        The exact+unique gate is modelled honestly: ONLY "FRTL-5" resolves, so a
+        descriptive phrase misses exactly as it does live.
+        """
+        import builder.tools.composites as composites_mod
+
+        queried: list[str] = []
+        catalog = self._CATALOG
+
+        def fake_lookup_cell_line_by_name(name):
+            queried.append(str(name))
+            if known and str(name).strip().casefold() == catalog.casefold():
+                return {
+                    "found": True,
+                    "data": {"accession": "CVCL_0265", "name": catalog, "synonyms": ["FRTL5"]},
+                    "error": None,
+                }
+            return {"found": False, "data": {}, "error": "no confident match"}
+
+        def fake_lookup_cell_line(accession):
+            if accession == "CVCL_0265":
+                return {
+                    "found": True,
+                    "data": {"name": catalog, "url": f"https://www.cellosaurus.org/{accession}"},
+                    "error": None,
+                }
+            return {"found": False, "data": {}, "error": "not found"}
+
+        monkeypatch.setattr(
+            composites_mod, "lookup_cell_line_by_name", fake_lookup_cell_line_by_name
+        )
+        monkeypatch.setattr(composites_mod, "lookup_cell_line", fake_lookup_cell_line)
+        return queried
+
+    def _by_type(self, engine: AgentEngine, type_name: str) -> list[Entity]:
+        return [e for e in engine.state.list_entities() if e.type == type_name]
+
+    def test_cell_line_accession_comes_from_the_lookup_not_the_plan(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """D5: only NAMES reach the composite; the accession is the looked-up value."""
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        seen_prompts = self._fake_leaf_chat_model(
+            monkeypatch, {"name": self._DESCRIPTIVE, "catalog_name": self._CATALOG}
+        )
+        queried = self._stub_cellosaurus(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        assert self._by_type(engine, "CellLineSample") == []
+
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        # The real leaf's prompt asks for the short catalogue name.
+        assert "catalog_name" in "\n".join(seen_prompts)
+
+        cells = self._by_type(engine, "CellLineSample")
+        assert len(cells) == 1
+        cell = cells[0]
+        # The name stays the documents' wording; the accession came from the lookup.
+        assert cell.fields["name"] == self._DESCRIPTIVE
+        assert cell.fields["accession"] == "CVCL_0265"
+        assert cell._completion["CellLineSample:accession"].status == "verified"
+        # And the descriptive phrase really was tried first and really did miss —
+        # so the catalogue name is doing the work, not a relaxed gate.
+        assert queried == [self._DESCRIPTIVE, self._CATALOG]
+
+    def test_no_accession_when_cellosaurus_has_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Honesty control: an uncatalogued line still mints, with NO accession.
+
+        This is the divergence from ``resolve_compound`` that keeps the crate
+        whole — the Sample survives so ``CellCulture.cell_line`` and the Study's
+        ``cell_lines`` mention still have something to point at — and it is also
+        the proof that the accession above was not manufactured by the wiring.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._fake_leaf_chat_model(monkeypatch, {"name": "Nonesuch primary cells"})
+        self._stub_cellosaurus(monkeypatch, known=False)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        cells = self._by_type(engine, "CellLineSample")
+        assert len(cells) == 1
+        assert cells[0].fields["name"] == "Nonesuch primary cells"
+        assert "accession" not in cells[0].fields
+
+    def test_an_accession_shaped_catalog_name_is_never_committed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`catalog_name` survives ``_strip_plan_identifiers`` — so it is guarded here.
+
+        A CVCL-shaped value in that NAME slot is refused before it is ever
+        queried, which is what stops the one D5 hole the new plan field opens.
+        """
+        import builder.agents.pipeline.pipeline as pipeline_mod
+
+        self._enable_provider(monkeypatch)
+        self._fake_leaf_chat_model(
+            monkeypatch, {"name": self._DESCRIPTIVE, "catalog_name": "CVCL_0265"}
+        )
+        queried = self._stub_cellosaurus(monkeypatch)
+
+        engine = _engine(self._titled_state())
+        pipeline_mod._scaffold_backbone(engine)
+        pipeline_mod._materialize_plan(engine)
+
+        cells = self._by_type(engine, "CellLineSample")
+        assert len(cells) == 1
+        assert "accession" not in cells[0].fields
+        assert queried == [self._DESCRIPTIVE]
 
 
 class TestPublicationFromPDF:

--- a/tests/test_composites_resolve_cell_line.py
+++ b/tests/test_composites_resolve_cell_line.py
@@ -1,0 +1,475 @@
+"""``resolve_cell_line`` — the deterministic arm's name→Cellosaurus path (#372).
+
+Every test drives the **real** composite over the **real** lookup stack
+(``lookup_cell_line_by_name`` → ``search_cellosaurus`` → ``_candidate`` →
+``cell_line_names_match``, and ``lookup_cell_line`` → ``lookup_cellosaurus``),
+with only the HTTP layer replayed by ``responses`` from fixtures recorded
+verbatim from ``api.cellosaurus.org``. Nothing here stubs the D5 exact+unique
+gate, which is the point: the composite's job is to choose *which name to ask
+about*, never to relax *what counts as an answer*.
+
+Two payload provenances, both honest about what they are:
+
+* the search bodies and the ``CVCL_0027`` record body are recorded fixtures,
+  already committed for #385 and the lookup contract tests;
+* the ``CVCL_0265`` record body is assembled **here** from the name-list recorded
+  in ``cellosaurus_search_id_frtl5.json``. That is real recorded data re-served
+  on the record endpoint; it pins the composite's *use* of the record, not the
+  endpoint's shape (``tests/test_lookups_contract.py`` owns that).
+
+The suite-wide ``_stub_composites_cellosaurus`` fixture defaults both primitives
+in the ``composites`` namespace to a miss; this module puts the real ones back,
+because a stub at that seam would leave the gate untested.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import responses
+from requests.exceptions import Timeout
+from responses import matchers
+
+import builder.tools.composites as composites
+from builder.state import CrateState
+from builder.tools.composites import resolve_cell_line
+from builder.tools.lookups import lookup_cell_line, lookup_cell_line_by_name
+from lookups._http import reset_circuit_breaker, reset_host_throttle
+from lookups.cellosaurus import lookup_cellosaurus, search_cellosaurus
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SEARCH_URL = "https://api.cellosaurus.org/search/cell-line"
+RECORD_URL = "https://api.cellosaurus.org/cell-line"
+EMPTY_SEARCH: dict[str, Any] = {"Cellosaurus": {"cell-line-list": []}}
+
+# The name as the S-VHPS22 documents word it, and the short catalogue name that
+# is the only thing Cellosaurus will match on.
+FRTL5_DESCRIPTIVE = "FRTL-5 TPO-overexpressing rat thyroid follicular cells"
+FRTL5_CATALOG = "FRTL-5"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _recorded_name_list(fixture: str, accession: str) -> list[dict]:
+    """The name-list recorded for *accession* in a committed search fixture."""
+    for entry in _load(fixture)["Cellosaurus"]["cell-line-list"]:
+        values = [a.get("value") for a in entry.get("accession-list", [])]
+        if accession in values:
+            return entry["name-list"]
+    raise AssertionError(f"{accession} is not in {fixture} — fixture drifted")
+
+
+def _record_body(name_list: list[dict]) -> dict:
+    """A record-endpoint envelope around a recorded name-list."""
+    return {"Cellosaurus": {"cell-line-list": [{"name-list": name_list}]}}
+
+
+def _route_search(query: str, **kwargs) -> None:
+    """Register a search response for exactly one Solr ``q`` value."""
+    responses.add(
+        responses.GET,
+        SEARCH_URL,
+        match=[matchers.query_param_matcher({"q": query}, strict_match=False)],
+        **kwargs,
+    )
+
+
+def _route_record(accession: str, **kwargs) -> None:
+    responses.add(responses.GET, f"{RECORD_URL}/{accession}?format=json", **kwargs)
+
+
+def _route_frtl5_search() -> None:
+    """The two-field union for both FRTL-5 spellings.
+
+    The descriptive phrase is routed to an EMPTY body, which is what the live API
+    returns for it — that miss is the whole reason ``catalog_name`` exists.
+    """
+    for field in ("id", "sy"):
+        _route_search(f'{field}:"{FRTL5_DESCRIPTIVE}"', json=EMPTY_SEARCH)
+    _route_search(f'id:"{FRTL5_CATALOG}"', json=_load("cellosaurus_search_id_frtl5.json"))
+    _route_search(f'sy:"{FRTL5_CATALOG}"', json=_load("cellosaurus_search_sy_frtl5.json"))
+
+
+def _route_frtl5_record(**kwargs) -> None:
+    if not kwargs:
+        kwargs = {
+            "json": _record_body(
+                _recorded_name_list("cellosaurus_search_id_frtl5.json", "CVCL_0265")
+            ),
+            "status": 200,
+        }
+    _route_record("CVCL_0265", **kwargs)
+
+
+def _route_hepg2(*, name: str = "HepG2") -> None:
+    """The recorded HepG2 union plus the recorded CVCL_0027 record body."""
+    _route_search(f'id:"{name}"', json=_load("cellosaurus_search_id_hepg2.json"))
+    _route_search(f'sy:"{name}"', json=_load("cellosaurus_search_sy_hepg2.json"))
+    _route_record("CVCL_0027", json=_load("cellosaurus_hepg2.json"), status=200)
+
+
+@pytest.fixture(autouse=True)
+def _real_cellosaurus_primitives(monkeypatch):
+    """Undo the suite-wide offline stub — this module tests the real stack.
+
+    ``tests/conftest.py`` defaults ``composites.lookup_cell_line_by_name`` /
+    ``composites.lookup_cell_line`` to a miss so no other module can reach the
+    network through the newly-wired composite. Here the network is already
+    intercepted by ``responses``, and stubbing the primitives would mean the D5
+    gate, the id∪sy union and the record parse are never exercised at all.
+    """
+    monkeypatch.setattr(composites, "lookup_cell_line_by_name", lookup_cell_line_by_name)
+    monkeypatch.setattr(composites, "lookup_cell_line", lookup_cell_line)
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Four ``lru_cache``s sit between the composite and the socket."""
+    for fn in (search_cellosaurus, lookup_cellosaurus, lookup_cell_line_by_name, lookup_cell_line):
+        fn.cache_clear()
+    reset_host_throttle()
+    reset_circuit_breaker()
+    yield
+    for fn in (search_cellosaurus, lookup_cellosaurus, lookup_cell_line_by_name, lookup_cell_line):
+        fn.cache_clear()
+    reset_circuit_breaker()
+
+
+def _cell_lines(state: CrateState) -> list:
+    return list(state.list_entities("CellLineSample"))
+
+
+def _entity(state: CrateState, entity_id: str):
+    """The entity a resolve returned, asserted present (the composite always mints)."""
+    entity = state.get_entity(entity_id)
+    assert entity is not None, f"resolve_cell_line reported {entity_id} but minted nothing"
+    return entity
+
+
+class TestResolveCellLine:
+    """The composite's contract: always mint, never fabricate."""
+
+    @responses.activate
+    def test_exact_name_resolves_to_the_looked_up_accession(self):
+        """A name Cellosaurus knows verbatim resolves and verifies in one call."""
+        _route_frtl5_search()
+        _route_frtl5_record()
+        state = CrateState()
+
+        result = resolve_cell_line(state, FRTL5_CATALOG)
+
+        assert result["accession"] == "CVCL_0265"
+        assert result["match"] == "exact"
+        assert result["query"] == FRTL5_CATALOG
+        assert result["verified"] is True
+        assert result["source"] == "cellosaurus"
+
+        entity = _entity(state, result["entity_id"])
+        assert entity.fields["accession"] == "CVCL_0265"
+        assert entity._completion["CellLineSample:accession"].status == "verified"
+        assert "cellosaurus" in entity._provenance.lookups_used
+
+    @responses.activate
+    def test_a_hint_accession_is_never_committed(self):
+        """Honesty control: a caller-supplied accession is refused outright (D5).
+
+        The ReAct arm's ``hints`` are model-authored, and a model that cannot
+        resolve a name has every incentive to reach for the nearest CVCL id in
+        its context (#383). The value committed must be the one the lookup
+        returned — and when the lookup returns nothing, the field must be absent
+        rather than falling back to the hint.
+        """
+        _route_frtl5_search()
+        _route_frtl5_record()
+        state = CrateState()
+
+        hit = resolve_cell_line(state, FRTL5_CATALOG, hints={"accession": "CVCL_9999"})
+
+        assert hit["accession"] == "CVCL_0265"
+        assert _entity(state, hit["entity_id"]).fields["accession"] == "CVCL_0265"
+
+        miss_state = CrateState()
+        for field in ("id", "sy"):
+            _route_search(f'{field}:"Unlisted line"', json=EMPTY_SEARCH)
+
+        miss = resolve_cell_line(miss_state, "Unlisted line", hints={"accession": "CVCL_9999"})
+
+        assert miss["accession"] == ""
+        assert "accession" not in _entity(miss_state, miss["entity_id"]).fields
+
+    @responses.activate
+    def test_catalog_name_resolves_when_the_descriptive_name_misses(self):
+        """The marquee case: a descriptive phrase reaches its record via the catalogue name.
+
+        The documents call the line "FRTL-5 TPO-overexpressing rat thyroid
+        follicular cells"; Cellosaurus knows it as "FRTL-5". The exact-match gate
+        is untouched — the phrase genuinely returns nothing — so the second
+        candidate is what closes the gap, and the entity's ``name`` stays the
+        documents' wording.
+        """
+        _route_frtl5_search()
+        _route_frtl5_record()
+        state = CrateState()
+
+        result = resolve_cell_line(state, FRTL5_DESCRIPTIVE, catalog_name=FRTL5_CATALOG)
+
+        assert result["accession"] == "CVCL_0265"
+        assert result["match"] == "catalog"
+        assert result["query"] == FRTL5_CATALOG
+
+        entity = _entity(state, result["entity_id"])
+        assert entity.fields["name"] == FRTL5_DESCRIPTIVE
+        # The Cellosaurus label is an alias, never the name.
+        assert "FRTL-5" in (entity.fields.get("alternateName") or [])
+
+    @responses.activate
+    def test_an_accession_shaped_catalog_name_is_refused(self):
+        """``catalog_name`` is a NAME slot; an accession may not ride in on it.
+
+        ``catalog_name`` is deliberately absent from ``_PLAN_IDENTIFIER_FIELDS``
+        so ``_strip_plan_identifiers`` leaves it — which is exactly what makes
+        this guard load-bearing rather than belt-and-braces.
+        """
+        for field in ("id", "sy"):
+            _route_search(f'{field}:"{FRTL5_DESCRIPTIVE}"', json=EMPTY_SEARCH)
+        state = CrateState()
+
+        for smuggled in ("CVCL_0265", "cvcl_0265", "CVCL-0265"):
+            result = resolve_cell_line(state, FRTL5_DESCRIPTIVE, catalog_name=smuggled)
+            assert result["accession"] == ""
+            assert result["match"] == "none"
+
+        # It was never even asked about: only the descriptive phrase was queried.
+        queried = " ".join(str(call.request.url or "") for call in responses.calls)
+        assert "0265" not in queried
+
+    @responses.activate
+    def test_a_miss_still_mints_the_cell_line_sample(self):
+        """The deliberate divergence from ``resolve_compound``.
+
+        A ``CellLineSample`` with only a name is a valid ISA Sample and is what
+        the arm produced before this composite. Returning ``{ok: False}`` would
+        delete the cell line from every crate whose line is not catalogued,
+        taking ``CellCulture.cell_line`` and the Study's ``cell_lines`` mention
+        with it — so the entity is always minted and there is no ``ok`` key.
+        """
+        for field in ("id", "sy"):
+            _route_search(f'{field}:"Nonesuch primary cells"', json=EMPTY_SEARCH)
+        state = CrateState()
+
+        result = resolve_cell_line(state, "Nonesuch primary cells")
+
+        assert "ok" not in result
+        assert result["accession"] == ""
+        assert result["match"] == "none"
+        entity = _entity(state, result["entity_id"])
+        assert entity.type == "CellLineSample"
+        assert entity.fields["name"] == "Nonesuch primary cells"
+
+    @responses.activate
+    def test_transient_outage_keeps_a_name_only_sample(self):
+        """An outage is not a miss, and not a failure either: mint, no accession."""
+        for field in ("id", "sy"):
+            _route_search(f'{field}:"{FRTL5_CATALOG}"', body=Timeout("timed out"))
+        state = CrateState()
+
+        result = resolve_cell_line(state, FRTL5_CATALOG)
+
+        assert result["accession"] == ""
+        assert result["verified"] is None
+        assert result["verifications"] == []
+        assert _cell_lines(state)[0].fields["name"] == FRTL5_CATALOG
+
+    @responses.activate
+    def test_a_transient_on_the_first_candidate_does_not_fall_through(self):
+        """An outage on the strongest candidate must not promote a weaker one.
+
+        Falling through would turn "Cellosaurus was down" into "the catalogue
+        name answered", which is a different — and quietly less supported —
+        claim about which record the documents mean.
+        """
+        for field in ("id", "sy"):
+            _route_search(f'{field}:"{FRTL5_DESCRIPTIVE}"', body=Timeout("timed out"))
+        _route_frtl5_search()
+        _route_frtl5_record()
+        state = CrateState()
+
+        result = resolve_cell_line(state, FRTL5_DESCRIPTIVE, catalog_name=FRTL5_CATALOG)
+
+        assert result["accession"] == ""
+        assert result["match"] == "none"
+
+    @responses.activate
+    def test_step_two_transient_failure_keeps_the_accession_unverified(self):
+        """The record endpoint being down says nothing about the accession."""
+        _route_frtl5_search()
+        _route_frtl5_record(body=Timeout("timed out"))
+        state = CrateState()
+
+        result = resolve_cell_line(state, FRTL5_CATALOG)
+
+        assert result["accession"] == "CVCL_0265"
+        assert result["verified"] is False
+        entity = _entity(state, result["entity_id"])
+        assert entity.fields["accession"] == "CVCL_0265"
+        assert entity._completion["CellLineSample:accession"].status == "filled"
+
+    @responses.activate
+    def test_step_two_definitive_miss_clears_the_accession(self):
+        """A search hit the record endpoint denies is evidence of nothing (D5).
+
+        404 is the *definitive* answer, as opposed to the timeout above: the
+        accession does not name a record, so publishing it would put a CVCL id
+        in the crate that does not dereference.
+        """
+        _route_frtl5_search()
+        _route_frtl5_record(json={"error": "not found"}, status=404)
+        state = CrateState()
+
+        result = resolve_cell_line(state, FRTL5_CATALOG)
+
+        assert result["accession"] == ""
+        assert result["match"] == "none"
+        assert result["verified"] is False
+        assert "accession" not in _cell_lines(state)[0].fields
+
+    @responses.activate
+    def test_a_definitive_miss_also_clears_an_accession_a_previous_call_wrote(self):
+        """Clearing must reach the ENTITY, not just the return value.
+
+        Without this the re-resolve would report no accession while the crate
+        still published one — and ``_mint_id`` would keep keying the node's
+        ``@id`` on an id the record endpoint denies.
+        """
+        _route_frtl5_search()
+        _route_frtl5_record()
+        state = CrateState()
+        first = resolve_cell_line(state, FRTL5_CATALOG)
+        assert first["accession"] == "CVCL_0265"
+
+        responses.reset()
+        for fn in (search_cellosaurus, lookup_cellosaurus, lookup_cell_line_by_name):
+            fn.cache_clear()
+        lookup_cell_line.cache_clear()
+        _route_frtl5_search()
+        _route_frtl5_record(json={"error": "not found"}, status=404)
+
+        second = resolve_cell_line(state, FRTL5_CATALOG)
+
+        assert second["entity_id"] == first["entity_id"]
+        assert second["accession"] == ""
+        assert "accession" not in _entity(state, second["entity_id"]).fields
+
+    @responses.activate
+    def test_the_record_url_never_lands_on_the_identifier_field(self):
+        """``lookup_cellosaurus``'s own ``identifier`` is a URL and must not persist.
+
+        ``verify_all_identifiers`` would re-query Cellosaurus with that URL
+        percent-encoded into the cell-line path, miss, and **pop** the field —
+        D5 destroying a value the authority actually gave us.
+        """
+        _route_hepg2()
+        state = CrateState()
+
+        result = resolve_cell_line(state, "HepG2")
+
+        assert result["accession"] == "CVCL_0027"
+        fields = _entity(state, result["entity_id"]).fields
+        assert "identifier" not in fields
+        assert fields["url"] == "https://www.cellosaurus.org/CVCL_0027"
+
+    @responses.activate
+    def test_only_the_documented_cellosaurus_fields_are_persisted(self):
+        """Every other record field is dropped, each for a reason that is written down.
+
+        Driven over the recorded CVCL_0027 body, which really does carry the
+        DefinedTerm node objects and the donor facts, so this is a claim about
+        the composite rather than about a thin double.
+        """
+        _route_hepg2()
+        state = CrateState()
+
+        result = resolve_cell_line(state, "HepG2")
+        fields = _entity(state, result["entity_id"]).fields
+
+        assert set(fields) <= {"name", "accession", "alternateName", "url", "sameAs"}
+        for dropped, _reason in composites._CELL_LINE_DROPPED_FIELDS:
+            if dropped == "name":
+                continue  # the entity keeps its OWN name — see the test below
+            assert dropped not in fields, f"{dropped} must not be persisted"
+        # The record really did offer them, so the assertion above has teeth.
+        record = lookup_cellosaurus("CVCL_0027")
+        assert {"identifier", "taxonomicRange", "disease", "anatomicalSite"} <= set(record)
+        # ...and the source name survives the Cellosaurus label ("Hep-G2").
+        assert fields["name"] == "HepG2"
+        assert "Hep-G2" in fields["alternateName"]
+
+    @responses.activate
+    def test_repeat_resolution_reuses_one_entity(self):
+        """Idempotent: a second resolve refreshes the entity, never replaces it.
+
+        ``draft_cell_line_sample`` is not idempotent and ``state.add_entity``
+        silently *replaces* under ``CellLineSample:<eid>``, so without the reuse
+        check in the composite a re-resolve would wipe the accession, its
+        verified status and its provenance.
+        """
+        _route_frtl5_search()
+        _route_frtl5_record()
+        state = CrateState()
+
+        first = resolve_cell_line(state, FRTL5_CATALOG)
+        second = resolve_cell_line(state, FRTL5_CATALOG)
+
+        assert first["entity_id"] == second["entity_id"]
+        assert len(_cell_lines(state)) == 1
+        entity = _entity(state, second["entity_id"])
+        assert entity.fields["accession"] == "CVCL_0265"
+        assert entity._completion["CellLineSample:accession"].status == "verified"
+
+    @responses.activate
+    def test_two_names_for_one_line_collapse_to_one_entity(self):
+        """One line under two names is ONE node, deduped by accession.
+
+        The shipped S-VHPS22 fixture names the same line two ways, and once the
+        accession drives the ``@id`` (``_crate_mapping._mint_id``) two entities
+        would mint the SAME ``@id`` — which ro-crate-py silently overwrites.
+        """
+        _route_frtl5_search()
+        _route_frtl5_record()
+        other = "FRTL-5 TPO-overexpressing cells"
+        _route_search(f'id:"{other}"', json=EMPTY_SEARCH)
+        _route_search(f'sy:"{other}"', json=EMPTY_SEARCH)
+        state = CrateState()
+
+        first = resolve_cell_line(state, FRTL5_DESCRIPTIVE, catalog_name=FRTL5_CATALOG)
+        second = resolve_cell_line(state, other, catalog_name=FRTL5_CATALOG)
+
+        assert first["entity_id"] == second["entity_id"]
+        assert len(_cell_lines(state)) == 1
+        entity = _entity(state, first["entity_id"])
+        # The first name stays primary; the second is kept as an alias, not lost.
+        assert entity.fields["name"] == FRTL5_DESCRIPTIVE
+        assert other in entity.fields["alternateName"]
+
+    @responses.activate
+    def test_the_lookup_primitive_still_requires_an_exact_match(self):
+        """Honesty control: the D5 gate was not relaxed to make the marquee green.
+
+        The candidate logic lives in the composite. The primitive it calls must
+        still refuse the descriptive phrase on its own — if this ever passes,
+        the catalogue-name test above is proving nothing.
+        """
+        for field in ("id", "sy"):
+            _route_search(f'{field}:"{FRTL5_DESCRIPTIVE}"', json=_load(
+                "cellosaurus_search_id_frtl5.json"
+            ))
+
+        result = lookup_cell_line_by_name(FRTL5_DESCRIPTIVE)
+
+        assert result["found"] is False
+        assert result["data"] == {}

--- a/tests/test_crate_mapping_identifiers.py
+++ b/tests/test_crate_mapping_identifiers.py
@@ -480,3 +480,83 @@ class TestChebiOnlyMolecularEntityId:
         )
         state.add_entity(chem)
         assert _mint_id(chem) == "#MolecularEntity_chem_plain"
+
+
+class TestCellLineSampleCellosaurusId:
+    """A resolved CellLineSample gets the resolvable Cellosaurus IRI @id (#372).
+
+    The Cellosaurus accession IS the cell line's identifier and it dereferences.
+    Minting ``#CellLineSample_cell_cho_k1`` next to a field holding CVCL_0214
+    published a private handle for something the world already has a public name
+    for: the crate would not merge with anyone else's and a reader could not
+    follow it. Person/ORCID, Organization/ROR, MolecularEntity/PubChem and
+    Publication/DOI already work this way — the cell line was the gap, and the
+    branch shipped in ``_mint_id`` untested until ``resolve_cell_line`` gave the
+    deterministic arm a way to produce an accession at all.
+    """
+
+    def _cell_state(self, **fields) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Cell line crate"
+        cell = Entity(
+            entity_id="cell_frtl_5",
+            type="CellLineSample",
+            fields={"name": "FRTL-5", **fields},
+            _provenance=EntityProvenance(created_by="lookup"),
+        )
+        state.add_entity(cell)
+        return state
+
+    def _cell(self, **fields) -> Entity:
+        return self._cell_state(**fields).list_entities("CellLineSample")[0]
+
+    def test_mint_id_is_the_cellosaurus_iri(self):
+        assert _mint_id(self._cell(accession="CVCL_0265")) == (
+            "https://www.cellosaurus.org/CVCL_0265"
+        )
+
+    def test_mint_id_not_a_fragment(self):
+        assert not _mint_id(self._cell(accession="CVCL_0265")).startswith("#")
+
+    def test_minted_id_is_absolute_uri(self):
+        assert _ABSOLUTE_URI.match(_mint_id(self._cell(accession="CVCL_0265")))
+
+    def test_node_built_under_the_cellosaurus_iri(self):
+        graph = _graph(self._cell_state(accession="CVCL_0265"))
+        cell = _by_id(graph, "https://www.cellosaurus.org/CVCL_0265")
+        assert cell is not None, "CellLineSample node @id must be the Cellosaurus IRI"
+        assert cell.get("additionalType") == "CellLine"
+
+    def test_accession_is_promoted_to_schema_identifier(self):
+        """The profile model derives ``identifier`` from ``accession``.
+
+        This is why ``resolve_cell_line`` persists the accession ONLY: a state
+        ``identifier`` field would arrive through ``_scalar_props`` and override
+        the model's own value (``default_properties | properties``), putting the
+        node's identifier under a second field that ``verify_identifier`` can pop
+        independently of the one the @id is minted from.
+        """
+        graph = _graph(self._cell_state(accession="CVCL_0265"))
+        cell = _by_id(graph, "https://www.cellosaurus.org/CVCL_0265")
+        assert cell is not None
+        assert cell.get("identifier") == "CVCL_0265"
+        assert cell.get("name") == "FRTL-5"
+
+    def test_rrid_prefixed_accession_resolves_the_same_iri(self):
+        """An ``RRID:CVCL_…`` / ``CVCL:…`` spelling is normalised, not fragmented."""
+        assert _mint_id(self._cell(rrid="RRID:CVCL_0265")) == (
+            "https://www.cellosaurus.org/CVCL_0265"
+        )
+
+    def test_a_full_url_accession_is_used_verbatim(self):
+        assert _mint_id(self._cell(accession="https://www.cellosaurus.org/CVCL_0265")) == (
+            "https://www.cellosaurus.org/CVCL_0265"
+        )
+
+    def test_no_accession_falls_back_to_the_fragment(self):
+        """D5 + the miss contract: a name-only cell line still builds, locally keyed.
+
+        ``resolve_cell_line`` deliberately mints a Sample when Cellosaurus has
+        nothing, so this fallback is the common case, not an edge case.
+        """
+        assert _mint_id(self._cell()) == "#CellLineSample_cell_frtl_5"

--- a/tests/test_offline_validation.py
+++ b/tests/test_offline_validation.py
@@ -313,3 +313,119 @@ class TestAValidatorThatCannotRunIsNotAPass:
             with _checks_must_run("isa"):
                 raise RuntimeError("boom")
         assert len(logging.getLogger("rocrate_validator").handlers) == before
+
+
+class TestCellosaurusResolvedCellLineContext:
+    """A Cellosaurus-resolved cell line must serialise to context-valid JSON-LD (#372).
+
+    The Cellosaurus record is far richer than the crate can absorb: three of its
+    fields are ``schema:DefinedTerm`` **node objects** (``taxonomicRange`` /
+    ``disease`` / ``anatomicalSite``), which ``_scalar_props`` would emit inline
+    as un-flattened nested entities, and three more (``donorSex`` / ``donorAge``
+    / ``category``) are not declared in the ``@context`` at all — the same class
+    of failure #243 hit with the ChEBI fallback's bare ``chebi_id``. This is the
+    gate proving ``_CELL_LINE_DATA_FIELDS`` is narrow enough, and that a
+    CellLineSample whose ``@id`` is now an external Cellosaurus IRI still builds.
+    """
+
+    @staticmethod
+    def _resolved_state(monkeypatch):
+        """A CrateState holding one Cellosaurus-resolved CellLineSample.
+
+        Drives the *real* ``resolve_cell_line`` over the *real* lookup stack with
+        only the two network primitives replaced, so the keys the entity carries
+        are exactly the ones the production path emits. The record double is the
+        recorded ``cellosaurus_hepg2.json`` body parsed by the real
+        ``lookup_cellosaurus``, reached through ``responses`` in
+        ``tests/test_composites_resolve_cell_line.py``; here it is handed over
+        directly to keep this module free of HTTP mocking.
+        """
+        from builder.state import CrateState
+        from builder.tools import composites, lookups
+
+        # tests/conftest.py defaults these to a miss suite-wide; this test needs
+        # the real primitives so the D5 gate and the record parse both run.
+        monkeypatch.setattr(
+            composites, "lookup_cell_line_by_name", lookups.lookup_cell_line_by_name
+        )
+        monkeypatch.setattr(composites, "lookup_cell_line", lookups.lookup_cell_line)
+        lookups.lookup_cell_line_by_name.cache_clear()
+        lookups.lookup_cell_line.cache_clear()
+
+        # CVCL_0027's real primary identifier is "Hep-G2"; "HepG2" is a synonym
+        # (#385), which is why the entity's own name and the label differ here.
+        candidates = (
+            {
+                "accession": "CVCL_0027",
+                "name": "Hep-G2",
+                "synonyms": ["HEP-G2", "Hep G2", "HEP G2", "HepG2", "HEPG2"],
+            },
+        )
+        record = {
+            "name": "Hep-G2",
+            "identifier": "https://www.cellosaurus.org/CVCL_0027",
+            "url": "https://www.cellosaurus.org/CVCL_0027",
+            "alternateName": ["HEP-G2", "Hep G2", "HEP G2", "HepG2", "HEPG2"],
+            "taxonomicRange": {
+                "@id": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+                "@type": "DefinedTerm",
+                "name": "Homo sapiens",
+            },
+            "disease": [
+                {
+                    "@id": "http://purl.obolibrary.org/obo/NCIT_C3728",
+                    "@type": "DefinedTerm",
+                    "name": "Hepatoblastoma",
+                }
+            ],
+            "anatomicalSite": {
+                "@id": "http://purl.obolibrary.org/obo/UBERON_0002107",
+                "@type": "DefinedTerm",
+                "name": "liver",
+            },
+            "donorSex": "Male",
+            "donorAge": "15Y",
+            "category": "Cancer cell line",
+            "sameAs": [
+                "http://purl.obolibrary.org/obo/CLO_0003703",
+                "https://www.wikidata.org/wiki/Q3512461",
+            ],
+        }
+        monkeypatch.setattr(lookups, "search_cellosaurus", lambda name, *a, **k: candidates)
+        monkeypatch.setattr(lookups, "lookup_cellosaurus", lambda accession: record)
+
+        state = CrateState()
+        state.metadata.title = "Cellosaurus crate"
+        result = composites.resolve_cell_line(state, name="HepG2")
+        assert result["accession"] == "CVCL_0027", result
+        return state, result
+
+    def test_cellosaurus_cell_line_passes_base_validation(self, monkeypatch):
+        from builder.tools.validation import build_and_validate
+
+        state, _ = self._resolved_state(monkeypatch)
+        report = build_and_validate(state, profile="base")
+
+        assert report["conformance"].get("base") is True, [
+            (i["entity_id"], i["property"], i["message"]) for i in report["issues"]
+        ]
+        joined = " ".join(i["message"] for i in report["issues"]).lower()
+        assert "not present in the @context" not in joined, report["issues"]
+
+    def test_only_context_valid_keys_reach_the_cell_line(self, monkeypatch):
+        state, _ = self._resolved_state(monkeypatch)
+        cell = next(e for e in state.list_entities() if e.type == "CellLineSample")
+
+        from profiles.context import ISA_TOX_CONTEXT as _CTX
+
+        context_terms = set(_CTX[0])
+        # `name`/`alternateName`/`url` are plain schema.org terms carried by the
+        # base RO-Crate context, so only the extension terms are checked here.
+        for key in cell.fields:
+            if key in {"name", "alternateName", "url"} or key.startswith("@"):
+                continue
+            assert key in context_terms, f"CellLineSample key {key!r} not in @context"
+
+        # The DefinedTerm node objects and the undeclared donor facts stayed off.
+        for dropped in ("taxonomicRange", "disease", "anatomicalSite", "donorSex", "category"):
+            assert dropped not in cell.fields

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -112,7 +112,12 @@ _PLAN: dict[str, Any] = {
         {"name": "Methimazole", "role": "test"},
         {"name": "Sodium iodide", "role": "control"},
     ],
-    "cell_lines": [{"name": "FRTL-5 TPO-overexpressing cells"}],
+    # The descriptive phrase the documents use, plus the short catalogue NAME
+    # (#372) — a name, not an identifier, and the only thing that clears
+    # Cellosaurus's exact-match gate for this line.
+    "cell_lines": [
+        {"name": "FRTL-5 TPO-overexpressing cells", "catalog_name": "FRTL-5"},
+    ],
     "protocols": [
         {
             "name": "Amplex Red fluorometric TPO activity readout",
@@ -251,6 +256,33 @@ def _stub_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
             "message": "ok",
         }
 
+    # resolve_cell_line → the two Cellosaurus primitives (#372). Step 2 IS the
+    # verification, so there is no separate verify stub for the accession. The
+    # gate is modelled honestly: ONLY the short catalogue name resolves, exactly
+    # as live, so the descriptive plan name reaches CVCL_0265 through
+    # `catalog_name` or not at all.
+    def fake_lookup_cell_line_by_name(name: str) -> dict[str, Any]:
+        if str(name).strip().casefold() == "frtl-5":
+            return {
+                "found": True,
+                "data": {"accession": "CVCL_0265", "name": "FRTL-5", "synonyms": ["FRTL5"]},
+                "error": None,
+            }
+        return {"found": False, "data": {}, "error": "no confident match"}
+
+    def fake_lookup_cell_line(accession: str) -> dict[str, Any]:
+        if accession == "CVCL_0265":
+            return {
+                "found": True,
+                "data": {
+                    "name": "FRTL-5",
+                    "url": "https://www.cellosaurus.org/CVCL_0265",
+                    "alternateName": ["FRTL 5", "FRTL5"],
+                },
+                "error": None,
+            }
+        return {"found": False, "data": {}, "error": "not found"}
+
     # materialize_aop_subgraph → lookup_aop (imported lazily from tool_lookups).
     def fake_lookup_aop(aop_id: str) -> dict[str, Any]:
         iri = f"https://aopwiki.org/aops/{aop_id}"
@@ -305,6 +337,8 @@ def _stub_leaves(monkeypatch: pytest.MonkeyPatch) -> None:
     # suite-wide by the ``_stub_composites_dtxsid`` autouse fixture in conftest.py.
     monkeypatch.setattr(composites_mod, "lookup_compound", fake_lookup_compound)
     monkeypatch.setattr(composites_mod, "verify_identifier", fake_verify_identifier)
+    monkeypatch.setattr(composites_mod, "lookup_cell_line_by_name", fake_lookup_cell_line_by_name)
+    monkeypatch.setattr(composites_mod, "lookup_cell_line", fake_lookup_cell_line)
     monkeypatch.setattr(
         composites_mod, "search_works_by_title", fake_search_works_by_title
     )
@@ -410,11 +444,16 @@ class TestPipelineE2EConformanceAndFidelity:
         assert chems
         assert all(c.fields.get("cas") == "60-56-0" for c in chems)
 
-        # A CellLine Sample.
+        # A CellLine Sample carrying its LOOKED-UP Cellosaurus accession (#372).
+        # The name assertion alone stayed green through the whole period the arm
+        # never called a cell-line lookup at all; the accession is what proves the
+        # resolution ran. Reaching it required the plan's `catalog_name`, because
+        # the descriptive phrase misses the exact-match gate.
         cells = state.list_entities("CellLineSample")
         assert [c.fields.get("name") for c in cells] == [
             "FRTL-5 TPO-overexpressing cells"
         ]
+        assert cells[0].fields.get("accession") == "CVCL_0265"
 
         # The full four-step LabProcess derivation chain.
         procs = state.list_entities("LabProcess")

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -523,6 +523,19 @@ class TestRealInputPipeline:
         # D5: the CAS is the LOOKED-UP value, never fabricated by the plan/leaf.
         assert t4.fields.get("cas") == "51-48-9"
 
+        # #372, the honest seam: this plan carries the documents' descriptive
+        # phrase and no short catalogue name, so the exact-match gate finds
+        # nothing — and the cell line must survive that anyway. A miss is not a
+        # failure: returning {ok: False} would delete the Sample and with it the
+        # CellCulture's `cell_line` input. No canned CVCL_0214 is handed over,
+        # because "CHO-K1 OATP1C1-overexpressing cells" is not a name Cellosaurus
+        # can resolve to the parent line.
+        cells = state.list_entities("CellLineSample")
+        assert [c.fields.get("name") for c in cells] == [
+            "CHO-K1 OATP1C1-overexpressing cells"
+        ]
+        assert "accession" not in cells[0].fields
+
         procs = state.list_entities("LabProcess")
         assert {"CellCulture", "Exposure", "EndpointReadout", "DataAnalysis"} <= {
             p.fields.get("process_type") for p in procs


### PR DESCRIPTION
Closes #533.

The deterministic arm materialised every cell line through `draft_cell_line_sample` with **empty hints**, so it never looked anything up. `lookup_cell_line_by_name` — the only name→Cellosaurus resolver in the tree — had no caller outside the ReAct arm, and no default-arm crate carried an accession.

`S-VHPS26` is a CHO-K1 hOATP1C1 transporter assay where the cell line **is** the test system. The deposit states `RRID = CVCL_0214` in four places and the graph names CHO-K1 seventeen times — and contains the string `CVCL` zero times.

`resolve_cell_line` is the cell-line counterpart of `resolve_compound`, wired into both arms.

## Two steps, and the second one *is* the verification

`_select_verifier("CellLineSample", "accession")` already resolves to `lookup_cell_line`. Following step 2 with `verify_identifier` would re-issue the same `lru_cache`d call to reach the same verdict, so the status is set directly instead — mirroring `_verify_compound_identifier`.

## A miss is not a failure

The one deliberate divergence from `resolve_compound`, which returns `{"ok": False}` and mints nothing.

A `CellLineSample` carrying only a name is a valid ISA Sample, and is exactly what the arm produced before this existed. Refusing to mint would **delete the cell line from every crate whose line is not catalogued** — taking `CellCulture.cell_line` and the Study's `cell_lines` mention with it. Always mint; the accession is enrichment. There is therefore no `ok` key — read `accession` / `match`.

## D5

- The name search keeps its **exact+unique gate unmodified**. An engineered derivative (`"CHO-K1 hOATP1C1"`) does not match its parent record and is treated as *unconfirmed*, never as wrong.
- **Identifier-bearing hints are refused outright**, so neither the ReAct model nor a plan field that slipped the identifier strip can hand this composite an accession. Every id it commits came back from Cellosaurus in that call.
- A **transient outage stops the candidate walk** rather than falling through to a weaker name — committing one because the strongest could not be asked would turn an outage into a quietly different answer.
- A **definitive 404 on step 2 clears** the accession, and pops it from an entity an earlier run wrote it to, rather than publishing a CVCL id that does not dereference.

## Reuse is keyed by accession first

One line routinely appears under two names in one submission — the shipped S-VHPS22 fixture calls it *"…rat thyroid follicular cells"* in the README and *"…overexpressing cells"* in both CSVs. Once the accession drives the `@id` (`_crate_mapping._mint_id`), two such entities collide onto **one** node at build time and ro-crate-py silently keeps whichever was written last.

## Only three record fields are persisted

`alternateName` / `url` / `sameAs`. Everything else the record offers is listed in `_CELL_LINE_DROPPED_FIELDS` **with the failure it would cause**:

| dropped | why |
|---|---|
| `taxonomicRange`, `disease`, `anatomicalSite` | DefinedTerm **node objects** — `_scalar_props` emits them inline, producing un-flattened nested entities that fail base conformance |
| `donorSex`, `donorAge`, `category` | not terms in the crate's JSON-LD context → *"not allowed in the compacted JSON-LD context"* |
| `name` | the entity's name is the name as the **source documents** word it; the Cellosaurus label belongs on `alternateName` |
| `identifier` | the quiet one — `lookup_cellosaurus` sets it to the record's full **URL**, so persisting it would have `verify_all_identifiers` re-query with that URL percent-encoded into the cell-line path, miss, and **pop the field**: D5 destroying a value the authority actually gave us |

Promoting the DefinedTerm trio to real flattened entities is its own lane, and is why this PR does not close #533's species/tissue acceptance bullet — see the issue for what remains.

## Reachability + test isolation

The `PIPELINE_UNREACHED` waiver for `lookup_cell_line_by_name` is removed. That check is two-sided — it fails on a waiver naming a now-reachable tool — so wiring the lookup forces the row out.

The new conftest stub is scoped to the symbols bound in the **`composites` namespace**, not to `builder.tools.lookups`: nine tests in `test_lookups_cellosaurus_recall` drive the real lookup with its HTTP replayed by `responses`, and stubbing one layer down would short-circuit the very D5 gate they pin. "Do not reach the network" and "do not resolve" are different claims.

## Verification

79 passed across `test_composites_resolve_cell_line.py` (new), `test_offline_validation.py`, `test_tool_reachability.py`. Pipeline + recall modules green (152 passed). `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)