### PR TITLE
fix(report): the tier ordering in What to do next was a no-op, and the section was unstyled

### DIFF
--- a/builder/tools/remediation.py
+++ b/builder/tools/remediation.py
@@ -54,6 +54,26 @@ _NOT_ACTIONABLE: tuple[tuple[str, str], ...] = (
 )
 
 
+# Keyed on the vocabulary the VALIDATOR emits, upper-cased. This used to read
+# {"MUST", "SHOULD", "MAY"} — the words the SHACL messages are written in — while
+# `group_findings` derives the tier from `finding["severity"]`, which
+# `builder/tools/validation.py` sets to "required" / "recommended" / "optional".
+# Nothing matched, so `.get(tier, 3)` returned 3 for EVERY action, every sort key
+# tied, and the tier term silently dropped out: ordering collapsed to "whichever
+# clears the most". A required-conformance action clearing one finding then ranked
+# below any bulk advisory action and could fall past `_NEXT_STEPS_CAP` entirely —
+# the report hiding the work that actually blocks the build, which is the one
+# thing this section exists to surface.
+_TIER_RANK = {"REQUIRED": 0, "RECOMMENDED": 1, "OPTIONAL": 2}
+
+# What each tier is called in the report. The validator's own word, not the
+# SHACL verb: a reader who sees "Required" beside an action can match it to the
+# "Required" count in the conformance table above it.
+TIER_LABEL = {"REQUIRED": "Required", "RECOMMENDED": "Recommended", "OPTIONAL": "Optional"}
+
+_DEFAULT_TIER = "RECOMMENDED"
+
+
 @dataclass
 class Action:
     """One thing a person could do, and what it would clear.
@@ -65,7 +85,9 @@ class Action:
         subject: What the action is about — an entity label, or a property name.
         entity_ids: Every entity the action touches.
         findings: The finding messages this action would clear.
-        tier: The strongest tier among those findings (MUST > SHOULD > MAY).
+        tier: The strongest tier among those findings
+            (REQUIRED > RECOMMENDED > OPTIONAL — the validator's own
+            vocabulary, so it lines up with the conformance table).
         actionable: False for a finding that is deliberately left open.
         note: Why it is not actionable, when it is not.
     """
@@ -75,7 +97,7 @@ class Action:
     subject: str
     entity_ids: list[str] = field(default_factory=list)
     findings: list[str] = field(default_factory=list)
-    tier: str = "SHOULD"
+    tier: str = _DEFAULT_TIER
     actionable: bool = True
     note: str | None = None
 
@@ -85,11 +107,15 @@ class Action:
         return len(self.findings)
 
 
-_TIER_RANK = {"MUST": 0, "SHOULD": 1, "MAY": 2}
-
-
 def _strongest(tiers: list[str]) -> str:
-    return sorted(tiers, key=lambda t: _TIER_RANK.get(t, 3))[0] if tiers else "SHOULD"
+    """The most severe tier in *tiers* — REQUIRED beats RECOMMENDED beats OPTIONAL.
+
+    An unrecognised tier sorts last rather than raising: a new validator severity
+    should make an action rank low, not crash the report. It is the DEFAULT that
+    carries the risk, so it stays "RECOMMENDED" — defaulting an unknown to
+    REQUIRED would push unclassified work above real conformance failures.
+    """
+    return sorted(tiers, key=lambda t: _TIER_RANK.get(t, 3))[0] if tiers else _DEFAULT_TIER
 
 
 def _not_actionable_note(message: str) -> str | None:
@@ -191,7 +217,7 @@ def group_findings(
                 ),
                 entity_ids=sorted({str(f.get("entity_id")) for f in live if f.get("entity_id")}),
                 findings=[str(f.get("message") or "") for f in live],
-                tier=_strongest([str(f.get("severity") or "SHOULD").upper() for f in live]),
+                tier=_strongest([str(f.get("severity") or _DEFAULT_TIER).upper() for f in live]),
             )
         )
         for f in live:
@@ -259,7 +285,14 @@ _WANTED: tuple[tuple[tuple[str, ...], str], ...] = (
     (("measurement method",), "Say which measurement method was used"),
     (("Key Event", "AOP"), "Link the measured endpoint to its AOP-Wiki Key Event"),
     (("creator",), "Name who created it"),
-    (("dateCreated", "date"), "Add the date it was created"),
+    # NOT a bare "date" needle. `_wanted` substring-matches the whole message
+    # blob, so "date" fired on datePublished / dateModified / "validate" alike and
+    # answered every one of them with "Add the date it was created" — a specific,
+    # confident, wrong instruction. The contract for `describe()` is the MOST
+    # SPECIFIC instruction that fits; a needle this broad is the opposite.
+    (("dateCreated",), "Add the date it was created"),
+    (("datePublished",), "Add the date it was published"),
+    (("dateModified",), "Add the date it was last modified"),
     (("description",), "Add a description"),
     (("termCode",), "Add the ontology code"),
     (("parameter value", "additional property"), "Record the parameters used"),
@@ -356,7 +389,7 @@ def group_orphans(orphans: list[str], *, labels: dict[str, str] | None = None) -
             subject=name,
             entity_ids=sorted(ids),
             findings=[f"{i} is not reachable from the crate root" for i in sorted(ids)],
-            tier="SHOULD",
+            tier=_DEFAULT_TIER,
         )
         for name, ids in clusters.items()
     ]

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -388,3 +388,32 @@ __CATEGORY_STYLES__
 .mat li.more > details.more-fold > summary:hover { color:var(--ink); }
 .mat li.more > details.more-fold > ul.sugg,
 .mat li.more > details.more-fold > ul.ind { margin:.35rem 0 0; font-style:normal; }
+
+/* --- What to do next (#561) -------------------------------------------------
+   These four classes shipped in the HTML with no rule anywhere, so the whole
+   section rendered at browser defaults: a bare <ol> with its count and its
+   sentence as two adjacent inline spans, which run together as "36Connect the
+   AOP-Wiki subgraph". The count is a figure, not a word in the sentence, so it
+   needs a column of its own — the same treatment the tier lists already give
+   their leading marks. */
+.mat ol.next-actions { list-style:none; margin:.35rem 0 0; padding:0; }
+.mat ol.next-actions > li { display:flex; gap:.6rem; align-items:baseline;
+  padding:.32rem 0; border-top:1px solid var(--hairline); }
+.mat ol.next-actions > li:first-child { border-top:0; }
+/* Tabular figures and a fixed column so the numbers line up as a column rather
+   than ragging with the width of each count. */
+.mat .na-n { flex:0 0 2.4rem; text-align:right; font-weight:650; color:var(--ink);
+  font-variant-numeric:tabular-nums; }
+.mat .na-t { color:var(--ink-2); }
+/* Named only on the tier that BLOCKS conformance — a badge on every row would
+   mark nothing. Warn, not bad: this is work outstanding, not a failure. */
+.mat .na-req { margin-left:.45rem; font-size:.7rem; text-transform:uppercase;
+  letter-spacing:.05em; padding:.05rem .3rem; border-radius:.3rem;
+  color:var(--warn-ink); background:color-mix(in srgb,var(--warn) 15%,transparent);
+  border:1px solid color-mix(in srgb,var(--warn) 45%,transparent); }
+.mat details.na-aside { margin:.5rem 0 0; }
+.mat details.na-aside > summary { cursor:pointer; color:var(--muted);
+  font-size:.86rem; }
+.mat details.na-aside > summary:hover { color:var(--ink); }
+.mat details.na-aside ul { margin:.35rem 0 0; color:var(--muted);
+  font-size:.86rem; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -882,7 +882,13 @@ def _render_next_steps_section(
     Renders nothing when there is nothing to act on — an empty exhortation is
     worse than silence.
     """
-    from builder.tools.remediation import describe, group_findings, group_orphans
+    from builder.tools.remediation import (
+        _TIER_RANK,
+        TIER_LABEL,
+        describe,
+        group_findings,
+        group_orphans,
+    )
     from builder.writers.provenance_dag import build_crate_graph
 
     if val is None or not _validation_has_signal(val):
@@ -907,18 +913,35 @@ def _render_next_steps_section(
     if not live:
         return ""
 
-    live.sort(key=lambda a: -a.cleared)
+    # Tier FIRST, then size — the same key `group_findings` sorted by, rather than
+    # re-sorting on `-cleared` alone. Sorting purely by size ranks a required
+    # conformance failure clearing one finding below any bulk advisory action, and
+    # `_NEXT_STEPS_CAP` then drops it off the list entirely: the report quietly
+    # hiding the work that blocks the build, which is the one thing this section
+    # exists to surface.
+    live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
     esc = html.escape
     rows = "".join(
         f'<li><span class="na-n">{a.cleared}</span>'
-        f'<span class="na-t">{esc(describe(a))}</span></li>'
+        f'<span class="na-t">{esc(describe(a))}'
+        # The tier is named only when it BLOCKS. Marking all three would put a
+        # badge on every row and mark nothing; the reader's question here is
+        # "what must I fix before this crate is conformant?".
+        + (
+            f'<span class="na-req">{esc(TIER_LABEL[a.tier])}</span>'
+            if _TIER_RANK.get(a.tier, 3) == 0
+            else ""
+        )
+        + "</span></li>"
         for a in live[:_NEXT_STEPS_CAP]
     )
     if len(live) > _NEXT_STEPS_CAP:
         rest = sum(a.cleared for a in live[_NEXT_STEPS_CAP:])
         rows += (
             f'<li><span class="na-n">{rest}</span><span class="na-t">'
-            f"…and {len(live) - _NEXT_STEPS_CAP} smaller items, listed in full below."
+            f"…and {len(live) - _NEXT_STEPS_CAP} smaller "
+            f"{'item' if len(live) - _NEXT_STEPS_CAP == 1 else 'items'}, "
+            "listed in full below."
             "</span></li>"
         )
     settled = [a for a in actions if not a.actionable]
@@ -927,15 +950,17 @@ def _render_next_steps_section(
         notes = "".join(f"<li>{esc(a.note or '')}</li>" for a in settled)
         total = sum(a.cleared for a in settled)
         aside = (
-            f'  <details class="na-aside"><summary>{total} findings left open on '
+            f'  <details class="na-aside"><summary>{total} '
+            f"{'finding' if total == 1 else 'findings'} left open on "
             f"purpose</summary><ul>{notes}</ul></details>\n"
         )
     covered = sum(a.cleared for a in live)
     return (
         "<section>\n"
         '  <div class="sec-h"><h2>What to do next</h2>'
-        f'<span class="sec-meta"><b>{len(live)}</b> actions clear '
-        f"<b>{covered}</b> findings</span></div>\n"
+        f'<span class="sec-meta"><b>{len(live)}</b> '
+        f"{'action clears' if len(live) == 1 else 'actions clear'} "
+        f"<b>{covered}</b> {'finding' if covered == 1 else 'findings'}</span></div>\n"
         f'  <ol class="next-actions">{rows}</ol>\n'
         f"{aside}"
         "</section>\n"

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -2014,3 +2014,80 @@ class TestTheOrphanListIsReachable:
 
         assert "more-fold" not in html
         assert "further" not in html
+
+
+class TestEveryClassTheReportEmitsIsStyled:
+    """A class in the HTML with no rule in the CSS renders at browser defaults.
+
+    "What to do next" shipped with four such classes. The section still LOOKED
+    plausible in a diff — the markup is correct and the text is right — but the
+    count and the sentence are two adjacent inline spans, so with no rule they
+    ran together as "36Connect the AOP-Wiki subgraph". Nothing failed; the page
+    was just wrong.
+
+    Scoped to the classes the report defines for ITSELF. Bare element styling
+    and any class inherited from elsewhere are not this test's business — the
+    claim is only that a class this file invents has somewhere to get its layout
+    from.
+    """
+
+    def _emitted_classes(self, page: str) -> set[str]:
+        import re
+
+        return {
+            cls
+            for attr in re.findall(r'class="([^"]+)"', page)
+            for cls in attr.split()
+        }
+
+    def _next_steps_html(self) -> str:
+        """The "What to do next" section, actually rendered.
+
+        Built here rather than taken from a fixture page because NO fixture
+        produces it: it needs a ValidationReport carrying `issue_records`, and
+        every golden crate renders the page without one. That is how four
+        unstyled classes shipped — and it is also why the first version of this
+        test passed with the rules deleted. It searched the whole page for the
+        class NAME, and the page INLINES the stylesheet, so every class matched
+        itself in the `<style>` block whether or not the markup used it.
+        """
+        from builder.tools.validation import ValidationReport
+        from builder.writers.maturity_report import _render_next_steps_section
+
+        val = ValidationReport()
+        val.base_passed = True
+        val.issue_records = [
+            {"profile": "base", "severity": "required", "entity_id": "./",
+             "message": "The root Dataset MUST have a licence"},
+            *[
+                {"profile": "tox", "severity": "optional", "entity_id": f"#e{i}",
+                 "message": f"A Sample SHOULD have a description of kind {i}"}
+                for i in range(11)
+            ],
+        ]
+        html_out = _render_next_steps_section(val, None)
+        assert 'class="na-n"' in html_out, "the section did not render; this test is inert"
+        return html_out
+
+    def test_no_class_in_the_page_is_missing_from_the_stylesheet(self) -> None:
+        from pathlib import Path
+
+        css = Path("builder/writers/maturity_report.css").read_text(encoding="utf-8")
+        # The whole page PLUS the section no fixture renders. Concatenated so one
+        # assertion covers both, and the section's classes cannot be quietly
+        # dropped from coverage again.
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21")) + self._next_steps_html()
+
+        # Classes the page carries but the stylesheet never mentions. `.mat` is
+        # the wrapper the stylesheet keys everything off, and `mermaid` is the
+        # renderer's own hook — neither is styled here by design.
+        exempt = {"mat", "mermaid"}
+        unstyled = sorted(
+            cls
+            for cls in self._emitted_classes(page)
+            if cls not in exempt and f".{cls}" not in css
+        )
+        assert unstyled == [], (
+            f"classes emitted with no rule in maturity_report.css, so they render "
+            f"at browser defaults: {unstyled}"
+        )

--- a/tests/test_remediation_grouping.py
+++ b/tests/test_remediation_grouping.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from builder.tools.remediation import Action, describe, group_findings, group_orphans
 
 
-def _f(entity_id, message, prop=None, severity="RECOMMENDED"):
+def _f(entity_id, message, prop=None, severity="recommended"):
     return {
         "entity_id": entity_id,
         "message": message,
@@ -167,23 +167,30 @@ class TestDeliberateFindingsAreNotRecommended:
 
 
 class TestTheStrongestTierWins:
-    def test_a_must_outranks_a_should(self):
+    # NB: "required", not "MUST". These used to say MUST/SHOULD — the verbs the
+    # SHACL messages are written in — and passed while the production vocabulary
+    # ("required"/"recommended"/"optional") matched no rank at all, so every
+    # action tied and tier ordering was a no-op. A test that supplies a
+    # vocabulary no producer emits is how that shipped green; see
+    # TestTheTierVocabularyMatchesTheValidator, which pins the two together.
+
+    def test_a_required_finding_outranks_a_recommended_one(self):
         findings = [
-            _f("#a", "one", severity="RECOMMENDED"),
-            _f("#a", "two", severity="MUST"),
+            _f("#a", "one", severity="recommended"),
+            _f("#a", "two", severity="required"),
         ]
-        assert group_findings(findings)[0].tier == "MUST"
+        assert group_findings(findings)[0].tier == "REQUIRED"
 
     def test_actions_are_ordered_by_tier_then_reach(self):
         findings = [
-            _f("#a", "one", severity="RECOMMENDED"),
-            _f("#a", "two", severity="RECOMMENDED"),
-            _f("#b", "three", severity="MUST"),
-            _f("#b", "four", severity="MUST"),
-            _f("#b", "five", severity="MUST"),
+            _f("#a", "one", severity="recommended"),
+            _f("#a", "two", severity="recommended"),
+            _f("#b", "three", severity="required"),
+            _f("#b", "four", severity="required"),
+            _f("#b", "five", severity="required"),
         ]
         actions = group_findings(findings)
-        assert actions[0].tier == "MUST"
+        assert actions[0].tier == "REQUIRED"
         assert actions[0].cleared == 3
 
 
@@ -255,3 +262,89 @@ class TestTheActionShape:
     def test_an_action_carries_the_entities_it_touches(self):
         findings = [_f("#a", "needs an affiliation"), _f("#a", "needs a URL")]
         assert group_findings(findings)[0].entity_ids == ["#a"]
+
+
+class TestTheTierVocabularyMatchesTheValidator:
+    """`_TIER_RANK` must key on the words the validator actually emits.
+
+    It keyed on "MUST"/"SHOULD"/"MAY" — the verbs the SHACL *messages* are
+    written in — while `group_findings` derives the tier from
+    ``finding["severity"]``, which `builder/tools/validation.py` sets to
+    "required"/"recommended"/"optional". Nothing matched, `.get(tier, 3)`
+    returned 3 for every action, and the tier term dropped silently out of the
+    sort key. The report then ordered purely by size and the cap hid the work
+    that blocks the build.
+
+    Two vocabularies that must agree, in two files, with no type to bind them —
+    so it is asserted rather than trusted.
+    """
+
+    def test_every_severity_the_validator_emits_has_a_rank(self) -> None:
+        from builder.tools.remediation import _TIER_RANK
+
+        # The literal set builder/tools/validation.py writes into issue_records.
+        for severity in ("required", "recommended", "optional"):
+            assert severity.upper() in _TIER_RANK, (
+                f"the validator emits severity={severity!r} and the report has no "
+                f"rank for it, so every action ties and tier ordering is a no-op"
+            )
+
+    def test_required_work_outranks_bulk_advisory_work(self) -> None:
+        """The user-visible consequence, at the size where it bites."""
+        from builder.tools.remediation import _TIER_RANK, group_findings
+
+        records = [
+            {"profile": "tox", "severity": "optional", "entity_id": f"#e{i}",
+             "message": f"SHOULD have a {field} of kind {i}"}
+            for i in range(12)
+            for field in ("description", "url")
+        ]
+        records.append({
+            "profile": "base", "severity": "required", "entity_id": "./",
+            "message": "The root Dataset MUST have a licence",
+        })
+
+        live = [a for a in group_findings(records, labels={}) if a.actionable and a.cleared]
+        live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
+        assert live[0].tier == "REQUIRED", (
+            "a required conformance failure must lead the list; sorted by size "
+            "alone it ranked 12th of 13 and fell past the cap entirely"
+        )
+
+    def test_an_unknown_severity_sorts_last_rather_than_first(self) -> None:
+        """A new validator severity should rank LOW, not be promoted above real
+        conformance failures by defaulting to the strongest tier."""
+        from builder.tools.remediation import _TIER_RANK, _strongest
+
+        assert _strongest(["SOMETHING_NEW", "OPTIONAL"]) == "OPTIONAL"
+        assert _TIER_RANK.get("SOMETHING_NEW", 3) == 3
+
+
+class TestTheDateInstructionNamesTheRightDate:
+    """A bare "date" needle answered every date question with the same sentence.
+
+    `_wanted` substring-matches the joined message blob, so "date" fired on
+    datePublished and dateModified alike — and on any message containing the
+    letters, e.g. "validate" — and returned "Add the date it was created". A
+    specific, confident, wrong instruction, which is worse than none: the
+    contract for `describe()` is the most specific instruction that FITS.
+    """
+
+    def test_each_date_property_gets_its_own_instruction(self) -> None:
+        from builder.tools.remediation import _wanted
+
+        assert _wanted(["A Dataset SHOULD have a dateCreated"]) == "Add the date it was created"
+        assert _wanted(["A Dataset SHOULD have a datePublished"]) == (
+            "Add the date it was published"
+        )
+        assert _wanted(["A Dataset SHOULD have a dateModified"]) == (
+            "Add the date it was last modified"
+        )
+
+    def test_a_word_that_merely_contains_date_does_not_trip_it(self) -> None:
+        for message in ("the crate must validate against the profile", "SHOULD have an update"):
+            from builder.tools.remediation import _wanted
+
+            assert "date it was" not in _wanted([message]), (
+                f"{message!r} answered with a date instruction"
+            )


### PR DESCRIPTION
Four defects in the "What to do next" section that #561 shipped. They were found by an adversarial review of that branch; the fixes were pushed to it but **#561 merged before they landed**, so main has the broken version. This is that commit, rebased onto main.

CI was green throughout. None of these are the kind of thing a test suite notices on its own.

## 1. The tier term never applied — required work could be hidden

```python
line 194:  tier = severity.upper()                        # "REQUIRED" / "RECOMMENDED" / "OPTIONAL"
line  88:  _TIER_RANK = {"MUST": 0, "SHOULD": 1, "MAY": 2}  # .get(tier, 3) == 3, always
```

`_TIER_RANK` keyed on the verbs the SHACL *messages* are written in; `group_findings` derives the tier from `finding["severity"]`, which `validation.py` sets to `required`/`recommended`/`optional`. Two vocabularies, two files, nothing binding them. Every action tied at rank 3 and ordering silently collapsed to "whichever clears the most".

The consequence is the exact inverse of this section's purpose. From real record shapes — 12 advisory jobs plus one required conformance failure:

| sort | rank of the REQUIRED action | shown, cap = 8 |
|---|---|---|
| old (`-cleared` only) | **12 of 13** | **no** |
| fixed (tier first) | 1 of 13 | yes |

The report hid the only thing blocking the build.

## 2. The render discarded the order anyway

`_render_next_steps_section` re-sorted on `-a.cleared`, throwing away the `(tier, size, subject)` key `group_findings` had just applied. It now sorts on the same key, and names the tier — **only on REQUIRED**, since a badge on every row marks nothing.

## 3. The section was unstyled

`next-actions`, `na-n`, `na-t`, `na-aside` shipped with no rule in `maturity_report.css`. The block rendered at browser defaults, and the count ran into the sentence:

```
36Connect the AOP-Wiki subgraph — 36 entities are unreachable.
```

## 4. A bare `"date"` needle gave a confidently wrong instruction

`_wanted` substring-matches the message blob, so `"date"` fired on `datePublished`, `dateModified`, and any message merely containing the letters — answering all of them *"Add the date it was created"*. That directly contradicts `describe()`'s stated contract to pick the most specific instruction that **fits**. Each date property now has its own.

## Why CI never saw any of it

Two existing tests supplied `severity="MUST"` — a vocabulary **no producer emits**. They exercised a synthetic world in which the code was correct. Now fixed to the real one.

And the new unstyled-class guard took two attempts. **The first version was itself vacuous**: it searched the whole page for the class name and passed with the rules deleted, because the page *inlines* its stylesheet — every class matched itself inside `<style>`. It now renders the section (no fixture does — it needs a `ValidationReport` carrying `issue_records`, which is also why nothing caught the original defect) and asserts the section rendered before checking anything.

Mutation-checked: deleting the `.na-n` rule fails the guard; restoring it passes.

## Verification

`tests/test_remediation_grouping.py` + `tests/test_maturity_report.py` — 151 passed. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)