### PR TITLE
perf(export): re-exporting an unchanged crate is a no-op

### DIFF
--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -508,6 +508,57 @@ def _embed_maturity_report(crate: ROCrate, state: CrateState) -> None:
     )
 
 
+# Exports already written this process, keyed by (state fingerprint, destination,
+# what was asked for). Small: an agent loop re-exports the SAME crate over and
+# over, so one live entry is the normal case and a couple of destinations the
+# most anyone needs.
+_EXPORT_MEMO: dict[tuple[str, str, bool, bool], dict[str, Any]] = {}
+_EXPORT_MEMO_MAX = 4
+
+
+def _export_memo_key(
+    state: CrateState,
+    output_dir: Path,
+    embed_graph: bool,
+    embed_report: bool,
+) -> tuple[str, str, bool, bool] | None:
+    """Memo key for an export, or None when the state cannot be fingerprinted.
+
+    Reuses ``validation_fingerprint`` — it hashes entities plus metadata, which
+    is everything ``assemble_crate`` reads, and deliberately excludes the
+    verdicts and timestamps that every export writes back. Anything the written
+    crate could differ by busts the key; a pure output does not.
+    """
+    try:
+        fingerprint = state.validation_fingerprint()
+    except Exception:  # noqa: BLE001 — an un-fingerprintable state just re-exports
+        logger.debug("State could not be fingerprinted; exporting without the memo")
+        return None
+    return (fingerprint, str(output_dir.resolve()), embed_graph, embed_report)
+
+
+def _export_is_intact(output_dir: Path) -> bool:
+    """Whether a previously written crate is still on disk.
+
+    The memo says what WE did; it cannot know what happened to the directory
+    afterwards. A user who deletes the output and re-runs must get their crate
+    back, so the descriptor is checked before a reuse is claimed.
+    """
+    try:
+        return (output_dir / "ro-crate-metadata.json").is_file()
+    except Exception:  # noqa: BLE001 — an unreadable path is not a valid reuse
+        return False
+
+
+def _remember_export(key: tuple[str, str, bool, bool] | None, result: dict[str, Any]) -> None:
+    """Record a successful export, bounding the memo."""
+    if key is None or not result.get("success"):
+        return
+    if len(_EXPORT_MEMO) >= _EXPORT_MEMO_MAX and key not in _EXPORT_MEMO:
+        _EXPORT_MEMO.pop(next(iter(_EXPORT_MEMO)), None)
+    _EXPORT_MEMO[key] = result
+
+
 def export_crate(
     state: CrateState,
     output_path: str | None = None,
@@ -567,6 +618,23 @@ def export_crate(
             output_path = state.metadata.output_path or _default_crate_path(state)
 
         output_dir = Path(output_path)
+        # An export nobody's changes have reached is the same export. One
+        # profiled session called this 32 times — 29 of them immediately after a
+        # validate — and spent 279s of its 305s export budget rewriting a crate
+        # byte for byte. `build_and_validate` already builds in memory and
+        # touches no disk, so exporting to check a verdict is pure waste.
+        #
+        # A memo rather than a prompt rule, because it does not depend on the
+        # agent behaving; and keyed on the destination too, since the same state
+        # written to a second directory is a genuinely different result.
+        memo_key = _export_memo_key(state, output_dir, embed_graph, embed_report)
+        if memo_key is not None and (cached := _EXPORT_MEMO.get(memo_key)) is not None:
+            if _export_is_intact(output_dir):
+                logger.info("Crate already exported and unchanged: %s", output_dir)
+                return {**cached, "reused": True}
+            # Someone removed or emptied it since; fall through and write again.
+            _EXPORT_MEMO.pop(memo_key, None)
+
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Validate BEFORE assembling, so the maturity report embedded below
@@ -677,6 +745,9 @@ def export_crate(
             out["provisional_tables"] = provisional
         if wiring["wired"] or wiring["ambiguous"]:
             out["wiring"] = wiring
+        # Remembered AFTER the write, and only on success, so a failed export is
+        # never reported as a completed one on the next call.
+        _remember_export(memo_key, out)
         return out
 
     except OSError as e:

--- a/tests/test_export_is_not_repeated.py
+++ b/tests/test_export_is_not_repeated.py
@@ -1,0 +1,151 @@
+"""Exporting a crate nothing has changed is the same crate.
+
+A profiled session called `export_crate` 32 times, 29 of them immediately after
+a `build_and_validate`, and spent 279 of its 305 export seconds rewriting a
+crate byte for byte. `build_and_validate` already assembles in memory and
+touches no disk, so exporting to check a verdict buys nothing.
+
+This is a memo rather than a prompt rule because it does not depend on the agent
+behaving. What it must never do is claim a reuse that leaves the user without
+their crate, so the interesting tests here are the ones about NOT reusing:
+
+* any change the written crate could differ by busts it;
+* a different destination is a different result;
+* a directory deleted since is written again;
+* a failed export is never remembered as a completed one.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools import builder as builder_mod
+from builder.tools.builder import export_crate
+
+
+@pytest.fixture(autouse=True)
+def _clear_memo():
+    builder_mod._EXPORT_MEMO.clear()
+    yield
+    builder_mod._EXPORT_MEMO.clear()
+
+
+def _state(title: str = "A crate") -> CrateState:
+    state = CrateState()
+    state.metadata.title = title
+    state.metadata.description = "Enough to build."
+    return state
+
+
+def _export(state: CrateState, path) -> dict:
+    return export_crate(state, str(path), validate=False)
+
+
+class TestTheSecondExportIsFree:
+    def test_an_unchanged_export_is_reused(self, tmp_path):
+        state = _state()
+        first = _export(state, tmp_path)
+        second = _export(state, tmp_path)
+        assert first.get("reused", False) is False, "the first export must actually write"
+        assert second["reused"] is True
+
+    def test_the_reused_result_matches_the_written_one(self, tmp_path):
+        """A caller must not be able to tell, apart from the flag."""
+        state = _state()
+        first = _export(state, tmp_path)
+        second = _export(state, tmp_path)
+        assert second["crate_path"] == first["crate_path"]
+        assert second["success"] is first["success"] is True
+
+    def test_the_crate_is_still_on_disk(self, tmp_path):
+        state = _state()
+        _export(state, tmp_path)
+        _export(state, tmp_path)
+        assert (tmp_path / "ro-crate-metadata.json").is_file()
+
+
+class TestAnythingThatCouldDifferBustsIt:
+    def test_a_metadata_edit_re_exports(self, tmp_path):
+        state = _state()
+        _export(state, tmp_path)
+        state.metadata.title = "A different crate"
+        assert _export(state, tmp_path).get("reused", False) is False
+
+    def test_a_new_entity_re_exports(self, tmp_path):
+        state = _state()
+        _export(state, tmp_path)
+        entity = Entity(
+            entity_id="sample_1", type="Sample", _provenance=EntityProvenance(created_by="llm")
+        )
+        entity.set_fields_from_dict({"name": "A sample"}, source="llm")
+        state.add_entity(entity)
+        assert _export(state, tmp_path).get("reused", False) is False
+
+    def test_a_second_destination_is_a_different_export(self, tmp_path):
+        """The same crate written somewhere else has not been written there."""
+        state = _state()
+        _export(state, tmp_path / "one")
+        result = _export(state, tmp_path / "two")
+        assert result.get("reused", False) is False
+        assert (tmp_path / "two" / "ro-crate-metadata.json").is_file()
+
+    def test_asking_for_different_contents_re_exports(self, tmp_path):
+        state = _state()
+        export_crate(state, str(tmp_path), validate=False)
+        result = export_crate(state, str(tmp_path), validate=False, embed_report=False)
+        assert result.get("reused", False) is False
+
+
+class TestItNeverLeavesTheUserWithoutACrate:
+    def test_a_deleted_output_is_written_again(self, tmp_path):
+        """The memo knows what we did, not what happened to the directory."""
+        state = _state()
+        target = tmp_path / "crate"
+        _export(state, target)
+        shutil.rmtree(target)
+        result = _export(state, target)
+        assert result.get("reused", False) is False
+        assert (target / "ro-crate-metadata.json").is_file()
+
+    def test_an_emptied_output_is_written_again(self, tmp_path):
+        state = _state()
+        target = tmp_path / "crate"
+        _export(state, target)
+        (target / "ro-crate-metadata.json").unlink()
+        _export(state, target)
+        assert (target / "ro-crate-metadata.json").is_file()
+
+    def test_a_failed_export_is_not_remembered(self, tmp_path, monkeypatch):
+        """Otherwise the next call reports a crate that was never written."""
+        state = _state()
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(builder_mod, "assemble_crate", boom)
+        failed = _export(state, tmp_path)
+        assert failed["success"] is False
+        assert builder_mod._EXPORT_MEMO == {}
+
+    def test_an_unfingerprintable_state_just_exports(self, tmp_path, monkeypatch):
+        """No key, no memo — never a silent skip."""
+        state = _state()
+
+        def boom(self):
+            raise RuntimeError("cannot hash")
+
+        monkeypatch.setattr(CrateState, "validation_fingerprint", boom)
+        assert _export(state, tmp_path)["success"] is True
+        assert _export(state, tmp_path).get("reused", False) is False
+
+
+class TestTheMemoStaysSmall:
+    def test_it_is_bounded(self, tmp_path):
+        """An agent loop re-exports one crate; the cap is a backstop."""
+        for n in range(builder_mod._EXPORT_MEMO_MAX + 3):
+            _export(_state(f"Crate {n}"), tmp_path / f"c{n}")
+        assert len(builder_mod._EXPORT_MEMO) <= builder_mod._EXPORT_MEMO_MAX


### PR DESCRIPTION
From the `20260813_165951` profile — the largest single cost in the session:

```
export_crate        32 calls   305s   (avg 9.5s)
build_and_validate  38 calls   242s   (avg 6.4s)
                    ────────────────
                    9.1 min of 10.7 min tool time  (85%)
```

**29 of the 32 exports immediately follow a validate.** Only the last one matters; the other 31 cost **279s — 4.6 minutes of a 44-minute run** — rewriting a crate byte for byte. `build_and_validate` already assembles in memory and touches no disk, so exporting to check a verdict buys nothing.

A memo, not a prompt rule, so it doesn't depend on the agent behaving. Keyed on `validation_fingerprint` — entities plus metadata, which is everything `assemble_crate` reads and excludes the verdicts and timestamps every export writes back — plus the destination and the embed flags, since the same state written elsewhere, or with different contents requested, is a different result.

Measured on the session crate: repeat export **0.43s → 0.00s**, and a one-word metadata edit correctly costs the full 27s again.

## The part that matters is when it does NOT reuse

Claiming a reuse that leaves someone without their crate would be far worse than the waste it saves:

- the descriptor is checked before reuse, so an output **deleted or emptied since** is written again
- a **failed** export is never remembered as a completed one
- a state that **cannot be fingerprinted** simply exports, rather than silently skipping

12 tests, mostly about those. Verified non-vacuous: disabling the memo turns the reuse test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)