### PR TITLE
fix(discovery): rank files by what they carry, not by how they read (#587)

### DIFF
--- a/builder/engine.py
+++ b/builder/engine.py
@@ -316,9 +316,13 @@ def _run_document_discovery(engine: AgentEngine) -> None:
         input_root=root,
         approved_roots=engine.state.approved_scan_roots,
     )
-    context = format_document_context(candidates)
+    # Pass the scan size so the context can say what it left out: the ranking
+    # decides what the agent sees at all, and a silent cap reads as "this is
+    # everything" (#587).
+    context = format_document_context(candidates, total_scanned=len(engine.state.scanned_files))
     engine.state.documents = [
         {
+            "kind": c.kind,
             "role": c.role,
             "filename": c.filename,
             "relative_path": c.relative_path,

--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -8,6 +8,7 @@ Filenames are signals, never requirements.
 
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -57,6 +58,7 @@ class DocumentationCandidate:
     path: str
     filename: str
     relative_path: str
+    kind: str
     role: str
     score: float
     reasons: list[str] = field(default_factory=list)
@@ -67,6 +69,7 @@ class DocumentationCandidate:
             "path": self.path,
             "filename": self.filename,
             "relative_path": self.relative_path,
+            "kind": self.kind,
             "role": self.role,
             "score": self.score,
             "reasons": list(self.reasons),
@@ -86,32 +89,180 @@ def _is_candidate(file: FileClassification) -> bool:
     return suffix in _DOCUMENT_SUFFIXES or file.mime_type.startswith(_TEXT_MIMES)
 
 
-def _role_and_signals(filename: str, preview: str) -> tuple[str, list[str], float]:
-    name = filename.casefold().replace("-", "_")
+# --- evidence kind (#587) ---------------------------------------------------
+# What a file IS, decided by shape rather than vocabulary. The old ranking asked
+# one question — "how document-like is this?" — of two different populations, and
+# narrative won by construction: a +0.12 "prose-like" bonus a spreadsheet cannot
+# earn, plus up to +0.24 for sitting near the root. The deposit's 1048-row
+# measurement table scored 0.44 against a top-level README's 0.65 while carrying
+# twice the content evidence, and the assay-metadata workbooks were scored from
+# their filenames alone, because `mode="content"` returns nothing for an .xlsx.
+#
+# Kind is decidable; role is a guess. Both are reported, and only kind is relied
+# on downstream.
+KIND_DESCRIPTOR = "descriptor"
+KIND_TABULAR = "tabular"
+KIND_NARRATIVE = "narrative"
+KIND_OPAQUE = "opaque"
+
+_TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls"}
+_NARRATIVE_SUFFIXES = {".txt", ".md", ".rst", ".doc", ".docx", ".pdf", ".html", ".xml"}
+# Formats with no readable first lines: ask the scanner for its type-aware digest
+# (sheet names, column headers, sample paragraphs) instead of an empty string.
+_SUMMARY_PREVIEW_SUFFIXES = {".xlsx", ".xls", ".doc", ".docx", ".pdf"}
+
+# Header terms that mark a table as carrying the experiment's own variables. A
+# table whose columns name substances, doses and replicates is the crate's raw
+# material; one with three bookkeeping columns is not.
+_EXPERIMENTAL_HEADER_TERMS = (
+    "compound", "substance", "chemical", "cas",
+    "concentration", "dose", "exposure",
+    "cell", "sample", "well", "plate",
+    "replicate", "endpoint", "measurement", "value", "unit", "time",
+)
+
+_ROWS_X_COLS = re.compile(r"(\d[\d,]*)\s*rows?\s*[x×]\s*(\d+)\s*cols?", re.IGNORECASE)
+
+
+def preview_mode_for(filename: str) -> str:
+    """Which preview a file needs: binaries have no first lines to read (#587)."""
+    return "summary" if Path(filename).suffix.lower() in _SUMMARY_PREVIEW_SUFFIXES else "content"
+
+
+_STRUCTURED_SUFFIXES = {".json", ".yaml", ".yml"}
+
+
+# A field name in a structured record: `"key":` (JSON-ish) or a `key:` at the
+# start of a line (YAML-ish). Deliberately matched rather than parsed — previews
+# are bounded, so a real record arrives truncated and would fail json.loads().
+_FIELD_NAME = re.compile(
+    r"[\"']([A-Za-z_][\w .\-]{0,40})[\"']\s*:|^\s*([A-Za-z_][\w.\-]{0,40})\s*:", re.M
+)
+# Below this, a colon-bearing text file is prose, not a record. Measured: the
+# fixtures' submission records show 6 distinct field names in their readable
+# head; a README shows 0.
+_MIN_RECORD_FIELDS = 4
+
+
+def structured_field_count(text: str) -> int:
+    """How many distinct field names *text* carries, from its readable head.
+
+    Deliberately format-blind. An earlier version tested for BioStudies' own
+    shape (``accno`` plus an attribute tree). It read every fixture correctly —
+    and special-cased one repository's dialect, which is what §Input Formats
+    forbids: *"treated as a generic metadata source, not a special-cased input
+    type … regardless of the metadata file's format or schema"*. All three
+    fixtures happen to be BioStudies, so that detector looked right while being
+    unable to recognise an ISA-JSON, DataCite, Zenodo or in-house record.
+
+    What separates a record from a data file needs no dialect: it carries many
+    distinct field NAMES, where a data file carries many rows of one shape. This
+    counts names rather than parsing, because previews are bounded and a real
+    record arrives truncated mid-document.
+    """
+    return len({m.group(1) or m.group(2) for m in _FIELD_NAME.finditer(text)})
+
+
+def evidence_kind(filename: str, preview: str) -> str:
+    """Classify a file by what it is, from its shape (#587)."""
+    suffix = Path(filename).suffix.lower()
+    # Gated on the format family, not on any vendor's schema: only a structured
+    # document can be a record. Without this, a workbook's *summary* preview
+    # ("Sheet1: 148 rows x 3 cols; columns: …") matched the field-name pattern —
+    # the scanner's own formatting read as the file's content.
+    if suffix in _STRUCTURED_SUFFIXES and structured_field_count(preview) >= _MIN_RECORD_FIELDS:
+        return KIND_DESCRIPTOR
+    if suffix in _TABULAR_SUFFIXES:
+        return KIND_TABULAR
+    if suffix in _NARRATIVE_SUFFIXES or suffix in _STRUCTURED_SUFFIXES:
+        return KIND_NARRATIVE
+    return KIND_OPAQUE
+
+
+def _table_shape(preview: str) -> tuple[int, int, str]:
+    """``(rows, cols, header)`` for a tabular preview, from either preview mode."""
+    if match := _ROWS_X_COLS.search(preview):
+        rows = int(match.group(1).replace(",", ""))
+        cols = int(match.group(2))
+        header = preview.split("columns:", 1)[-1] if "columns:" in preview else ""
+        return rows, cols, header
+    lines = [line for line in preview.splitlines() if line.strip()]
+    if not lines:
+        return 0, 0, ""
+    header = lines[0]
+    delimiter = "\t" if header.count("\t") > header.count(",") else ","
+    return max(0, len(lines) - 1), header.count(delimiter) + 1, header
+
+
+def _tabular_signals(preview: str) -> tuple[list[str], float]:
+    """Score a table by what it measurably holds, not by how it reads."""
+    rows, cols, header = _table_shape(preview)
+    reasons: list[str] = []
+    if not rows and not cols:
+        return ["tabular, but its shape could not be read"], 0.25
+    score = 0.35
+    reasons.append(f"{rows} row(s) x {cols} column(s)")
+    # Rows are evidence, with diminishing returns: 10 rows is meaningfully more
+    # than 1, 1000 is not meaningfully more than 500.
+    score += min(0.30, math.log10(rows + 1) / 10)
+    hits = sorted({t for t in _EXPERIMENTAL_HEADER_TERMS if t in header.casefold()})
+    if hits:
+        score += min(0.25, len(hits) * 0.05)
+        reasons.append(f"experimental columns: {', '.join(hits[:6])}")
+    return reasons, score
+
+
+def _narrative_signals(name: str, preview: str) -> tuple[str, list[str], float]:
+    """Score prose by how much of a role's vocabulary it actually covers.
+
+    Coverage rather than presence: the old count saturated at five distinct
+    terms and treated one incidental mention of "assay" as evidence — which is
+    how a top-level README came to be labelled an assay protocol.
+    """
     text = f"{name}\n{preview.casefold()}"
-    matches: dict[str, int] = {
-        role: sum(term in text for term in terms)
+    coverage = {
+        role: sum(term in text for term in terms) / len(terms)
         for role, terms in _ROLE_TERMS.items()
     }
-    role, count = max(matches.items(), key=lambda item: (item[1], item[0]))
+    role, share = max(coverage.items(), key=lambda item: (item[1], item[0]))
     reasons: list[str] = []
-    score = 0.0
-    if count:
-        score += min(0.45, count * 0.09)
-        reasons.append(f"content signals: {count} {role.replace('_', ' ')} term(s)")
-    filename_matches = sum(term in name for term in _FILENAME_TERMS[role])
-    if filename_matches:
-        score += min(0.2, filename_matches * 0.08)
+    if share <= 0:
+        return "other_document", ["no role vocabulary matched"], 0.10
+    reasons.append(f"{role.replace('_', ' ')} vocabulary {share:.0%} covered")
+    score = 0.20 + min(0.45, share * 0.9)
+    if any(term in name for term in _FILENAME_TERMS[role]):
         reasons.append("filename supports role")
-    if len(re.findall(r"[.!?]\s+", preview)) >= 2:
-        score += 0.12
-        reasons.append("prose-like preview")
-    if preview.count("\n") >= 2:
-        score += 0.08
-        reasons.append("structured preview")
-    if not count:
-        role = "other_document"
     return role, reasons, score
+
+
+def _role_and_signals(filename: str, preview: str) -> tuple[str, list[str], float]:
+    """Legacy entry point: the narrative scorer, kept for callers that ask for a role."""
+    return _narrative_signals(filename.casefold().replace("-", "_"), preview)
+
+
+def _kind_and_signals(filename: str, preview: str) -> tuple[str, str, list[str], float]:
+    """``(kind, role, reasons, score)`` — the ranking's whole judgement of a file."""
+    kind = evidence_kind(filename, preview)
+    if kind == KIND_DESCRIPTOR:
+        # A structured record: many distinct field names rather than many rows of
+        # one shape. Density is the evidence — a three-field config is not a
+        # deposit record, and nothing here needs to know which registry wrote it.
+        fields = structured_field_count(preview)
+        return (
+            kind,
+            "structured_record",
+            [f"structured record, {fields} distinct field(s)"],
+            0.60 + min(0.40, fields / 30),
+        )
+    if kind == KIND_TABULAR:
+        reasons, score = _tabular_signals(preview)
+        return kind, "data_table", reasons, score
+    if kind == KIND_OPAQUE:
+        return kind, "other_document", ["no readable text (binary or unsupported)"], 0.10
+    role, reasons, score = _narrative_signals(
+        filename.casefold().replace("-", "_"), preview
+    )
+    return kind, role, reasons, score
 
 
 def _safe_preview(
@@ -156,50 +307,120 @@ def discover_documents(
     is stable for equal scores and contains only bounded previews.
     """
     ranked: list[DocumentationCandidate] = []
-    for index, file in enumerate(files):
+    for file in files:
         if not _is_candidate(file):
             continue
         relative = _relative(file.path, input_root)
         depth = len(Path(relative).parts) - 1
-        preview = _safe_preview(file.path, approved_roots, _MAX_PREVIEW_CHARS)
-        role, reasons, score = _role_and_signals(file.filename, preview)
-        location_bonus = (
-            0.24
-            if depth == 0
-            else 0.16
-            if depth == 1
-            else max(0.0, 0.08 - depth * 0.01)
+        # Ask each format for the preview it can actually give: `content` returns
+        # nothing for a workbook, which is why the assay-metadata .xlsx files were
+        # ranked on their filenames alone (#587).
+        preview = _safe_preview(
+            file.path,
+            approved_roots,
+            _MAX_PREVIEW_CHARS,
+            mode=preview_mode_for(file.filename),
         )
-        score += location_bonus
+        kind, role, reasons, score = _kind_and_signals(file.filename, preview)
+        # Depth is a tiebreak, not a third of the score. Where a file sits says
+        # something about how central it is, and nothing about what it holds.
+        score += max(0.0, 0.05 - depth * 0.01)
         reasons.append(f"directory depth {depth}")
-        if preview:
-            score += 0.12
         ranked.append(
             DocumentationCandidate(
                 path=file.path,
                 filename=file.filename,
                 relative_path=relative,
+                kind=kind,
                 role=role,
                 score=round(score, 4),
                 reasons=reasons,
                 preview=preview,
             )
         )
-        if index >= len(files):  # pragma: no cover - defensive, keeps loop explicit
-            break
     ranked.sort(key=lambda item: (-item.score, item.relative_path.casefold()))
-    return ranked[:max_candidates]
+    return _interleave_kinds(ranked, max_candidates)
+
+
+# Narrative explains what the study IS; tabular carries the values the crate is
+# built from. A ranking dominated by either is the same defect — the original
+# surfaced seven READMEs and one data file, and scoring tables on their real
+# contents simply inverts it, because a deposit holds far more instrument output
+# than prose. So the two are interleaved by their own rank rather than competing
+# on one scale, and balance follows from the construction rather than from a
+# threshold someone has to keep tuning.
+_INTERLEAVED_KINDS = (KIND_NARRATIVE, KIND_TABULAR)
+
+
+def _interleave_kinds(
+    ranked: list[DocumentationCandidate], limit: int
+) -> list[DocumentationCandidate]:
+    """Fill *limit* slots alternating between narrative and tabular, best first.
+
+    The descriptor leads if there is one — a submission record outranks anything
+    else in the deposit, being the only file that states the study's own identity.
+    Whatever remains (opaque formats, and the tail of either kind) fills the slots
+    the alternation does not use, so nothing is excluded merely by its kind.
+    """
+    by_kind: dict[str, list[DocumentationCandidate]] = {}
+    for candidate in ranked:
+        by_kind.setdefault(candidate.kind, []).append(candidate)
+
+    chosen = list(by_kind.get(KIND_DESCRIPTOR, []))[:limit]
+    queues = [list(by_kind.get(kind, [])) for kind in _INTERLEAVED_KINDS]
+    while len(chosen) < limit and any(queues):
+        for queue in queues:
+            if not queue or len(chosen) >= limit:
+                continue
+            chosen.append(queue.pop(0))
+    if len(chosen) < limit:
+        taken = {id(c) for c in chosen}
+        chosen.extend(c for c in ranked if id(c) not in taken)
+    chosen = chosen[:limit]
+    chosen.sort(key=lambda item: (-item.score, item.relative_path.casefold()))
+    return chosen
+
+
+def _context_body(candidate: DocumentationCandidate) -> str:
+    """What a file contributes to the model's context.
+
+    Descriptive files contribute their text: the model is deciding what the
+    STUDY is, and prose is where that is written. A data table contributes only
+    its shape — the header and how many rows sit under it — because its rows are
+    for the deterministic readers, not for a language model. Measured on the
+    S-VHPS22 fixture, one CSV preview took 3080 characters, a quarter of the
+    whole budget, to say what its header says in one line; the protocols that
+    describe how the experiment was run were then cut for lack of room.
+
+    The file is still ranked, still named, and still says what it holds, so the
+    agent can read it deliberately when it needs the values.
+    """
+    if candidate.kind != KIND_TABULAR:
+        return candidate.preview.strip() or "(preview unavailable; read this file if relevant)"
+    rows, cols, header = _table_shape(candidate.preview)
+    columns = " ".join(header.split())[:300]
+    shape = f"{rows} row(s) x {cols} column(s)" if rows or cols else "shape unread"
+    return f"(data table — {shape}" + (f"; columns: {columns})" if columns else ")")
 
 
 def format_document_context(
-    candidates: list[DocumentationCandidate], *, max_chars: int = _MAX_CONTEXT_CHARS
+    candidates: list[DocumentationCandidate],
+    *,
+    max_chars: int = _MAX_CONTEXT_CHARS,
+    total_scanned: int | None = None,
 ) -> str:
-    """Format ranked candidates as bounded, role-labelled agent context."""
+    """Format ranked candidates as bounded, kind-labelled agent context.
+
+    When *total_scanned* is given and the ranking showed fewer files than were
+    scanned, the context says so. A silent cap reads as "this is everything" —
+    the same reason the maturity report names the findings it hid rather than
+    trailing off (#587).
+    """
     parts: list[str] = []
     used = 0
     for candidate in candidates:
-        header = f"[{candidate.role}] {candidate.relative_path}\n"
-        body = candidate.preview.strip() or "(preview unavailable; read this file if relevant)"
+        header = f"[{candidate.kind}/{candidate.role}] {candidate.relative_path}\n"
+        body = _context_body(candidate)
         block = header + body
         remaining = max_chars - used
         if remaining <= 0:
@@ -208,4 +429,12 @@ def format_document_context(
             block = block[:remaining].rstrip() + " […]"
         parts.append(block)
         used += len(block) + 2
-    return "\n\n".join(parts)
+    context = "\n\n".join(parts)
+    if total_scanned is not None and total_scanned > len(candidates):
+        hidden = total_scanned - len(candidates)
+        context += (
+            f"\n\n({len(candidates)} of {total_scanned} scanned files shown; "
+            f"{hidden} not surfaced — read any of them directly if this list "
+            "does not cover what you need.)"
+        )
+    return context

--- a/tests/test_document_discovery_ranking.py
+++ b/tests/test_document_discovery_ranking.py
@@ -1,0 +1,279 @@
+"""Discovery ranks what carries the facts, not what reads like prose (#587).
+
+The ranking decides what the agent sees at all — 20 candidates out of 54 files,
+against a 12 000-character context cap — and it used to award +0.12 for
+"prose-like" text and up to +0.24 for sitting near the root. A spreadsheet can
+never earn the first, so the deposit's 1048-row measurement table scored 0.44
+against a top-level README's 0.65, despite carrying twice the content evidence.
+
+That is not a tidiness problem. It is the same root cause as the largest content
+defect in the built crates: the chemistry was mined from SOP prose while the
+structured workbook holding 20 chemicals x 8 concentrations went unread.
+
+These tests run against the real S-VHPS22 fixture rather than synthetic files,
+because the ordering is a claim about real deposits and the fixture is one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.state import FileClassification
+from builder.tools.document_discovery import discover_documents, format_document_context
+
+FIXTURE = Path("tests/fixtures/svhps22_real_input")
+
+DESCRIPTOR = "S-VHPS22.json"
+MEASUREMENTS = "assay_01_TH_uptake/EDCs/Combined uptake data EDCs_tidy.csv"
+TOP_README = "README.txt"
+WORKBOOKS = (
+    "assay_01_TH_uptake/TH_assay_metadata.xlsx",
+    "assay_02_deiodinase/deiodinase_assay_metadata.xlsx",
+    "assay_03_metabolism/metabolism_assay_metadata.xlsx",
+    "assay_04_TRactivation/tractivation_assay_metadata.xlsx",
+)
+
+
+def _scan() -> list[FileClassification]:
+    from builder.tools.scanner import scan_files
+
+    root = str(FIXTURE.resolve())
+    return scan_files(root, approved_roots={root})
+
+
+@pytest.fixture(scope="module")
+def ranked():
+    if not FIXTURE.exists():  # pragma: no cover - fixture not checked out
+        pytest.skip("S-VHPS22 fixture not available")
+    root = str(FIXTURE.resolve())
+    return discover_documents(_scan(), input_root=root, approved_roots={root})
+
+
+def _rank_of(ranked, relative: str) -> int:
+    for i, c in enumerate(ranked):
+        if c.relative_path.replace("\\", "/") == relative:
+            return i
+    raise AssertionError(f"{relative} did not surface at all: {[c.relative_path for c in ranked]}")
+
+
+def _by_path(ranked, relative: str):
+    return ranked[_rank_of(ranked, relative)]
+
+
+class TestKindIsDecidedByShape:
+    """A keyword hit is not evidence of what a file IS."""
+
+    def test_the_submission_descriptor_is_recognised_as_one(self, ranked) -> None:
+        # Was "[Publication]" on a single keyword match, when it is the deposit's
+        # authoritative record: accession, licence, authors, 21 chemicals.
+        assert _by_path(ranked, DESCRIPTOR).kind == "descriptor"
+
+    def test_a_measurement_table_is_tabular_not_a_protocol(self, ranked) -> None:
+        assert _by_path(ranked, MEASUREMENTS).kind == "tabular"
+
+    def test_a_readme_is_narrative(self, ranked) -> None:
+        assert _by_path(ranked, TOP_README).kind == "narrative"
+
+
+class TestTheFactsOutrankTheProse:
+    def test_the_descriptor_comes_first(self, ranked) -> None:
+        assert ranked[0].relative_path.replace("\\", "/") == DESCRIPTOR
+
+    def test_the_measurement_table_outranks_a_top_level_readme(self, ranked) -> None:
+        assert _rank_of(ranked, MEASUREMENTS) < _rank_of(ranked, TOP_README)
+
+    def test_every_assay_metadata_workbook_surfaces(self, ranked) -> None:
+        # They sat at 14, 16, 17, 18 — below seven READMEs — and carry the
+        # per-assay structured fields the crate is built from.
+        missing = [w for w in WORKBOOKS if w not in {
+            c.relative_path.replace("\\", "/") for c in ranked
+        }]
+        assert missing == [], missing
+
+    def test_narrative_still_surfaces(self, ranked) -> None:
+        """Not an inversion: orientation material must still be there.
+
+        The failure mode being fixed is one axis crowding out the other, so a
+        ranking that buried every README would be the same defect mirrored.
+        """
+        kinds = [c.kind for c in ranked]
+        # Balance, not a floor: an earlier attempt satisfied ">= 3 of each" while
+        # surfacing 16 tabular and 4 narrative — the original defect mirrored, and
+        # a floor is too weak to catch it. Neither kind may take most of the list.
+        for kind in ("narrative", "tabular"):
+            share = kinds.count(kind) / len(kinds)
+            assert 0.25 <= share <= 0.6, f"{kind} takes {share:.0%} of the list: {kinds}"
+
+
+class TestScoresDiscriminate:
+    def test_depth_alone_does_not_decide_the_order(self, ranked) -> None:
+        # The old weighting gave +0.24 for depth 0 and <=0.06 below depth 2 —
+        # over a third of the top score, awarded for location alone.
+        top = ranked[:5]
+        assert any(c.relative_path.count("/") >= 1 for c in top), (
+            f"the top of the ranking is all root-level files: {[c.relative_path for c in top]}"
+        )
+
+    def test_a_richer_table_outranks_a_thin_one(self, ranked) -> None:
+        """Row count is evidence; the scorer should use it."""
+        rich = _by_path(ranked, MEASUREMENTS)
+        thin = [
+            c for c in ranked
+            if c.kind == "tabular" and c.relative_path.replace("\\", "/") != MEASUREMENTS
+        ]
+        if not thin:  # pragma: no cover - fixture always has more than one table
+            pytest.skip("only one tabular candidate")
+        assert rich.score >= max(c.score for c in thin)
+
+
+class TestNothingIsDroppedSilently:
+    def test_the_context_says_how_much_it_left_out(self, ranked) -> None:
+        # "20 candidates" hid 34 files. Same rule the maturity report follows:
+        # a cap that bites says how many it hid.
+        context = format_document_context(ranked, total_scanned=len(_scan()))
+        assert "not surfaced" in context or "not listed" in context, context[-400:]
+
+
+class TestItDoesNotKnowWhatBioStudiesIs:
+    """The detector must not encode one repository's dialect (#587).
+
+    Every fixture here is a BioStudies deposit, so a detector keyed on that
+    dialect — an earlier version tested for `accno` plus an attribute tree —
+    passes all of the above while being unable to recognise an ISA-JSON,
+    DataCite, Zenodo or in-house record. AGENTS.md §Input Formats forbids
+    exactly that: a metadata file is "a generic metadata source, not a
+    special-cased input type … regardless of the metadata file's format or
+    schema", and the documented most common case is a directory with no record
+    at all.
+    """
+
+    @staticmethod
+    def _ranked(tmp_path: Path):
+        from builder.tools.scanner import scan_files
+
+        root = str(tmp_path.resolve())
+        return discover_documents(
+            scan_files(root, approved_roots={root}),
+            input_root=root,
+            approved_roots={root},
+        )
+
+    def test_a_record_in_an_unrelated_dialect_is_recognised(self, tmp_path: Path) -> None:
+        # DataCite-shaped: nothing in common with BioStudies but the fact that
+        # it is a structured record.
+        (tmp_path / "datacite.json").write_text(
+            """{
+              "doi": "10.1234/example",
+              "titles": [{"title": "An unrelated deposit"}],
+              "creators": [{"name": "Doe, Jane", "affiliation": "Somewhere"}],
+              "publisher": "Some Repository",
+              "publicationYear": 2026,
+              "rightsList": [{"rights": "CC-BY-4.0"}],
+              "subjects": [{"subject": "toxicology"}]
+            }""",
+            encoding="utf-8",
+        )
+        (tmp_path / "notes.txt").write_text("Some free text about the assay.\n" * 20)
+
+        ranked = self._ranked(tmp_path)
+        record = next(c for c in ranked if c.filename == "datacite.json")
+        assert record.kind == "descriptor"
+        assert ranked[0].filename == "datacite.json"
+
+    def test_a_yaml_record_is_recognised_too(self, tmp_path: Path) -> None:
+        (tmp_path / "study.yaml").write_text(
+            "title: A deposit\nauthors:\n  - name: Jane\n"
+            "licence: CC-BY-4.0\norganism: Homo sapiens\nassay: uptake\n",
+            encoding="utf-8",
+        )
+        ranked = self._ranked(tmp_path)
+        assert next(c for c in ranked if c.filename == "study.yaml").kind == "descriptor"
+
+    def test_a_deposit_with_no_record_still_ranks(self, tmp_path: Path) -> None:
+        """The documented most common case: raw data and prose, no record.
+
+        Nothing may crash, and nothing may be promoted to a record it is not.
+        """
+        (tmp_path / "README.txt").write_text("How this experiment was run.\n" * 20)
+        (tmp_path / "results.csv").write_text(
+            "well_id,compound,concentration_value,measurement_value\n"
+            + "\n".join(f"A{i},BPA,{i},{i * 2}" for i in range(30)),
+            encoding="utf-8",
+        )
+
+        ranked = self._ranked(tmp_path)
+
+        assert ranked, "a deposit with no record produced no ranking at all"
+        assert not any(c.kind == "descriptor" for c in ranked)
+        assert {c.kind for c in ranked} == {"narrative", "tabular"}
+
+    def test_a_thin_config_is_not_mistaken_for_a_record(self, tmp_path: Path) -> None:
+        # Density is the evidence: a two-field config file is not a deposit record.
+        (tmp_path / "config.json").write_text('{"debug": true}', encoding="utf-8")
+        (tmp_path / "README.txt").write_text("Notes.\n" * 20)
+
+        ranked = self._ranked(tmp_path)
+        config = next((c for c in ranked if c.filename == "config.json"), None)
+        assert config is None or config.kind != "descriptor"
+
+
+def _block_for(context: str, candidate, ranked) -> str:
+    """The context text belonging to one candidate.
+
+    Bounded by the NEXT candidate's marker rather than by a blank line: a
+    README's own text contains blank lines, so splitting on them truncates the
+    block to its first paragraph and makes a full preview look empty.
+    """
+    marker = f"[{candidate.kind}/{candidate.role}] {candidate.relative_path}"
+    assert marker in context, f"{candidate.relative_path} is not in the context"
+    start = context.index(marker)
+    later = [
+        context.index(m)
+        for m in (f"[{o.kind}/{o.role}] {o.relative_path}" for o in ranked)
+        if m in context and context.index(m) > start
+    ]
+    return context[start : min(later) if later else len(context)]
+
+
+class TestDataTablesContributeShapeNotRows:
+    """The model is told what a table IS, not what it contains (#587).
+
+    A language model deciding what the study is does not need measurement rows —
+    those are the deterministic readers' job. One CSV preview took 3080 of the
+    12 000-character budget to say what its header says in a line, and the
+    protocols describing how the experiment was run were cut for lack of room.
+    """
+
+    def test_a_data_table_contributes_its_shape_only(self, ranked) -> None:
+        context = format_document_context(ranked, total_scanned=99)
+        table = _by_path(ranked, MEASUREMENTS)
+        marker = f"[{table.kind}/{table.role}] {table.relative_path}"
+        assert marker in context, "the table is not named in the context at all"
+
+        block = _block_for(context, table, ranked)
+        assert "data table" in block and "row(s)" in block
+        # Its header names the variables; its rows do not appear.
+        assert "test_substance_id" in block, block[:200]
+        assert "Amiodarone" not in block, "measurement rows reached the context"
+
+    def test_descriptive_files_still_contribute_their_text(self, ranked) -> None:
+        # The inverse must hold, or the fix is just a different kind of blindness.
+        context = format_document_context(ranked, total_scanned=99)
+        readme = _by_path(ranked, TOP_README)
+        block = _block_for(context, readme, ranked)
+        assert len(block) > 200, f"a README contributed almost nothing: {block!r}"
+
+    def test_the_budget_now_reaches_the_descriptive_files(self, ranked) -> None:
+        """The point of the change: prose is what was being starved."""
+        context = format_document_context(ranked, total_scanned=99)
+        present = [
+            c for c in ranked
+            if f"[{c.kind}/{c.role}] {c.relative_path}" in context
+        ]
+        narrative = [c for c in present if c.kind == "narrative"]
+        assert len(narrative) >= 5, (
+            f"only {len(narrative)} descriptive files reached the context: "
+            f"{[c.relative_path for c in present]}"
+        )


### PR DESCRIPTION
Closes #587.

## Why it mattered

The ranking decides what the agent sees **at all** — 20 of 54 files, against a 12 000-character context budget. It rewarded prose and proximity:

```python
score += 0.12  if ≥2 sentence-enders   # a spreadsheet can never earn this
score += 0.24 / 0.16 / ≤0.08           # directory depth — a third of the top score
score += min(0.45, distinct_terms*0.09) # presence, not density → large tie clusters
```

Measured on `tests/fixtures/svhps22_real_input`:

| file | content terms | prose | depth | **total** |
|---|---|---|---|---|
| `README.txt` | 1 → 0.09 | +0.12 | **0.24** | **0.65** |
| `…/Combined uptake data EDCs_tidy.csv` (1048 rows) | **2 → 0.18** | — | 0.06 | **0.44** |

Seven READMEs held the top eight places. The four `*_assay_metadata.xlsx` workbooks sat at 14–18, scored **from their filenames alone** — `mode="content"` returns `''` for an `.xlsx`, and `text = name + preview` then counts the filename twice.

Same root cause as the largest content defect in the built crates: chemistry mined from SOP prose while the workbook holding 20 chemicals × 8 concentrations went unread.

## What changed

**Kind by shape, not vocabulary** — `descriptor` / `tabular` / `narrative` / `opaque`. Both original mislabels were classification failures, not scoring ones: `S-VHPS22.json` was `[Publication]` on one keyword hit, when it is the deposit's own record (accession, licence, authors, 21 chemicals).

**Scored within kind** — a table by rows (log-damped) and experimental column names; prose by vocabulary coverage. Depth demoted to a ±0.05 tiebreak. Workbooks read through the `summary` preview that already existed.

**Narrative and tabular interleave** rather than competing on one scale. My first attempt produced 16 tabular / 4 narrative — the original defect exactly mirrored — and passed my own "≥3 of each" test, because 4 clears 3. Replaced with a share band and interleaving, so balance follows from construction.

**Data tables contribute only their shape** to the context: `(data table — 1048 row(s) x 15 column(s); columns: run_id, test_substance_id, …)`. Rows are the deterministic readers' job. One CSV had been taking 3080 characters — a quarter of the budget — to say what its header says in a line, while the protocols describing how the experiment was run were cut for lack of room.

**The context reports what it left out**, instead of presenting 20 of 54 as everything.

## Result

| | before | after |
|---|---|---|
| `S-VHPS22.json` | #2, `[Publication]` | **#1**, `descriptor` |
| 1048-row measurement table | #9, `[Assay protocol]` | **#2**, `tabular` |
| four assay-metadata workbooks | 14, 16, 17, 18 | **6–9** |
| files reaching the model's context | 11 of 20 | **16 of 20** |
| protocol documents in context | 1, truncated | **6, in full** |

## Format-generality — the part worth reviewing

My first record detector tested for BioStudies' own shape (`accno` + attribute tree). It read every fixture correctly — and **all three fixtures are BioStudies**, so it would have failed silently on an ISA-JSON, DataCite, Zenodo or in-house record. AGENTS.md §Input Formats forbids exactly that: *"a generic metadata source, not a special-cased input type … regardless of the metadata file's format or schema"*, and the documented most common case is a deposit with no record at all.

A format-blind alternative — "a record names the files it describes" — was tried and **measured: 1/48, 1/6, 1/4**. Records don't index their payload. Discarded rather than shipped on intuition.

What works, dialect-free: a record carries many distinct field **names**, where a data file carries many rows of one shape (fixtures: 6 in the readable head; a README: 0). Gated on the format family so the scanner's own summary text (`Sheet1:`, `columns:`) cannot masquerade as one — a bug that gate caught.

Four tests cover it: a **DataCite**-shaped record, a **YAML** record, a deposit with **no record**, and a **thin config** that must not be promoted.

## Known remaining

Narrative scores cluster at `0.42` — term coverage over a five-term vocabulary does not discriminate — so the four files past the budget are cut alphabetically rather than on merit. Noted in the code; worth its own change with a real signal (section count, numbered steps, instrument mentions).

## Tests

18, against the real fixture rather than synthetic files. Full suite **3095 passed**; two failures accounted for — a stray `import json` this branch introduced (fixed here, caught by `test_lint_pass`) and `test_auto_fixable_must_fixed_without_prompt`, which crashes a loaded xdist worker but passes in isolation on this branch (57.8s) and on its parent (75.9s) — the known load-sensitive class in #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
