### PR TITLE
feat(report): mark entities as entities, name their type, and count the set-aside

### DIFF
--- a/builder/tools/remediation.py
+++ b/builder/tools/remediation.py
@@ -28,6 +28,7 @@ belong together.
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -96,6 +97,15 @@ class Action:
     kind: str
     subject: str
     entity_ids: list[str] = field(default_factory=list)
+    # The subject's entity labels, unjoined. `subject` is the reader-facing
+    # string; this is what it was built FROM, so a renderer can rebuild the same
+    # phrase with each name marked up instead of parsing commas back out of it.
+    subject_names: list[str] = field(default_factory=list)
+    # Parallel to `subject_names`: the reader-facing type word for each ("Person",
+    # "CellLine", …), or "" where the type says nothing worth saying. Kept apart
+    # from the name so the renderer can chip the NAME and leave the type as
+    # ordinary prose — the chip marks what is a thing in the crate.
+    subject_types: list[str] = field(default_factory=list)
     findings: list[str] = field(default_factory=list)
     tier: str = _DEFAULT_TIER
     actionable: bool = True
@@ -174,6 +184,22 @@ def _id_variants(entity_id: str) -> tuple[str, ...]:
     return tuple(seen)
 
 
+def _lookup(mapping: dict[str, Any] | None, entity_id: str) -> Any:
+    """Read *entity_id* out of a graph-keyed map, trying every id spelling.
+
+    Shared by the name and the @type lookups so they cannot drift: both are
+    keyed on the graph's `@id` and both are asked with the validator's
+    base-resolved form, and fixing only one of them is exactly the bug that
+    produced "for CellLine H4" in one column and a bare "for H4" in the next.
+    """
+    if not mapping:
+        return None
+    for key in _id_variants(entity_id):
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
 def _entity_label(entity_id: str, labels: dict[str, str] | None) -> str:
     """A name a reader recognises, or an honest description of what the thing is.
 
@@ -182,9 +208,8 @@ def _entity_label(entity_id: str, labels: dict[str, str] | None) -> str:
     name — which for several of these IS the finding being reported — does this
     fall back to describing it, and it never invents one.
     """
-    for key in _id_variants(entity_id):
-        if labels and (name := labels.get(key)):
-            return name
+    if name := _lookup(labels, entity_id):
+        return str(name)
 
     if entity_id in ("./", ".", ""):
         return "the crate itself"
@@ -206,6 +231,53 @@ def _entity_label(entity_id: str, labels: dict[str, str] | None) -> str:
     return tail.replace("_", " ").strip() or entity_id
 
 
+# The @type words worth saying out loud, mapped to how a person says them. A
+# reader scanning "Add an identifier for H4" cannot tell a cell line from a
+# person from a file; "for CellLine H4" costs three characters and removes the
+# question. Types NOT listed are omitted rather than shown raw — "PropertyValue
+# sample role" reads worse than "sample role", and a bare schema.org class name
+# is jargon the report otherwise avoids.
+_TYPE_WORDS: dict[str, str] = {
+    "Person": "Person",
+    "Organization": "Organization",
+    "CellLineSample": "CellLine",
+    "MolecularEntity": "Compound",
+    "Sample": "Sample",
+    "File": "File",
+    "Dataset": "Dataset",
+    "LabProtocol": "Protocol",
+    "LabProcess": "Process",
+    "ScholarlyArticle": "Publication",
+    "Publication": "Publication",
+}
+
+
+def _type_word(entity_type: Any) -> str:
+    """The reader-facing word for an entity's ``@type``, or "" if not worth saying.
+
+    A node's ``@type`` is often a LIST (``["csvw:Column", "schema:DefinedTerm"]``)
+    and often namespaced, so this takes the first recognised word from it rather
+    than assuming a bare string.
+    """
+    candidates = entity_type if isinstance(entity_type, list) else [entity_type]
+    for candidate in candidates:
+        bare = str(candidate or "").rsplit(":", 1)[-1].rsplit("/", 1)[-1]
+        if bare in _TYPE_WORDS:
+            return _TYPE_WORDS[bare]
+    return ""
+
+
+def _display(name: str, type_word: str) -> str:
+    """"Person Nathalie Dierichs" — the type only when it adds something.
+
+    Skipped when the name already opens with the word, so a file called
+    "File manifest.csv" does not become "File File manifest.csv".
+    """
+    if not type_word or name.casefold().startswith(type_word.casefold()):
+        return name
+    return f"{type_word} {name}"
+
+
 def _property_label(prop: str) -> str:
     return (prop or "").rsplit("/", 1)[-1].rsplit("#", 1)[-1] or "property"
 
@@ -214,6 +286,7 @@ def group_findings(
     findings: list[dict[str, Any]],
     *,
     labels: dict[str, str] | None = None,
+    types: dict[str, Any] | None = None,
 ) -> list[Action]:
     """Collapse *findings* into the actions that would clear them, best first.
 
@@ -277,15 +350,19 @@ def group_findings(
     actions: list[Action] = []
 
     def _take(kind: str, subject_id: str, live: list[dict[str, Any]]) -> None:
+        label = (
+            _entity_label(subject_id, labels)
+            if kind == "entity"
+            else _property_label(subject_id)
+        )
+        type_word = _type_word(_lookup(types, subject_id)) if kind == "entity" else ""
         actions.append(
             Action(
                 key=f"{kind}:{subject_id}",
                 kind=kind,
-                subject=(
-                    _entity_label(subject_id, labels)
-                    if kind == "entity"
-                    else _property_label(subject_id)
-                ),
+                subject=_display(label, type_word),
+                subject_names=[label],
+                subject_types=[type_word],
                 entity_ids=sorted({str(f.get("entity_id")) for f in live if f.get("entity_id")}),
                 findings=[str(f.get("message") or "") for f in live],
                 tier=_strongest([str(f.get("severity") or _DEFAULT_TIER).upper() for f in live]),
@@ -342,7 +419,7 @@ def describe(action: Action) -> str:
     return f"{what} for {subject}." if what else f"Complete the metadata for {subject}."
 
 
-def describe_parts(action: Action) -> tuple[str, str]:
+def describe_parts(action: Action, subject: str | None = None) -> tuple[str, str]:
     """*(instruction, subject)* — the same sentence, split where it changes topic.
 
     ``describe`` returns one string because callers that emit plain text want one
@@ -358,11 +435,21 @@ def describe_parts(action: Action) -> tuple[str, str]:
 
     The subject half is empty when the sentence has no entity list to separate
     (a deliberate non-action, whose text is a note about the whole finding).
+
+    Args:
+        action: The action to word.
+        subject: Optional pre-rendered replacement for ``action.subject`` — the
+            HTML list passes the same entities with each one marked up. Nothing
+            else about the sentence changes, so the two renderings stay one
+            wording.
     """
     if not action.actionable:
         return describe(action), ""
     what = _wanted(action.findings)
-    subject = action.subject
+    # An already-rendered subject (the HTML list marks each entity up) is
+    # substituted here rather than assembled by the caller, so this function
+    # stays the ONE place the sentence is composed.
+    subject = action.subject if subject is None else subject
     n = action.cleared
     plural = "entity is" if n == 1 else "entities are"
     if action.kind == "orphan":
@@ -420,12 +507,26 @@ def _wanted(messages: list[str]) -> str:
     return ""
 
 
-def _join(names: list[str], limit: int = 3) -> str:
-    """ "Ada, Grace and 2 others" — a subject line that stays a line."""
+def _join(
+    names: list[str],
+    limit: int = 3,
+    wrap: Callable[[str], str] | None = None,
+) -> str:
+    """ "Ada, Grace and 2 others" — a subject line that stays a line.
+
+    *wrap* decorates each NAME without touching the connective words, so the
+    HTML renderer can put every entity in a ``<code>`` chip and still get this
+    function's wording, counting and pluralisation. Written as a parameter
+    rather than a second formatter next to it: the plain sentence and the
+    rendered one are the same sentence, and two implementations of "and N
+    others" would eventually disagree about N.
+    """
+    mark = wrap or (lambda name: name)
+    shown = [mark(n) for n in names[:limit]]
     if len(names) <= limit:
-        return names[0] if len(names) == 1 else f"{', '.join(names[:-1])} and {names[-1]}"
+        return shown[0] if len(shown) == 1 else f"{', '.join(shown[:-1])} and {shown[-1]}"
     rest = len(names) - limit
-    return f"{', '.join(names[:limit])} and {rest} other{'s' if rest > 1 else ''}"
+    return f"{', '.join(shown)} and {rest} other{'s' if rest > 1 else ''}"
 
 
 def _merge_identical(actions: list[Action]) -> list[Action]:
@@ -451,12 +552,17 @@ def _merge_identical(actions: list[Action]) -> list[Action]:
         if len(group) == 1:
             merged.append(group[0])
             continue
-        subjects = [a.subject for a in group]
+        # The BARE names and their types, not each action's already-composed
+        # `subject`: re-prefixing a composed one would yield "Person Person Ada".
+        names = [a.subject_names[0] if a.subject_names else a.subject for a in group]
+        type_words = [a.subject_types[0] if a.subject_types else "" for a in group]
         merged.append(
             Action(
                 key="entities:" + "|".join(sorted(a.key for a in group)),
                 kind="entities",
-                subject=_join(subjects),
+                subject=_join([_display(n, t) for n, t in zip(names, type_words)]),
+                subject_names=list(names),
+                subject_types=list(type_words),
                 entity_ids=sorted({e for a in group for e in a.entity_ids}),
                 # Every finding, so `cleared` still totals the whole list.
                 findings=[m for a in group for m in a.findings],
@@ -467,7 +573,12 @@ def _merge_identical(actions: list[Action]) -> list[Action]:
     return merged
 
 
-def group_orphans(orphans: list[str], *, labels: dict[str, str] | None = None) -> list[Action]:
+def group_orphans(
+    orphans: list[str],
+    *,
+    labels: dict[str, str] | None = None,
+    types: dict[str, Any] | None = None,
+) -> list[Action]:
     """Collapse orphaned entities into actions, clustered by what they are.
 
     Thirty-six unreachable AOP nodes are one job — wire the pathway to the assay
@@ -490,6 +601,8 @@ def group_orphans(orphans: list[str], *, labels: dict[str, str] | None = None) -
             key=f"orphan:{name}",
             kind="orphan",
             subject=name,
+            subject_names=[name],
+            subject_types=[""],
             entity_ids=sorted(ids),
             findings=[f"{i} is not reachable from the crate root" for i in sorted(ids)],
             tier=_DEFAULT_TIER,

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -400,10 +400,15 @@ __CATEGORY_STYLES__
 .mat ol.next-actions > li { display:flex; gap:.6rem; align-items:baseline;
   padding:.32rem 0; border-top:1px solid var(--hairline); }
 .mat ol.next-actions > li:first-child { border-top:0; }
-/* Tabular figures and a fixed column so the numbers line up as a column rather
+/* The count is a MULTIPLIER — how many findings this one instruction clears —
+   not the point of the row. It shipped at weight 650 on the darkest ink, which
+   made it heavier than the instruction beside it (.na-do, weight 600) and put
+   the page's emphasis on an arithmetic detail. Muted and lighter now, so the
+   eye lands on the verb and reads the number only once it wants the size of the
+   job. Tabular figures and a fixed column keep it scannable as a column rather
    than ragging with the width of each count. */
-.mat .na-n { flex:0 0 2.4rem; text-align:right; font-weight:650; color:var(--ink);
-  font-variant-numeric:tabular-nums; }
+.mat .na-n { flex:0 0 2.4rem; text-align:right; font-weight:500; font-size:.82rem;
+  color:var(--muted); font-variant-numeric:tabular-nums; }
 .mat .na-t { color:var(--ink-2); }
 /* Named only on the tier that BLOCKS conformance — a badge on every row would
    mark nothing. Warn, not bad: this is work outstanding, not a failure. */

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -425,3 +425,16 @@ __CATEGORY_STYLES__
    as the quieter supporting clause they are. */
 .mat .na-do { color:var(--ink); font-weight:600; }
 .mat .na-of { color:var(--muted); }
+
+/* Entity chips in the actions list, the same convention the profile-adherence
+   suggestions already use — a reader should be able to tell at a glance which
+   words are things in their crate and which are the instruction. */
+.mat ol.next-actions code,
+.mat details.na-aside code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+  font-size:.76rem; background:var(--surface-2); border:1px solid var(--border);
+  border-radius:3px; padding:.02rem .32rem; color:var(--ink); }
+/* The aside's reasons are a counted list like the actions above it, so they
+   share the number column rather than inventing a second alignment. */
+.mat details.na-aside ul { list-style:none; padding:0; }
+.mat details.na-aside > ul > li { display:flex; gap:.6rem; align-items:baseline;
+  padding:.22rem 0; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -885,6 +885,7 @@ def _render_next_steps_section(
     from builder.tools.remediation import (
         _TIER_RANK,
         TIER_LABEL,
+        _join,
         describe_parts,
         group_findings,
         group_orphans,
@@ -904,11 +905,16 @@ def _render_next_steps_section(
         for n in raw_nodes
         if isinstance(n, dict) and isinstance(n.get("name"), str)
     }
-    actions = group_findings(issues, labels=labels)
+    types = {
+        str(n.get("@id")): n.get("@type")
+        for n in raw_nodes
+        if isinstance(n, dict) and n.get("@type") is not None
+    }
+    actions = group_findings(issues, labels=labels, types=types)
     if graph is not None:
         model = build_crate_graph(graph)
         orphans = [str(n["id"]) for n in model.get("nodes", []) if n.get("orphan")]
-        actions += group_orphans(orphans, labels=labels)
+        actions += group_orphans(orphans, labels=labels, types=types)
     live = [a for a in actions if a.actionable and a.cleared]
     if not live:
         return ""
@@ -921,8 +927,34 @@ def _render_next_steps_section(
     # exists to surface.
     live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
     esc = html.escape
+    def _subject_html(action: Any) -> str:
+        """The subject clause with every entity in a ``<code>`` chip.
+
+        Rebuilt through `_join` with a wrapper rather than marked up after the
+        fact: the plain sentence and this one must agree on the wording, the
+        truncation and the "and N others" count, and a regex over the finished
+        string would be a second implementation of all three.
+
+        Falls back to the plain clause for an action with no entity list to
+        mark up (a property action's subject is a property NAME, and a
+        deliberate non-action's is a note).
+        """
+        names = list(getattr(action, "subject_names", []) or [])
+        kinds = list(getattr(action, "subject_types", []) or [])
+        if not names or action.kind not in ("entity", "entities", "orphan"):
+            return esc(describe_parts(action)[1])
+        marked = _join([
+            (f"{esc(kind)} " if kind else "") + f"<code>{esc(name)}</code>"
+            for name, kind in zip(names, kinds + [""] * (len(names) - len(kinds)))
+        ])
+        # Re-run the SENTENCE with the marked-up subject substituted in, rather
+        # than marking up the finished string: one place composes the sentence,
+        # so the plain and rendered wordings cannot drift.
+        return describe_parts(action, subject=marked)[1]
+
     def _row(action: Any) -> str:
-        instruction, subject = describe_parts(action)
+        instruction, _subject = describe_parts(action)
+        subject = _subject_html(action)
         # The tier is named only when it BLOCKS. A badge on every row marks
         # nothing; the reader's question here is "what must I fix before this
         # crate is conformant?".
@@ -934,7 +966,7 @@ def _render_next_steps_section(
         return (
             f'<li><span class="na-n">{action.cleared}</span>'
             f'<span class="na-t"><span class="na-do">{esc(instruction)}</span> '
-            f'<span class="na-of">{esc(subject)}</span>{mark}</span></li>'
+            f'<span class="na-of">{subject}</span>{mark}</span></li>'
         )
 
     rows = "".join(_row(a) for a in live[:_NEXT_STEPS_CAP])
@@ -950,7 +982,20 @@ def _render_next_steps_section(
     settled = [a for a in actions if not a.actionable]
     aside = ""
     if settled:
-        notes = "".join(f"<li>{esc(a.note or '')}</li>" for a in settled)
+        # Grouped by REASON with a count each. "119 findings left open on
+        # purpose" is a bigger number than most of the actions above it, and
+        # without the breakdown a reader cannot tell whether that is 119
+        # distinct decisions or — as it always is — two recommendations
+        # repeated once per payload file.
+        by_reason: dict[str, int] = {}
+        for a in settled:
+            reason = a.note or ""
+            by_reason[reason] = by_reason.get(reason, 0) + a.cleared
+        notes = "".join(
+            f'<li><span class="na-n">{count}</span>'
+            f'<span class="na-of">{esc(reason)}</span></li>'
+            for reason, count in sorted(by_reason.items(), key=lambda kv: -kv[1])
+        )
         total = sum(a.cleared for a in settled)
         aside = (
             f'  <details class="na-aside"><summary>{total} '

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -2091,3 +2091,59 @@ class TestEveryClassTheReportEmitsIsStyled:
             f"classes emitted with no rule in maturity_report.css, so they render "
             f"at browser defaults: {unstyled}"
         )
+
+
+class TestActionEntitiesAreMarkedAsEntities:
+    """Entity names ride in `<code>` chips, the same convention the
+    profile-adherence suggestions already use, so a reader can see at a glance
+    which words name things in their crate and which are the instruction."""
+
+    def _section(self) -> str:
+        from builder.tools.validation import ValidationReport
+        from builder.writers.maturity_report import _render_next_steps_section
+
+        graph = {
+            "@graph": [
+                {"@id": "#CellLineSample_cell_h4", "@type": "CellLineSample", "name": "H4"},
+                {"@id": "#File_f1", "@type": "File", "name": "uptake.csv"},
+            ]
+        }
+        val = ValidationReport()
+        val.base_passed = True
+        val.issue_records = [
+            {"profile": "tox", "severity": "recommended",
+             "entity_id": "./#CellLineSample_cell_h4",
+             "message": "Entity SHOULD have a non-empty identifier"},
+            *[
+                {"profile": "base", "severity": "recommended", "entity_id": f"./#File_f{i}",
+                 "message": "A File SHOULD have a mainEntityOfPage"}
+                for i in range(9)
+            ],
+        ]
+        return _render_next_steps_section(val, graph)
+
+    def test_the_name_is_chipped_and_the_type_is_not(self) -> None:
+        """The chip marks the thing, not the classification — "CellLine" is the
+        report talking, "H4" is the crate's own word."""
+        section = self._section()
+        assert "CellLine <code>H4</code>" in section
+        assert "<code>CellLine H4</code>" not in section
+
+    def test_the_instruction_is_never_chipped(self) -> None:
+        section = self._section()
+        assert "<code>Add an identifier</code>" not in section
+
+    def test_the_set_aside_bucket_says_how_many_per_reason(self) -> None:
+        """"119 findings left open on purpose" is a bigger number than most of the
+        actions above it. Without a count per reason a reader cannot tell whether
+        that is 119 decisions or one recommendation repeated per file."""
+        import re
+
+        section = self._section()
+        aside = re.search(r'<details class="na-aside">.*?</details>', section, re.S)
+        assert aside, "nothing was set aside, so this test proves nothing"
+        rows = re.findall(r"<li>(.*?)</li>", aside.group(0))
+        assert len(rows) == 1, "one reason fired, so one row — not one row per entity"
+        assert '<span class="na-n">9</span>' in rows[0], (
+            "the reason must carry the number of findings it accounts for"
+        )

--- a/tests/test_remediation_grouping.py
+++ b/tests/test_remediation_grouping.py
@@ -437,3 +437,61 @@ class TestTheSplitSentenceIsTheSameSentence:
             instruction, subject = describe_parts(action)
             joined = f"{instruction} {subject}".strip() if subject else instruction
             assert joined == describe(action)
+
+
+class TestAnActionSaysWhatKindOfThingItIsAbout:
+    """"Add an identifier for H4" does not say whether H4 is a cell line, a
+    person or a file. "for CellLine H4" costs three characters."""
+
+    def test_the_type_is_named_when_it_is_worth_naming(self):
+        from builder.tools.remediation import group_findings
+
+        findings = [_f("./#CellLineSample_cell_h4", "SHOULD have a non-empty identifier")]
+        actions = group_findings(
+            findings,
+            labels={"#CellLineSample_cell_h4": "H4"},
+            types={"#CellLineSample_cell_h4": "CellLineSample"},
+        )
+        assert actions[0].subject == "CellLine H4"
+
+    def test_the_type_lookup_takes_the_validators_id_spelling(self):
+        """The name lookup and the type lookup are keyed the same way and asked
+        the same way, so fixing one and not the other gives "CellLine H4" in one
+        row and a bare "H4" in the next. They share `_lookup`."""
+        from builder.tools.remediation import _lookup
+
+        graph_keyed = {"#CellLineSample_cell_h4": "CellLineSample"}
+        assert _lookup(graph_keyed, "./#CellLineSample_cell_h4") == "CellLineSample"
+
+    def test_an_unhelpful_type_is_omitted_rather_than_shown_raw(self):
+        """A bare schema.org class is jargon: "PropertyValue sample role" reads
+        worse than "sample role"."""
+        from builder.tools.remediation import _type_word
+
+        assert _type_word("PropertyValue") == ""
+        assert _type_word(["csvw:Column", "schema:DefinedTerm"]) == ""
+        # …and a namespaced or listed @type still resolves when it IS useful.
+        assert _type_word(["schema:Person"]) == "Person"
+
+    def test_the_type_is_not_repeated_when_the_name_already_says_it(self):
+        from builder.tools.remediation import _display
+
+        assert _display("File manifest.csv", "File") == "File manifest.csv"
+        assert _display("H4", "CellLine") == "CellLine H4"
+
+    def test_merging_does_not_double_the_type_word(self):
+        """`_merge_identical` re-composes the subject from several actions. Taking
+        each one's already-composed `subject` would yield "Person Person Ada"."""
+        from builder.tools.remediation import group_findings
+
+        findings = [
+            _f("./#p1", "The author SHOULD have an organizational affiliation"),
+            _f("./#p2", "The author SHOULD have an organizational affiliation"),
+        ]
+        actions = group_findings(
+            findings,
+            labels={"#p1": "Ada", "#p2": "Grace"},
+            types={"#p1": "Person", "#p2": "Person"},
+        )
+        assert actions[0].subject == "Person Ada and Person Grace"
+        assert "Person Person" not in actions[0].subject


### PR DESCRIPTION
Three things a reader could not get from the actions list.

```
5   Add an institutional affiliation  for Person `Nathalie Dierichs`.
2   Add an identifier                 for CellLine `H4`.
2   Add a description                 for Protocol `UPLC protocol` and File `Combined uptake data.csv`.
```

## 1. What is an entity

Entity names ride in `<code>` chips — the convention the profile-adherence suggestions already use — so the words naming things in the crate are visibly different from the instruction around them.

## 2. What kind of thing it is

*"Add an identifier for H4"* does not say whether H4 is a cell line, a person or a file. It now reads **"for CellLine H4"**.

The type is prose and the **name** is the chip: the chip marks the thing, not its classification.

Only types worth saying are said. A bare schema.org class is jargon the report otherwise avoids, so `PropertyValue sample role` stays **"sample role"**. A type is also dropped when the name already opens with it, so a file called `File manifest.csv` does not become *"File File manifest.csv"*.

**The type lookup goes through the same `_lookup` as the name lookup.** Both are keyed on the graph's `@id` and both are asked with the validator's base-resolved `./#` form — so fixing one and not the other gives "CellLine H4" in one row and a bare "H4" in the next. That is exactly what my first cut did.

## 3. How big is "left open on purpose"

The fold-out said *"119 findings left open on purpose"* and then listed reasons with no numbers. 119 is larger than every action above it, and nothing on the page tells you whether that is 119 decisions or — as it always is — two recommendations repeated once per payload file:

```
87 findings left open on purpose
  86   Applies to files published behind a landing page elsewhere …
   1   Left as-is on purpose: the ISA profile REQUIRES the root identifier …
```

## The sentence is still composed in one place

`describe_parts` takes an optional pre-rendered subject, so the HTML passes the same entities marked up and gets back the same wording, truncation and "and N others" count. The alternative — regexing the finished string to insert tags — would have been a second implementation of all three, free to disagree about N.

`_merge_identical` re-composes a subject from several actions, so it reads each one's **bare** name and type rather than its already-composed subject; taking the composed one yields *"Person Person Ada"*. Pinned by a test.

## Verification

165 tests across `test_maturity_report.py` + `test_remediation_grouping.py`. `ruff` and `ty` clean. Rendered against the entity shapes from the report above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)