### PR TITLE
fix(report): name entities the way a reader would, not the way the graph does

### DIFF
--- a/builder/tools/remediation.py
+++ b/builder/tools/remediation.py
@@ -125,13 +125,84 @@ def _not_actionable_note(message: str) -> str | None:
     return None
 
 
+# How each authority's IRI is said out loud when the entity it names carries no
+# name of its own. The point is to say WHAT the thing is: a reader shown
+# "0000-0002-7685-9462" cannot tell a person from a grant from a checksum.
+_IRI_PHRASING: tuple[tuple[str, str], ...] = (
+    ("https://orcid.org/", "the person with ORCID {}"),
+    ("https://ror.org/", "the organization with ROR {}"),
+    ("https://doi.org/", "the publication with DOI {}"),
+    ("https://www.cellosaurus.org/", "the cell line {}"),
+    ("https://pubchem.ncbi.nlm.nih.gov/compound/", "the compound with PubChem CID {}"),
+)
+
+# Type prefixes on a minted fragment id. `_make_entity_id` builds
+# `#<Type>_<internal_id>`, and the internal id USUALLY repeats the type as its
+# own first token — `#Sample_sample_…`, `#Study_study_…`, `#LabProtocol_protocol_…`
+# — so stripping only the CamelCase prefix leaves "Sample sample proc … output
+# sample". Both layers come off.
+_ID_TYPE_PREFIXES: tuple[str, ...] = (
+    "CitationAuthor_", "DefinedTerm_", "LabProcess_", "LabProtocol_", "PropertyValue_",
+    "MolecularEntity_", "CellLineSample_", "Organization_", "Publication_", "Person_",
+    "Sample_", "Study_", "Assay_", "Investigation_", "File_", "Dataset_",
+)
+_ID_ECHO_TOKENS: tuple[str, ...] = (
+    "sample_", "study_", "assay_", "proc_", "protocol_", "pv_", "param_", "org_",
+    "chem_", "cell_", "dt_", "inv_",
+)
+
+
+def _id_variants(entity_id: str) -> tuple[str, ...]:
+    """The spellings of *entity_id* a lookup should try, most literal first.
+
+    The validator reports a fragment entity as ``./#Thing`` — resolved against
+    the crate base — while the graph writes the same node's ``@id`` as
+    ``#Thing``. Not one node in a real crate carries the ``./#`` form, so an
+    exact-match lookup missed EVERY fragment entity and every one of them fell
+    through to the id-mangling fallback: "PropertyValue pv sample role" and
+    "Sample sample proc … output sample" in a list that had their real names
+    available the whole time.
+    """
+    seen: list[str] = []
+    for candidate in (
+        entity_id,
+        entity_id.removeprefix("./"),
+        entity_id if entity_id.startswith("./") else f"./{entity_id}",
+    ):
+        if candidate and candidate not in seen:
+            seen.append(candidate)
+    return tuple(seen)
+
+
 def _entity_label(entity_id: str, labels: dict[str, str] | None) -> str:
-    """A name a reader recognises, falling back to the id's readable tail."""
-    if labels and (name := labels.get(entity_id)):
-        return name
+    """A name a reader recognises, or an honest description of what the thing is.
+
+    Order matters: the crate's own name for the entity always wins, because that
+    is what the reader will search the report for. Only when the entity has no
+    name — which for several of these IS the finding being reported — does this
+    fall back to describing it, and it never invents one.
+    """
+    for key in _id_variants(entity_id):
+        if labels and (name := labels.get(key)):
+            return name
+
+    if entity_id in ("./", ".", ""):
+        return "the crate itself"
+
+    for prefix, phrasing in _IRI_PHRASING:
+        if entity_id.startswith(prefix):
+            return phrasing.format(entity_id[len(prefix) :].strip("/"))
+
     tail = entity_id.rsplit("/", 1)[-1].lstrip("#").removeprefix("./")
-    for prefix in ("CitationAuthor_", "DefinedTerm_", "LabProcess_", "LabProtocol_"):
-        tail = tail.removeprefix(prefix)
+    for prefix in _ID_TYPE_PREFIXES:
+        if tail.startswith(prefix):
+            tail = tail[len(prefix) :]
+            # …and the type token the internal id repeats right after it.
+            for echo in _ID_ECHO_TOKENS:
+                if tail.startswith(echo):
+                    tail = tail[len(echo) :]
+                    break
+            break
     return tail.replace("_", " ").strip() or entity_id
 
 
@@ -269,6 +340,38 @@ def describe(action: Action) -> str:
     if action.kind == "property":
         return f"Supply {subject} for the {n} {'entity' if n == 1 else 'entities'} missing it."
     return f"{what} for {subject}." if what else f"Complete the metadata for {subject}."
+
+
+def describe_parts(action: Action) -> tuple[str, str]:
+    """*(instruction, subject)* — the same sentence, split where it changes topic.
+
+    ``describe`` returns one string because callers that emit plain text want one
+    string. But the HTML list runs the instruction and a long entity list
+    together, and the entity list is by far the longer half — "Add an identifier
+    for proc thyroid hormone receptor activation endpoint readout raw
+    measurements.csv, proc … .csv, proc … .csv and 15 others." The reader is
+    scanning for the verb, and it is buried.
+
+    The two are returned separately so the renderer can give the entity list its
+    own visual weight. Joining them reproduces ``describe`` exactly, and a test
+    pins that, so the plain-text and HTML wordings cannot drift.
+
+    The subject half is empty when the sentence has no entity list to separate
+    (a deliberate non-action, whose text is a note about the whole finding).
+    """
+    if not action.actionable:
+        return describe(action), ""
+    what = _wanted(action.findings)
+    subject = action.subject
+    n = action.cleared
+    plural = "entity is" if n == 1 else "entities are"
+    if action.kind == "orphan":
+        return "Connect", f"{subject} to the crate — {n} {plural} unreachable."
+    if action.kind == "property":
+        return "Supply", (
+            f"{subject} for the {n} {'entity' if n == 1 else 'entities'} missing it."
+        )
+    return (what or "Complete the metadata"), f"for {subject}."
 
 
 # What a finding is asking for, keyed on words the message actually uses. Only

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -417,3 +417,11 @@ __CATEGORY_STYLES__
 .mat details.na-aside > summary:hover { color:var(--ink); }
 .mat details.na-aside ul { margin:.35rem 0 0; color:var(--muted);
   font-size:.86rem; }
+
+/* The instruction and the entities it applies to (#561 follow-up). The entity
+   list is by far the longer half — "Add an identifier for proc … .csv, proc …
+   .csv and 15 others" — so with both at one weight the reader scans a wall of
+   ids looking for the verb. The verb carries the page's ink; the entities read
+   as the quieter supporting clause they are. */
+.mat .na-do { color:var(--ink); font-weight:600; }
+.mat .na-of { color:var(--muted); }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -885,7 +885,7 @@ def _render_next_steps_section(
     from builder.tools.remediation import (
         _TIER_RANK,
         TIER_LABEL,
-        describe,
+        describe_parts,
         group_findings,
         group_orphans,
     )
@@ -921,20 +921,23 @@ def _render_next_steps_section(
     # exists to surface.
     live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
     esc = html.escape
-    rows = "".join(
-        f'<li><span class="na-n">{a.cleared}</span>'
-        f'<span class="na-t">{esc(describe(a))}'
-        # The tier is named only when it BLOCKS. Marking all three would put a
-        # badge on every row and mark nothing; the reader's question here is
-        # "what must I fix before this crate is conformant?".
-        + (
-            f'<span class="na-req">{esc(TIER_LABEL[a.tier])}</span>'
-            if _TIER_RANK.get(a.tier, 3) == 0
+    def _row(action: Any) -> str:
+        instruction, subject = describe_parts(action)
+        # The tier is named only when it BLOCKS. A badge on every row marks
+        # nothing; the reader's question here is "what must I fix before this
+        # crate is conformant?".
+        mark = (
+            f'<span class="na-req">{esc(TIER_LABEL[action.tier])}</span>'
+            if _TIER_RANK.get(action.tier, 3) == 0
             else ""
         )
-        + "</span></li>"
-        for a in live[:_NEXT_STEPS_CAP]
-    )
+        return (
+            f'<li><span class="na-n">{action.cleared}</span>'
+            f'<span class="na-t"><span class="na-do">{esc(instruction)}</span> '
+            f'<span class="na-of">{esc(subject)}</span>{mark}</span></li>'
+        )
+
+    rows = "".join(_row(a) for a in live[:_NEXT_STEPS_CAP])
     if len(live) > _NEXT_STEPS_CAP:
         rest = sum(a.cleared for a in live[_NEXT_STEPS_CAP:])
         rows += (

--- a/tests/test_remediation_grouping.py
+++ b/tests/test_remediation_grouping.py
@@ -348,3 +348,92 @@ class TestTheDateInstructionNamesTheRightDate:
             assert "date it was" not in _wanted([message]), (
                 f"{message!r} answered with a date instruction"
             )
+
+
+class TestActionsNameEntitiesAReaderRecognises:
+    """The list said "PropertyValue pv sample role" while the crate knew the name.
+
+    `labels` is keyed on the graph's `@id` (`#Thing`), but the validator reports
+    the same entity resolved against the crate base (`./#Thing`). Not one node in
+    a real crate carries the `./#` form, so the exact-match lookup missed EVERY
+    fragment entity and each one fell through to mangling its id — in a list
+    whose whole job is telling a human what to go and fix.
+    """
+
+    def test_a_validator_id_finds_the_graph_name(self):
+        from builder.tools.remediation import _entity_label
+
+        labels = {"#PropertyValue_pv_sample_role": "sample role"}
+        assert _entity_label("./#PropertyValue_pv_sample_role", labels) == "sample role"
+        # …and the bare form still works, so nothing that resolved before stops.
+        assert _entity_label("#PropertyValue_pv_sample_role", labels) == "sample role"
+
+    def test_an_unnamed_entity_is_described_not_reduced_to_digits(self):
+        """A reader shown "0000-0002-7685-9462" cannot tell a person from a grant.
+
+        This entity has no name ON PURPOSE in the data — "MUST have a name" is
+        the finding being reported — so there is nothing to look up and nothing
+        may be invented. Saying what the thing IS costs nothing and is honest.
+        """
+        from builder.tools.remediation import _entity_label
+
+        assert (
+            _entity_label("https://orcid.org/0000-0002-7685-9462", {})
+            == "the person with ORCID 0000-0002-7685-9462"
+        )
+        assert _entity_label("https://ror.org/012p63287", {}) == (
+            "the organization with ROR 012p63287"
+        )
+
+    def test_a_name_in_the_graph_still_wins_over_the_description(self):
+        """The control: describing is the FALLBACK, never a replacement. A reader
+        searches the report for the name the crate uses."""
+        from builder.tools.remediation import _entity_label
+
+        labels = {"https://orcid.org/0000-0002-7685-9462": "Nathalie Dierichs"}
+        assert (
+            _entity_label("https://orcid.org/0000-0002-7685-9462", labels)
+            == "Nathalie Dierichs"
+        )
+
+    def test_the_root_is_called_the_crate_not_a_dot_slash(self):
+        from builder.tools.remediation import _entity_label
+
+        assert _entity_label("./", {}) == "the crate itself"
+
+    def test_the_repeated_type_token_is_dropped(self):
+        """`_make_entity_id` builds `#<Type>_<internal_id>` and the internal id
+        usually repeats the type, so stripping one layer left "Sample sample proc
+        … output sample"."""
+        from builder.tools.remediation import _entity_label
+
+        assert _entity_label("./#Sample_sample_proc_x_output_sample", {}) == (
+            "proc x output sample"
+        )
+        assert _entity_label("./#LabProcess_proc_exposure_process", {}) == "exposure process"
+
+
+class TestTheSplitSentenceIsTheSameSentence:
+    """`describe_parts` exists so the HTML can weight the two halves differently.
+
+    It must not become a second, drifting wording: the plain-text sentence and
+    the rendered one are the same claim, and a reader comparing them should not
+    find two different instructions.
+    """
+
+    def test_the_parts_rejoin_into_describe_exactly(self):
+        from builder.tools.remediation import Action, describe, describe_parts
+
+        actions = [
+            Action(key="k", kind="entity", subject="a.csv and 15 others",
+                   findings=["SHOULD have an identifier"] * 16),
+            Action(key="k", kind="orphan", subject="the AOP-Wiki subgraph",
+                   findings=["unreachable"] * 36),
+            Action(key="k", kind="property", subject="name", findings=["x"] * 3),
+            Action(key="k", kind="entity", subject="X", findings=["y"],
+                   actionable=False, note="Left as-is."),
+        ]
+        for action in actions:
+            instruction, subject = describe_parts(action)
+            joined = f"{instruction} {subject}".strip() if subject else instruction
+            assert joined == describe(action)


### PR DESCRIPTION
The actions list read:

```
6  Complete the metadata for PropertyValue pv sample role, PropertyValue pv cell line identity, proc exposure process and 3 others.
4  Complete the metadata for 0000-0002-7685-9462.
6  Record the parameters used for Sample sample proc thyroid hormone transport assay cell culture output sample, …
```

…while naming other entities perfectly well — **"Add an institutional affiliation for Nathalie Dierichs."** — two lines apart. That inconsistency was the clue.

## Root cause: the name lookup never matched

`labels` is keyed on the graph's `@id` (`#Thing`). The validator reports the same entity **resolved against the crate base** (`./#Thing`).

```
svhps26_real_input_crate_v65:  125 fragment @ids,  0 of them in the "./#" form
```

So the exact-match lookup missed **every** fragment entity, and each one fell through to mangling its own id. The real names were in the crate the whole time. The lookup now tries both spellings.

| validator reports | before | after |
|---|---|---|
| `./#PropertyValue_pv_sample_role` | PropertyValue pv sample role | **sample role** |
| `./#Study_study_nwa_129219272_…` | Study study nwa 129219272 wp24 … | **NWA 129219272 WP24 thyroid hormone assays** |
| `./#LabProcess_proc_exposure_process` | proc exposure process | **exposure process** |
| `./` | . | **the crate itself** |

## The mangling was bad on its own account, so it is fixed too

`_make_entity_id` builds `#<Type>_<internal_id>`, and the internal id usually **repeats the type** as its own first token — `#Sample_sample_…`, `#Study_study_…`, `#LabProtocol_protocol_…`. Stripping one layer left *"Sample sample proc … output sample"*. Both layers come off now.

## An unnamed entity is described, not reduced to digits

```
before:  Complete the metadata for 0000-0002-7685-9462.
after:   Complete the metadata for the person with ORCID 0000-0002-7685-9462.
```

A reader shown the bare number cannot tell a person from a grant from a checksum.

**Nothing is invented.** For several of these, *"a Contextual Entity MUST have a `name`"* is the finding being reported — there is no name to look up, and making one up would be fabricating metadata. A name in the graph always wins; describing is only the fallback, and a test pins that order.

## Visual structure

The entity list is by far the longer half of each line, so at one weight the reader scans a wall of ids hunting for the verb. `describe_parts` returns the instruction and the entities separately, and the renderer weights them differently — the verb takes the page's ink, the entities read as the supporting clause they are.

```
 1   Complete the metadata   for the crate itself.                              [Required]
18   Add an identifier       for x0.csv, x1.csv, x2.csv and 15 others.
 4   Complete the metadata   for the person with ORCID 0000-0002-7685-9462.
```

It is the **same sentence**: a test asserts the parts rejoin into `describe()` exactly, so the plain-text and HTML wordings cannot drift into two different instructions.

## Verification

157 tests across `test_maturity_report.py` + `test_remediation_grouping.py`. `ruff` and `ty` clean. Rendered against the real id shapes from the report above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)