### PR TITLE
feat(build): keep a field no entity type declares, as a PropertyValue

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -465,6 +465,7 @@ def populate_crate(
     _add_generator_provenance(state, crate)
     _wire_mentions(state, idx)
     _wire_dataset_aliases(state, crate, idx)
+    _preserve_unowned_fields(state, crate, idx)
     _mirror_profile_predicates(crate)
 
 
@@ -598,6 +599,91 @@ def _context_terms() -> frozenset[str]:
     return frozenset(key for block in blocks if isinstance(block, dict) for key in block)
 
 
+def _preserved_name(field: str) -> str:
+    """A field key said the way a person would read it: ``work_package`` -> "work package"."""
+    return field.replace("_", " ").strip() or field
+
+
+def _preserve_unowned_fields(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
+    """Keep a field the build cannot emit, as a ``PropertyValue``, instead of deleting it.
+
+    ``_scalar_props`` deletes a key the JSON-LD context does not define, and it
+    must: emitting one fails BASE conformance in a way nobody can repair by
+    editing the crate, because it is regenerated from state on every build.
+
+    Deleting was never the only option, though. ``schema:additionalProperty``
+    takes a PropertyValue node, the context defines it, and the crate already
+    uses it for ISA characteristics — so the value can be kept in a form that
+    validates. ``work_package`` and ``project_reference`` reached a real build,
+    were declared by no entity type (so :mod:`builder.tools.rehome` had nowhere
+    to route them) and were dropped: a WP number somebody typed deliberately,
+    deleted for being unmodelled rather than for being wrong.
+
+    A plain ``PropertyValue`` node, NOT ``ParameterValue``: that class stamps
+    ``additionalType: "ParameterValue"``, which asserts the value is an ISA
+    experimental parameter. A work-package number is not one, and saying so would
+    be inventing a claim about the data in the act of rescuing it.
+
+    Runs after the index is complete, so every entity has a built node to hang
+    the property on, and after ``rehome_misplaced_fields`` has already moved
+    anything that had a home — what reaches here is what nothing else could
+    place.
+    """
+    for entity in state.list_entities():
+        leftovers = {
+            key: value
+            for key, value in entity.fields.items()
+            if field_would_be_dropped(key) and value not in (None, "", [], {})
+        }
+        if not leftovers:
+            continue
+        node = idx.get(f"{entity.type}:{entity.entity_id}") or idx.get(entity.entity_id)
+        if node is None:
+            # No built node to attach to — nothing to do, and inventing one to
+            # hold a stray field would put an entity in the crate that the crate
+            # does not otherwise describe.
+            continue
+        for key, value in leftovers.items():
+            text = str(value)
+            prop = crate.add(
+                ContextEntity(
+                    crate,
+                    param_id(key, text),
+                    properties={
+                        "@type": "PropertyValue",
+                        "name": _preserved_name(key),
+                        "value": text,
+                    },
+                )
+            )
+            node.append_to("additionalProperty", prop)
+            logger.info(
+                "Kept %r on %s as a PropertyValue (no entity type declares it)",
+                key,
+                entity.entity_id,
+            )
+
+
+def field_would_be_dropped(field: str) -> bool:
+    """Whether :func:`_scalar_props` would DELETE *field* rather than emit it.
+
+    The drop rule, asked as a question so the two places that need to know —
+    :mod:`builder.tools.rehome`, which moves such a field to the entity that
+    consumes it, and :func:`_preserve_unowned_fields`, which keeps whatever is
+    left as a PropertyValue — cannot hold their own copy of it and drift.
+
+    Mirrors the branch in ``_scalar_props`` exactly: a snake_case key that no
+    context term defines under either spelling, and that the reference/structural
+    pipelines do not already consume.
+    """
+    if field.startswith("@") or field in (_REF_FIELDS | _STRUCT_FIELDS):
+        return False
+    if "_" not in field or field in _context_terms():
+        return False
+    renamed = _camel_case(field)
+    return renamed not in _context_terms() and renamed not in (_REF_FIELDS | _STRUCT_FIELDS)
+
+
 def _scalar_props(entity: Entity, skip: tuple[str, ...] = ()) -> dict[str, Any]:
     """Plain-value properties of an entity (references/discriminators removed).
 
@@ -653,8 +739,13 @@ def _scalar_props(entity: Entity, skip: tuple[str, ...] = ()) -> dict[str, Any]:
             # ("not allowed in the compacted JSON-LD context") in a way the agent
             # cannot fix by editing the crate, because the invalid key is
             # regenerated from state on every build.
-            logger.warning(
-                "Dropped %r from %s (not a term in the crate's JSON-LD context)",
+            # NOT "dropped" any more, and the message must not say so: the key
+            # cannot be emitted as JSON-LD (the context does not define it, and a
+            # bare key fails BASE), but `_preserve_unowned_fields` keeps the
+            # VALUE as a PropertyValue on this same entity. A log line claiming
+            # data loss that did not happen sends the reader looking for a bug.
+            logger.debug(
+                "%r is not a JSON-LD term; keeping it on %s as a PropertyValue",
                 key,
                 entity.entity_id,
             )

--- a/builder/tools/rehome.py
+++ b/builder/tools/rehome.py
@@ -84,25 +84,14 @@ def _declares(entity_type: str, field: str) -> bool:
 def _would_be_dropped(field: str) -> bool:
     """Whether the build would delete *field* rather than emit it.
 
-    Deliberately the SAME question ``_scalar_props`` asks, imported from there,
-    so the rescuer and the dropper cannot disagree about which fields are at
-    risk. A rescuer working from its own copy of the rule would either move
-    fields that were never in danger or miss the ones that were.
+    Delegates to `_crate_mapping.field_would_be_dropped`, which lives beside the
+    code that does the dropping. A rescuer working from its own copy of the rule
+    would either move fields that were never in danger or miss the ones that
+    were — so there is exactly one copy, and this is not it.
     """
-    from builder.tools._crate_mapping import (
-        _REF_FIELDS,
-        _STRUCT_FIELDS,
-        _camel_case,
-        _context_terms,
-    )
+    from builder.tools._crate_mapping import field_would_be_dropped
 
-    if field.startswith("@") or field in (_REF_FIELDS | _STRUCT_FIELDS):
-        return False
-    if "_" not in field or field in _context_terms():
-        return False
-    return _camel_case(field) not in _context_terms() and _camel_case(field) not in (
-        _REF_FIELDS | _STRUCT_FIELDS
-    )
+    return field_would_be_dropped(field)
 
 
 def _target_for(

--- a/tests/test_offline_validation.py
+++ b/tests/test_offline_validation.py
@@ -429,3 +429,40 @@ class TestCellosaurusResolvedCellLineContext:
         # The DefinedTerm node objects and the undeclared donor facts stayed off.
         for dropped in ("taxonomicRange", "disease", "anatomicalSite", "donorSex", "category"):
             assert dropped not in cell.fields
+
+
+class TestAPreservedFieldStillConforms:
+    """The whole reason the drop existed, asserted rather than assumed.
+
+    A bare `work_package` key fails BASE with "not allowed in the compacted
+    JSON-LD context", and that failure cannot be repaired by editing the crate
+    because it is regenerated from state on every build. Keeping the value as a
+    `PropertyValue` is only an improvement if the crate still passes — otherwise
+    it trades a silent deletion for a loud failure.
+    """
+
+    def test_base_is_clean_with_preserved_fields_in_the_graph(self) -> None:
+        from builder.state import CrateState
+        from builder.tools.builder import assemble_crate
+        from builder.tools.drafters import draft_investigation, draft_study
+        from profiles.validator import validate_crate_dict
+
+        state = CrateState()
+        investigation = draft_investigation(state, {"name": "Investigation"})
+        study = draft_study(state, investigation.entity_id, {"name": "Thyroid study"})
+        study.set_fields_from_dict(
+            {"project_reference": "NWA 1292.19.272", "work_package": "WP2.4"}, source="user"
+        )
+        crate = assemble_crate(
+            state, None, materialize_payload=False, include_all_scanned=False
+        )
+        document = crate.metadata.generate()
+
+        # The values ARE in the graph — otherwise a clean verdict proves nothing.
+        assert any(
+            node.get("name") == "work package" for node in document["@graph"]
+        ), "nothing was preserved, so this test does not exercise the risk"
+
+        results = validate_crate_dict(document, profile="base")
+        required = [issue for r in results for issue in getattr(r, "required_issues", [])]
+        assert required == [], f"preserving a field broke BASE conformance: {required}"

--- a/tests/test_rehome_misplaced_fields.py
+++ b/tests/test_rehome_misplaced_fields.py
@@ -241,3 +241,76 @@ class TestProvenanceSurvivesTheMove:
         status = _step(state, "EndpointReadout").get_field_status("detection_instrument")
         assert status is not None
         assert status.source == "llm"
+
+
+class TestAnUnownedFieldIsKeptAsAPropertyValue:
+    """No entity type declares `work_package`, so there is nowhere to route it —
+    but deleting it was still the wrong answer.
+
+    `schema:additionalProperty` takes a PropertyValue, the context defines it,
+    and the crate already uses it for ISA characteristics. So the value can be
+    kept in a form that validates. A WP number somebody typed deliberately was
+    being deleted for being unmodelled rather than for being wrong.
+    """
+
+    def _study_with(self, **fields: str):
+        state = CrateState()
+        investigation = draft_investigation(state, {"name": "Investigation"})
+        study = draft_study(
+            state, investigation.entity_id, {"name": "Thyroid hormone disruption study"}
+        )
+        study.set_fields_from_dict(dict(fields), source="user")
+        crate = assemble_crate(state, None, materialize_payload=False, include_all_scanned=False)
+        return study, crate.metadata.generate()["@graph"]
+
+    def test_the_value_survives_as_a_property_value(self) -> None:
+        _study, graph = self._study_with(
+            project_reference="NWA 1292.19.272", work_package="WP2.4"
+        )
+        kept = {
+            node.get("name"): node.get("value")
+            for node in graph
+            if node.get("@type") == "PropertyValue"
+        }
+        assert kept.get("work package") == "WP2.4"
+        assert kept.get("project reference") == "NWA 1292.19.272"
+
+    def test_it_hangs_off_the_entity_it_was_written_on(self) -> None:
+        """A preserved value that nothing references is an orphan — kept in the
+        file, lost to a reader."""
+        _study, graph = self._study_with(work_package="WP2.4")
+        study_node = next(
+            n for n in graph if "Thyroid hormone disruption" in str(n.get("name", ""))
+        )
+        referenced = {
+            ref.get("@id")
+            for ref in (
+                study_node["additionalProperty"]
+                if isinstance(study_node.get("additionalProperty"), list)
+                else [study_node.get("additionalProperty")]
+            )
+            if isinstance(ref, dict)
+        }
+        wp = next(n for n in graph if n.get("name") == "work package")
+        assert wp["@id"] in referenced
+
+    def test_it_is_not_also_emitted_as_a_bare_key(self) -> None:
+        """The reason the drop existed. A bare `work_package` key fails BASE, so
+        preserving the value must not reintroduce it."""
+        _study, graph = self._study_with(work_package="WP2.4")
+        assert all("work_package" not in node for node in graph)
+
+    def test_it_is_a_plain_property_value_not_an_isa_parameter(self) -> None:
+        """`ParameterValue` stamps additionalType "ParameterValue", asserting the
+        value is an ISA experimental parameter. A work-package number is not one,
+        and saying so would invent a claim about the data while rescuing it."""
+        _study, graph = self._study_with(work_package="WP2.4")
+        wp = next(n for n in graph if n.get("name") == "work package")
+        assert wp.get("additionalType") is None
+
+    def test_a_field_that_round_trips_is_not_duplicated(self) -> None:
+        """The control. `description` is a real context term and is emitted
+        normally, so it must not ALSO appear as a PropertyValue."""
+        _study, graph = self._study_with(description="A real description.")
+        names = [n.get("name") for n in graph if n.get("@type") == "PropertyValue"]
+        assert "description" not in names


### PR DESCRIPTION
Follow-up to #577, which moved a **misplaced** field to the entity that consumes it. `work_package` and `project_reference` reached that same build and were declared by **no type at all**, so there was nowhere to route them and they were still deleted — a WP number somebody typed deliberately, dropped for being unmodelled rather than for being wrong.

## Deleting was never the only option

`schema:additionalProperty` takes a `PropertyValue`, the context defines it, and the crate already uses it for ISA characteristics. So the value can be kept in a form that validates:

```
preserved as PropertyValue: [('project reference', 'NWA 1292.19.272'), ('work package', 'WP2.4')]
referenced from the Study : True
NOT emitted as a bare key : True
```

## A plain PropertyValue, deliberately not ParameterValue

`ParameterValue` stamps `additionalType: "ParameterValue"`, asserting the value is an ISA **experimental parameter**. A work-package number is not one, and saying so would invent a claim about the data in the very act of rescuing it.

## The drop rule is untouched

The **key** still never reaches the JSON-LD. A bare `work_package` fails BASE with *"not allowed in the compacted JSON-LD context"*, and that failure cannot be repaired by editing the crate because it is regenerated from state on every build. Only the **value** is kept, in a shape the context defines.

This is the one risk that mattered, so it is asserted rather than assumed — a test builds a crate carrying both fields and checks BASE:

```
BASE required issues total : 0
context/undeclared-key ones: none
```

It first asserts the values are actually in the graph, so a clean verdict cannot pass vacuously.

## One predicate, not three

`field_would_be_dropped` moves to `_crate_mapping`, beside the code that does the dropping, and `rehome` delegates to it. Three places now need to agree on *"would this be deleted?"* — the dropper, the router and the preserver — and each holding its own copy is exactly how they would come to disagree.

The log line changes with the behaviour: it said `"Dropped 'work_package' …"` at WARNING, which is now false and would send a reader hunting for data loss that did not happen.

## Also pinned

- a field that round-trips normally (`description`) is **not** also emitted as a PropertyValue
- a preserved value is **referenced from its entity**, not left in the file as an orphan nobody can reach

## Verification

19 tests in the rehome/preserve module; 42 passing across offline-validation, read-back and output-payload. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)