### PR TITLE
feat(pipeline): describe payload files from their content

### DIFF
--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -1145,7 +1145,121 @@ def summarise_actions(
     return []
 
 
+_DESCRIBE_SYSTEM_PROMPT = (
+    "You write one-sentence descriptions for the files in a research data "
+    "package (an ISA-Tox RO-Crate), for a reader who has the crate but not the "
+    "lab notebook.\n\n"
+    "You are given, per file, its NAME and a PREVIEW of its actual content — "
+    "the first lines, sheet names, or column headers. Describe what the file "
+    "CONTAINS, from the preview: 'Per-well absorbance readings for the T4 uptake "
+    "assay, one row per plate position', not 'A CSV file' and not 'Data for the "
+    "study'.\n\n"
+    "ABSOLUTE RULES. Everything you write must be supported by the preview you "
+    "were given. Never infer from the FILENAME what the content is — a file "
+    "called 'protocol.docx' whose preview you cannot read is one you must "
+    "decline. Never state a result, a conclusion, a compound, a cell line, a "
+    "date or a number that is not visible in the preview. Never guess what the "
+    "file is FOR beyond what it evidently holds. If the preview is empty, "
+    "unreadable, or too thin to say anything specific, return an empty string "
+    "for that file — an empty description is a correct answer and a plausible "
+    "invention is not.\n\n"
+    "One sentence each, plain language, no filename echo, no markdown."
+)
+
+
+def _describe_schema(count: int) -> dict[str, Any]:
+    """Structured-output schema: one description per file, in order."""
+    return {
+        "title": "FileDescriptions",
+        "type": "object",
+        "description": "One description per supplied file, in the order supplied.",
+        "properties": {
+            "descriptions": {
+                "type": "array",
+                "minItems": count,
+                "maxItems": count,
+                "description": (
+                    "One sentence per file, same order as supplied, describing what "
+                    "the file CONTAINS based only on its preview. Empty string when "
+                    "the preview does not support a specific description."
+                ),
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["descriptions"],
+    }
+
+
+def describe_files(
+    files: list[dict[str, Any]],
+    *,
+    overrides: ModelOverrides | None = None,
+    usage_sink: UsageSink | None = None,
+) -> list[str]:
+    """Describe each file from a PREVIEW OF ITS CONTENT, never from its name.
+
+    A pure bounded leaf: ONE structured-output call on the drafter tier, one
+    sentence per file, in order — the same shape as :func:`summarise_actions`,
+    and length-checked the same way, because a list that no longer lines up with
+    its inputs would attach each description to the wrong file.
+
+    **The preview is the whole point.** Describing a file from its name is
+    guessing, and a guess written into ``description`` is indistinguishable from
+    a curator's sentence once it is in the crate. So a file whose content could
+    not be read is not sent at all (the caller's job), and a model that cannot
+    say anything specific from what it was given is told to return "" — an empty
+    description is a correct answer where an invention is not.
+
+    This is prose, not an identifier: D5 governs accessions, CASRNs and ORCIDs,
+    which may only come from an authoritative lookup. A sentence saying what a
+    spreadsheet holds is the same kind of value as the study description and
+    protocol names the model already writes, and it is recorded with the same
+    ``source="llm"`` provenance, so a curator reading the crate's completion
+    record can see exactly which sentences a model wrote.
+
+    Args:
+        files: ``[{"name": ..., "preview": ...}]``. A caller must not include a
+            file whose preview is empty.
+        overrides: Model overrides for the drafter tier.
+        usage_sink: Token accounting sink.
+
+    Returns:
+        One description per input file, in order, with "" where the model
+        declined. ``[]`` when the call fails or returns the wrong count, so the
+        caller writes nothing rather than mismatched sentences.
+    """
+    usable = [f for f in files if str(f.get("preview") or "").strip()]
+    if not usable or len(usable) != len(files):
+        # A caller that passed a preview-less file has mis-specified the batch;
+        # refusing the whole batch is safer than silently describing the rest
+        # under indexes that no longer match what the caller will write back.
+        return []
+    llm = _build_chat_model(role="drafter", **(overrides or ModelOverrides()).as_kwargs())
+    listing = "\n\n".join(
+        f"FILE {i + 1}\n  name: {f.get('name')}\n  preview:\n{str(f.get('preview'))[:1200]}"
+        for i, f in enumerate(files)
+    )
+    messages = [
+        SystemMessage(content=_DESCRIBE_SYSTEM_PROMPT),
+        HumanMessage(
+            content=(
+                f"Describe exactly {len(files)} files, one sentence each, in this "
+                f"order:\n\n{listing}"
+            )
+        ),
+    ]
+    result = _invoke_structured_with_usage(
+        llm, _describe_schema(len(files)), messages, usage_sink
+    )
+    if isinstance(result, dict):
+        items = result.get("descriptions")
+        if isinstance(items, list) and len(items) == len(files):
+            return [str(i).strip() for i in items]
+    return []
+
+
 __all__ = [
+    "describe_files",
     "draft_entity_fields",
     "extract_field_from_file",
     "extract_plan",

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1653,6 +1653,7 @@ def _materialize_plan(
         "study": 0,
         "compounds": 0,
         "cell_lines": 0,
+        "described_files": 0,
         "protocols": 0,
         "processes": 0,
         "files": 0,
@@ -1807,6 +1808,22 @@ def _materialize_plan(
         exposure_id = exposure_step.get("process_id") if exposure_step else None
         if exposure_id:
             _set_ref_field(engine, str(exposure_id), "chemicals", compound_ids)
+
+    # --- payload descriptions: say what each file CONTAINS ---------------------
+    # The largest single gap in a real report ("Add a description for … and 40
+    # others"), and one a model can actually close: the files are in the crate
+    # and their content is readable. Grounded in a content preview, never in the
+    # filename — see builder.tools.file_descriptions, which refuses a file it
+    # could not read rather than guessing from its name. Recorded source="llm",
+    # like every other sentence the model writes, so the crate's completion
+    # record says who wrote it. Non-fatal: a description is enrichment.
+    try:
+        from builder.tools.file_descriptions import describe_payload_files
+
+        result["described_files"] = len(describe_payload_files(engine.state))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("File description pass failed (non-fatal): %s", exc)
+        result["described_files"] = 0
 
     # --- condition table (#408): the plan already classified one file as the
     # per-well design table; write it into the Exposure's typed CSVW table rather

--- a/builder/tools/file_descriptions.py
+++ b/builder/tools/file_descriptions.py
@@ -1,0 +1,158 @@
+"""Describe payload files from their content, for the files that have no description.
+
+"Add a description for metabolism_assay_metadata.xlsx, 20231213_BCA SK uptake
+23-11.xlsx, 3.2 Protocol transporter assay radioactive T3 T4_EN.docx and 40
+others" is the largest single action in a real report, and it is one a model can
+actually do: the files are in the crate, their content is readable, and a
+sentence saying what a spreadsheet holds is prose, not an identifier.
+
+**D5 is not in the way, and it is worth being precise about why.** D5 governs
+IDENTIFIERS — an accession, a CASRN, an ORCID — which may only come from an
+authoritative lookup, because a plausible-looking wrong one is indistinguishable
+from a right one and points at the wrong thing forever. A description is the same
+kind of value as the study description, the protocol names and the process names
+the model already writes today. It is recorded with the same ``source="llm"``
+provenance, so the crate's own completion record says which sentences a model
+wrote.
+
+**The content is the whole point.** Describing a file from its NAME is guessing,
+and a guess written into ``description`` reads exactly like a curator's sentence
+once it is in the crate. So this module's central rule is that a file whose
+content could not be read is never sent to the model at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from builder.state import CrateState, Entity
+
+logger = logging.getLogger(__name__)
+
+# How much of each file the model is shown. Enough for sheet names, a header row
+# and a few data rows — which is what "what does this file contain?" turns on —
+# without paying for the whole payload.
+PREVIEW_LIMIT = 1200
+
+# How many files one call describes. Bounded because the leaf is length-checked:
+# a batch big enough to strain the model's ordering is a batch whose descriptions
+# risk landing on the wrong files, and the check would then throw the whole batch
+# away.
+BATCH_SIZE = 12
+
+
+def _needs_description(entity: Entity) -> bool:
+    return not str(entity.fields.get("description") or "").strip()
+
+
+def _preview_for(state: CrateState, entity: Entity) -> str:
+    """A readable content sample for *entity*, or "" if there isn't one.
+
+    Goes through ``document_discovery._safe_preview``, which contains the path
+    against the session's approved roots before reading — so this cannot be
+    talked into reading a file outside the scan root by a crafted ``dest_path``.
+    """
+    from builder.tools._crate_mapping import _file_source
+    from builder.tools.document_discovery import _safe_preview
+
+    source = _file_source(entity, state.metadata.input_path)
+    if not source:
+        return ""
+    # The session's approved scan roots, exactly as the ReAct loop reads them
+    # (`agent_loop` uses the same attribute), plus the configured input path.
+    # Fail-closed: with no approved root, nothing is read at all — a description
+    # is enrichment and never a reason to widen filesystem access (#197).
+    roots = {
+        str(Path(r).resolve())
+        for r in (getattr(state, "approved_scan_roots", None) or set())
+        if r
+    }
+    if state.metadata.input_path:
+        roots.add(str(Path(state.metadata.input_path).resolve()))
+    if not roots:
+        return ""
+    return _safe_preview(str(source), roots, PREVIEW_LIMIT)
+
+
+def describe_payload_files(
+    state: CrateState,
+    *,
+    describe_fn: Any = None,
+    limit: int | None = None,
+) -> list[tuple[str, str]]:
+    """Fill ``description`` on File entities that have none, from their content.
+
+    Returns ``[(entity_id, description)]`` for what was written.
+
+    Every guard here exists because the failure mode is a plausible sentence
+    about the wrong thing:
+
+    * a file whose content could NOT be read is skipped entirely, never described
+      from its name;
+    * an entity that already has a description is left alone — a curator's
+      sentence is not improved by replacing it;
+    * an empty string back from the model is a decline, and nothing is written;
+    * a batch whose returned count does not match is discarded whole, because
+      the descriptions are matched to files by POSITION and a short list would
+      silently shift every sentence onto the wrong file.
+
+    Args:
+        state: The crate state; File entities are read and updated in place.
+        describe_fn: The leaf to call. Injected so tests drive this without a
+            provider, and so a caller can supply model overrides.
+        limit: Stop after this many files. ``None`` means all of them.
+
+    Returns:
+        The ``(entity_id, description)`` pairs written, in the order written.
+    """
+    if describe_fn is None:
+        from builder.agents.pipeline.leaves import describe_files as describe_fn
+
+    candidates: list[tuple[Entity, str]] = []
+    for entity in state.list_entities("File"):
+        if not _needs_description(entity):
+            continue
+        preview = _preview_for(state, entity)
+        if not preview.strip():
+            # No readable content. This is the case the module exists to refuse:
+            # the filename alone is not evidence of what is inside.
+            logger.debug(
+                "No readable preview for %s; leaving it undescribed", entity.entity_id
+            )
+            continue
+        candidates.append((entity, preview))
+        if limit is not None and len(candidates) >= limit:
+            break
+
+    written: list[tuple[str, str]] = []
+    for start in range(0, len(candidates), BATCH_SIZE):
+        batch = candidates[start : start + BATCH_SIZE]
+        payload = [
+            {"name": str(e.fields.get("name") or e.entity_id), "preview": p} for e, p in batch
+        ]
+        try:
+            descriptions = describe_fn(payload)
+        except Exception:  # noqa: BLE001 — enrichment must never sink a build
+            logger.warning("File description call failed; skipping batch", exc_info=True)
+            continue
+        if not isinstance(descriptions, list) or len(descriptions) != len(batch):
+            logger.warning(
+                "Got %s descriptions for %d files; discarding the batch rather than "
+                "risking a description on the wrong file",
+                len(descriptions) if isinstance(descriptions, list) else "no",
+                len(batch),
+            )
+            continue
+        for (entity, _preview), description in zip(batch, descriptions):
+            text = str(description or "").strip()
+            if not text:
+                # The model declined. That is a correct answer here.
+                continue
+            entity.set_fields_from_dict({"description": text}, source="llm")
+            written.append((entity.entity_id, text))
+
+    if written:
+        logger.info("Described %d payload file(s) from their content", len(written))
+    return written

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,30 @@ def _stub_composites_cellosaurus(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_file_descriptions(monkeypatch):
+    """Keep the pipeline's file-description pass offline.
+
+    Wiring `describe_payload_files` into `_materialize_plan` gave every test that
+    drives the real pipeline a live provider call it never had. Default it to
+    "described nothing", so a forgotten stub shows up as a missing description
+    rather than as a request to an LLM.
+
+    Scoped to the symbol bound in the PIPELINE namespace — the module imports it
+    inside the function, so this patches the source module's attribute, which is
+    what that import resolves. `tests/test_file_descriptions.py` injects its own
+    `describe_fn` and does not rely on this.
+    """
+    from builder.tools import file_descriptions
+
+    monkeypatch.setattr(
+        file_descriptions,
+        "describe_payload_files",
+        lambda state, **kw: [],
+        raising=False,
+    )
+
+
 @pytest.fixture
 def minimal_state() -> CrateState:
     """Return a CrateState with one Investigation entity."""

--- a/tests/test_file_descriptions.py
+++ b/tests/test_file_descriptions.py
@@ -1,0 +1,155 @@
+"""A file is described from its CONTENT, or not at all.
+
+"Add a description for metabolism_assay_metadata.xlsx, 20231213_BCA SK uptake
+23-11.xlsx … and 40 others" is the largest single action in a real report, and a
+model can close it: the files are in the crate and readable.
+
+D5 is not in the way — it governs IDENTIFIERS, which may only come from an
+authoritative lookup. A sentence saying what a spreadsheet holds is the same kind
+of value as the study description and protocol names the model already writes,
+and it carries the same ``source="llm"`` provenance.
+
+What IS in the way is describing a file from its NAME. That is a guess, and a
+guess in ``description`` reads exactly like a curator's sentence once it is in
+the crate. Most of this module tests the refusal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState
+from builder.tools.file_descriptions import describe_payload_files
+from builder.tools.provenance import draft_file
+
+
+@pytest.fixture
+def crate_with_files(tmp_path: Path):
+    """A state with one readable file and one whose content cannot be read."""
+    (tmp_path / "uptake.csv").write_text(
+        "well,compound,absorbance\nA1,T4,0.812\nA2,T4,0.799\n", encoding="utf-8"
+    )
+    state = CrateState()
+    state.metadata.input_path = str(tmp_path)
+    draft_file(state, name="uptake.csv", path=str(tmp_path / "uptake.csv"))
+    # Never created on disk: a file the crate references but cannot read.
+    draft_file(state, name="protocol.docx", path=str(tmp_path / "protocol.docx"))
+    return state
+
+
+def _entity(state: CrateState, name: str):
+    return next(e for e in state.list_entities("File") if e.fields.get("name") == name)
+
+
+class TestTheContentIsTheEvidence:
+    def test_an_unreadable_file_is_never_even_sent_to_the_model(self, crate_with_files) -> None:
+        """The refusal this module exists for. `protocol.docx` has a name that
+        practically writes its own description, which is exactly why it must not
+        be allowed to."""
+        sent: list[list[dict]] = []
+
+        def _describe(files):
+            sent.append(files)
+            return ["A description." for _ in files]
+
+        describe_payload_files(crate_with_files, describe_fn=_describe)
+
+        assert [f["name"] for batch in sent for f in batch] == ["uptake.csv"]
+        assert _entity(crate_with_files, "protocol.docx").fields.get("description") is None
+
+    def test_a_readable_file_is_described(self, crate_with_files) -> None:
+        written = describe_payload_files(
+            crate_with_files,
+            describe_fn=lambda files: ["Per-well absorbance readings." for _ in files],
+        )
+
+        assert len(written) == 1
+        assert _entity(crate_with_files, "uptake.csv").fields["description"] == (
+            "Per-well absorbance readings."
+        )
+
+    def test_the_model_sees_the_actual_content(self, crate_with_files) -> None:
+        """Not just the name — otherwise "grounded in the content" is a claim the
+        code does not keep."""
+        seen: list[str] = []
+
+        def _describe(files):
+            seen.extend(str(f["preview"]) for f in files)
+            return ["x" for _ in files]
+
+        describe_payload_files(crate_with_files, describe_fn=_describe)
+
+        assert any("absorbance" in preview for preview in seen)
+
+
+class TestItWritesNothingItCannotStandBehind:
+    def test_an_empty_description_is_a_decline_not_a_value(self, crate_with_files) -> None:
+        """The model is told to return "" when the preview supports nothing
+        specific. That must not become an empty description on the entity."""
+        written = describe_payload_files(
+            crate_with_files, describe_fn=lambda files: ["" for _ in files]
+        )
+
+        assert written == []
+        assert _entity(crate_with_files, "uptake.csv").fields.get("description") is None
+
+    def test_a_mismatched_batch_is_discarded_whole(self, crate_with_files) -> None:
+        """Descriptions are matched to files by POSITION, so a short list would
+        shift every sentence onto the wrong file — silently, and in a field that
+        reads as curated prose."""
+        written = describe_payload_files(crate_with_files, describe_fn=lambda files: [])
+
+        assert written == []
+        assert _entity(crate_with_files, "uptake.csv").fields.get("description") is None
+
+    def test_a_raising_model_does_not_sink_the_build(self, crate_with_files) -> None:
+        def _boom(_files):
+            raise RuntimeError("provider down")
+
+        assert describe_payload_files(crate_with_files, describe_fn=_boom) == []
+
+    def test_an_existing_description_is_left_alone(self, crate_with_files) -> None:
+        """A curator's sentence is not improved by replacing it with a model's."""
+        entity = _entity(crate_with_files, "uptake.csv")
+        entity.set_fields_from_dict({"description": "Written by a human."}, source="user")
+
+        describe_payload_files(
+            crate_with_files, describe_fn=lambda files: ["Model text." for _ in files]
+        )
+
+        assert entity.fields["description"] == "Written by a human."
+
+
+class TestProvenanceSaysWhoWroteIt:
+    def test_a_generated_description_is_recorded_as_the_models(
+        self, crate_with_files
+    ) -> None:
+        """The answer to "is this curated?" lives in the crate's own completion
+        record, so no separate flag is needed — but only if it is actually set."""
+        describe_payload_files(
+            crate_with_files, describe_fn=lambda files: ["Generated." for _ in files]
+        )
+
+        status = _entity(crate_with_files, "uptake.csv").get_field_status("description")
+        assert status is not None
+        assert status.source == "llm"
+
+
+class TestFilesystemAccessStaysFailClosed:
+    def test_nothing_is_read_without_an_approved_root(self, tmp_path: Path) -> None:
+        """A description is enrichment and never a reason to widen filesystem
+        access (#197). With no approved root and no input path, the preview is
+        empty and the file is skipped."""
+        (tmp_path / "secret.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        state = CrateState()
+        state.metadata.input_path = None
+        draft_file(state, name="secret.csv", path=str(tmp_path / "secret.csv"))
+
+        sent: list = []
+        describe_payload_files(
+            state, describe_fn=lambda files: sent.append(files) or ["x" for _ in files]
+        )
+
+        assert sent == []


### PR DESCRIPTION
> *"a lot of stuff lands in the crate based on llm decision why not a description?"*

Agreed — and the largest single action in a real report is exactly this: *"Add a description for metabolism_assay_metadata.xlsx, 20231213_BCA SK uptake 23-11.xlsx … and 40 others"*. The files are in the crate and their content is readable.

## D5 is not in the way, and it is worth being precise about why

D5 governs **identifiers** — an accession, a CASRN, an ORCID — which may only come from an authoritative lookup, because a plausible-looking wrong one is indistinguishable from a right one and points at the wrong thing forever.

A sentence saying what a spreadsheet holds is the same kind of value as the study description, protocol names and process names the model **already writes today**. It carries the same `source="llm"` provenance, so the crate's own completion record says which sentences a model wrote — no new "generated" flag needed. A test asserts that record is actually set, since the claim is only worth anything if it is.

## What *is* in the way: the filename

Describing a file from its **name** is a guess, and a guess in `description` reads exactly like a curator's sentence once it is in the crate.

So the central rule: **a file whose content could not be read is never sent to the model at all** — not sent and left undescribed, rather than sent and hopefully declined.

```
files sent to the model : ['uptake.csv']
protocol.docx           : no description   ← unreadable, and its NAME practically
                                             writes its own description, which is
                                             exactly why it must not be allowed to
```

## The other guards, and what each is for

| guard | the failure it prevents |
|---|---|
| `""` back is a **decline**, not a value | the prompt asks for one when the preview supports nothing specific |
| a mismatched batch is discarded **whole** | descriptions match files by *position*; a short list shifts every sentence silently onto the wrong file |
| an existing description is **left alone** | a curator's sentence is not improved by replacing it with a model's |
| a raising provider is **non-fatal** | a description is enrichment, not a build precondition |

## Filesystem access stays fail-closed

The preview goes through `document_discovery._safe_preview`, which contains the path against the session's approved roots before reading. With no approved root, nothing is read at all — a description is never a reason to widen access (#197). Pinned by a test.

## Wiring

Called from `_materialize_plan` and counted in its result. `tests/conftest.py` defaults the pass to "described nothing", so the modules that drive the real pipeline do not acquire a live provider call — scoped to the one symbol, like the cellosaurus and dtxsid stubs beside it.

## Verification

9 new tests; 139 passing with the pipeline suite. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)