### PR TITLE
fix(pipeline): describe .xlsx and .docx too — the feature was inert on a real deposit

### DIFF
--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -114,15 +114,26 @@ def _role_and_signals(filename: str, preview: str) -> tuple[str, list[str], floa
     return role, reasons, score
 
 
-def _safe_preview(path: str, approved_roots: set[str], limit: int) -> str:
-    """Read a small preview only after approved-root containment succeeds."""
+def _safe_preview(
+    path: str, approved_roots: set[str], limit: int, *, mode: str = "content"
+) -> str:
+    """Read a small preview only after approved-root containment succeeds.
+
+    *mode* is passed through to ``read_file_sample``. It defaults to ``"content"``
+    — the first lines of the file — which is right for CSV and text and returns
+    NOTHING for a binary format: an .xlsx or .docx has no first lines to read.
+    ``"summary"`` gets the file-type-aware digest instead (sheet names, column
+    headers, sample paragraphs), which is what a caller describing a workbook
+    needs. Exposed rather than hard-coded so a caller can ask for the one it
+    needs; the default keeps every existing caller's behaviour unchanged.
+    """
     from builder.tools.scanner import _contain, read_file_sample
 
     contained = _contain(path, approved_roots)
     if contained is None or not contained.is_file():
         return ""
     try:
-        value = read_file_sample(str(contained), lines=40, mode="content")
+        value = read_file_sample(str(contained), lines=40, mode=mode)
     except (OSError, RuntimeError, ValueError):
         return ""
     if not value:

--- a/builder/tools/file_descriptions.py
+++ b/builder/tools/file_descriptions.py
@@ -73,7 +73,16 @@ def _preview_for(state: CrateState, entity: Entity) -> str:
         roots.add(str(Path(state.metadata.input_path).resolve()))
     if not roots:
         return ""
-    return _safe_preview(str(source), roots, PREVIEW_LIMIT)
+    # Content first — the actual rows of a CSV are the best evidence of what it
+    # holds. Then the file-type summary, because `mode="content"` returns NOTHING
+    # for a binary format: measured against the real corpus, every .xlsx and
+    # .docx came back 0 characters, which is most of a deposit. The summary gives
+    # sheet names, column headers and sample paragraphs — still the file's own
+    # content, just the part that survives not being plain text.
+    preview = _safe_preview(str(source), roots, PREVIEW_LIMIT)
+    if preview.strip():
+        return preview
+    return _safe_preview(str(source), roots, PREVIEW_LIMIT, mode="summary")
 
 
 def describe_payload_files(

--- a/tests/test_file_descriptions.py
+++ b/tests/test_file_descriptions.py
@@ -153,3 +153,101 @@ class TestFilesystemAccessStaysFailClosed:
         )
 
         assert sent == []
+
+
+class TestABinaryFileIsStillDescribableFromItsContent:
+    """The feature was inert on a real deposit until this.
+
+    `read_file_sample(mode="content")` returns the first LINES of a file, which
+    is right for CSV and text and is **nothing at all** for a binary format.
+    Measured against the shipped corpus, every .xlsx and .docx came back 0
+    characters — and a deposit is mostly .xlsx and .docx, so "describe the payload
+    files" described none of them.
+
+    The file-type summary is still the file's own content — sheet names, column
+    headers, sample paragraphs — just the part that survives not being plain
+    text. Driven against committed fixtures rather than a synthesised workbook,
+    because what broke here was the behaviour of the real readers on real files.
+    """
+
+    FIXTURES = Path(__file__).parent / "fixtures"
+
+    def _describable(self, source: Path, tmp_path: Path) -> list[dict]:
+        import shutil
+
+        shutil.copy(source, tmp_path / source.name)
+        state = CrateState()
+        state.metadata.input_path = str(tmp_path)
+        draft_file(state, name=source.name, path=str(tmp_path / source.name))
+
+        seen: list[dict] = []
+
+        def _describe(files):
+            seen.extend(files)
+            return ["A description." for _ in files]
+
+        describe_payload_files(state, describe_fn=_describe)
+        return seen
+
+    def test_an_xlsx_reaches_the_model_with_its_sheets_and_columns(
+        self, tmp_path: Path
+    ) -> None:
+        source = self.FIXTURES / "svhps22_real_input" / "Metadataveldenlijst_1.2.0.xlsx"
+        assert source.is_file(), "fixture missing; this test would pass vacuously"
+
+        sent = self._describable(source, tmp_path)
+
+        assert len(sent) == 1, "the workbook was skipped as unreadable"
+        preview = sent[0]["preview"]
+        assert "Excel" in preview
+        # The part that makes a description possible: what is actually in it.
+        assert "rows" in preview and "columns" in preview
+
+    def test_a_docx_reaches_the_model_with_its_text(self, tmp_path: Path) -> None:
+        source = (
+            self.FIXTURES
+            / "svhps22_real_input"
+            / "assay_01_TH_uptake"
+            / "3.2 Protocol transporter assay radioactive T3 T4_EN.docx"
+        )
+        assert source.is_file(), "fixture missing; this test would pass vacuously"
+
+        sent = self._describable(source, tmp_path)
+
+        assert len(sent) == 1, "the document was skipped as unreadable"
+        assert "Word" in sent[0]["preview"]
+
+    def test_plain_text_still_uses_its_actual_lines(self, tmp_path: Path) -> None:
+        """The control. The summary is a FALLBACK, not a replacement — the rows
+        of a CSV are better evidence than a description of its shape."""
+        (tmp_path / "uptake.csv").write_text(
+            "well,compound,absorbance\nA1,T4,0.812\n", encoding="utf-8"
+        )
+        state = CrateState()
+        state.metadata.input_path = str(tmp_path)
+        draft_file(state, name="uptake.csv", path=str(tmp_path / "uptake.csv"))
+
+        seen: list[dict] = []
+        describe_payload_files(
+            state,
+            describe_fn=lambda files: seen.extend(files) or ["x" for _ in files],
+        )
+
+        assert "A1,T4,0.812" in seen[0]["preview"]
+        assert "Format:" not in seen[0]["preview"]
+
+    def test_a_file_that_is_not_there_is_still_refused(self, tmp_path: Path) -> None:
+        """The fallback must not become a way to describe a file that does not
+        exist — the summary reader returns nothing for it too, and nothing is
+        exactly what should reach the model."""
+        state = CrateState()
+        state.metadata.input_path = str(tmp_path)
+        draft_file(state, name="absent.xlsx", path=str(tmp_path / "absent.xlsx"))
+
+        seen: list[dict] = []
+        describe_payload_files(
+            state,
+            describe_fn=lambda files: seen.extend(files) or ["x" for _ in files],
+        )
+
+        assert seen == []


### PR DESCRIPTION
#579 shipped a working refusal and nothing else.

`_safe_preview` asks `read_file_sample` for `mode="content"` — the first **lines** of a file. That is right for CSV and text, and it is **nothing at all** for a binary format. Measured against the shipped corpus:

```
Metadataveldenlijst_1.2.0.xlsx            ->  0 chars
metabolism_assay_metadata.xlsx            ->  0 chars
20251114_cell culture protocol H4.docx    ->  0 chars
Assay-metadata-CHO-K1_OATP1C1-v1.1.xlsx   ->  0 chars
```

A deposit is mostly `.xlsx` and `.docx`. So "describe the payload files" correctly refused to describe almost all of them — the guard working exactly as designed, on a feature that consequently did nothing.

## The readers already existed

`_summarize_xlsx` and `_summarize_docx` are reached by `mode="summary"`:

```
Format: Excel (.xlsx)
  Template: 62 rows x 4 cols; columns: Field, Standard or ontology reference, Value, Comments
  Template (Metabolism Assay): 83 rows x 4 cols; …
```

That is still the file's **own content** — sheet names, column headers, sample paragraphs, the part that survives not being plain text — so nothing about the grounding rule changes.

**Content is tried first**, because the actual rows of a CSV are better evidence than a description of its shape. The summary is the fallback. A control test asserts a `.csv` still gets its real lines and *not* the summary.

`_safe_preview` gains a `mode` parameter defaulting to `"content"`, so its existing caller behaves exactly as before.

## The refusal is unchanged

A file that is not there returns nothing from the summary reader too, and nothing is exactly what should reach the model. Still pinned.

## The tests use real fixtures

Committed `.xlsx`/`.docx` rather than a synthesised workbook — what failed here was the behaviour of the **real readers on real files**, and a hand-built stand-in would have passed the whole time. Each asserts the fixture exists first, so a moved file surfaces as a failure rather than a vacuous pass.

## Verification

13 tests in the module (4 new); 99 passing with the scanner suite. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)