### PR TITLE
feat(crate): an unstated licence says so, instead of claiming all rights reserved (#540)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1541,6 +1541,18 @@ warning, so the heaviest payloads are still removed.
 The Investigation **is** the Root Data Entity (`./`); the ISA RO-Crate profile mandates this and
 the SHACL shapes forbid alternatives (a Study carrying `additionalType "Study"` MUST be `hasPart`
 of the root via `StudyMustBeReferencedFromInvestigation`, so the root cannot itself be a Study).
+**An unstated licence says so, and claims nothing (#540).** `license` is a base MUST, so the field
+cannot be left empty — but answering it with `ALL RIGHTS RESERVED BY THE AUTHORS`, as it once did,
+converts an unanswered question into the most restrictive claim available, asserted by machine over
+someone else's data by a tool whose purpose is FAIR outputs. RO-Crate allows `license` to be a
+`CreativeWork` rather than a URL, so a crate with no declared terms carries `LICENCE_NOT_STATED_ID`
+(`#licence-not-stated`) — an entity whose name and description record that the depositor stated
+nothing, which is neither a grant nor a restriction. It satisfies the requirement, keeps the crate
+conformant, and is machine-readable: a consumer branches on the `@id` rather than string-matching
+prose. A licence the depositor *did* state always wins, and is emitted as a described entity when
+`describe_license` recognises it (never renamed when it does not). The gap engine and MIT scorer
+discount the entity by id, so an unstated licence never reads as filled — see §Gap Analysis.
+
 `_add_structural` (`builder/tools/_crate_mapping.py`) therefore:
 
 - **Folds a single Investigation entity onto the root** instead of emitting a duplicate
@@ -2477,10 +2489,12 @@ imports and calls it. It calls (does not re-implement) the three assessors:
   engine is what made the loop ask for identifiers the crate already carried. The
   document assembled for the SHACL sweep is threaded into the MIT pass, so a
   `GapReport` costs **one** assembly, not two. A value the build *synthesized* in
-  the user's absence (the placeholder root name/description, the default
-  `license`) never counts as filled — crediting it would stop the loop asking for
-  the real one; the values are imported from the build's own constants rather
-  than duplicated.
+  the user's absence (the placeholder root name/description, the "licence not
+  stated" entity) never counts as filled — crediting it would stop the loop asking
+  for the real one; the values are imported from the build's own constants rather
+  than duplicated. The licence discount is keyed on `LICENCE_NOT_STATED_ID`, and
+  `_nonempty` unwraps a single-key `{"@id": …}` before checking, so a placeholder
+  is not made real by being modelled as an entity rather than a string (#540).
 - `assess_fair_maturity` — every *failing* indicator is a gap.
 
 **Tiering** mirrors the §6 validation layers (MUST = blocking, SHOULD =

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -2780,7 +2780,7 @@ def open_items(state: CrateState, *, actionable_only: bool = False) -> list[str]
         if attribution:
             items.append(f"crate attribution: {', '.join(attribution)} not set")
         if not getattr(meta, "license", None):
-            items.append("licence not chosen (the crate will say ALL RIGHTS RESERVED)")
+            items.append("licence not chosen (the crate will say the terms were never stated)")
 
         # A submission that ships four assay folders and gets modelled as one
         # assay validates perfectly and is three-quarters missing. Nothing in the
@@ -3074,9 +3074,9 @@ def _completeness_nudge(state: CrateState) -> str:
     # "complete" naming six publication authors and no owner at all.
     meta = state.metadata
     has_attribution = bool(meta.publisher or meta.creator or meta.contact)
-    # No licence means the crate ships the "ALL RIGHTS RESERVED" fallback the
-    # BASE shape requires — legally the most restrictive option, chosen by
-    # nobody. That silence is worth one question.
+    # No licence means the crate ships the "licence not stated" entity the BASE
+    # shape requires it to carry — honest, but no use to anyone wanting to reuse
+    # the data, since unknown terms are not permission. Worth one question.
     has_license = bool(meta.license)
     orphans = _unreferenced_entities(state)
 
@@ -3108,7 +3108,7 @@ def _completeness_nudge(state: CrateState) -> str:
     if not has_attribution:
         missing.append("crate owner (publisher/creator/contact)")
     if not has_license:
-        missing.append("licence (defaulting to ALL RIGHTS RESERVED)")
+        missing.append("licence (the crate will record that none was stated)")
     if orphans:
         detail = ", ".join(f"{len(ids)} {t}" for t, ids in sorted(orphans.items()))
         missing.append(f"links for {detail}")

--- a/builder/agents/react/system_prompt.py
+++ b/builder/agents/react/system_prompt.py
@@ -181,9 +181,10 @@ have no owner.
 ### The Licence: Ask, With the Trade-offs
 
 A crate with no licence does not ship "no licence" — BASE requires one, so it
-ships **ALL RIGHTS RESERVED BY THE AUTHORS**, the most restrictive option there
-is, chosen by nobody. So ask, once, before export, and give the user enough to
-decide. Record the answer with `set_crate_metadata(license=<URL>)`.
+ships an entity saying the depositor never stated any terms. That is honest, and
+it is still a dead end for anyone wanting to reuse the data: unknown terms are
+not permission. So ask, once, before export, and give the user enough to decide.
+Record the answer with `set_crate_metadata(license=<URL>)`.
 
 Offer these, with the trade-off stated plainly — a licence is a legal decision
 about someone else's data, so **never pick one silently**:

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1143,6 +1143,41 @@ def _mirror_profile_predicates(crate: ROCrate) -> None:
 # not an oversight.
 
 
+# The licence entity a crate carries when the depositor stated no terms (#540).
+# `license` is a base MUST, so the field cannot be left empty — but answering it
+# with "ALL RIGHTS RESERVED BY THE AUTHORS", as this did, turns an unanswered
+# question into the most restrictive claim available, asserted by machine over
+# someone else's data by a tool whose purpose is FAIR outputs.
+#
+# RO-Crate allows `license` to be a CreativeWork rather than a URL, so the crate
+# satisfies the requirement while claiming nothing. The id is stable and local so
+# a consumer can branch on it instead of string-matching English prose, and so
+# `mit_assessment` can keep refusing to credit it — an unstated licence must not
+# read as filled, or the loop stops asking for the real one.
+LICENCE_NOT_STATED_ID = "#licence-not-stated"
+_LICENCE_NOT_STATED_NAME = "Licence not stated"
+_LICENCE_NOT_STATED_DESCRIPTION = (
+    "The depositor did not state licence terms for this dataset. This is neither "
+    "a grant of rights nor a restriction — the terms are simply unknown. Ask the "
+    "depositor before reusing this data."
+)
+
+
+def _licence_not_stated(crate: ROCrate) -> Any:
+    """The licence entity for a crate whose depositor stated no terms (#540)."""
+    return crate.add(
+        ContextEntity(
+            crate,
+            LICENCE_NOT_STATED_ID,
+            properties={
+                "@type": "CreativeWork",
+                "name": _LICENCE_NOT_STATED_NAME,
+                "description": _LICENCE_NOT_STATED_DESCRIPTION,
+            },
+        )
+    )
+
+
 def _license_value(crate: ROCrate, license_value: str) -> Any:
     """The root's ``license``: a described contextual entity when we can name it.
 
@@ -1185,12 +1220,13 @@ def _populate_root_and_conformance(state: CrateState, crate: ROCrate) -> None:
     if m.date_modified:
         crate.root_dataset["dateModified"] = m.date_modified
     crate.root_dataset["additionalType"] = "Investigation"
-    # Base RO-Crate MUST: the Root Data Entity has a license. A license the user
-    # gave wins; the ISA-Tox shape endorses this placeholder when none is known.
+    # Base RO-Crate MUST: the Root Data Entity has a license. One the depositor
+    # stated wins; otherwise the crate says the terms were never stated rather
+    # than asserting the most restrictive ones on their behalf (#540).
     if m.license:
         crate.root_dataset["license"] = _license_value(crate, m.license)
     elif not crate.root_dataset.get("license"):
-        crate.root_dataset["license"] = "ALL RIGHTS RESERVED BY THE AUTHORS"
+        crate.root_dataset["license"] = _licence_not_stated(crate)
 
     # Conformance placement follows RO-Crate 1.2 (ro-crate-1.2.0.md §Profiles,
     # isa_tox.md §Conformance): the metadata file descriptor's conformsTo is

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -130,6 +130,7 @@ def _placeholder_values() -> frozenset[str]:
     """
     global _PLACEHOLDER_CACHE
     if _PLACEHOLDER_CACHE is None:
+        from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
         from builder.tools.builder import (
             _DEFAULT_ROOT_NAME,
             _PLACEHOLDER_ROOT_DESCRIPTION,
@@ -142,10 +143,14 @@ def _placeholder_values() -> frozenset[str]:
                 _PLACEHOLDER_ROOT_NAME,
                 _DEFAULT_ROOT_NAME,
                 _PLACEHOLDER_ROOT_DESCRIPTION,
-                # _crate_mapping's default root license; there is no constant for
-                # it, and the module already refuses to credit `conditionsOfAccess`
-                # from it for the same reason.
-                "ALL RIGHTS RESERVED BY THE AUTHORS",
+                # The licence entity a crate carries when the depositor stated no
+                # terms (#540). Discounted for the same reason its all-rights-
+                # reserved predecessor was: crediting it would read an unanswered
+                # question as answered and stop the loop asking for the real one.
+                # Keyed on the entity id, so the discount follows the value rather
+                # than a spelling — the module already refuses `conditionsOfAccess`
+                # derived from it on the same grounds.
+                LICENCE_NOT_STATED_ID,
             )
         )
     return _PLACEHOLDER_CACHE
@@ -174,15 +179,24 @@ def _additional_type_of(node: dict[str, Any]) -> str | None:
 def _nonempty(value: Any) -> bool:
     """A property counts as filled when it carries a real, non-placeholder value.
 
-    A bare ``{"@id": …}`` reference or a list of them counts. A value the BUILD
-    synthesized in the user's absence does not — see :data:`_PLACEHOLDER_VALUES`.
+    A bare ``{"@id": …}`` reference or a list of them counts — unless the thing
+    it points AT is itself synthesized. A placeholder is not made real by being
+    modelled as an entity: the root's licence is a reference now (#540), and
+    crediting it would read an unanswered question as answered and stop the loop
+    asking for the real one. Values the BUILD synthesized in the user's absence
+    never count, whether they arrive as a string or as a reference to one — see
+    :func:`_placeholder_values`.
     """
     if value is None:
         return False
     if isinstance(value, str):
         return bool(value) and value.strip().lower() not in _placeholder_values()
-    if isinstance(value, (list, dict)):
+    if isinstance(value, dict):
+        if set(value) == {"@id"}:
+            return _nonempty(value["@id"])
         return len(value) > 0
+    if isinstance(value, list):
+        return any(_nonempty(item) for item in value)
     return True
 
 

--- a/tests/test_deposit_licence.py
+++ b/tests/test_deposit_licence.py
@@ -180,3 +180,94 @@ class TestTheDeclaredLicenceReachesTheCrate:
         assert licence.id == "https://creativecommons.org/licenses/by/4.0/legalcode"
         assert licence["name"] == "Creative Commons Attribution 4.0 International"
         assert licence["description"]
+
+
+class TestAnUnstatedLicenceSaysSo:
+    """The root carries a licence entity that states the absence (#540).
+
+    ``license`` is a base MUST, so the field cannot simply be dropped — the
+    earlier attempt cost 56 tests and every licence-less crate its base verdict.
+    But answering that MUST with ``ALL RIGHTS RESERVED BY THE AUTHORS`` converts
+    an unanswered question into the most restrictive claim available, asserted
+    by machine over someone else's data.
+
+    RO-Crate lets ``license`` be a ``CreativeWork`` rather than a URL, so the
+    crate can satisfy the requirement while claiming nothing: an entity whose
+    name and description say the terms were never stated. A consumer branches on
+    its ``@id`` instead of string-matching English prose.
+    """
+
+    @staticmethod
+    def _root(license: str | None) -> tuple[dict, dict]:
+        from rocrate.rocrate import ROCrate
+
+        from builder.tools._crate_mapping import populate_crate
+
+        state = CrateState()
+        state.metadata.title = "A crate"
+        state.metadata.license = license
+        crate = ROCrate()
+        populate_crate(state, crate, None, materialize_payload=False)
+        graph = crate.metadata.generate()["@graph"]
+        root = next(n for n in graph if n.get("@id") == "./")
+        return root, {str(n.get("@id")): n for n in graph}
+
+    def test_the_licence_is_an_entity_not_a_restrictive_string(self) -> None:
+        from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+
+        root, by_id = self._root(None)
+
+        assert root["license"] == {"@id": LICENCE_NOT_STATED_ID}
+        entity = by_id[LICENCE_NOT_STATED_ID]
+        assert entity["@type"] == "CreativeWork"
+        assert entity["name"]
+        assert entity["description"]
+
+    def test_it_claims_neither_rights_nor_restrictions(self) -> None:
+        from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+
+        _root, by_id = self._root(None)
+        text = f"{by_id[LICENCE_NOT_STATED_ID]['name']} {by_id[LICENCE_NOT_STATED_ID]['description']}"
+
+        assert "all rights reserved" not in text.lower()
+        # It must not read as a grant either — an unknown licence is not open.
+        for grant in ("public domain", "freely available", "may be reused without"):
+            assert grant not in text.lower(), grant
+
+    def test_the_base_requirement_is_still_satisfied(self) -> None:
+        """The whole point of an entity over an omission: crates stay conformant."""
+        from rocrate.rocrate import ROCrate
+
+        from builder.tools._crate_mapping import populate_crate
+        from profiles.validator import validate_crate_dict
+
+        state = CrateState()
+        state.metadata.title = "A crate"
+        crate = ROCrate()
+        populate_crate(state, crate, None, materialize_payload=False)
+        doc = crate.metadata.generate()
+
+        messages = [
+            issue.message
+            for result in validate_crate_dict(doc, severity="required", profile="base")
+            for issue in result.issues
+            if issue.severity == "required"
+        ]
+        assert not any("license" in m.lower() for m in messages), messages
+
+    def test_a_declared_licence_is_untouched(self) -> None:
+        root, by_id = self._root("https://creativecommons.org/licenses/by/4.0/")
+        assert root["license"] == {"@id": "https://creativecommons.org/licenses/by/4.0/"}
+        assert by_id["https://creativecommons.org/licenses/by/4.0/"]["name"]
+
+    def test_an_unstated_licence_never_counts_as_filled(self) -> None:
+        """It must not stop the loop asking for the real one.
+
+        The MIT scorer discounted the old placeholder string for exactly this
+        reason; the discount has to follow the value, not the spelling.
+        """
+        from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+        from builder.tools.mit_assessment import _nonempty, _placeholder_values
+
+        assert not _nonempty({"@id": LICENCE_NOT_STATED_ID})
+        assert LICENCE_NOT_STATED_ID.lower() in {v.lower() for v in _placeholder_values()}

--- a/tests/test_external_metadata_carry_through.py
+++ b/tests/test_external_metadata_carry_through.py
@@ -133,10 +133,32 @@ class TestTheLicenceSaysWhatItIs:
         assert root is not None
         assert root["license"] == "https://example.org/lab-terms"
 
-    def test_the_placeholder_stays_a_string(self):
-        root = _node(_doc(CrateState()), "./")
+    def test_an_unstated_licence_is_an_entity_that_says_so(self):
+        """Was ``test_the_placeholder_stays_a_string`` (#540).
+
+        The placeholder used to be the literal "ALL RIGHTS RESERVED BY THE
+        AUTHORS", and this pinned it staying a plain string rather than being
+        dressed up as a described licence entity — which was right, because
+        naming it as a licence would have made the invented claim look
+        deliberate.
+
+        It is no longer a claim to dress up: an unstated licence is now an
+        entity that states the absence, so it satisfies the base MUST while
+        asserting no terms at all. The distinction the original test protected
+        still holds — a real licence and an unstated one must never be
+        indistinguishable — and is asserted here on the new shape.
+        """
+        from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+
+        doc = _doc(CrateState())
+        root = _node(doc, "./")
         assert root is not None
-        assert root["license"] == "ALL RIGHTS RESERVED BY THE AUTHORS"
+        assert root["license"] == {"@id": LICENCE_NOT_STATED_ID}
+
+        entity = _node(doc, LICENCE_NOT_STATED_ID)
+        assert entity is not None
+        assert entity["@type"] == "CreativeWork"
+        assert "all rights reserved" not in entity["description"].lower()
 
     @pytest.mark.parametrize(
         ("url", "expected"),


### PR DESCRIPTION
Reopens and closes the substance of #540, by the route that survived scrutiny.

## The change

A crate whose depositor stated no terms used to assert:

```json
"license": "ALL RIGHTS RESERVED BY THE AUTHORS"
```

It now carries:

```json
"license": { "@id": "#licence-not-stated" }

{ "@id": "#licence-not-stated", "@type": "CreativeWork",
  "name": "Licence not stated",
  "description": "The depositor did not state licence terms for this dataset. This is
                  neither a grant of rights nor a restriction — the terms are simply
                  unknown. Ask the depositor before reusing this data." }
```

`license` is a base MUST, so the field cannot just be dropped — I measured that: **56 failures**, and every licence-less crate loses its base verdict. But answering the MUST with all-rights-reserved converts an unanswered question into the most restrictive claim available, asserted by machine over someone else's data. RO-Crate permits `license` to be a `CreativeWork`, so the crate satisfies the requirement while claiming nothing.

`LICENCE_NOT_STATED_ID` is exported so consumers branch on the id rather than string-matching English. A licence the depositor *did* state still wins, described when `describe_license` recognises it.

**Cost: 1 failure, versus 56 for omission.** Full suite **3080 passed, 0 failed**.

## The subtle part — please look here

Moving the placeholder from a string to an entity would have **silently broken the gap loop**. `_nonempty` counted any `{"@id": …}` as a real value, so an unstated licence would have started scoring as *filled* — and the loop would have stopped asking for the real one, which is the exact failure the discount exists to prevent. `_nonempty` now unwraps a single-key reference and checks the target:

```python
if isinstance(value, dict):
    if set(value) == {"@id"}:
        return _nonempty(value["@id"])
```

A placeholder is not made real by being modelled as an entity rather than a string.

## @mmarras — I edited one of your tests

`test_the_placeholder_stays_a_string` (yours, 08-12) pinned exactly the behaviour this changes. I rewrote it rather than deleted it, as `test_an_unstated_licence_is_an_entity_that_says_so`, keeping the distinction it was actually protecting — *a real licence and an unstated one must never be indistinguishable* — asserted on the new shape, with a docstring recording what it was and why. Please push back if you read that differently; this is the third time our work has met on this field.

## Also updated

- **The agent's own words.** `system_prompt.py` told users the crate "ships **ALL RIGHTS RESERVED BY THE AUTHORS**, the most restrictive option there is" — no longer true. Rewritten there and in three `agent_loop.py` prompts, keeping the point that unknown terms are still no use to a reuser.
- **AGENTS.md**: D13 gains the licence contract; the gap-analysis passage records that the discount is keyed on `LICENCE_NOT_STATED_ID` and why `_nonempty` unwraps references.
- The string is gone from `builder/` except the comment recording what replaced it.

## Background

#540 was originally closed on my incorrect claim that the default came from upstream. It does not — it appears in no installed package; `profiles/docs/isa.md` is a vendored draft no shape reads. #585 fixed the half that was purely wording (a `sh:message` prescribing a literal); this is the half that changes what the crate says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)