### PR TITLE
fix(tools): bridge a missing id to the entity by NAME

### DIFF
--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -7,6 +7,7 @@ field-level completion tracking.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from builder.state import (
@@ -294,6 +295,70 @@ def resolve_entity_id(state: CrateState, raw: str) -> str:
 _ROOT_ALIASES: frozenset[str] = frozenset({"./", ".", "/", "#", "./#", "root", "#root", "./#root"})
 
 
+def _name_words(text: str) -> set[str]:
+    """The identifying words in an id or a name, for comparing the two.
+
+    An id is a slugged name (``person_nathalie_dierichs``), so dropping the type
+    prefix and the separators leaves the words the name itself carries. Short
+    tokens go too: an initial matches far too much to be evidence.
+    """
+    # `[\W_]` and not `[^\w]`: \w INCLUDES the underscore, so the latter leaves
+    # `person_nathalie_dierichs` as a single "word" and the comparison below can
+    # never match the name it was built from.
+    words = {w for w in re.split(r"[\W_]+", str(text or "").casefold()) if len(w) > 2}
+    return words - _ID_PREFIX_WORDS
+
+
+# Type prefixes the drafters mint ids with. They say what KIND of thing this is,
+# not which one, so they are noise when matching an id against a name.
+_ID_PREFIX_WORDS: frozenset[str] = frozenset(
+    {
+        "person",
+        "org",
+        "organization",
+        "assay",
+        "study",
+        "inv",
+        "investigation",
+        "proto",
+        "protocol",
+        "proc",
+        "process",
+        "sample",
+        "file",
+        "pub",
+        "publication",
+        "term",
+        "chem",
+        "compound",
+    }
+)
+
+
+def _entities_named_like(state: CrateState, entity_id: str, limit: int) -> list[tuple[str, str]]:
+    """``(entity_id, name)`` for entities whose NAME matches a missing id's words.
+
+    Requires every identifying word of the guess to appear in the entity's name,
+    so "nathalie dierichs" finds Nathalie Dierichs while a partial overlap does
+    not drag in a different person. An empty guess matches nothing.
+    """
+    wanted = _name_words(entity_id)
+    if not wanted:
+        return []
+    out: list[tuple[str, str]] = []
+    try:
+        entities = state.list_entities()
+    except Exception:  # noqa: BLE001 — an error message must never raise
+        return []
+    for entity in entities:
+        name = str((entity.fields or {}).get("name") or "").strip()
+        if name and wanted <= _name_words(name):
+            out.append((entity.entity_id, name))
+        if len(out) >= limit:
+            break
+    return out
+
+
 def entity_not_found_message(state: CrateState, entity_id: str, *, limit: int = 3) -> str:
     """ "Entity not found", plus the ids it was most likely reaching for.
 
@@ -347,6 +412,24 @@ def entity_not_found_message(state: CrateState, entity_id: str, *, limit: int = 
 
     close = difflib.get_close_matches(str(entity_id), known, n=limit, cutoff=0.6)
     if not close:
+        # String similarity cannot bridge two id SCHEMES. A resolved author is
+        # keyed by their ORCID URL, while an agent addresses them by the id it
+        # expected a drafter to mint — `person_nathalie_dierichs` against
+        # `https://orcid.org/0009-0000-5074-6239`. Those share no characters, so
+        # the comparison above scores zero and the agent is handed a list of
+        # unrelated ids for someone who IS in the crate. One session failed
+        # twenty-one set_fields calls this way, each name attempted twice.
+        #
+        # So the miss is also read as a NAME. It is the same person, and the
+        # crate knows their name even when it does not know that id.
+        if named := _entities_named_like(state, entity_id, limit):
+            suggestions = ", ".join(f"{eid} ({name})" for eid, name in named)
+            return (
+                f"{base}. Did you mean: {suggestions}? "
+                "That entity is in the crate under a different id — a looked-up "
+                "person or organization is keyed by its registry IRI, not by a "
+                "name-derived id. Use the id as listed."
+            )
         # Nothing similar: naming a few real ids still beats a dead end, and the
         # count tells the model whether the list it is seeing is the whole crate.
         shown = ", ".join(known[:limit])

--- a/tests/test_not_found_errors_suggest.py
+++ b/tests/test_not_found_errors_suggest.py
@@ -100,3 +100,87 @@ class TestTheMessageStaysUseful:
         state = _state(("sample_alpha", "Sample"), ("proc_a", "LabProcess"))
         with pytest.raises(ValueError, match="minted by the drafting tools"):
             link(state, "proc_a", "input", "sample_alfa")
+
+
+class TestAnIdSchemeChangeIsBridgedByName:
+    """String similarity cannot connect two id schemes; the name can.
+
+    A resolved author is keyed by their ORCID URL, while the agent addresses
+    them by the id it expected a drafter to mint. `person_nathalie_dierichs` and
+    `https://orcid.org/0009-0000-5074-6239` share no characters, so difflib
+    scores zero and the agent is handed a list of unrelated ids for someone who
+    IS in the crate. One profiled session failed twenty-one set_fields calls
+    that way, each name attempted twice — the agent had no bridge, so it simply
+    tried again.
+    """
+
+    def _person(self, entity_id: str, name: str) -> Entity:
+        entity = Entity(
+            entity_id=entity_id, type="Person", _provenance=EntityProvenance(created_by="lookup")
+        )
+        entity.set_fields_from_dict({"name": name}, source="lookup")
+        return entity
+
+    def _state_with(self, *people: tuple[str, str]) -> CrateState:
+        state = CrateState()
+        for entity_id, name in people:
+            state.add_entity(self._person(entity_id, name))
+        return state
+
+    def test_a_name_derived_guess_finds_the_orcid_keyed_person(self):
+        from builder.tools.management import entity_not_found_message
+
+        state = self._state_with(("https://orcid.org/0009-0000-5074-6239", "Nathalie Dierichs"))
+        message = entity_not_found_message(state, "person_nathalie_dierichs")
+        assert "0009-0000-5074-6239" in message
+        assert "Nathalie Dierichs" in message
+
+    def test_initials_in_the_name_do_not_break_it(self):
+        from builder.tools.management import entity_not_found_message
+
+        state = self._state_with(("https://orcid.org/0000-0002-5248-863X", "W. Edward Visser"))
+        assert "0000-0002-5248-863X" in entity_not_found_message(state, "person_w_edward_visser")
+
+    def test_an_organization_is_bridged_too(self):
+        from builder.tools.management import entity_not_found_message
+
+        state = CrateState()
+        org = Entity(
+            entity_id="https://ror.org/00dn4t376",
+            type="Organization",
+            _provenance=EntityProvenance(created_by="lookup"),
+        )
+        org.set_fields_from_dict({"name": "Brunel University of London"}, source="lookup")
+        state.add_entity(org)
+        message = entity_not_found_message(state, "org_brunel_university_of_london")
+        assert "00dn4t376" in message
+
+    def test_a_different_person_is_not_offered(self):
+        """A partial overlap must not drag in somebody else."""
+        from builder.tools.management import entity_not_found_message
+
+        state = self._state_with(
+            ("https://orcid.org/0000-0000-0000-0001", "Nathalie Bernard"),
+            ("https://orcid.org/0000-0000-0000-0002", "Peter Dierichs"),
+        )
+        message = entity_not_found_message(state, "person_nathalie_dierichs")
+        assert "Did you mean" not in message
+        assert "Existing ids include" in message
+
+    def test_a_genuine_miss_still_lists_real_ids(self):
+        from builder.tools.management import entity_not_found_message
+
+        state = self._state_with(("https://orcid.org/0009-0000-5074-6239", "Nathalie Dierichs"))
+        message = entity_not_found_message(state, "person_nobody_here")
+        assert "Existing ids include" in message
+
+    def test_an_underscored_id_is_split_into_words(self):
+        """`\\w` includes the underscore, so the naive split never matches."""
+        from builder.tools.management import _name_words
+
+        assert _name_words("person_nathalie_dierichs") == {"nathalie", "dierichs"}
+
+    def test_the_type_prefix_is_not_evidence(self):
+        from builder.tools.management import _name_words
+
+        assert "person" not in _name_words("person_ada_lovelace")


### PR DESCRIPTION
From the `20260813_192943` profile. The export problem is **gone** — 32 calls → 2, tool time 10.7 → 7.9 min, tokens 4.7M → 2.9M — and a new signal took its place: **21 `set_fields` failures**, every one the same shape.

```
Entity not found: person_nathalie_dierichs
Entity not found: person_ellen_hessel
Entity not found: person_aldert_piersma        … each attempted twice
```

Those people are all **in the crate**:

```
https://orcid.org/0009-0000-5074-6239   Nathalie Dierichs
https://orcid.org/0000-0003-3960-7523   Ellen Hessel
https://orcid.org/0000-0002-1943-7793   Aldert Piersma
```

The author cascade keys a resolved Person by their **ORCID URL**; the agent addresses them by the **name-derived id** a drafter would have minted. Same human, two id schemes — and `#566`'s "Did you mean" cannot help, because `difflib` scores zero on strings that share no characters. The agent got a list of unrelated ids, had no bridge, and tried again. Hence exactly twice per name.

**A miss is now also read as a name.** Every identifying word of the guess must appear in the entity's name, so "nathalie dierichs" finds Nathalie Dierichs while a partial overlap does not drag in a different person; type prefixes (`person`, `org`, `assay`, …) are dropped since they say what *kind* of thing it is, not which one.

```
person_nathalie_dierichs
  -> Did you mean: https://orcid.org/0009-0000-5074-6239 (Nathalie Dierichs)?
     That entity is in the crate under a different id — a looked-up person or
     organization is keyed by its registry IRI, not by a name-derived id.
```

A genuine miss still falls back to listing real ids.

## One subtlety, carrying a comment

The split is `[\W_]+`, **not** `[^\w]+`. `\w` includes the underscore, so the obvious pattern leaves `person_nathalie_dierichs` as a single "word" and can never match the name it was built from. That is exactly how my first version failed — silently, returning nothing, looking like the bridge simply had no match.

15 tests, including that a *different* person is not offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)