### PR TITLE
feat(lookup): recover an affiliation from the author's own papers

### DIFF
--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -55,9 +55,10 @@ from builder.tools.lookups import (
 # entity type from" — imported rather than restated so the two cannot drift.
 from builder.tools.provenance import _PROCESS_LINK_HOMES as _BUILD_HONOURED_HOMES
 from builder.tools.verification import verify_identifier
+from lookups.affiliation_from_works import cached_affiliation_from_works, institution_of
 from lookups.crossref import search_works_by_title
 from lookups.orcid import lookup_orcid_by_name
-from lookups.ror import fetch_ror_by_id
+from lookups.ror import fetch_ror_by_id, search_ror
 
 logger = logging.getLogger(__name__)
 
@@ -1025,6 +1026,86 @@ def _find_or_draft_organization(state: CrateState, name: str, ror: str | None = 
     return org.entity_id
 
 
+def _affiliation_from_papers(orcid: str, family: str) -> str:
+    """An institution the person's own papers agree on, or ``""`` — never raises.
+
+    The fallback for the many ORCID records that carry no employment section at
+    all. It is still retrieval, not inference: the value is what Crossref
+    published on the author line of a paper this ORCID record itself lists, and
+    it is only believed when the papers agree (see
+    :mod:`lookups.affiliation_from_works` for the rule). A conflict returns
+    nothing so the question reaches a human rather than being settled by a guess.
+
+    Failure is silent by design — a missing affiliation is a recommendation, an
+    author cascade that dies because Crossref is briefly down is a broken build.
+    """
+    if not orcid:
+        return ""
+    try:
+        return cached_affiliation_from_works(orcid, family or "")
+    except Exception:
+        logger.debug("affiliation-from-works lookup failed for %s", orcid, exc_info=True)
+        return ""
+
+
+def _registered_institution(affiliation: str) -> tuple[str, str | None]:
+    """A Crossref affiliation string resolved to a registered institution.
+
+    Crossref publishes affiliations as free text with the department, street and
+    postcode attached. Stored verbatim that becomes an Organization named
+    "Centre for Pollution Research and Policy, Brunel University London,
+    Kingston Lane, Uxbridge UB8 3PH, U.K." — which will never match another
+    spelling of the same employer and is not what anyone calls the institution.
+
+    So the employer is picked out of the string and looked up in ROR, which is
+    the registry built for exactly this. The match is CHECKED rather than
+    trusted: ROR's name must actually appear in the affiliation the paper
+    printed. A search is a guess, and a guess that quietly renames someone's
+    employer is the kind of error nobody reads twice. Unverified, the extracted
+    institution is kept as a plain name with no ROR attached — still better than
+    the postcode, and still only what the paper said.
+    """
+    institution = institution_of(affiliation) or affiliation
+    try:
+        match = search_ror(institution) or {}
+    except Exception:
+        logger.debug("ROR search failed for %r", institution, exc_info=True)
+        return institution, None
+    name = str(match.get("name") or "").strip()
+    if name and _same_institution(name, institution):
+        return name, str(match.get("@id") or "") or None
+    return institution, None
+
+
+# Connectives that differ between an institution's registered name and the way a
+# paper prints it, and carry no identifying weight either way.
+_NAME_NOISE = frozenset({"of", "the", "and", "at", "for", "de", "der", "van", "di", "du"})
+
+
+def _significant(name: str) -> set[str]:
+    return {w for w in re.split(r"[^\w]+", name.casefold()) if w and w not in _NAME_NOISE}
+
+
+def _same_institution(ror_name: str, printed: str) -> bool:
+    """Whether a ROR match and a printed affiliation name the same employer.
+
+    Checked BOTH ways, because each direction catches a different mistake.
+
+    ROR's registered name rarely matches the printed one character for
+    character — it registers "Brunel University of London" where the paper
+    prints "Brunel University London" — so requiring containment rejects correct
+    matches over a connective. Requiring only that ROR's words appear in the
+    printed name accepts a wrong one: "University of London" is a real and
+    different institution whose words all appear inside "Brunel University
+    London".
+
+    Demanding the significant words agree in both directions keeps the first and
+    refuses the second, because "Brunel" is missing from one side.
+    """
+    left, right = _significant(ror_name), _significant(printed)
+    return bool(left) and bool(right) and left == right
+
+
 def _ror_website(ror_id: str) -> dict[str, str]:
     """``{"url": ...}`` for a known ROR id, or ``{}`` — never raises.
 
@@ -1075,8 +1156,11 @@ def _ensure_person_for_orcid(state: CrateState, orcid: str, data: dict) -> Entit
     # and wire the Person's `affiliation` to that Organization's reference id —
     # the build's `_wire_reference` then resolves it to the Organization node.
     affiliation_name = data.get("affiliation_name")
+    affiliation_ror = data.get("affiliation_ror")
+    if not affiliation_name and (from_papers := _affiliation_from_papers(bare, str(family or ""))):
+        affiliation_name, affiliation_ror = _registered_institution(from_papers)
     if affiliation_name:
-        org_id = _find_or_draft_organization(state, affiliation_name, data.get("affiliation_ror"))
+        org_id = _find_or_draft_organization(state, affiliation_name, affiliation_ror)
         if org_id is not None:
             fields["affiliation"] = {"@id": org_id}
     # The ISA profile asks every Person for a job title, and ORCID publishes one

--- a/lookups/affiliation_from_works.py
+++ b/lookups/affiliation_from_works.py
@@ -1,0 +1,264 @@
+"""Recover an author's affiliation from the papers their ORCID record lists.
+
+Many ORCID records carry no employment at all — the researcher never filled that
+section in — and the profile still asks every author for an institution. The
+papers are usually right there on the same record, and Crossref names the
+affiliation on the author line, so the fact exists; it is simply one hop away:
+
+    ORCID iD -> works on that record -> DOIs -> Crossref -> affiliation string
+
+This is retrieval, not inference. Every value returned was published by a
+registry about this person; nothing is guessed from a name, an email domain, or
+a co-author.
+
+WHEN TO TRUST IT (the rule this module implements):
+
+* every affiliation found agrees -> take it, even from two papers. Two
+  independent records saying the same institution is corroboration, and
+  demanding a third would throw away a good answer for someone who has only
+  published twice.
+* they disagree -> the THREE MOST RECENT decide. People move; an old paper is
+  evidence of where someone used to be, which is a different claim.
+* still split -> return nothing and let a human answer. A confident wrong
+  affiliation in a scientific record is worse than an open question.
+
+Author matching prefers the ORCID Crossref itself carries; a family-name match
+is the fallback. Names alone would pick the wrong person on a paper with two
+Schmidts, and the affiliation would look perfectly plausible.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+from collections import Counter
+from urllib.parse import quote
+
+from lookups._http import NOT_FOUND, TransientLookupError, http_get_json
+
+_ORCID_BASE = "https://pub.orcid.org/v3.0"
+_CROSSREF_BASE = "https://api.crossref.org/works"
+_ORCID_HEADERS = {"Accept": "application/json"}
+
+# How many of the record's works to dereference. Enough for the agreement rule
+# to have something to weigh, bounded so one prolific author cannot turn a build
+# into a hundred HTTP round-trips.
+_MAX_WORKS = 8
+
+# How many recent works break a tie, per the rule above.
+_RECENT_WINDOW = 3
+
+
+def _bare(orcid_id: str) -> str:
+    return (orcid_id or "").strip().rstrip("/").rsplit("/", 1)[-1]
+
+
+def _publication_year(summary: dict) -> int:
+    """The work's year, or 0 when ORCID does not state one (sorts oldest)."""
+    date = (summary.get("publication-date") or {}) or {}
+    year = ((date.get("year") or {}) or {}).get("value")
+    try:
+        return int(str(year))
+    except (TypeError, ValueError):
+        return 0
+
+
+def recent_dois(orcid_id: str, limit: int = _MAX_WORKS) -> list[str]:
+    """DOIs from an ORCID record's works, most recently published first.
+
+    Returns ``[]`` when the record has no works, no DOIs, or does not resolve.
+    Raises TransientLookupError so a caller can distinguish an outage from an
+    author who genuinely has none.
+    """
+    bare = _bare(orcid_id)
+    if not bare:
+        return []
+    data = http_get_json(f"{_ORCID_BASE}/{quote(bare, safe='')}/works", headers=_ORCID_HEADERS)
+    if data is NOT_FOUND or not isinstance(data, dict):
+        return []
+
+    dated: list[tuple[int, str]] = []
+    for group in data.get("group") or []:
+        summaries = group.get("work-summary") or [{}]
+        year = max((_publication_year(s) for s in summaries), default=0)
+        for ext in (group.get("external-ids") or {}).get("external-id") or []:
+            if str(ext.get("external-id-type") or "").lower() == "doi":
+                value = str(ext.get("external-id-value") or "").strip()
+                if value:
+                    dated.append((year, value))
+                    break
+    dated.sort(key=lambda pair: -pair[0])
+    seen: set[str] = set()
+    out: list[str] = []
+    for _, doi in dated:
+        key = doi.casefold()
+        if key not in seen:
+            seen.add(key)
+            out.append(doi)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _author_matches(author: dict, orcid: str, family: str) -> bool:
+    """Whether a Crossref author line is the person we are asking about.
+
+    The ORCID Crossref carries is decisive when present. Falling back to the
+    family name is deliberate but weaker, and is why the caller still requires
+    agreement across papers before believing the answer.
+    """
+    listed = _bare(str(author.get("ORCID") or ""))
+    if listed and orcid:
+        return listed.casefold() == orcid.casefold()
+    if not family:
+        return False
+    return str(author.get("family") or "").strip().casefold() == family.strip().casefold()
+
+
+def _affiliations_on(doi: str, orcid: str, family: str) -> list[str]:
+    """Affiliation strings Crossref lists for this person on this DOI."""
+    try:
+        data = http_get_json(f"{_CROSSREF_BASE}/{quote(doi, safe='/')}")
+    except TransientLookupError:
+        raise
+    except Exception:
+        return []
+    if data is NOT_FOUND or not isinstance(data, dict):
+        return []
+    message = data.get("message") or {}
+    out: list[str] = []
+    for author in message.get("author") or []:
+        if not _author_matches(author, orcid, family):
+            continue
+        for affiliation in author.get("affiliation") or []:
+            name = str((affiliation or {}).get("name") or "").strip()
+            if name:
+                out.append(name)
+    return out
+
+
+# Punctuation and postal noise that stop two spellings of one institution from
+# matching. Crossref affiliation strings are free text: the same university
+# arrives as "Brunel University London, Uxbridge, UK." and "…, Kingston Lane,
+# Uxbridge UB8 3PH, U.K.".
+_NOISE = re.compile(r"[.,;]|\b[A-Z]{1,2}\d{1,2}\s*\d?[A-Z]{0,2}\b")
+
+
+def institution_of(affiliation: str) -> str:
+    """The employer named inside a Crossref affiliation string.
+
+    Crossref publishes affiliations as free text with the department, street and
+    postcode attached — "Centre for Pollution Research and Policy, Brunel
+    University London, Kingston Lane, Uxbridge UB8 3PH, U.K." Storing that as an
+    Organization name is not wrong so much as useless: it will never match
+    another spelling of the same employer, and it is not what anyone would call
+    the institution. This returns the part that is ("Brunel University London"),
+    ready to look up in ROR.
+    """
+    parts = [p.strip() for p in (affiliation or "").split(",") if p.strip()]
+    best_rank, chosen = len(_INSTITUTION_WORDS), (affiliation or "").strip()
+    for part in parts:
+        lowered = part.casefold()
+        for rank, word in enumerate(_INSTITUTION_WORDS):
+            if word in lowered and rank < best_rank:
+                best_rank, chosen = rank, part
+                break
+    return chosen
+
+
+def _institution_key(affiliation: str) -> str:
+    """A comparison key for one affiliation string.
+
+    Departments, streets and postcodes differ between records of the same
+    employer, so the key keeps the longest comma-separated part that looks like
+    an institution — the segment naming a university, institute, hospital or
+    centre — and falls back to the whole string when none does.
+    """
+    # Strength beats length: one record spells the employer "Centre for
+    # Pollution Research and Policy, Brunel University London, …" and another
+    # "Institute of …, Brunel University London, …". Taking the LONGEST
+    # institution-ish part picks the department both times, and two spellings of
+    # one employer then look like two employers. The university outranks
+    # whatever sits in front of it.
+    return " ".join(_NOISE.sub(" ", institution_of(affiliation)).split()).casefold()
+
+
+# Institution words, STRONGEST FIRST. A department, centre or laboratory is part
+# of an employer, not the employer, so it only names the affiliation when
+# nothing broader is present in the string.
+_INSTITUTION_WORDS: tuple[str, ...] = (
+    "universit",
+    "hochschule",
+    "polytechnic",
+    "hospital",
+    "college",
+    "academy",
+    "institut",
+    "school",
+    "centre",
+    "center",
+    "laborator",
+    "museum",
+    "agency",
+    "council",
+)
+
+
+def affiliation_from_works(
+    orcid_id: str,
+    family_name: str = "",
+    *,
+    limit: int = _MAX_WORKS,
+) -> str:
+    """The institution this person's papers agree on, or ``""``.
+
+    Implements the trust rule in the module docstring: unanimous wins outright,
+    a disagreement is settled by the three most recent works, and anything still
+    split returns ``""`` so the caller asks a human instead of guessing.
+
+    Args:
+        orcid_id: The author's ORCID (bare or as a URL).
+        family_name: Used to match the author on papers where Crossref carries
+            no ORCID. Without it only ORCID-tagged author lines are read.
+        limit: How many works to dereference at most.
+
+    Returns:
+        The affiliation string as Crossref published it — the caller resolves it
+        to an Organization (ROR) rather than storing prose. ``""`` when the
+        record has no works, none names an affiliation, or the evidence
+        conflicts and recency cannot settle it.
+    """
+    bare = _bare(orcid_id)
+    if not bare:
+        return ""
+    try:
+        dois = recent_dois(bare, limit=limit)
+    except TransientLookupError:
+        raise
+    except Exception:
+        return ""
+
+    # Most recent first, so an ordered list is already the recency ranking.
+    found: list[str] = []
+    for doi in dois:
+        found.extend(_affiliations_on(doi, bare, family_name))
+    if not found:
+        return ""
+
+    keys = [_institution_key(a) for a in found]
+    if len(set(keys)) == 1:
+        return found[0]
+
+    recent = keys[:_RECENT_WINDOW]
+    winner, count = Counter(recent).most_common(1)[0]
+    # A plurality is not agreement: with three sources split 2/1 the majority
+    # decides, but a 1/1/1 split has no answer and must go to a human.
+    if count <= len(recent) / 2:
+        return ""
+    return next(a for a, k in zip(found, keys, strict=True) if k == winner)
+
+
+@functools.lru_cache(maxsize=256)
+def cached_affiliation_from_works(orcid_id: str, family_name: str = "") -> str:
+    """Cached :func:`affiliation_from_works` — several authors share a paper."""
+    return affiliation_from_works(orcid_id, family_name)

--- a/tests/test_affiliation_from_works.py
+++ b/tests/test_affiliation_from_works.py
@@ -1,0 +1,220 @@
+"""An author's affiliation, recovered from the papers their ORCID record lists.
+
+Many ORCID records carry no employment section at all, and the profile still
+asks every author for an institution. The papers are on the same record and
+Crossref names the affiliation on the author line, so the fact exists one hop
+away: ORCID iD -> works -> DOIs -> Crossref -> affiliation.
+
+This is retrieval, not inference — every value was published by a registry about
+this person. What makes it safe is knowing when NOT to answer, and that is what
+these tests pin:
+
+* every affiliation agrees -> take it, even from two papers. Two independent
+  records saying the same thing is corroboration; demanding a third would throw
+  away a good answer for someone who has published twice.
+* they disagree -> the three most recent decide, because people move and an old
+  paper is evidence of where someone USED to be.
+* still split -> answer nothing and let a human settle it. A confident wrong
+  affiliation in a scientific record is worse than an open question.
+
+No test here touches the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lookups import affiliation_from_works as mod
+from lookups.affiliation_from_works import affiliation_from_works, institution_of
+
+BRUNEL_A = "Centre for Pollution Research and Policy, Brunel University London, Uxbridge, UK."
+BRUNEL_B = "Institute of Environment, Health and Societies, Brunel University London, Uxbridge, UK"
+BRUNEL_C = "Brunel University London, Kingston Lane, Uxbridge UB8 3PH, U.K."
+UTRECHT = "Institute for Risk Assessment Sciences, Utrecht University, Utrecht, The Netherlands"
+
+
+@pytest.fixture
+def papers(monkeypatch):
+    """Drive the chain from a list of (doi, affiliation) pairs, newest first."""
+
+    def _install(pairs: list[tuple[str, str]]) -> None:
+        monkeypatch.setattr(mod, "recent_dois", lambda oid, limit=8: [d for d, _ in pairs])
+        table = dict(pairs)
+        monkeypatch.setattr(
+            mod,
+            "_affiliations_on",
+            lambda doi, orcid, family: [table[doi]] if table.get(doi) else [],
+        )
+
+    return _install
+
+
+class TestAgreementIsEnough:
+    def test_two_papers_that_agree_settle_it(self, papers):
+        """Corroboration, not a quorum: a third paper adds nothing here."""
+        papers([("10.1/a", BRUNEL_A), ("10.1/b", BRUNEL_B)])
+        assert "Brunel" in affiliation_from_works("0000-0002-9569-7562", "Scholze")
+
+    def test_one_paper_is_still_an_answer(self, papers):
+        """Nothing contradicts it, and it is what a registry published."""
+        papers([("10.1/a", BRUNEL_A)])
+        assert "Brunel" in affiliation_from_works("0000-0002-9569-7562", "Scholze")
+
+    def test_different_spellings_of_one_employer_still_agree(self, papers):
+        """Department, street and postcode differ; the institution does not."""
+        papers([("10.1/a", BRUNEL_A), ("10.1/b", BRUNEL_B), ("10.1/c", BRUNEL_C)])
+        assert "Brunel" in affiliation_from_works("0000-0002-9569-7562", "Scholze")
+
+
+class TestConflictGoesToRecency:
+    def test_the_recent_majority_wins(self, papers):
+        """People move: two recent papers outweigh an older employer."""
+        papers(
+            [
+                ("10.1/new1", BRUNEL_A),
+                ("10.1/new2", BRUNEL_B),
+                ("10.1/old", UTRECHT),
+            ]
+        )
+        assert "Brunel" in affiliation_from_works("0000-0002-9569-7562", "Scholze")
+
+    def test_an_old_paper_cannot_outvote_the_recent_ones(self, papers):
+        papers(
+            [
+                ("10.1/new1", UTRECHT),
+                ("10.1/new2", UTRECHT),
+                ("10.1/old1", BRUNEL_A),
+                ("10.1/old2", BRUNEL_B),
+                ("10.1/old3", BRUNEL_C),
+            ]
+        )
+        assert "Utrecht" in affiliation_from_works("0000-0002-9569-7562", "Scholze")
+
+
+class TestAnUnsettledAnswerIsNoAnswer:
+    def test_a_three_way_split_asks_a_human(self, papers):
+        """1/1/1 has no majority — guessing here would invent an employer."""
+        papers(
+            [
+                ("10.1/a", BRUNEL_A),
+                ("10.1/b", UTRECHT),
+                ("10.1/c", "Erasmus MC, Rotterdam, The Netherlands"),
+            ]
+        )
+        assert affiliation_from_works("0000-0002-9569-7562", "Scholze") == ""
+
+    def test_an_even_split_asks_a_human(self, papers):
+        papers([("10.1/a", BRUNEL_A), ("10.1/b", UTRECHT)])
+        assert affiliation_from_works("0000-0002-9569-7562", "Scholze") == ""
+
+    def test_no_works_is_no_answer(self, papers):
+        papers([])
+        assert affiliation_from_works("0000-0002-9569-7562", "Scholze") == ""
+
+    def test_works_without_affiliations_are_no_answer(self, papers):
+        papers([("10.1/a", ""), ("10.1/b", "")])
+        assert affiliation_from_works("0000-0002-9569-7562", "Scholze") == ""
+
+    def test_no_orcid_is_no_lookup(self):
+        assert affiliation_from_works("", "Scholze") == ""
+
+
+class TestTheInstitutionIsPickedOutOfTheString:
+    @pytest.mark.parametrize(
+        ("affiliation", "expected"),
+        [
+            (BRUNEL_A, "Brunel University London"),
+            (BRUNEL_B, "Brunel University London"),
+            (UTRECHT, "Utrecht University"),
+            ("Erasmus MC, Rotterdam, The Netherlands", "Erasmus MC, Rotterdam, The Netherlands"),
+        ],
+    )
+    def test_the_employer_beats_the_department(self, affiliation, expected):
+        """A centre or institute is part of an employer, not the employer."""
+        assert institution_of(affiliation) == expected
+
+    def test_an_empty_string_stays_empty(self):
+        assert institution_of("") == ""
+
+
+class TestFailureIsNeverFatal:
+    def test_a_broken_works_call_yields_nothing(self, monkeypatch):
+        def boom(orcid_id, limit=8):
+            raise RuntimeError("ORCID is down")
+
+        monkeypatch.setattr(mod, "recent_dois", boom)
+        assert affiliation_from_works("0000-0002-9569-7562", "Scholze") == ""
+
+    def test_a_transient_outage_propagates(self, monkeypatch):
+        """A caller must be able to tell an outage from a genuine absence."""
+        from lookups._http import TransientLookupError
+
+        def flaky(orcid_id, limit=8):
+            raise TransientLookupError("429")
+
+        monkeypatch.setattr(mod, "recent_dois", flaky)
+        with pytest.raises(TransientLookupError):
+            affiliation_from_works("0000-0002-9569-7562", "Scholze")
+
+
+class TestTheRorMatchIsCheckedNotTrusted:
+    """A search is a guess; a guess that renames an employer is not readable back."""
+
+    def test_a_registered_name_differing_by_a_connective_is_accepted(self):
+        from builder.tools.composites import _same_institution
+
+        assert _same_institution("Brunel University of London", "Brunel University London")
+
+    def test_a_real_but_different_institution_is_refused(self):
+        """ "University of London" is not "Brunel University London"."""
+        from builder.tools.composites import _same_institution
+
+        assert not _same_institution("University of London", "Brunel University London")
+
+    def test_an_unrelated_match_is_refused(self):
+        from builder.tools.composites import _same_institution
+
+        assert not _same_institution("Utrecht University", "Brunel University London")
+
+    def test_an_unverified_match_keeps_the_printed_name_and_no_ror(self, monkeypatch):
+        """Better the paper's own words than a confidently wrong registry id."""
+        import builder.tools.composites as composites
+
+        monkeypatch.setattr(
+            composites, "search_ror", lambda name: {"name": "Somewhere Else", "@id": "x"}
+        )
+        name, ror = composites._registered_institution(BRUNEL_A)
+        assert name == "Brunel University London"
+        assert ror is None
+
+    def test_a_ror_outage_keeps_the_printed_name(self, monkeypatch):
+        import builder.tools.composites as composites
+
+        def boom(name):
+            raise RuntimeError("ROR is down")
+
+        monkeypatch.setattr(composites, "search_ror", boom)
+        name, ror = composites._registered_institution(BRUNEL_A)
+        assert name == "Brunel University London"
+        assert ror is None
+
+
+class TestTheAuthorIsMatchedNotAssumed:
+    def test_an_orcid_on_the_author_line_is_decisive(self):
+        assert mod._author_matches(
+            {"ORCID": "https://orcid.org/0000-0002-9569-7562"}, "0000-0002-9569-7562", ""
+        )
+
+    def test_a_different_orcid_is_not_this_person(self):
+        """Two Schmidts on one paper — the name alone would take either."""
+        assert not mod._author_matches(
+            {"ORCID": "https://orcid.org/0000-0000-0000-0001", "family": "Scholze"},
+            "0000-0002-9569-7562",
+            "Scholze",
+        )
+
+    def test_the_family_name_is_the_fallback(self):
+        assert mod._author_matches({"family": "Scholze"}, "0000-0002-9569-7562", "Scholze")
+
+    def test_without_a_name_or_orcid_nobody_matches(self):
+        assert not mod._author_matches({"family": "Scholze"}, "", "")


### PR DESCRIPTION
Some ORCID records carry no employment section at all, and the profile still asks every author for an institution. The papers are on the same record and Crossref names the affiliation on the author line, so the fact is one hop away:

```
ORCID iD -> works -> DOIs -> Crossref -> affiliation -> ROR
```

For the author who prompted this — `0000-0002-9569-7562`, **no ORCID employments whatsoever** — the crate now carries:

```json
{"name": "Brunel University of London",
 "ror": "https://ror.org/00dn4t376",
 "url": "https://www.brunel.ac.uk"}
```

from three of his own papers.

## When to believe it

Implements the rule from review, and the refinement matters:

- **all affiliations agree → take it, even from two papers.** Two independent records saying the same thing is corroboration; demanding a third would throw away a good answer for someone who has published twice.
- **they conflict → the three most recent decide.** People move, and an old paper is evidence of where someone *used* to be — a different claim.
- **still split → return nothing**, and the question reaches a human. A confident wrong affiliation in a scientific record is worse than an open question.

This is retrieval, not inference: every value was published by a registry about this person. Nothing is guessed from a name, an email domain or a co-author.

## Two places the obvious implementation is wrong

**Picking the employer out of the string.** Crossref publishes free text with department, street and postcode attached. Taking the *longest* institution-ish part picks the department every time — "Centre for Pollution Research and Policy" — and two spellings of one employer then look like two employers, which breaks the agreement rule. Strength beats length.

**Checking the ROR match.** ROR registers "Brunel University **of** London" where the paper prints "Brunel University London", so containment rejects a correct match over a connective. But requiring only ROR's words to appear accepts a wrong one: "University of London" is a real, different institution whose words all sit inside "Brunel University London". Requiring the significant words to agree **both ways** keeps the first and refuses the second. Unverified, the printed name is kept with no ROR attached — better the paper's own words than a confidently wrong registry id.

Bounded to 8 works per author, only for authors ORCID could not answer, and every failure is silent: a missing affiliation is a recommendation, a cascade that dies because Crossref is briefly down is a broken build.

21 tests, none touching the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)