### PR TITLE
fix(ui): a validation tier that has been swept never locks again

### DIFF
--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -238,6 +238,10 @@ class UiSnapshot:
     should_issue_count: int = 0
     may_issue_count: int = 0
     assessed_tiers: tuple[str, ...] = ()
+    # ``(tier, count)`` for tiers whose findings were retired as stale. A tier
+    # that HAS been swept and one that never has are different facts, and
+    # `_work_field` reports them differently.
+    stale_tier_counts: tuple[tuple[str, int], ...] = ()
 
 
 @dataclass
@@ -398,6 +402,7 @@ def snapshot_from_engine(engine: AgentEngine) -> UiSnapshot:
         should_issue_count=len(val.should_issues),
         may_issue_count=len(val.may_issues),
         assessed_tiers=tuple(sorted(getattr(val, "assessed_tiers", ()) or ())),
+        stale_tier_counts=tuple(sorted((getattr(val, "stale_tier_counts", None) or {}).items())),
     )
 
 
@@ -459,17 +464,28 @@ def _work_field(snap: UiSnapshot) -> tuple[str, str]:
     "54 files" telling it nothing. Once drafting begins the slot earns its place
     by showing the open findings instead.
 
-    A tier that has not been swept shows as **locked** rather than as ``0``. This
-    is honest, not decorative: ``build_and_validate`` defaults to the REQUIRED
-    gate, and a gate is a floor — RECOMMENDED and OPTIONAL checks are not
-    evaluated at all until the gate is lowered, so their counts are genuinely
-    unknown, not zero. ``assessed_tiers`` is what the validator actually
-    assessed, so it is the thing to read.
+    A tier has three states here, not two:
+
+    * **swept** — ``4 rec``, the count this verdict answers for;
+    * **stale** — ``4 rec?``, what the last sweep found, with the crate edited
+      since. The findings are retired (they described an older crate) but the
+      number is still the best thing known, and far better than the alternatives:
+      ``0 rec`` reads as a clean bill, and "locked" reads as never-looked-at;
+    * **locked** — never swept. ``build_and_validate`` defaults to the REQUIRED
+      gate, and a gate is a floor: RECOMMENDED and OPTIONAL checks are not
+      evaluated at all until the gate is lowered, so their counts are genuinely
+      unknown, not zero.
+
+    Which is why a tier only ever moves BACK to locked when nothing has looked at
+    it. Once a tier has been swept, the footer keeps reporting it — the run that
+    reported "3 req · rec/opt locked" after having shown those counts for half a
+    session was reading retirement as ignorance.
     """
     if snap.entity_count == 0:
         return "files", f"{snap.file_count} files"
 
     assessed = set(snap.assessed_tiers)
+    stale = dict(snap.stale_tier_counts)
     parts: list[str] = []
     locked: list[str] = []
     for tier, label, count in (
@@ -479,6 +495,8 @@ def _work_field(snap: UiSnapshot) -> tuple[str, str]:
     ):
         if tier in assessed:
             parts.append(f"{count} {label}")
+        elif tier in stale:
+            parts.append(f"{stale[tier]} {label}?")
         else:
             locked.append(label)
     if locked:
@@ -566,6 +584,7 @@ def status_field_values(snap: UiSnapshot) -> dict[str, Any]:
             snap.should_issue_count,
             snap.may_issue_count,
             snap.assessed_tiers,
+            snap.stale_tier_counts,
         ),
         "base": snap.base_passed,
         "isa": snap.isa_passed,

--- a/builder/state.py
+++ b/builder/state.py
@@ -641,6 +641,21 @@ class ValidationReport:
             renderers (the maturity report's per-profile fold-outs, #510) never
             have to re-parse that display format. Empty on a verdict recorded
             before the field existed — consumers must fall back, not infer.
+        assessed_tiers: The tiers whose findings this verdict CURRENTLY answers
+            for. A gate is a floor, so a "recommended" sweep marks both
+            ``required`` and ``recommended``; a tier the crate has moved on from
+            is retired here rather than left describing an older crate.
+        stale_tier_counts: How many findings a RETIRED tier held when it was
+            last swept. Retirement is about freshness, but the status footer read
+            it as ignorance and printed "rec/opt locked" — the very same thing it
+            shows for a tier nobody ever ran, so a session that had been
+            reporting "4 rec 11 opt" appeared to lock them again after one
+            REQUIRED-gated run over an edited crate. Keeping the last count lets
+            the footer say what it knew and mark it unverified, instead of
+            choosing between claiming ignorance and printing a 0 that reads as
+            clean. Not serialized: a resumed session restores its own verdict,
+            and this only ever describes findings THIS process computed and then
+            retired.
         payload_checked: Whether anything actually looked at the crate's files.
             The in-memory gate validates a document, so checks that need a
             payload — "is every declared Data Entity present?" — emit nothing
@@ -659,6 +674,7 @@ class ValidationReport:
     should_issues: list[str] = field(default_factory=list)
     may_issues: list[str] = field(default_factory=list)
     assessed_tiers: set[str] = field(default_factory=set)
+    stale_tier_counts: dict[str, int] = field(default_factory=dict, repr=False)
     issue_records: list[dict[str, str]] = field(default_factory=list)
     payload_checked: bool = False
     input_fingerprint: str = ""
@@ -1258,9 +1274,7 @@ class CrateState:
         validator could observe busts the cache, while a change to a pure output
         (a verdict, a score) does not.
         """
-        metadata = (
-            self.metadata.to_dict() if hasattr(self.metadata, "to_dict") else None
-        )
+        metadata = self.metadata.to_dict() if hasattr(self.metadata, "to_dict") else None
         if metadata is not None:
             # WHERE the crate was written and WHEN — neither is anything the
             # validator can observe. Two exports of an identical crate to
@@ -1488,8 +1502,7 @@ class StateSerializer:
             # thing persisting them was meant to prevent. Coerced so a
             # hand-edited session file cannot inject non-bool values.
             validation_preferences={
-                str(k): bool(v)
-                for k, v in (data.get("validation_preferences") or {}).items()
+                str(k): bool(v) for k, v in (data.get("validation_preferences") or {}).items()
             },
             user_answers=[
                 {"question": str(a.get("question", "")), "answer": str(a.get("answer", ""))}

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -132,6 +132,14 @@ def validate(state: CrateState, crate_path: str) -> ValidationReport:
         required_issues=required_issues,
         should_issues=should_issues,
         may_issues=may_issues,
+        # Every pass here runs at `Severity.OPTIONAL` — the widest gate — so this
+        # verdict answers for all three tiers. Saying so is not bookkeeping: the
+        # footer and the maturity report both read `assessed_tiers` to tell "no
+        # findings" from "never ran", and leaving it empty made a full disk
+        # validation render as three locked tiers sitting beside its own findings.
+        # Only the success path claims this; the early returns above are failures
+        # that swept nothing.
+        assessed_tiers=set(_TIER_ORDER),
         issue_records=issue_records,
         # This path validated a directory, so the payload checks the in-memory
         # gate cannot run did run here — the verdict covers the files too (#530).
@@ -810,6 +818,15 @@ def apply_validation_result(
     """
     if tool_name == "validate" and isinstance(result, ValidationReport):
         result.input_fingerprint = state.validation_fingerprint()
+        # A whole report replaces the previous one, so anything the old verdict
+        # remembered goes with it — except for a tier this one did not answer
+        # for (the failure reports `validate` returns when the validator is
+        # missing or the directory is not there assess nothing at all).
+        result.stale_tier_counts = {
+            tier: count
+            for tier, count in state.validation.stale_tier_counts.items()
+            if tier not in result.assessed_tiers
+        }
         state.validation = result
         return
     if tool_name != "build_and_validate" or not isinstance(result, dict):
@@ -851,6 +868,15 @@ def apply_validation_result(
     if report.input_fingerprint and report.input_fingerprint != fingerprint:
         for tier in _TIER_ORDER:
             if tier not in covered:
+                # Retire the FINDINGS, remember the COUNT. Retirement says the
+                # findings no longer describe this crate; it does not say the
+                # tier was never looked at, and the footer could not tell those
+                # apart — so a run that had been showing "4 rec 11 opt" went back
+                # to "rec/opt locked" the moment a REQUIRED-gated sweep followed
+                # an edit. The count is what the footer needs to say "4, as of
+                # the last sweep" rather than to claim ignorance or print a 0.
+                if tier in report.assessed_tiers:
+                    report.stale_tier_counts[tier] = len(getattr(report, _TIER_FIELDS[tier]) or [])
                 setattr(report, _TIER_FIELDS[tier], [])
                 report.assessed_tiers.discard(tier)
                 tier_records[tier] = []
@@ -861,6 +887,7 @@ def apply_validation_result(
     for tier in covered:
         setattr(report, _TIER_FIELDS[tier], order_issues(issues, tier))
         report.assessed_tiers.add(tier)
+        report.stale_tier_counts.pop(tier, None)  # answered again; nothing to remember
         tier_records[tier] = _issue_records(issues, tier)
     report.issue_records = [r for tier in _TIER_ORDER for r in tier_records[tier]] + [
         r for tier, records in tier_records.items() if tier not in _TIER_ORDER for r in records

--- a/tests/test_status_footer.py
+++ b/tests/test_status_footer.py
@@ -117,6 +117,75 @@ class TestTheMiddleSlot:
         assert "req/rec/opt locked" in line
 
 
+class TestASweptTierNeverLocksAgain:
+    """Retirement is about freshness, and the footer read it as ignorance.
+
+    A REQUIRED-gated sweep over an edited crate retires the wider tiers — their
+    findings described the crate as it was. The counts were then dropped and the
+    tiers rendered exactly like tiers nobody had ever run, so a session that had
+    been reporting "121 rec 66 opt" for half its life went back to "rec/opt
+    locked". The user's rule: once a tier has been shown, it stays shown.
+    """
+
+    def test_a_retired_tier_keeps_its_count(self):
+        line = _plain(
+            render_status_markup(
+                _snap(
+                    entity_count=97,
+                    required_issue_count=3,
+                    assessed_tiers=("required",),
+                    stale_tier_counts=(("optional", 66), ("recommended", 121)),
+                )
+            )
+        )
+        assert "3 req" in line
+        assert "121 rec?" in line
+        assert "66 opt?" in line
+        assert "locked" not in line
+
+    def test_a_stale_zero_is_marked_unverified(self):
+        """`0 rec` is a clean bill of health; `0 rec?` is what we last saw."""
+        line = _plain(
+            render_status_markup(
+                _snap(
+                    entity_count=97,
+                    assessed_tiers=("required",),
+                    stale_tier_counts=(("recommended", 0),),
+                )
+            )
+        )
+        assert "0 rec?" in line
+
+    def test_a_tier_nobody_ran_is_still_locked(self):
+        """Only what has actually been swept is remembered — the rest is unknown."""
+        line = _plain(
+            render_status_markup(
+                _snap(
+                    entity_count=97,
+                    assessed_tiers=("required",),
+                    stale_tier_counts=(("recommended", 121),),
+                )
+            )
+        )
+        assert "121 rec?" in line
+        assert "opt locked" in line
+
+    def test_a_fresh_sweep_wins_over_the_memory(self):
+        """The stale count is a fallback, never something that shadows a result."""
+        line = _plain(
+            render_status_markup(
+                _snap(
+                    entity_count=97,
+                    should_issue_count=4,
+                    assessed_tiers=("required", "recommended"),
+                    stale_tier_counts=(("recommended", 121),),
+                )
+            )
+        )
+        assert "4 rec" in line
+        assert "121" not in line
+
+
 class TestFader:
     def test_issue_counts_are_comparable_for_highlighting(self):
         """The fader tints a field when its value changes, so the new slot needs one."""

--- a/tests/test_validation_writeback.py
+++ b/tests/test_validation_writeback.py
@@ -185,9 +185,7 @@ class TestValidationFreshness:
             {"ok": True, "conformance": {"base": True, "isa": True, "tox": True}, "issues": []},
             severity="required",
         )
-        assert engine.state.validation.input_fingerprint == (
-            engine.state.validation_fingerprint()
-        )
+        assert engine.state.validation.input_fingerprint == (engine.state.validation_fingerprint())
 
 
 class TestIssueRecords:
@@ -274,19 +272,68 @@ class TestIssueRecords:
         assert any(r["severity"] == "recommended" for r in state.validation.issue_records)
 
         # Same state: a REQUIRED-only refresh must not discard fresh advisory records.
-        apply_validation_result(
-            state, "build_and_validate", self._result([]), severity="required"
-        )
+        apply_validation_result(state, "build_and_validate", self._result([]), severity="required")
         assert any(r["severity"] == "recommended" for r in state.validation.issue_records)
 
         # Crate changed: the advisory records describe an older crate — retire
         # them alongside the advisory string lists.
         state.metadata.title = "Edited after validating"
-        apply_validation_result(
-            state, "build_and_validate", self._result([]), severity="required"
-        )
+        apply_validation_result(state, "build_and_validate", self._result([]), severity="required")
         assert state.validation.issue_records == []
         assert state.validation.should_issues == []
+
+    def test_a_retired_tier_leaves_its_count_behind(self) -> None:
+        """Retiring findings must not also erase that the tier was ever swept.
+
+        The status footer had no way to tell a retired tier from one nobody had
+        run, so it locked both — and a session that had been reporting its
+        RECOMMENDED count went back to "rec/opt locked" after a single
+        REQUIRED-gated sweep over an edited crate.
+        """
+        from builder.tools.validation import apply_validation_result
+
+        state = self._state()
+        advisory = {
+            "severity": "recommended",
+            "profile": "isa",
+            "entity_id": "#s",
+            "message": "consider a license",
+        }
+        apply_validation_result(
+            state, "build_and_validate", self._result([advisory]), severity="recommended"
+        )
+        assert state.validation.stale_tier_counts == {}, "a fresh tier remembers nothing"
+
+        state.metadata.title = "Edited after validating"
+        apply_validation_result(state, "build_and_validate", self._result([]), severity="required")
+        assert state.validation.should_issues == []
+        assert "recommended" not in state.validation.assessed_tiers
+        assert state.validation.stale_tier_counts["recommended"] == 1
+        # OPTIONAL was never swept, so there is nothing to remember about it —
+        # unknown and stale are different answers.
+        assert "optional" not in state.validation.stale_tier_counts
+
+    def test_sweeping_a_tier_again_clears_its_memory(self) -> None:
+        from builder.tools.validation import apply_validation_result
+
+        state = self._state()
+        advisory = {
+            "severity": "recommended",
+            "profile": "isa",
+            "entity_id": "#s",
+            "message": "consider a license",
+        }
+        apply_validation_result(
+            state, "build_and_validate", self._result([advisory]), severity="recommended"
+        )
+        state.metadata.title = "Edited after validating"
+        apply_validation_result(state, "build_and_validate", self._result([]), severity="required")
+        assert state.validation.stale_tier_counts
+
+        apply_validation_result(
+            state, "build_and_validate", self._result([]), severity="recommended"
+        )
+        assert state.validation.stale_tier_counts == {}
 
     def test_a_covered_tier_replaces_its_records_rather_than_accumulating(self) -> None:
         from builder.tools.validation import apply_validation_result
@@ -298,7 +345,9 @@ class TestIssueRecords:
             "entity_id": "./",
             "message": "missing identifier",
         }
-        apply_validation_result(state, "build_and_validate", self._result([first]), severity="required")
+        apply_validation_result(
+            state, "build_and_validate", self._result([first]), severity="required"
+        )
         second = {**first, "message": "still missing a name"}
         apply_validation_result(
             state, "build_and_validate", self._result([second]), severity="required"


### PR DESCRIPTION
## The report

> I saw `3 req · rec/opt locked` after it had already shown stuff in the footer. We said we don't want to relock — once the flag has been set once it's unlocked for good unless the human says to lock it.

## What was happening

`assessed_tiers` answers two different questions, and the footer read the wrong one:

* **has this tier been opened** — a gate the human sets, sticky;
* **are this tier's findings current** — freshness, and it can go stale.

A REQUIRED-gated sweep over an edited crate retires the wider tiers, because their findings describe a crate that no longer exists. That is correct and it keeps happening. What was wrong is that retirement also erased *that the tier had ever been swept*, so the footer rendered a retired tier exactly like one nobody has ever run.

Reproduces on the plain path: escalate to RECOMMENDED, edit anything, validate at the default gate — `rec/opt locked`, on a session that has been reporting those counts all along.

## The fix

The count survives retirement (`ValidationReport.stale_tier_counts`), and the footer has three states rather than two:

| | shown | means |
|---|---|---|
| swept | `4 rec` | this verdict answers for the tier |
| stale | `4 rec?` | last known count; the crate has been edited since |
| locked | `rec locked` | never swept — genuinely unknown, not zero |

A fresh sweep always wins over the memory, and a tier nobody ran stays locked — unknown and stale are different answers. Not serialized: a resumed session restores its own verdict.

## Second bug, same symptom

The disk `validate` runs every profile at `Severity.OPTIONAL` — the widest gate — and recorded **no assessed tiers at all**. A full three-pass validation therefore rendered as three locked tiers sitting beside its own findings, in the footer and in the maturity report both. It now records what it assessed, on the success path only: the early returns are failures that swept nothing.

## Tests

* `TestASweptTierNeverLocksAgain` — the four display states, including that a stale `0` is marked unverified rather than reading as a clean bill.
* `TestIssueRecords::test_a_retired_tier_leaves_its_count_behind` / `test_sweeping_a_tier_again_clears_its_memory` — the memory is written on retirement and cleared when the tier is answered again.

Local: `test_status_footer`, `test_validation_writeback`, `test_validation_escalation`, `test_maturity_report`, `test_payload_verification`, `test_state_serializer`, `test_dashboard_status`, `test_tools_build_and_validate`, `test_offline_validation`, `tests/agents/test_ui` — all green. `ruff check` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)