### PR TITLE
fix(shapes): a validation message states the requirement, not the value to write (#584)

### DIFF
--- a/profiles/shapes/tox/9_investigation_strict.ttl
+++ b/profiles/shapes/tox/9_investigation_strict.ttl
@@ -33,7 +33,7 @@ tox:InvestigationMustHaveDescriptors a sh:NodeShape ;
         a sh:PropertyShape ;
         sh:path schema:license ;
         sh:minCount 1 ;
-        sh:message "Investigation MUST specify a schema:license (use 'ALL RIGHTS RESERVED BY THE AUTHORS' if none available)" ;
+        sh:message "Investigation MUST specify a schema:license — the terms under which this crate may be reused, as stated by the depositor" ;
         sh:severity sh:Violation ;
     ] ;
     sh:property [

--- a/tests/test_shape_messages_state_requirements.py
+++ b/tests/test_shape_messages_state_requirements.py
@@ -1,0 +1,72 @@
+"""A SHACL message says what the data must satisfy, not what to write (#584).
+
+The licence shape used to read:
+
+    "Investigation MUST specify a schema:license
+     (use 'ALL RIGHTS RESERVED BY THE AUTHORS' if none available)"
+
+which is a category error with consequences. A ``sh:message`` is the validator
+speaking about the data in front of it; prescribing a literal turns it into
+content policy — and the literal prescribed here was the most restrictive
+licence available, applied by machine to someone else's data, by a tool whose
+purpose is FAIR outputs.
+
+Naming the *kind* of value is still welcome, and the rest of the profile already
+does it ("InChIKey, CAS, PubChem CID, …", "e.g. Culture Medium"): those describe
+what would satisfy the shape without dictating the answer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SHAPES = sorted(Path("profiles/shapes/tox").glob("*.ttl"))
+
+# `use 'X'` / `use "X"` — the shape handing the author a literal to paste.
+_PRESCRIBES_A_LITERAL = re.compile(r"\buse\s+['\"][^'\"]+['\"]", re.IGNORECASE)
+
+_MESSAGE = re.compile(r"sh:message\s+\"([^\"]+)\"")
+
+
+def _messages(path: Path) -> list[str]:
+    return _MESSAGE.findall(path.read_text(encoding="utf-8"))
+
+
+def test_the_profile_has_messages_to_check() -> None:
+    # Guards the guard: a glob that matched nothing would pass every test below.
+    assert _SHAPES, "no tox shapes found"
+    assert sum(len(_messages(p)) for p in _SHAPES) > 10
+
+
+@pytest.mark.parametrize("shape", _SHAPES, ids=lambda p: p.name)
+def test_no_message_prescribes_a_literal_value(shape: Path) -> None:
+    offenders = [m for m in _messages(shape) if _PRESCRIBES_A_LITERAL.search(m)]
+    assert offenders == [], (
+        f"{shape.name}: a validation message tells the author what to write, "
+        f"rather than what the data must satisfy: {offenders}"
+    )
+
+
+def test_no_message_names_an_all_rights_reserved_default() -> None:
+    """The specific claim worth never making by machine."""
+    offenders = [
+        (shape.name, m)
+        for shape in _SHAPES
+        for m in _messages(shape)
+        if "all rights reserved" in m.lower()
+    ]
+    assert offenders == [], offenders
+
+
+def test_the_licence_shape_still_requires_a_licence() -> None:
+    # The point is the wording, not the requirement: dropping the rule would be
+    # a different (and much larger) decision — see #540.
+    strict = Path("profiles/shapes/tox/9_investigation_strict.ttl").read_text(encoding="utf-8")
+    assert "schema:license" in strict
+    licence_message = next(m for m in _messages(Path(
+        "profiles/shapes/tox/9_investigation_strict.ttl"
+    )) if "license" in m)
+    assert "MUST" in licence_message


### PR DESCRIPTION
Closes #584.

## The change

`profiles/shapes/tox/9_investigation_strict.ttl`:

```diff
-sh:message "Investigation MUST specify a schema:license (use 'ALL RIGHTS RESERVED BY THE AUTHORS' if none available)" ;
+sh:message "Investigation MUST specify a schema:license — the terms under which this crate may be reused, as stated by the depositor" ;
```

A `sh:message` is the validator speaking about the data in front of it. Handing the author a literal to paste turns it into content policy — and the literal here was the most restrictive licence available, recommended by machine, over someone else's data, by a tool whose purpose is FAIR outputs.

**Every sibling message already gets this right**, by naming the *kind* of value rather than the value:

```
"MolecularEntity SHOULD have a schema:identifier (InChIKey, CAS, PubChem CID, ...) resolving the compound"
"CellCulture process MUST have at least one schema:additionalProperty (e.g. Culture Medium)"
"Cell-line Sample SHOULD have a schema:identifier resolving to a Cellosaurus accession (CVCL_...)"
```

The licence message was the only outlier in the profile.

## What does not change

The requirement. The root Investigation still MUST carry a `license` at `sh:Violation`. **No crate changes verdict** — this is wording only, and the full suite reflects that: **3075 passed, 0 failed.**

## The guard

`tests/test_shape_messages_state_requirements.py` pins the principle across the whole tox profile rather than this one line:

- no `sh:message` may hand the author a literal (the `use '…'` shape);
- none may name an all-rights-reserved default;
- the licence rule itself must still be a MUST (so the guard cannot be satisfied by deleting the requirement);
- plus a guard-the-guard assertion, since a glob that matched nothing would pass everything else.

Verified to genuinely catch the regression: restoring the old message fails 2 of the guards, then the fix restores them.

## Record correction

While investigating I had told @johannehouweling this string came from upstream. **It does not** — it appears in no installed package:

```
grep -rn 'ALL RIGHTS RESERVED' .venv/lib/python3.12/site-packages/rocrate_validator/   -> 0
grep -rl 'ALL RIGHTS RESERVED' .venv/                                                  -> 0
```

`profiles/docs/isa.md` is a vendored draft document that no shape reads. I have corrected #540 and #584 accordingly. Whether `_crate_mapping` should keep writing the default remains open and rests on migration cost (56 tests, base conformance for licence-less crates), not on any spec obligation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)