### PR TITLE
feat(aop): an assay can measure more than one Key Event

### DIFF
--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -267,6 +267,20 @@ def _is_key_event_gap(gap: Gap) -> bool:
     return "key event" in (gap.message or "").casefold()
 
 
+def _split_key_event_answer(text: str) -> list[str]:
+    """One answer naming several Key Events, split into names.
+
+    NOT on the comma. AOP-Wiki names contain them — "Inhibition, organic
+    anion-transporting polypeptide 1C1 (OATP1C1)" — so a comma split tears every
+    real name in half and then matches none of them. Semicolons, newlines and a
+    spelled-out "and" are what someone listing two events actually types, and
+    none of them appear inside a Key Event name.
+    """
+    parts = re.split(r"[;\n]| and (?![a-z]*ase\b)", text)
+    names = [p.strip(" .;") for p in parts if p and p.strip(" .;")]
+    return names or [text.strip()]
+
+
 def _key_event_candidates(engine: AgentEngine) -> list[dict[str, str]]:
     """The Key Events the crate already holds, as answer options.
 
@@ -675,13 +689,33 @@ def _apply_key_event_value(
             return False
         assay_id = instances[0].entity_id
 
+    # An assay can measure more than one Key Event — a viability control beside
+    # the inhibition it is built to detect is one experiment reporting two — so
+    # an answer naming several is a normal answer, not a malformed one. Split on
+    # separators a person actually types; a Key Event name contains commas
+    # ("Inhibition, OATP1C1"), which is exactly why the split is on ';' and
+    # ' and ' rather than the comma that would tear those names in half.
+    names = _split_key_event_answer(text)
     try:
-        result = engine.run_tool("link_assay_to_key_event", assay_id=assay_id, event_name=text)
+        result = engine.run_tool(
+            "link_assay_to_key_event",
+            assay_id=assay_id,
+            event_name=names if len(names) > 1 else names[0],
+        )
     except Exception as exc:  # noqa: BLE001 — a tool failure is a guidance skip
         logger.warning("guidance: key event link failed for %r: %s", text, exc)
         return False
 
     if isinstance(result, dict) and result.get("ok"):
+        # A partly-resolved answer is progress, but the reader is told which
+        # names went nowhere rather than left assuming all of them landed.
+        unmatched = [str(u.get("name")) for u in (result.get("unmatched") or [])]
+        if unmatched:
+            _notify(
+                human,
+                f"linked {len(result.get('key_event_ids') or [])} key event(s); "
+                f"{', '.join(unmatched)} did not name one in the crate and was not stored.",
+            )
         return True
 
     offered = result.get("candidates") or [] if isinstance(result, dict) else []

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -657,18 +657,37 @@ def _event_tokens(text: str) -> frozenset[str]:
     return frozenset(cleaned.split())
 
 
-def link_assay_to_key_event(state: CrateState, assay_id: str, event_name: str) -> dict[str, Any]:
-    """Link an Assay to the AOP Key Event it measures, by Key Event name.
+def link_assay_to_key_event(
+    state: CrateState, assay_id: str, event_name: str | list[str]
+) -> dict[str, Any]:
+    """Link an Assay to the AOP Key Event(s) it measures, by Key Event name.
+
+    An assay can measure more than one Key Event — a viability control beside
+    the transporter inhibition it is built to detect is one experiment reporting
+    two events — so ``event_name`` takes a list as well as a single name. The
+    single-name form is unchanged for existing callers.
+
+    Names are resolved INDEPENDENTLY and each is held to the same standard: a
+    name matching zero or several Key Events is reported and not written, while
+    the ones that matched exactly one are linked. Refusing the whole answer over
+    a single typo would throw away correct science; claiming the typo resolved
+    would invent it. The result says which did and which did not.
+
+    Links ACCUMULATE rather than replace. Each call states something the assay
+    measures, and a later call naming one event is not a claim that the earlier
+    ones were wrong — so a second answer adds to the first, deduplicated.
+    Removing a link is `set_fields`' job, where it is explicit.
 
     Args:
         state: The crate state holding the Assay and the materialized Key Events.
         assay_id: ``entity_id`` of the Assay.
-        event_name: The Key Event's name as written by the depositor.
+        event_name: One Key Event name, or several.
 
     Returns:
-        ``{"ok": True, "assay_id", "key_event_id", "matched_name"}`` on a single
-        unambiguous match, else ``{"ok": False, "error", "candidates"}`` with
-        nothing written.
+        ``{"ok": True, "assay_id", "key_event_ids", "matched_names", "unmatched"}``
+        when at least one name resolved (``key_event_id``/``matched_name`` are
+        kept as the first match for existing callers), else
+        ``{"ok": False, "error", "candidates"}`` with nothing written.
     """
     from builder.tools.management import set_fields
 
@@ -687,8 +706,67 @@ def link_assay_to_key_event(state: CrateState, assay_id: str, event_name: str) -
             "candidates": [],
         }
 
-    wanted = _event_tokens(event_name)
-    matches = [
+    candidates = [{"@id": e.entity_id, "name": e.fields.get("name")} for e in events]
+    wanted_names = [event_name] if isinstance(event_name, str) else list(event_name)
+    wanted_names = [str(n).strip() for n in wanted_names if str(n).strip()]
+    if not wanted_names:
+        return {"ok": False, "error": "no Key Event name given", "candidates": candidates}
+
+    linked: list[Entity] = []
+    unmatched: list[dict[str, Any]] = []
+    for name in wanted_names:
+        matches = _key_events_named(events, name)
+        if len(matches) != 1:
+            unmatched.append({"name": name, "matches": len(matches)})
+            continue
+        if matches[0] not in linked:
+            linked.append(matches[0])
+
+    if not linked:
+        detail = "; ".join(f"{u['matches']} match {u['name']!r}" for u in unmatched)
+        return {
+            "ok": False,
+            "error": (f"{detail}; refusing to guess which Key Event this assay measures"),
+            "candidates": candidates,
+        }
+
+    # Union with what is already recorded: a second answer adds to the first.
+    # `set_fields` normalises a `{"@id": …}` reference down to the bare id, so
+    # what comes back out is a string even though a dict went in — read both, or
+    # the union sees nothing and the second answer silently REPLACES the first.
+    existing = [
+        ref.get("@id") if isinstance(ref, dict) else str(ref)
+        for ref in _as_reference_list(assay.fields.get("keyEvent"))
+        if ref
+    ]
+    ids = list(dict.fromkeys([i for i in existing if i] + [e.entity_id for e in linked]))
+    value: Any = [{"@id": i} for i in ids]
+    set_fields(
+        state,
+        assay_id,
+        {"keyEvent": value if len(value) > 1 else value[0]},
+        source="lookup",
+    )
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "assay_id": assay_id,
+        "key_event_ids": ids,
+        "matched_names": [e.fields.get("name") for e in linked],
+        # Kept singular for callers written against the one-event form.
+        "key_event_id": linked[0].entity_id,
+        "matched_name": linked[0].fields.get("name"),
+    }
+    if unmatched:
+        result["unmatched"] = unmatched
+        result["candidates"] = candidates
+    return result
+
+
+def _key_events_named(events: list[Entity], name: str) -> list[Entity]:
+    """Key Events whose name (or a known alias) is *name*."""
+    wanted = _event_tokens(name)
+    return [
         event
         for event in events
         if any(
@@ -701,25 +779,13 @@ def link_assay_to_key_event(state: CrateState, assay_id: str, event_name: str) -
             if alias
         )
     ]
-    candidates = [{"@id": e.entity_id, "name": e.fields.get("name")} for e in events]
-    if len(matches) != 1:
-        return {
-            "ok": False,
-            "error": (
-                f"{len(matches)} Key Events match {event_name!r}; refusing to guess "
-                "which one this assay measures"
-            ),
-            "candidates": candidates,
-        }
 
-    event = matches[0]
-    set_fields(state, assay_id, {"keyEvent": {"@id": event.entity_id}}, source="lookup")
-    return {
-        "ok": True,
-        "assay_id": assay_id,
-        "key_event_id": event.entity_id,
-        "matched_name": event.fields.get("name"),
-    }
+
+def _as_reference_list(value: Any) -> list[Any]:
+    """A reference field's value as a list, whether it held one or many."""
+    if value in (None, "", [], {}):
+        return []
+    return list(value) if isinstance(value, list) else [value]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_key_event_gap_is_answerable.py
+++ b/tests/test_key_event_gap_is_answerable.py
@@ -160,3 +160,116 @@ class TestTheChoiceStaysTheScientists:
             {"property": "mentions", "candidates": [f"Event {n}" for n in range(30)]}
         )
         assert "and 18 more" in block
+
+
+class TestAnAssayCanMeasureSeveralKeyEvents:
+    """One experiment can report two events — a viability control beside the
+    inhibition it is built to detect — so an answer naming several is a normal
+    answer, not a malformed one.
+    """
+
+    def _crate(self) -> CrateState:
+        state = CrateState()
+        assay = Entity(
+            entity_id="assay_1", type="Assay", _provenance=EntityProvenance(created_by="llm")
+        )
+        assay.set_fields_from_dict({"name": "An assay"}, source="llm")
+        state.add_entity(assay)
+        for eid, name in (
+            ("KeyEvent:ke1", "Inhibition, OATP1C1"),
+            ("KeyEvent:ke2", "Decreased cell viability"),
+        ):
+            event = Entity(
+                entity_id=eid, type="KeyEvent", _provenance=EntityProvenance(created_by="lookup")
+            )
+            event.set_fields_from_dict({"name": name}, source="lookup")
+            state.add_entity(event)
+        return state
+
+    def test_two_events_link_in_one_call(self):
+        from builder.tools.composites import link_assay_to_key_event
+
+        state = self._crate()
+        result = link_assay_to_key_event(
+            state, "assay_1", ["Inhibition, OATP1C1", "Decreased cell viability"]
+        )
+        assert result["ok"] is True
+        assert result["key_event_ids"] == ["KeyEvent:ke1", "KeyEvent:ke2"]
+
+    def test_a_second_answer_adds_rather_than_replaces(self):
+        """Naming one event later is not a claim the earlier one was wrong."""
+        from builder.tools.composites import link_assay_to_key_event
+
+        state = self._crate()
+        link_assay_to_key_event(state, "assay_1", "Inhibition, OATP1C1")
+        result = link_assay_to_key_event(state, "assay_1", "Decreased cell viability")
+        assert result["key_event_ids"] == ["KeyEvent:ke1", "KeyEvent:ke2"]
+
+    def test_the_same_event_twice_is_recorded_once(self):
+        from builder.tools.composites import link_assay_to_key_event
+
+        state = self._crate()
+        link_assay_to_key_event(state, "assay_1", "Inhibition, OATP1C1")
+        result = link_assay_to_key_event(state, "assay_1", "Inhibition, OATP1C1")
+        assert result["key_event_ids"] == ["KeyEvent:ke1"]
+
+    def test_a_good_name_survives_a_bad_one(self):
+        """Refusing everything over one typo throws away correct science."""
+        from builder.tools.composites import link_assay_to_key_event
+
+        state = self._crate()
+        result = link_assay_to_key_event(
+            state, "assay_1", ["Inhibition, OATP1C1", "Not a real event"]
+        )
+        assert result["ok"] is True
+        assert result["key_event_ids"] == ["KeyEvent:ke1"]
+        assert [u["name"] for u in result["unmatched"]] == ["Not a real event"]
+
+    def test_no_name_matching_writes_nothing(self):
+        from builder.tools.composites import link_assay_to_key_event
+
+        state = self._crate()
+        result = link_assay_to_key_event(state, "assay_1", ["Nope", "Also nope"])
+        assert result["ok"] is False
+        assay = state.get_entity("assay_1")
+        assert assay is not None
+        assert assay.fields.get("keyEvent") is None
+
+    def test_the_single_name_form_is_unchanged(self):
+        from builder.tools.composites import link_assay_to_key_event
+
+        state = self._crate()
+        result = link_assay_to_key_event(state, "assay_1", "Inhibition, OATP1C1")
+        assert result["key_event_id"] == "KeyEvent:ke1"
+        assert result["matched_name"] == "Inhibition, OATP1C1"
+
+
+class TestSeveralNamesInOneAnswer:
+    """A Key Event name contains commas, so the comma cannot be the separator."""
+
+    def test_a_name_with_commas_stays_whole(self):
+        from builder.agents.pipeline.guidance import _split_key_event_answer
+
+        name = "Inhibition, organic anion-transporting polypeptide 1C1 (OATP1C1)"
+        assert _split_key_event_answer(name) == [name]
+
+    def test_a_semicolon_separates(self):
+        from builder.agents.pipeline.guidance import _split_key_event_answer
+
+        assert _split_key_event_answer("Inhibition, OATP1C1; Decreased viability") == [
+            "Inhibition, OATP1C1",
+            "Decreased viability",
+        ]
+
+    def test_a_spelled_out_and_separates(self):
+        from builder.agents.pipeline.guidance import _split_key_event_answer
+
+        assert _split_key_event_answer("Inhibition, OATP1C1 and Decreased viability") == [
+            "Inhibition, OATP1C1",
+            "Decreased viability",
+        ]
+
+    def test_an_empty_answer_is_not_split_into_nothing(self):
+        from builder.agents.pipeline.guidance import _split_key_event_answer
+
+        assert _split_key_event_answer("   ") == [""]


### PR DESCRIPTION
Agreed in review: an assay can legitimately measure several Key Events — a viability control beside the transporter inhibition it is built to detect is one experiment reporting two. `link_assay_to_key_event` committed a single value.

It now takes several names, resolved **independently** and each held to the same standard: a name matching zero or several Key Events is reported and not written, while the ones matching exactly one are linked. Refusing the whole answer over one typo throws away correct science; claiming the typo resolved would invent it. The result says which did and which did not, and guidance tells the reader rather than leaving them to assume all of them landed.

## Two things the obvious implementation gets wrong

**Links must accumulate, and `set_fields` fights it.** A later answer naming one event is not a claim the earlier ones were wrong, so a second call adds to the first. But `set_fields` normalises a `{"@id": …}` reference down to the bare id — what goes in as a dict comes back as a string. Reading only for dicts, the union saw nothing and the second answer **silently replaced** the first. Caught by testing two sequential calls rather than one call with two names.

**The separator cannot be the comma.** AOP-Wiki names contain them — `"Inhibition, organic anion-transporting polypeptide 1C1 (OATP1C1)"` — so splitting on commas tears every real name in half and then matches none. Splitting on `;`, newlines and a spelled-out "and" is what someone listing two events actually types, and none of those appear inside a Key Event name.

```
"Inhibition, organic anion-transporting polypeptide 1C1 (OATP1C1)"
    -> ['Inhibition, organic anion-transporting polypeptide 1C1 (OATP1C1)']
"Inhibition, OATP1C1; Decreased cell viability"
    -> ['Inhibition, OATP1C1', 'Decreased cell viability']
```

Still not decided here: **which** events an assay measures. The crate offers its own Key Events; nothing picks among them.

22 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)