### PR TITLE
fix(models): a crate we write can be opened in the process that wrote it

### DIFF
--- a/profiles/models/isa.py
+++ b/profiles/models/isa.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E501
 from __future__ import annotations
 
+import functools
 import hashlib
 import re
 from pathlib import Path
@@ -17,6 +18,58 @@ def param_id(name: str, value: str) -> str:
     digest = hashlib.sha1(f"{name}|{value}".encode("utf-8")).hexdigest()[:10]
     base = re.sub(r"[^\w.-]", "_", name or "").strip("_") or "param"
     return f"#param_{base}_{digest}"
+
+
+def reader_compatible(cls):
+    """Let ro-crate-py's READER construct this class, without changing our own API.
+
+    ``ROCrate(path)`` builds its class map from every imported subclass of
+    ``ContextEntity``, keys it by class NAME, and constructs the match
+    positionally (``rocrate.py:294``)::
+
+        type_map = {_.__name__: _ for _ in subclasses(ContextEntity)}
+        cls = pick_type(entity, type_map, fallback=ContextEntity)
+        self.add(cls(self, identifier, entity))    # (crate, identifier, properties)
+
+    Our modelling classes are written for the WRITE path, where the third
+    parameter is the thing the entity is about — ``Sample(crate, id, name)``,
+    ``LabProcess(crate, id, labprotocol)``. Under the reader the properties dict
+    binds to that parameter instead, and the entity is built with ``name`` set to
+    a whole JSON-LD dict, which dies as ``ValueError: no @id in {...}``.
+
+    Merely IMPORTING ``profiles.models`` arms this — no registration call is
+    involved — so any crate carrying a ``Sample``, a ``LabProcess`` or a
+    ``ParameterValue`` was unreadable inside this repo's own process, including
+    ``read_existing_crate`` and every build→read→build round trip. External
+    consumers were never affected: without these imports ``pick_type`` falls back
+    to plain ``ContextEntity`` (#544).
+
+    The read path does not need the rich classes — it needs not to crash. So a
+    third positional argument that is a ``dict`` is taken as the reader's
+    ``properties`` and handed to ``ContextEntity`` directly. That test is
+    unambiguous rather than merely convenient: across all eleven affected classes
+    the third parameter is a ``str``, a ``list`` or a ``LabProtocol``, and not one
+    of them accepts a mapping, so no legitimate write-path call can be mistaken
+    for a read.
+
+    Deliberately NOT done by reordering every signature to put ``properties``
+    third: that is the more principled fix and it churns every construction site
+    in the codebase, for a benefit the reader alone consumes.
+    """
+    original_init = cls.__init__
+
+    @functools.wraps(original_init)
+    def __init__(self, crate, identifier=None, *args, **kwargs):
+        if args and isinstance(args[0], dict):
+            # ro-crate-py's reader. Bypass this class's own __init__ entirely:
+            # it exists to COMPOSE an entity from parts, and the reader already
+            # has the finished JSON-LD.
+            ContextEntity.__init__(self, crate, identifier, args[0])
+            return
+        original_init(self, crate, identifier, *args, **kwargs)
+
+    cls.__init__ = __init__
+    return cls
 
 
 class AutoAddContextEntity(ContextEntity):
@@ -64,6 +117,7 @@ class AutoAddFile(File):
 
 
 # Lab Process
+@reader_compatible
 class LabProcess(AutoAddContextEntity):
     """Bioschemas LabProcess (DRAFT) mapping of an ISA-JSON Process.
 
@@ -280,6 +334,7 @@ class LabProtocol(AutoAddFile):
 
 
 # Parameter defines the specific settings or values used in a protocol (e.g., temperature, duration, operator).
+@reader_compatible
 class ParameterValue(AutoAddContextEntity):
     def __init__(
         self,
@@ -309,6 +364,7 @@ class ParameterValue(AutoAddContextEntity):
 
 
 # Factor represents an independent variable manipulated by the researcher to affect a biological system.
+@reader_compatible
 class FactorValue(ParameterValue):
     def __init__(
         self,
@@ -337,6 +393,7 @@ class FactorValue(ParameterValue):
 
 
 # Factor represents an independent variable manipulated by the researcher to affect a biological system.
+@reader_compatible
 class CharacteristicValue(ParameterValue):
     def __init__(
         self,
@@ -365,6 +422,7 @@ class CharacteristicValue(ParameterValue):
 
 
 # Factor represents an independent variable manipulated by the researcher to affect a biological system.
+@reader_compatible
 class Component(ParameterValue):
     def __init__(
         self,
@@ -449,6 +507,7 @@ class NamedFile(AutoAddFile):
         ]
 
 
+@reader_compatible
 class Sample(AutoAddContextEntity):
     def __init__(
         self,

--- a/profiles/models/tox.py
+++ b/profiles/models/tox.py
@@ -7,6 +7,7 @@ from profiles.models.isa import (
     ParameterValue,
     Sample,
     param_id,
+    reader_compatible,
 )
 from profiles.ontology_iris import iri
 
@@ -65,6 +66,7 @@ def _pvs(*candidates):
     return [p for p in candidates if p is not None]
 
 
+@reader_compatible
 class LabProcessExposure(LabProcess):
     """Exposure step (additionalType "Exposure").
 
@@ -137,6 +139,7 @@ class LabProcessExposure(LabProcess):
         )
 
 
+@reader_compatible
 class LabProcessEndpointReadout(LabProcess):
     def __init__(
         self,
@@ -233,6 +236,7 @@ class LabProcessEndpointReadout(LabProcess):
         )
 
 
+@reader_compatible
 class LabProcessCellCulture(LabProcess):
     def __init__(
         self,
@@ -270,6 +274,7 @@ class LabProcessCellCulture(LabProcess):
         )
 
 
+@reader_compatible
 class LabProcessDataAnalysis(LabProcess):
     """Data analysis process: turns the EndpointReadout's raw measurements into
     reported results. Consumes raw-data File(s) as ``object`` and emits the
@@ -337,6 +342,7 @@ class LabProcessDataAnalysis(LabProcess):
 # Toxicology-specific Sample class for the Tox ISA RO-Crate Profile
 
 
+@reader_compatible
 class CellLineSample(Sample):
     """The cell-based test system, modelled as a Sample carrying a categorical
     annotation via ``sampleType`` (a schema:DefinedTerm) and a cell-line identity

--- a/tests/test_models_are_readable.py
+++ b/tests/test_models_are_readable.py
@@ -1,0 +1,128 @@
+"""A crate this tool writes must open in the process that wrote it (#544).
+
+ro-crate-py builds its read-time class map from every imported subclass of
+``ContextEntity``, keyed by class NAME, and constructs the match positionally::
+
+    cls = pick_type(entity, type_map, fallback=ContextEntity)
+    self.add(cls(self, identifier, entity))          # (crate, identifier, properties)
+
+Our modelling classes are written for the WRITE path, where the third parameter
+is what the entity is about — ``Sample(crate, id, name)``. Under the reader the
+properties dict bound to that parameter and the entity was built with ``name``
+set to a whole JSON-LD dict, dying as ``ValueError: no @id in {...}``.
+
+Importing ``profiles.models`` is enough to arm it, so this affected
+``read_existing_crate`` and every build→read→build round trip. External
+consumers were never affected — without those imports ``pick_type`` falls back
+to plain ``ContextEntity`` — which is why #532's guard reads a crate in a
+SUBPROCESS and this one reads it in-process. Two different claims, two tests.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from rocrate.model.contextentity import ContextEntity
+from rocrate.rocrate import ROCrate
+
+# Imported for the side effect the bug depends on: this is what puts our classes
+# into ro-crate-py's type map.
+import profiles.models.isa  # noqa: F401
+import profiles.models.tox  # noqa: F401
+from builder.tools.builder import export_crate
+from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+
+def _our_context_entity_classes() -> list[type]:
+    """Every ContextEntity subclass of ours the reader can pick, at any depth."""
+
+    def descend(cls: type):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from descend(sub)
+
+    return [
+        c
+        for c in dict.fromkeys(descend(ContextEntity))
+        if c.__module__.startswith("profiles.")
+    ]
+
+
+class TestEveryModelTheReaderCanPickIsConstructibleByIt:
+    """The rule, asserted against the classes rather than one sample crate.
+
+    A crate-based test only covers the ``@type``s that crate happens to contain,
+    so a new model class would reintroduce the bug and stay green until some
+    fixture grew an instance of it. This enumerates the map the reader actually
+    builds.
+    """
+
+    def test_the_reader_can_construct_each_one(self) -> None:
+        crate = ROCrate()
+        broken: list[str] = []
+        for cls in _our_context_entity_classes():
+            properties = {"@id": "#probe", "@type": "Thing", "name": "probe"}
+            try:
+                # Exactly the reader's call: positional, properties third.
+                entity = cls(crate, "#probe", properties)
+            except Exception as exc:  # noqa: BLE001 — collecting, not handling
+                broken.append(f"{cls.__name__}: {type(exc).__name__}: {exc}")
+                continue
+            if entity.id != "#probe":
+                broken.append(f"{cls.__name__}: built with id {entity.id!r}")
+        assert broken == [], (
+            "these classes cannot be built the way ROCrate(path) builds them, so "
+            "any crate containing one is unreadable in this process:\n  "
+            + "\n  ".join(broken)
+        )
+
+    def test_the_write_path_signatures_are_untouched(self) -> None:
+        """The control. The fix must not have quietly turned every model into a
+        properties bag — the third parameter is still what the entity is about,
+        and every existing construction site still means what it says."""
+        from profiles.models.isa import Sample
+
+        third = list(inspect.signature(Sample.__init__).parameters)[3]
+        assert third == "name", (
+            "Sample's write-path signature changed; the reader fix was supposed to "
+            "leave it alone"
+        )
+        crate = ROCrate()
+        sample = Sample(crate, "#s1", "MDCK1 cells")
+        assert sample["name"] == "MDCK1 cells"
+
+
+class TestACrateWeWroteOpensInThisProcess:
+    """End to end, on a real exported crate — the symptom the issue reported."""
+
+    @pytest.fixture(scope="class")
+    def written_crate(self, tmp_path_factory: pytest.TempPathFactory):
+        out = tmp_path_factory.mktemp("readable") / "crate"
+        state = vhps_fixture_state("S-VHPS21")
+        state.metadata.output_path = str(out)
+        result = export_crate(state, str(out))
+        assert result["success"], result["error"]
+        return out
+
+    def test_it_opens(self, written_crate) -> None:
+        ROCrate(str(written_crate))
+
+    def test_the_fixture_actually_exercises_the_bug(self, written_crate) -> None:
+        """Without an affected @type in it, the test above proves nothing."""
+        import json
+
+        graph = json.loads(
+            (written_crate / "ro-crate-metadata.json").read_text(encoding="utf-8")
+        )["@graph"]
+        names = {c.__name__ for c in _our_context_entity_classes()}
+        present = {
+            t
+            for e in graph
+            for t in (e.get("@type") if isinstance(e.get("@type"), list) else [e.get("@type")])
+            if t in names
+        }
+        assert present, (
+            "this crate carries none of our modelled @types, so opening it does "
+            "not exercise the reader path at all"
+        )


### PR DESCRIPTION
Closes #544.

`ro-crate-py` builds its read-time class map from every imported subclass of `ContextEntity`, keys it by class **name**, and constructs the match **positionally** (`rocrate.py:294`):

```python
cls = pick_type(entity, type_map, fallback=ContextEntity)
self.add(cls(self, identifier, entity))      # (crate, identifier, properties)
```

Our modelling classes are written for the **write** path, where the third parameter is what the entity is *about* — `Sample(crate, id, name)`, `LabProcess(crate, id, labprotocol)`. Under the reader the properties dict binds to that parameter, so the entity is built with `name` set to a whole JSON-LD dict and dies as `ValueError: no @id in {...}`.

Merely **importing** `profiles.models` arms it. Verified before fixing — the four most recent crates in `output/`:

```
in-process (our models imported)     clean process
FAIL v62  ValueError: no @id in …    OK  v62
FAIL v63                             OK  v63
FAIL v64                             OK  v64
FAIL v65                             OK  v65
```

External consumers were never affected: without our imports `pick_type` falls back to plain `ContextEntity`. That is exactly why #532's guard reads a crate in a **subprocess** — it pins the claim receiving labs care about. Two different claims, so two tests, each saying in its docstring which one it is.

## The fix

A `reader_compatible` decorator on the eleven affected classes. A third positional argument that is a `dict` is the reader's `properties` and goes straight to `ContextEntity`; anything else runs the class's own `__init__` unchanged.

**That test is unambiguous, not merely convenient.** Checked by introspection rather than by eye — across all eleven classes the third parameter is a `str`, a `list` or a `LabProtocol`, and not one accepts a mapping:

```
LabProcess                 labprotocol    LabProtocol
LabProcessExposure         duration       str | None
LabProcessEndpointReadout  samples        list[Sample] | None
LabProcessDataAnalysis     object         list[File]
Sample / CellLineSample / ParameterValue / FactorValue /
CharacteristicValue / Component / LabProcessCellCulture   name   str
```

So no legitimate write-path call can be mistaken for a read.

Reordering every signature to put `properties` third is the more principled fix and was **rejected**: it churns every construction site in the codebase for a benefit only the reader consumes. A control test asserts the write-path signatures did *not* change.

## Tests

The main guard **enumerates the type map the reader actually builds** rather than reading one sample crate. A crate-based test only covers the `@type`s that crate happens to contain, so a new model class would reintroduce this and stay green until some fixture grew an instance of it.

A second test opens a real exported crate, and a third asserts that crate actually contains an affected `@type` — so "it opens" cannot pass vacuously.

`ruff` and `ty` clean; 43 tests across the readability, read-back and mapping modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)