### PR TITLE
fix(tools): answer a missing id with the ids it probably meant

### DIFF
--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -307,7 +307,9 @@ def draft_process_chain(
 
     assay = state.get_entity(assay_id)
     if assay is None:
-        raise ValueError(f"draft_process_chain assay not found: {assay_id!r}.")
+        from builder.tools.management import entity_not_found_message
+
+        raise ValueError(f"draft_process_chain assay: {entity_not_found_message(state, assay_id)}")
     if assay.type != "Assay":
         raise ValueError(
             f"draft_process_chain assay_id must be an Assay; {assay_id!r} is a {assay.type}."

--- a/builder/tools/provenance.py
+++ b/builder/tools/provenance.py
@@ -29,6 +29,7 @@ from typing import Any
 from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools._crate_mapping import PROVENANCE_RELATIONS, _file_source
 from builder.tools.drafters import _make_entity_id
+from builder.tools.management import entity_not_found_message
 from builder.tools.scanner import encoding_format_for_name
 
 logger = logging.getLogger(__name__)
@@ -169,11 +170,15 @@ def link(state: CrateState, from_id: str, relation: str, to_id: str) -> dict[str
     if relation not in PROVENANCE_RELATIONS:
         valid = ", ".join(sorted(PROVENANCE_RELATIONS))
         raise ValueError(f"Unknown provenance relation {relation!r}. Valid relations are: {valid}.")
+    # Route a miss through the shared message so it names the ids the caller was
+    # most likely reaching for. A flat "not found" tells the agent its guess was
+    # wrong without telling it what is right, so it guesses again — one profiled
+    # session lost four iterations to exactly that, on ids it had never been shown.
     src = state.get_entity(from_id)
     if src is None:
-        raise ValueError(f"link source entity not found: {from_id!r}.")
+        raise ValueError(f"link source: {entity_not_found_message(state, from_id)}")
     if state.get_entity(to_id) is None:
-        raise ValueError(f"link target entity not found: {to_id!r}.")
+        raise ValueError(f"link target: {entity_not_found_message(state, to_id)}")
 
     # Write where the build reads, not where the caller pointed — see
     # _PROCESS_LINK_HOMES. Silently storing an edge assembly discards is worse
@@ -282,7 +287,7 @@ def attach_files(
     """
     target = state.get_entity(to)
     if target is None:
-        raise ValueError(f"attach_files target not found: {to!r}.")
+        raise ValueError(f"attach_files target: {entity_not_found_message(state, to)}")
     if target.type not in ("Study", "Assay"):
         raise ValueError(
             f"attach_files target must be a Study or Assay; {to!r} is a "

--- a/tests/test_not_found_errors_suggest.py
+++ b/tests/test_not_found_errors_suggest.py
@@ -1,0 +1,102 @@
+"""A missing entity id is answered with the ids it was probably reaching for.
+
+Ids are minted by the drafting tools from an entity's name, so an agent that
+rebuilds one from the name it remembers gets close but not exact —
+``assay_inhibition_of_oatp1c1_mediated_cellular_uptake_of_thyroxine`` for an
+assay actually stored under a shorter id, ``org_erasmus_mc`` for
+``org_erasmus_medical_center``.
+
+``entity_not_found_message`` was written for exactly this and says "Did you
+mean: …". It was wired into ``set_fields`` and nowhere else, so the three tools
+that fail this way in practice — ``link``, ``attach_files`` and
+``draft_process_chain`` — still answered with a flat "not found". A profiled
+session lost four iterations to it: each failure told the agent its guess was
+wrong without telling it what was right, so it guessed again.
+
+These tests pin every entry point to the shared message, so the next tool that
+grows an id argument is the only one that can regress.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+
+
+def _state(*ids: tuple[str, str]) -> CrateState:
+    state = CrateState()
+    for entity_id, entity_type in ids:
+        entity = Entity(
+            entity_id=entity_id,
+            type=entity_type,  # ty: ignore[invalid-argument-type]
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+        entity.set_fields_from_dict({"name": entity_id}, source="llm")
+        state.add_entity(entity)
+    return state
+
+
+class TestTheNearMissIsNamed:
+    def test_link_names_the_id_it_meant(self):
+        """The session's actual failure: org_erasmus_mc."""
+        from builder.tools.provenance import link
+
+        state = _state(("org_erasmus_medical_center", "Organization"), ("proc_a", "LabProcess"))
+        with pytest.raises(ValueError, match="org_erasmus_medical_center"):
+            link(state, "proc_a", "input", "org_erasmus_mc")
+
+    def test_link_checks_its_source_too(self):
+        from builder.tools.provenance import link
+
+        state = _state(("proc_cell_culture", "LabProcess"), ("sample_a", "Sample"))
+        with pytest.raises(ValueError, match="proc_cell_culture"):
+            link(state, "proc_cellculture", "result", "sample_a")
+
+    def test_attach_files_names_the_id_it_meant(self):
+        from builder.tools.provenance import attach_files
+
+        state = _state(("study_oatp1c1_uptake", "Study"))
+        with pytest.raises(ValueError, match="study_oatp1c1_uptake"):
+            attach_files(state, to="study_oatp1c1_inhibition")
+
+    def test_draft_process_chain_names_the_id_it_meant(self):
+        from builder.tools.composites import draft_process_chain
+
+        state = _state(("assay_oatp1c1_uptake_inhibition", "Assay"))
+        with pytest.raises(ValueError, match="assay_oatp1c1_uptake_inhibition"):
+            draft_process_chain(state, assay_id="assay_oatp1c1_uptake_inhibiton", chain=[])
+
+
+class TestWithNoNearMissItStillHelps:
+    def test_it_lists_real_ids_rather_than_dead_ending(self):
+        """Naming a few real ids beats "no" when nothing is close."""
+        from builder.tools.provenance import link
+
+        state = _state(("sample_alpha", "Sample"), ("proc_a", "LabProcess"))
+        with pytest.raises(ValueError, match="Existing ids include"):
+            link(state, "proc_a", "input", "zzzzzzzzzzzz")
+
+    def test_an_empty_crate_says_so(self):
+        from builder.tools.provenance import attach_files
+
+        with pytest.raises(ValueError, match="no entities yet"):
+            attach_files(CrateState(), to="study_1")
+
+
+class TestTheMessageStaysUseful:
+    def test_it_names_the_tool_that_failed(self):
+        """Three tools share one message; the caller must stay identifiable."""
+        from builder.tools.provenance import attach_files
+
+        state = _state(("study_a", "Study"))
+        with pytest.raises(ValueError, match="attach_files target"):
+            attach_files(state, to="study_b")
+
+    def test_it_explains_where_ids_come_from(self):
+        """The fix is to reuse the drafter's id, not to guess a better one."""
+        from builder.tools.provenance import link
+
+        state = _state(("sample_alpha", "Sample"), ("proc_a", "LabProcess"))
+        with pytest.raises(ValueError, match="minted by the drafting tools"):
+            link(state, "proc_a", "input", "sample_alfa")


### PR DESCRIPTION
From the `20260813_165951` profile — four failures, all the same shape:

```
draft_process_chain  assay not found: 'assay_inhibition_of_oatp1c1_mediated_cellular_uptake_of_thyroxine'
attach_files         target not found: 'study_oatp1c1_inhibition'
attach_files         target not found: 'assay_inhibition_of_oatp1c1_…'
link                 target entity not found: 'org_erasmus_mc'
```

We **had** already fixed this: `entity_not_found_message` does `difflib.get_close_matches` and says "Did you mean: …". It was wired into `set_fields` and **nowhere else** — one call site — so the three tools that fail this way in practice never used it.

`link` now answers:

> `link target: Entity not found: org_erasmus_mc. Did you mean: org_erasmus_medical_center? Ids are minted by the drafting tools — use the one they returned rather than rebuilding it from the entity's name.`

Where nothing is close it lists real ids rather than dead-ending, and an empty crate says so. Each message still names the tool that failed, so sharing one message doesn't cost the caller its identity.

Same class as the `protocol`/`labprotocol` fix: the agent reaches for the obvious name and we answered with a flat no.

8 tests, one per entry point, so the next tool to grow an id argument is the only one that can regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)