### PR TITLE
fix(build): move a misplaced field to the entity that consumes it, don't delete it

### DIFF
--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -25,6 +25,7 @@ from builder.tools._crate_mapping import (
     _file_dest,
     populate_crate,
 )
+from builder.tools.rehome import rehome_misplaced_fields
 from profiles.context import ISA_TOX_CONTEXT
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,31 @@ def assemble_crate(
         A populated :class:`ROCrate`. Nothing is written unless the caller
         invokes ``crate.write()``.
     """
+    # Before anything is composed: move a field written on an entity that cannot
+    # hold it to the one that consumes it. `_scalar_props` would otherwise DELETE
+    # it — correct for a key the model invented, wrong for a field this codebase
+    # asks for by name and then files under the wrong type. Twelve such values
+    # (instrument, manufacturer, measured entity, replicate count, across three
+    # assays) were deleted from one real build, and the report went on to raise
+    # "say which measurement technique was used" about their absence.
+    #
+    # Mutates `state`, deliberately: the crate is built from state on every
+    # export, so rescuing the value only for this build would let the next one
+    # delete it again. Never raises — a rescue that breaks the build is worse
+    # than the deletion it prevents.
+    try:
+        rehomed = rehome_misplaced_fields(state)
+    except Exception:  # noqa: BLE001 — a rescue must never sink an export
+        logger.warning("Could not re-home misplaced fields; continuing", exc_info=True)
+        rehomed = []
+    for move in rehomed:
+        logger.info(
+            "Kept %r by moving it from %s to %s, which is the type that consumes it",
+            move.field,
+            move.from_id,
+            move.to_id,
+        )
+
     crate = ROCrate()
     crate.metadata.extra_contexts = ISA_TOX_CONTEXT
     populate_crate(

--- a/builder/tools/rehome.py
+++ b/builder/tools/rehome.py
@@ -1,0 +1,238 @@
+"""Move a field written on the wrong entity to the one that consumes it.
+
+A build reported this at exit, twelve times over three assays::
+
+    · Dropped 'detection_instrument' from assay_deiodinase_activity_assay
+      (not a term in the crate's JSON-LD context)
+    · Dropped 'instrument_manufacturer' from assay_deiodinase_activity_assay …
+    · Dropped 'measured_entity' from assay_deiodinase_activity_assay …
+    · Dropped 'technical_replicate' from assay_deiodinase_activity_assay …
+
+The drop rule itself is sound: a JSON-LD key the context does not define fails
+BASE conformance in a way nobody can repair by editing the crate, because the
+invalid key is regenerated from state on every build. What was wrong is that it
+treated two different things as one — a key the model INVENTED, and a field this
+codebase asks for by name.
+
+All four above are documented inputs. ``ENTITY_DRAFT_SCHEMA`` declares them on
+``LabProcess`` and ``_build_process`` consumes them into
+``LabProcessEndpointReadout``; ``tools_spec`` instructs the agent to fill them
+from the assay metadata workbook. They were written on the **Assay** instead,
+which declares only ``name`` / ``description`` / ``identifier``, so nothing read
+them and they were deleted.
+
+They were then reported as missing. "Say which measurement technique was used
+for Deiodinase activity assay" is a finding about information the crate had been
+given and had thrown away.
+
+**Nothing here decides which entity owns a field.** ``ENTITY_DRAFT_SCHEMA`` has
+always declared that, per type, and this inverts it. A field added to a schema
+teaches this module about it for free, and the two cannot drift apart, which they
+would if the ownership were restated here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from builder.state import CrateState, Entity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Rehomed:
+    """One field moved, recorded so the move can be reported rather than guessed at.
+
+    A silent move is a worse failure than the silent drop it replaces: a value
+    that quietly changes entity is a value the reader cannot account for.
+    """
+
+    field: str
+    value: Any
+    from_id: str
+    from_type: str
+    to_id: str
+    to_type: str
+
+
+def _field_owners() -> dict[str, set[str]]:
+    """``field -> {entity types that declare it}``, inverted from the schema.
+
+    Read fresh rather than cached at import: the schema is a module-level dict
+    that tests legitimately patch, and a cache would serve them the wrong answer.
+    """
+    from builder.tools._crate_mapping import ENTITY_DRAFT_SCHEMA
+
+    owners: dict[str, set[str]] = {}
+    for entity_type, schema in ENTITY_DRAFT_SCHEMA.items():
+        for field in getattr(schema, "scalar_fields", {}) or {}:
+            owners.setdefault(field, set()).add(entity_type)
+    return owners
+
+
+def _declares(entity_type: str, field: str) -> bool:
+    """Whether *entity_type*'s own schema declares *field*."""
+    from builder.tools._crate_mapping import ENTITY_DRAFT_SCHEMA
+
+    schema = ENTITY_DRAFT_SCHEMA.get(entity_type)
+    return bool(schema and field in (getattr(schema, "scalar_fields", {}) or {}))
+
+
+def _would_be_dropped(field: str) -> bool:
+    """Whether the build would delete *field* rather than emit it.
+
+    Deliberately the SAME question ``_scalar_props`` asks, imported from there,
+    so the rescuer and the dropper cannot disagree about which fields are at
+    risk. A rescuer working from its own copy of the rule would either move
+    fields that were never in danger or miss the ones that were.
+    """
+    from builder.tools._crate_mapping import (
+        _REF_FIELDS,
+        _STRUCT_FIELDS,
+        _camel_case,
+        _context_terms,
+    )
+
+    if field.startswith("@") or field in (_REF_FIELDS | _STRUCT_FIELDS):
+        return False
+    if "_" not in field or field in _context_terms():
+        return False
+    return _camel_case(field) not in _context_terms() and _camel_case(field) not in (
+        _REF_FIELDS | _STRUCT_FIELDS
+    )
+
+
+def _target_for(
+    state: CrateState, source: Entity, owners: set[str], wanted_step: str | None
+) -> Entity | None:
+    """The entity that should hold this field, or ``None`` if there isn't one.
+
+    Only relationships the graph already records are followed — this invents no
+    entity to receive a value. An assay's processes are found by the ``assay_id``
+    the drafter stamps on every ``LabProcess``; the ``process_type`` is not
+    guessed, it comes from the schema description, which names the step it
+    belongs to ("EndpointReadout: detection instrument.").
+
+    Returns ``None`` when the owning type has no instance related to *source*,
+    which is the honest answer: the value stays where it is and the caller
+    decides what to do about it, rather than being attached to an unrelated
+    entity of the right class.
+    """
+    if "LabProcess" not in owners:
+        return None
+    if source.type != "Assay":
+        return None
+    candidates = [
+        e
+        for e in state.list_entities("LabProcess")
+        if str(e.fields.get("assay_id") or "") == source.entity_id
+    ]
+    if wanted_step is not None:
+        # Select BY step rather than taking the first process and checking it
+        # afterwards: the chain is CellCulture -> Exposure -> EndpointReadout ->
+        # DataAnalysis, so "the first one" is almost never the one that consumes
+        # an EndpointReadout field, and checking after selecting would reject the
+        # move on a chain that has a perfectly good home for it.
+        candidates = [
+            e for e in candidates if str(e.fields.get("process_type") or "") == wanted_step
+        ]
+    if not candidates:
+        return None
+    return candidates[0]
+
+
+def _process_type_for(field: str) -> str | None:
+    """The process step a LabProcess field belongs to, per its schema description.
+
+    ``ENTITY_DRAFT_SCHEMA["LabProcess"]`` documents each field as
+    ``"EndpointReadout: detection instrument."`` — the step is already written
+    down beside the field, so it is read rather than restated here.
+    """
+    from builder.tools._crate_mapping import ENTITY_DRAFT_SCHEMA
+    from builder.tools.drafters import VALID_PROCESS_TYPES
+
+    schema = ENTITY_DRAFT_SCHEMA.get("LabProcess")
+    description = str((getattr(schema, "scalar_fields", {}) or {}).get(field) or "")
+    head = description.split(":", 1)[0].strip()
+    return head if head in VALID_PROCESS_TYPES else None
+
+
+def rehome_misplaced_fields(state: CrateState) -> list[Rehomed]:
+    """Move every field written on an entity that cannot hold it to one that can.
+
+    Runs before the build composes nodes, so the graph is already correct by the
+    time ``_scalar_props`` decides what to emit — rather than trying to rescue a
+    value from inside a function that only ever holds one entity and has nowhere
+    to put it.
+
+    Conservative on every axis. A field is moved only when ALL of these hold:
+
+    * the build would otherwise DELETE it (``_would_be_dropped``) — a field that
+      round-trips fine is never touched, whatever schema it appears in;
+    * the entity holding it does NOT declare it, and exactly one other type does
+      — an ambiguous field is left alone rather than sent somewhere arguable;
+    * a related entity of that type already exists, found through a link the
+      graph records;
+    * the target does not already have a value for that field, which would make
+      this a silent overwrite of something written deliberately.
+
+    Returns what it moved, so the caller can say so. Never raises: a rescue that
+    breaks the build is worse than the deletion it was preventing.
+    """
+    moves: list[Rehomed] = []
+    owners = _field_owners()
+
+    for source in list(state.list_entities()):
+        for field in list(source.fields):
+            value = source.fields.get(field)
+            if value in (None, "", [], {}):
+                continue
+            if _declares(source.type, field) or not _would_be_dropped(field):
+                continue
+            holders = owners.get(field) or set()
+            if len(holders) != 1:
+                continue
+            # The step the field belongs to is resolved BEFORE the target is
+            # picked, so the search is for the process that consumes this field
+            # rather than for any process at all.
+            target = _target_for(state, source, holders, _process_type_for(field))
+            if target is None:
+                continue
+            if target.fields.get(field) not in (None, "", [], {}):
+                continue
+
+            # Carry the ORIGINAL provenance across. Moving a value does not
+            # change who supplied it — stamping it "rehomed" would erase the fact
+            # that a model wrote it, which is exactly what a D5 audit reads
+            # `_completion` to find out. Falls back to "llm" only when the source
+            # entity recorded nothing, which is the conservative answer: an
+            # unattributed value is treated as model-supplied, not as verified.
+            existing = source.get_field_status(field)
+            target.fields[field] = value
+            target.set_field_status(
+                field, "filled", existing.source if existing else "llm"
+            )
+            del source.fields[field]
+            moves.append(
+                Rehomed(
+                    field=field,
+                    value=value,
+                    from_id=source.entity_id,
+                    from_type=source.type,
+                    to_id=target.entity_id,
+                    to_type=target.type,
+                )
+            )
+            logger.info(
+                "Moved %r from %s (%s) to %s (%s) — the type that consumes it",
+                field,
+                source.entity_id,
+                source.type,
+                target.entity_id,
+                target.type,
+            )
+
+    return moves

--- a/tests/test_rehome_misplaced_fields.py
+++ b/tests/test_rehome_misplaced_fields.py
@@ -1,0 +1,243 @@
+"""A documented field written on the wrong entity is moved, not deleted.
+
+A real build printed this at exit, twelve times over three assays::
+
+    · Dropped 'detection_instrument' from assay_deiodinase_activity_assay
+      (not a term in the crate's JSON-LD context)
+
+and the report then raised "Say which measurement technique was used for
+Deiodinase activity assay" — a finding about information the crate had been given
+and had thrown away.
+
+The drop rule is right for a key the model invented. These four are declared on
+``LabProcess`` in ``ENTITY_DRAFT_SCHEMA``, consumed by ``_build_process``, and
+requested by name in ``tools_spec``. They landed on the Assay, which declares
+only name/description/identifier, so nothing read them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools.builder import assemble_crate
+from builder.tools.drafters import (
+    draft_assay,
+    draft_investigation,
+    draft_process,
+    draft_study,
+)
+from builder.tools.rehome import rehome_misplaced_fields
+
+_READOUT_FIELDS = (
+    "detection_instrument",
+    "instrument_manufacturer",
+    "measured_entity",
+    "technical_replicate",
+)
+
+
+def _assay_with_chain(state: CrateState, *steps: str):
+    """An Assay with a process chain, in the order the pipeline builds it."""
+    investigation = draft_investigation(state, {"name": "Investigation"})
+    study = draft_study(state, investigation.entity_id, {"name": "Thyroid study"})
+    assay = draft_assay(state, study.entity_id, {"name": "Deiodinase activity assay"})
+    for step in steps:
+        draft_process(state, assay.entity_id, step, {"name": f"{step} step"})
+    return assay
+
+
+def _step(state: CrateState, process_type: str):
+    return next(
+        e
+        for e in state.list_entities("LabProcess")
+        if str(e.fields.get("process_type")) == process_type
+    )
+
+
+class TestTheReportedCase:
+    def test_the_four_fields_reach_the_process_that_consumes_them(self) -> None:
+        state = CrateState()
+        # EndpointReadout deliberately NOT first: the chain is CellCulture ->
+        # Exposure -> EndpointReadout, so a router that took "the first process"
+        # would file the instrument under the cell culture.
+        assay = _assay_with_chain(state, "CellCulture", "Exposure", "EndpointReadout")
+        assay.set_fields_from_dict(
+            dict(zip(_READOUT_FIELDS, ("Wallac 1470", "PerkinElmer", "Radioactivity", "3"))),
+            source="llm",
+        )
+
+        moved = rehome_misplaced_fields(state)
+
+        assert {m.field for m in moved} == set(_READOUT_FIELDS)
+        assert not [f for f in _READOUT_FIELDS if f in assay.fields]
+        readout = _step(state, "EndpointReadout")
+        assert readout.fields["instrument_manufacturer"] == "PerkinElmer"
+        assert not [f for f in _READOUT_FIELDS if f in _step(state, "CellCulture").fields]
+
+    def test_the_value_survives_into_the_built_crate(self) -> None:
+        """The point of the exercise. Previously this string was in state, then
+        gone from the graph, with only a log line at exit to say so."""
+        state = CrateState()
+        assay = _assay_with_chain(state, "CellCulture", "EndpointReadout")
+        assay.set_fields_from_dict({"instrument_manufacturer": "PerkinElmer"}, source="llm")
+
+        crate = assemble_crate(state, None, materialize_payload=False, include_all_scanned=False)
+        graph = crate.metadata.generate()["@graph"]
+
+        assert any("PerkinElmer" in json.dumps(node) for node in graph)
+
+
+class TestItMovesOnlyWhatItShould:
+    def test_a_field_the_entity_declares_is_untouched(self) -> None:
+        """`name` is valid on an Assay. Nothing about it is at risk."""
+        state = CrateState()
+        assay = _assay_with_chain(state, "EndpointReadout")
+
+        rehome_misplaced_fields(state)
+
+        assert assay.fields["name"] == "Deiodinase activity assay"
+
+    def test_a_field_that_would_not_be_dropped_is_untouched(self) -> None:
+        """The trigger is "the build would DELETE this", not "this looks
+        misfiled" — a value that round-trips fine is nobody's emergency."""
+        from builder.tools.rehome import _would_be_dropped
+
+        assert _would_be_dropped("description") is False
+        assert _would_be_dropped("detection_instrument") is True
+
+    def test_an_ambiguous_field_is_left_alone(self) -> None:
+        """`name` is declared by thirteen types. There is no single right home,
+        so guessing one is worse than leaving it where its author put it."""
+        from builder.tools.rehome import _field_owners
+
+        assert len(_field_owners()["name"]) > 1
+
+    def test_nothing_moves_when_there_is_no_process_to_receive_it(self) -> None:
+        """An Assay with no EndpointReadout has no home for the value. It stays
+        put rather than being attached to an unrelated entity of the right class
+        — this rescues values, it does not relocate them somewhere arguable."""
+        state = CrateState()
+        assay = _assay_with_chain(state, "CellCulture")
+        assay.set_fields_from_dict({"detection_instrument": "Wallac 1470"}, source="llm")
+
+        assert rehome_misplaced_fields(state) == []
+        assert assay.fields["detection_instrument"] == "Wallac 1470"
+
+    def test_an_existing_value_on_the_target_is_never_overwritten(self) -> None:
+        """The process's own value was written deliberately and by something that
+        knew where it belonged. A rescue must not clobber it."""
+        state = CrateState()
+        assay = _assay_with_chain(state, "EndpointReadout")
+        _step(state, "EndpointReadout").set_fields_from_dict(
+            {"detection_instrument": "the process's own value"}, source="llm"
+        )
+        assay.set_fields_from_dict({"detection_instrument": "the assay's stray copy"}, source="llm")
+
+        assert rehome_misplaced_fields(state) == []
+        assert _step(state, "EndpointReadout").fields["detection_instrument"] == (
+            "the process's own value"
+        )
+
+
+class TestOwnershipComesFromTheSchema:
+    """This module must never carry its own opinion about who owns a field.
+
+    ``ENTITY_DRAFT_SCHEMA`` has always declared that per type. Restating it here
+    would create two tables free to disagree, and the disagreement would show up
+    as data silently filed under the wrong entity.
+    """
+
+    def test_the_table_follows_the_schema(self, monkeypatch) -> None:
+        import builder.tools._crate_mapping as mapping
+        from builder.tools.rehome import _field_owners
+
+        assert "a_brand_new_field" not in _field_owners()
+
+        import dataclasses
+
+        schema = dict(mapping.ENTITY_DRAFT_SCHEMA)
+        schema["LabProcess"] = dataclasses.replace(
+            schema["LabProcess"],
+            scalar_fields={
+                **schema["LabProcess"].scalar_fields,
+                "a_brand_new_field": "EndpointReadout: something new.",
+            },
+        )
+        monkeypatch.setattr(mapping, "ENTITY_DRAFT_SCHEMA", schema)
+
+        assert _field_owners().get("a_brand_new_field") == {"LabProcess"}
+
+    def test_the_step_is_read_from_the_field_description(self) -> None:
+        """The schema documents each field as "EndpointReadout: …", so the step
+        is already written down beside it and is not restated here."""
+        from builder.tools.rehome import _process_type_for
+
+        assert _process_type_for("detection_instrument") == "EndpointReadout"
+        assert _process_type_for("duration") == "Exposure"
+        assert _process_type_for("name") is None
+
+
+class TestARescueNeverSinksTheBuild:
+    def test_a_raising_rehome_is_caught(self, monkeypatch) -> None:
+        """A rescue that breaks the export is worse than the deletion it
+        prevents, so the call site swallows anything this module throws."""
+        import builder.tools.builder as builder_mod
+
+        def _boom(_state):
+            raise RuntimeError("rehome exploded")
+
+        monkeypatch.setattr(builder_mod, "rehome_misplaced_fields", _boom)
+
+        state = CrateState()
+        _assay_with_chain(state, "EndpointReadout")
+        crate = assemble_crate(state, None, materialize_payload=False, include_all_scanned=False)
+        assert crate.metadata.generate()["@graph"]
+
+
+class TestTheDropIsStillReported:
+    """A key nobody declares is still dropped — this PR does not claim to keep
+    everything. `work_package` and `project_reference` have no owning type, so
+    there is nowhere to route them and they remain a known loss."""
+
+    @pytest.mark.parametrize("field", ["work_package", "project_reference"])
+    def test_an_unowned_field_is_not_rehomed(self, field: str) -> None:
+        from builder.tools.rehome import _field_owners
+
+        assert field not in _field_owners()
+
+
+class TestProvenanceSurvivesTheMove:
+    """Moving a value does not change who supplied it.
+
+    Stamping the moved field with a "rehomed" source would erase the fact that a
+    model wrote it — which is precisely what a D5 audit reads ``_completion`` to
+    find out. The value's origin is a fact about the value, not about where it
+    currently sits.
+    """
+
+    def test_the_original_source_is_carried_across(self) -> None:
+        state = CrateState()
+        assay = _assay_with_chain(state, "EndpointReadout")
+        assay.set_fields_from_dict({"detection_instrument": "Wallac 1470"}, source="user")
+
+        rehome_misplaced_fields(state)
+
+        status = _step(state, "EndpointReadout").get_field_status("detection_instrument")
+        assert status is not None
+        assert status.source == "user", "a human's answer must not be re-attributed"
+
+    def test_an_unattributed_value_is_treated_as_model_supplied(self) -> None:
+        """The conservative fallback: unattributed is assumed to be the model's,
+        never promoted to verified."""
+        state = CrateState()
+        assay = _assay_with_chain(state, "EndpointReadout")
+        assay.fields["detection_instrument"] = "Wallac 1470"  # no status recorded
+
+        rehome_misplaced_fields(state)
+
+        status = _step(state, "EndpointReadout").get_field_status("detection_instrument")
+        assert status is not None
+        assert status.source == "llm"


### PR DESCRIPTION
Your build printed this at exit, twelve times over three assays:

```
· Dropped 'detection_instrument'    from assay_deiodinase_activity_assay
· Dropped 'instrument_manufacturer' from assay_deiodinase_activity_assay
· Dropped 'measured_entity'         from assay_deiodinase_activity_assay
· Dropped 'technical_replicate'     from assay_deiodinase_activity_assay
```

…and the report then raised **"Say which measurement technique was used for Deiodinase activity assay"** — a finding about information the crate had been given and had thrown away.

## The drop rule was right about the wrong thing

An undefined JSON-LD key fails BASE conformance in a way nobody can repair by editing the crate, since it is regenerated from state on every build. That justifies dropping. What it does **not** justify is treating a key the model *invented* and a field this codebase *asks for by name* as the same case.

All four are declared on `LabProcess` in `ENTITY_DRAFT_SCHEMA`, consumed by `_build_process` into `LabProcessEndpointReadout`, and requested by name in `tools_spec`. They were written on the **Assay**, which declares only `name`/`description`/`identifier` — so nothing read them and they were deleted.

## The fix

A pass over `CrateState` before the build composes nodes, moving such a field to the entity that consumes it. Verified end to end — the value now survives into the graph as the ISA ParameterValue it was always meant to be:

```
BEFORE  on the Assay        : detection_instrument, instrument_manufacturer, measured_entity, technical_replicate
AFTER   on the Assay        : none — moved
AFTER   on EndpointReadout  : {'detection_instrument': 'Wallac 1470', 'instrument_manufacturer': 'PerkinElmer', …}
NOT on CellCulture          : correct, empty
SURVIVES INTO THE CRATE     : True -> #param_Instrument_Manufacturer_24b4da2043
```

## Nothing here decides who owns a field

`ENTITY_DRAFT_SCHEMA` has always declared that, per type — this **inverts** it. A field added to a schema teaches the router about it for free, and the two cannot drift apart; a test patches the schema and asserts the routing follows. The process **step** is read the same way, out of the field's own description (`"EndpointReadout: detection instrument."`), rather than restated.

The trigger is the same predicate `_scalar_props` uses, **imported from it**, so the rescuer and the dropper cannot disagree about which fields are at risk.

## Conservative on every axis

A field moves only when *all* of these hold:

- the build would otherwise **delete** it — a value that round-trips fine is never touched
- the holder does not declare it, and **exactly one** other type does (ambiguous → left alone)
- a related entity of that type **already exists**, found through a link the graph records
- the target has **no value of its own** (never a silent overwrite)

The target is selected **by step**, not "the first process": the chain runs CellCulture → Exposure → EndpointReadout, so the first one is almost never the consumer.

**Provenance is carried across, not restamped.** Moving a value does not change who supplied it, and marking it `"rehomed"` would erase the fact that a model wrote it — which is what a D5 audit reads `_completion` to learn. (`ty` caught this: `CompletionSource` has no such member. Preserving the original is the better answer anyway.)

The pass **mutates state deliberately** — the crate is rebuilt from state on every export, so rescuing a value for one build would let the next delete it. It never sinks an export: the call site swallows anything it raises, pinned by a test, because a rescue that breaks the build is worse than the deletion it prevents.

## Not claimed

`work_package` and `project_reference` have **no owning type**, so there is nowhere to route them and they remain a known loss. Preserving unowned keys as ISA characteristics is a separate change — worth doing, since a WP number is real provenance somebody typed deliberately.

## Verification

14 new tests; 197 passing across the rehome, mapping, output-payload, read-back, offline-validation and pipeline suites. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)