### PR TITLE
feat(report): order actions by what the fix is worth, not by how many it clears

### DIFF
--- a/builder/tools/remediation.py
+++ b/builder/tools/remediation.py
@@ -75,6 +75,67 @@ TIER_LABEL = {"REQUIRED": "Required", "RECOMMENDED": "Recommended", "OPTIONAL": 
 _DEFAULT_TIER = "RECOMMENDED"
 
 
+# How much a fix is worth to somebody REUSING the dataset, which is not the same
+# question as how loudly a profile asks for it. Both are needed: the tier says
+# what blocks conformance, this says what the crate is worth once it passes.
+#
+# The calibration is the user's, from reading a real report:
+#
+#   "Say which measurement technique was used …"  -> "this sounds way more impactful"
+#   "Add a job title for Max Tio, W. Edward Visser …"
+#       -> "I don't think the data will be less worth or more worth if we have a
+#           job title of those gentleman, sure we can do but it is not that
+#           important from a dataset perspective"
+#
+# Three bands, and the test for each is a question about the READER of the crate:
+#
+#   0 CAN THEY UNDERSTAND THE EXPERIMENT?   what was measured, how, on what, under
+#     which conditions. Absent, the numbers cannot be interpreted at all.
+#   1 CAN THEY FIND, TRUST AND CITE IT?     identifiers, dates, licence, who did it,
+#     where to write. Absent, the data is usable but the record is weak.
+#   2 COURTESY DETAIL.                      true and worth having; nobody's reuse
+#     turns on it.
+#
+# This is a judgement, so it is written down in one place and ordered
+# most-specific-first like `_WANTED` — not spread through the sort function where
+# it could not be argued with. An unlisted finding lands in band 1: the middle is
+# the honest default for something nobody has classified.
+_IMPACT_BANDS: tuple[tuple[tuple[str, ...], int], ...] = (
+    # --- 0: without this the measurement cannot be interpreted ---------------
+    (("measurement technique", "measurement method"), 0),
+    (("Key Event", "AOP"), 0),
+    (("parameter value", "additional property"), 0),
+    (("protocol",), 0),
+    (("description",), 0),
+    (("measured entity", "endpoint"), 0),
+    # --- 2: nobody's reuse turns on it (checked BEFORE the generic identifier
+    #        band below, which "job title" would otherwise fall into) ---------
+    (("job title",), 2),
+    # --- 1: everything else — findable, trustable, citable -------------------
+    (("ORCID", "identifier"), 1),
+    (("affiliation", "contactPoint", "contact point", "email"), 1),
+    (("licence", "license", "dateCreated", "datePublished", "dateModified"), 1),
+    (("creator", "publisher", "author"), 1),
+)
+
+_DEFAULT_IMPACT = 1
+
+
+def _impact(messages: list[str]) -> int:
+    """Which band the strongest finding in *messages* falls into.
+
+    First match wins, `_WANTED`-style, so the ordering of `_IMPACT_BANDS` is the
+    specification. An entity missing several things is ranked by the most
+    valuable of them — the action clears all of them at once, so ranking it by
+    the least valuable would bury a job worth doing.
+    """
+    blob = " ".join(messages)
+    for needles, band in _IMPACT_BANDS:
+        if any(n in blob for n in needles):
+            return band
+    return _DEFAULT_IMPACT
+
+
 @dataclass
 class Action:
     """One thing a person could do, and what it would clear.
@@ -108,6 +169,10 @@ class Action:
     subject_types: list[str] = field(default_factory=list)
     findings: list[str] = field(default_factory=list)
     tier: str = _DEFAULT_TIER
+    # How much the fix is worth to a reuser (0 best). Ordered WITHIN a tier, never
+    # across one: a required conformance failure still outranks the most valuable
+    # recommendation, because one blocks the build and the other improves it.
+    impact: int = _DEFAULT_IMPACT
     actionable: bool = True
     note: str | None = None
 
@@ -366,6 +431,7 @@ def group_findings(
                 entity_ids=sorted({str(f.get("entity_id")) for f in live if f.get("entity_id")}),
                 findings=[str(f.get("message") or "") for f in live],
                 tier=_strongest([str(f.get("severity") or _DEFAULT_TIER).upper() for f in live]),
+                impact=_impact([str(f.get("message") or "") for f in live]),
             )
         )
         for f in live:
@@ -394,7 +460,7 @@ def group_findings(
 
     actions = _merge_identical(actions)
 
-    actions.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
+    actions.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), a.impact, -a.cleared, a.subject))
     return actions + list(deferred.values())
 
 
@@ -566,10 +632,11 @@ def _merge_identical(actions: list[Action]) -> list[Action]:
                 entity_ids=sorted({e for a in group for e in a.entity_ids}),
                 # Every finding, so `cleared` still totals the whole list.
                 findings=[m for a in group for m in a.findings],
+                impact=min(a.impact for a in group),
                 tier=_strongest([a.tier for a in group]),
             )
         )
-    merged.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
+    merged.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), a.impact, -a.cleared, a.subject))
     return merged
 
 

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -699,7 +699,7 @@ def _render_profile_section(
     esc = html.escape
     if stale:
         return (
-            "<section>\n"
+            '<section id="adherence">\n'
             '  <div class="sec-h"><h2>Profile adherence</h2>'
             '<span class="sec-meta">out of date</span></div>\n'
             '  <p class="lead">The last recorded verdict was computed against an earlier '
@@ -709,7 +709,7 @@ def _render_profile_section(
         )
     if tiers is None:
         return (
-            "<section>\n"
+            '<section id="adherence">\n'
             '  <div class="sec-h"><h2>Profile adherence</h2></div>\n'
             '  <p class="lead">Not yet validated — run validation to populate profile '
             "adherence.</p>\n"
@@ -732,7 +732,7 @@ def _render_profile_section(
     sugg = "" if has_findings else f'<p class="good-note">{_clean_note(val)}</p>'
 
     return (
-        "<section>\n"
+        '<section id="adherence">\n'
         '  <div class="sec-h"><h2>Profile adherence</h2>'
         '<span class="sec-meta">3 layers · 3 severity tiers</span></div>\n'
         f'  <div class="prof-grid">{cards}</div>\n'
@@ -925,7 +925,11 @@ def _render_next_steps_section(
     # `_NEXT_STEPS_CAP` then drops it off the list entirely: the report quietly
     # hiding the work that blocks the build, which is the one thing this section
     # exists to surface.
-    live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), -a.cleared, a.subject))
+    # Tier, then IMPACT, then size. Size last on purpose: "add a job title for 8
+    # people" clears more findings than "say which measurement technique was
+    # used", and ranking by count put the first above the second — which is
+    # backwards for anyone who has to reuse the data.
+    live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), a.impact, -a.cleared, a.subject))
     esc = html.escape
     def _subject_html(action: Any) -> str:
         """The subject clause with every entity in a ``<code>`` chip.
@@ -975,8 +979,12 @@ def _render_next_steps_section(
         rows += (
             f'<li><span class="na-n">{rest}</span><span class="na-t">'
             f"…and {len(live) - _NEXT_STEPS_CAP} smaller "
-            f"{'item' if len(live) - _NEXT_STEPS_CAP == 1 else 'items'}, "
-            "listed in full below."
+            f"{'item' if len(live) - _NEXT_STEPS_CAP == 1 else 'items'}, in "
+            # "listed in full below" named a place without pointing at it — on a
+            # page this long "below" is several screens and three sections away.
+            # The findings these actions were built FROM live under Profile
+            # adherence, so say that and link to it.
+            '<a href="#adherence">Profile adherence</a>.'
             "</span></li>"
         )
     settled = [a for a in actions if not a.actionable]

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -2147,3 +2147,32 @@ class TestActionEntitiesAreMarkedAsEntities:
         assert '<span class="na-n">9</span>' in rows[0], (
             "the reason must carry the number of findings it accounts for"
         )
+
+
+class TestTheOverflowLinePointsSomewhere:
+    """"listed in full below" named a place without pointing at it — on a page
+    this long "below" is several screens and three sections away."""
+
+    def test_the_overflow_line_links_to_the_findings(self) -> None:
+        import re
+
+        from builder.tools.validation import ValidationReport
+        from builder.writers.maturity_report import _render_next_steps_section
+
+        val = ValidationReport()
+        val.base_passed = True
+        val.issue_records = [
+            {"profile": "tox", "severity": "recommended", "entity_id": f"./#e{i}",
+             "message": f"SHOULD have a thing of kind {i}"}
+            for i in range(12)
+        ]
+        section = _render_next_steps_section(val, None)
+        overflow = re.findall(r"<li>.*?</li>", section)[-1]
+        assert "smaller item" in overflow, "no overflow row rendered; this test is inert"
+        assert 'href="#adherence"' in overflow
+
+    def test_the_anchor_it_points_at_exists_on_the_page(self) -> None:
+        """A link to an id nothing defines is a dead link that still looks fine
+        in the markup — the same class of bug as a class with no CSS rule."""
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
+        assert 'id="adherence"' in page

--- a/tests/test_remediation_grouping.py
+++ b/tests/test_remediation_grouping.py
@@ -495,3 +495,75 @@ class TestAnActionSaysWhatKindOfThingItIsAbout:
         )
         assert actions[0].subject == "Person Ada and Person Grace"
         assert "Person Person" not in actions[0].subject
+
+
+class TestActionsAreOrderedByWhatTheFixIsWorth:
+    """Profile tier says what BLOCKS; impact says what the crate is worth once it
+    passes. The report needs both, and it had only the first.
+
+    Calibrated on the user's reading of a real report: "say which measurement
+    technique was used" is "way more impactful", while a job title "is not that
+    important from a dataset perspective" — yet the job-title action cleared 8
+    findings and the technique one cleared 3, so ordering by size put the wrong
+    one first.
+    """
+
+    def test_a_valuable_small_job_outranks_a_bulky_trivial_one(self):
+        from builder.tools.remediation import _TIER_RANK, describe, group_findings
+
+        findings = [
+            *[
+                _f(f"./#p{i}", "A Person SHOULD have a job title")
+                for i in range(8)
+            ],
+            *[
+                _f(f"./#A_{a}", "An Assay SHOULD say which measurement technique was used")
+                for a in ("deiodinase", "gene_expression", "metabolism")
+            ],
+        ]
+        live = [a for a in group_findings(findings, labels={}) if a.actionable and a.cleared]
+        live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), a.impact, -a.cleared, a.subject))
+        assert "measurement technique" in describe(live[0])
+        assert live[0].cleared < live[-1].cleared, (
+            "this test only means something while the valuable action is the SMALLER "
+            "one — otherwise size ordering would have got it right anyway"
+        )
+
+    def test_impact_never_outranks_the_profile_tier(self):
+        """A required conformance failure still leads, however trivial. One blocks
+        the build; the other only improves it."""
+        from builder.tools.remediation import _TIER_RANK, group_findings
+
+        findings = [
+            _f("./#root", "A Person SHOULD have a job title", severity="required"),
+            _f("./#a1", "An Assay SHOULD say which measurement technique was used"),
+        ]
+        live = [a for a in group_findings(findings, labels={}) if a.actionable and a.cleared]
+        live.sort(key=lambda a: (_TIER_RANK.get(a.tier, 3), a.impact, -a.cleared, a.subject))
+        assert live[0].tier == "REQUIRED"
+
+    def test_an_unclassified_finding_lands_in_the_middle(self):
+        """Not band 0 — an unrecognised message must not jump the queue over
+        things somebody actually judged important."""
+        from builder.tools.remediation import _DEFAULT_IMPACT, _impact
+
+        assert _impact(["something nobody has ever classified"]) == _DEFAULT_IMPACT
+        assert _impact(["An Assay SHOULD say which measurement method was used"]) < _DEFAULT_IMPACT
+        assert _impact(["A Person SHOULD have a job title"]) > _DEFAULT_IMPACT
+
+    def test_a_job_title_is_not_read_as_an_identifier(self):
+        """"job title" sits ABOVE the generic identifier/ORCID band on purpose:
+        those needles are broad, and a message mentioning both would otherwise
+        promote the job title to band 1."""
+        from builder.tools.remediation import _impact
+
+        assert _impact(["A Person SHOULD have a job title and an identifier"]) == 2
+
+    def test_an_entity_is_ranked_by_its_most_valuable_finding(self):
+        """The action clears all of them at once, so ranking by the least
+        valuable would bury a job worth doing."""
+        from builder.tools.remediation import _impact
+
+        assert _impact(
+            ["A Person SHOULD have a job title", "SHOULD say which measurement technique"]
+        ) == 0


### PR DESCRIPTION
The profile tier says what **blocks** conformance. It does not say what the crate is **worth** once it passes — and the list had only the first, so it ranked by size:

```
8   Add a job title for Max Tio, W. Edward Visser, Marcel Erwin Meima and 5 others.
3   Say which measurement technique was used for Deiodinase activity assay, …
```

Backwards for anyone reusing the data. Now:

```
3   Say which measurement technique was used for Deiodinase activity assay, …
8   Add a job title for Max Tio, W. Edward Visser, Marcel Erwin Meima and 5 others.
```

## The calibration is the user's, not mine

> *"Say which measurement technique was used …"* — **"this sounds way more impactful"**
>
> *"Add a job title for Max Tio, W. Edward Visser …"* — **"I don't think the data will be less worth or more worth if we have a job title of those gentleman, sure we can do but it is not that important from a dataset perspective"**

## Three bands, each a question about the reader of the crate

| band | question | examples |
|---|---|---|
| **0** | can they **understand the experiment**? | measurement technique/method, AOP Key Event link, parameters, protocols, descriptions, the endpoint |
| **1** | can they **find, trust and cite it**? | identifiers, dates, licence, creator/publisher, contact |
| **2** | **courtesy detail** | a job title |

Ordering is **tier → band → size**, with size last.

- **Impact never outranks the tier.** A required conformance failure still leads however trivial: one blocks the build, the other only improves it. Pinned by a test.
- **An entity is ranked by its most valuable finding**, since the action clears all of them at once — ranking by the least valuable would bury a job worth doing.
- **An unclassified message lands in the middle band, not the top.** Something nobody has judged must not jump the queue.
- **`job title` is listed above the identifier band deliberately.** Those needles (`ORCID`, `identifier`) are broad, and a message naming both would otherwise promote it. Pinned.

This is a judgement, so it lives in **one ordered table with the reasoning written beside it**, rather than spread through the sort function where it could not be argued with.

## Also: the overflow line now points somewhere

*"…and 6 smaller items, listed in full below"* named a place without pointing at it — on a page this long, "below" is several screens and three sections away. It now links to **Profile adherence**, where the findings those actions were built from actually live.

The section carries an `id` on **all three** of its rendering branches (stale / not-yet-validated / full), so the link cannot dangle depending on which one produced it. A test asserts the target exists on a real page — a link to an undefined id looks perfectly fine in the markup.

## Verification

172 tests across `test_maturity_report.py` + `test_remediation_grouping.py`. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)