### PR TITLE
fix(pipeline): the design table is found by its rows, not by a label …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,8 +346,20 @@ workbook could only be one and lost the other. Its consumers are
 `composites._deposited_outputs` and `_deposit_evidences` (§5, *Derivation Chain
 Tools*), `provenance.attach_files` (which stamps it as the File's `role` unless
 the caller names one), the pipeline spine's `_attach_scanned_files`, the ReAct
-gap engine, and the maturity report's "data files included" row. The one holdout
-is the extraction leaf's `condition_table` plan role (#594).
+gap engine, and the maturity report's "data files included" row.
+
+The last holdout, the extraction leaf's `condition_table` plan role, is gone too
+(#594) — but NOT by folding it into the classification. Which file is the design
+table is not what a file IS: measured over the three real deposits the only table
+that qualifies is svhps22's tidy per-condition export, classified
+`processed_data_file` because it carries the measured value alongside the design,
+while the same content is `metadata` as `plate_map.csv` and `raw_data_file` as
+`conditions.csv`. The spine asks the rows instead, through
+`data_content.condition_table_fit` — a well key AND columns that map onto the
+canonical schema. That is the same predicate `populate_condition_table` must
+satisfy to write anything, so what is detected and what is writable cannot
+disagree. The plan's whole `files` array is retired with it: nothing read it once
+the role went.
 
 `File.role` is the *stamp*, not the classification. It is free text — `draft_file`
 records whatever the agent passes, and the spine stamped `raw_data`/`processed_data`

--- a/builder/agents/pipeline/leaves.py
+++ b/builder/agents/pipeline/leaves.py
@@ -228,7 +228,7 @@ _PLAN_SYSTEM_PROMPT = (
     "and connections the documents support: the study, test/control compounds, "
     "cell lines, the CellCulture -> Exposure -> EndpointReadout -> DataAnalysis "
     "process chain, AOPs (only if an AOP id is explicitly stated), people, "
-    "publications, and files. This is a PROPOSAL for the user to confirm, not "
+    "and publications. This is a PROPOSAL for the user to confirm, not "
     "committed truth. Propose ONLY what the documents support; leave any field "
     "you cannot support empty and record ambiguities or things the user should "
     "confirm in 'notes'. "
@@ -416,32 +416,15 @@ def _plan_schema() -> dict[str, Any]:
                 {"title": {**str_field, "description": "Publication title only (no DOI)."}},
                 required=["title"],
             ),
-            "files": _array_of(
-                {
-                    "path": {**str_field, "description": "File path or name."},
-                    # The last vocabulary #591 did not absorb. Three of these
-                    # four values are answered better by the file classification
-                    # (`metadata`/`protocol`/`raw_data_file`/`processed_data_file`,
-                    # read from the file's own content); the fourth has no home
-                    # in it, because a plate map classifies as `metadata`. Only
-                    # `condition_table` is read — by
-                    # `_populate_condition_table_from_plan` — and replacing it
-                    # needs a content-first detector rather than a lookup (#594).
-                    "role": {
-                        "type": "string",
-                        "enum": ["raw", "processed", "condition_table", "other"],
-                        "description": (
-                            "What kind of data file this is. `condition_table` "
-                            "means a per-well experimental DESIGN table or plate "
-                            "map — rows or grid cells per well giving compound, "
-                            "concentration, duration. A metadata or parameter "
-                            "template (Parameter/Value sheets) is `other`, never "
-                            "`condition_table`."
-                        ),
-                    },
-                },
-                required=["path"],
-            ),
+            # NO `files` array (#594). It carried `path` plus a
+            # raw/processed/condition_table/other `role`, and both are gone: the
+            # role was a label a cheap model assigned from filenames it was shown
+            # in a listing, and the spine now finds the design table by trying the
+            # projection on the deposit's own tables — the same predicate
+            # `populate_condition_table` must satisfy to write anything, so what
+            # is detected and what is writable cannot disagree. With the role
+            # retired nothing read `path` either, so asking for the array at all
+            # was tokens spent inviting a model to invent paths.
             "notes": {
                 **str_field,
                 "description": (

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1194,6 +1194,61 @@ def _scanned_path_for_name(
     return None
 
 
+_DESIGN_TABLE_SUFFIXES = frozenset({".csv", ".tsv", ".tab", ".xlsx", ".xlsm"})
+
+
+def _design_table_candidates(
+    engine: AgentEngine,
+) -> tuple[list[tuple[int, int, str]], list[tuple[str, str]]]:
+    """Scanned tables that read as a per-condition design table, best first (#594).
+
+    Every scanned table is tried, not the ones classified `metadata`. The class
+    says what a file IS and cannot scope this search: measured over the three real
+    deposits the only table that passes is svhps22's tidy per-condition export,
+    which is `processed_data_file` — it carries one row per well AND the value
+    measured there, so it is genuinely derived data and genuinely the design
+    table. The same content classifies `metadata` as `plate_map.csv` and
+    `raw_data_file` as `conditions.csv`, so the name decides the class while only
+    the rows decide this.
+
+    Reading is fail-closed to ``approved_scan_roots`` — the same guard
+    :func:`_scanned_path_for_name` applies, for the same reason.
+
+    Returns:
+        ``(candidates, unreadable)`` — ``[(wells, mapped_columns, path)]`` sorted
+        best first, and ``[(path, error)]`` for tables no reader could open.
+        Candidates are usually empty: two of the three real deposits carry no
+        such table at all.
+
+        The unreadable list is kept separate and reported, because a table that
+        reads fine and is simply not per-condition is the ordinary case — most
+        tables in a submission are measurements — while one that cannot be opened
+        is the failure #422 exists to stop hiding behind a header-only export.
+    """
+    from pathlib import Path, PurePath
+
+    from builder.tools.data_content import condition_table_fit_of
+    from builder.tools.scanner import _contain
+
+    roots = engine.state.approved_scan_roots
+    found: list[tuple[int, int, str]] = []
+    unreadable: list[tuple[str, str]] = []
+    for f in engine.state.scanned_files:
+        name = f.filename or PurePath(f.path).name
+        if PurePath(name).suffix.lower() not in _DESIGN_TABLE_SUFFIXES:
+            continue
+        if _contain(f.path, roots) is None:
+            logger.debug("Scanned file %s is outside approved scan roots — refusing.", f.path)
+            continue
+        wells, mapped, error = condition_table_fit_of(Path(f.path))
+        if wells:
+            found.append((wells, mapped, f.path))
+        elif error:
+            unreadable.append((f.path, error))
+    found.sort(reverse=True)
+    return found, unreadable
+
+
 def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
     """Path of the scanned PDF a plan publication *title* refers to, or ``None``.
 
@@ -1269,22 +1324,29 @@ def _fall_back_to_proposal(
     return primary
 
 
-def _populate_condition_table_from_plan(
-    engine: AgentEngine, plan: dict[str, Any], exposure_id: str
+def _populate_condition_table_from_deposit(
+    engine: AgentEngine, exposure_id: str
 ) -> dict[str, Any]:
-    """Write the plan's ``condition_table`` file into the Exposure's CSV (#408).
+    """Write the deposit's design table into the Exposure's CSV (#408, #594).
 
-    The extraction leaf classifies every plan file into
-    ``raw``/``processed``/``condition_table``/``other``, and the spine reads that
-    answer here rather than re-deriving one — an earlier version derived a role
-    from the filename and could only ever return raw or processed, so
-    ``condition_table`` was unreachable and every exported table shipped
-    header-only while the per-well payload sat beside it as an untyped ``File``.
+    Which file is the design table is a question its ROWS answer. It used to be
+    answered by a ``condition_table`` label the extraction leaf assigned from a
+    filename listing — the last vocabulary outside the one file classification
+    (#591), and a guess made before anything was read. A file mislabelled ``raw``
+    shipped a header-only table while its per-well payload sat on disk.
 
-    This plan role is the last consumer of a vocabulary other than the one file
-    classification (#591): a plate map classifies as ``metadata``, so finding
-    which metadata file IS the plate map has to become the same content-first
-    question — a metadata table carrying one row per well. Tracked in #594.
+    Every scanned table is now tried against :func:`~builder.tools.data_content.
+    condition_table_fit`: does it carry a well key AND columns that map onto the
+    canonical schema? That is the same predicate ``populate_condition_table``
+    must satisfy to write anything, so what is detected and what is writable
+    cannot disagree — which a separate filename heuristic would eventually let
+    them do.
+
+    The file CLASS cannot scope this search, though it is tempting: measured over
+    the three real deposits the only table that passes is svhps22's tidy
+    per-condition export, classified ``processed_data_file`` because it carries
+    the measured value alongside the design. The same content is ``metadata`` as
+    ``plate_map.csv`` and ``raw_data_file`` as ``conditions.csv``.
 
     Deterministic and conservative:
 
@@ -1311,44 +1373,67 @@ def _populate_condition_table_from_plan(
         result carrying ``proposed`` / ``fallback_from``. Surfaced in
         :func:`_materialize_plan`'s result so it reaches ``run_pipeline``.
     """
-    entries = [f for f in (plan.get("files") or []) if isinstance(f, dict)]
-    candidates = [e for e in entries if str(e.get("role") or "").strip() == "condition_table"]
+    from pathlib import PurePath
+
+    candidates, unreadable = _design_table_candidates(engine)
     if not candidates:
-        # The user supplied no plate map. Rather than shipping a header-only
-        # table beside compounds it should have named, PROPOSE the design from
-        # what the crate already knows (#438) — compound identity, cell line and
-        # assay are entities, so restating them asserts nothing new. Anything the
-        # crate never states stays blank and comes back as a question for the
-        # human; no concentration is ever invented.
-        return _propose_condition_table(engine, exposure_id)
-    if len(candidates) > 1:
-        # Deliberately NO proposal fallback here (#422): several claimed plate
-        # maps is genuine ambiguity a human must settle — synthesizing rows
-        # while real design tables sit unread would paper over the question.
-        names = ", ".join(sorted(str(c.get("path") or "?") for c in candidates))
-        return {
-            "populated": False,
-            "reason": f"{len(candidates)} condition_table candidates ({names}) — refusing to guess",
-        }
-
-    named = str(candidates[0].get("path") or "").strip()
-    if not named:
-        return _fall_back_to_proposal(
-            engine,
-            exposure_id,
-            {"populated": False, "reason": "the condition_table entry carries no path"},
-        )
-
-    path = _scanned_path_for_name(engine, named)
-    if path is None:
+        # No table in the deposit carries per-condition rows. This is the ORDINARY
+        # case, not the edge — two of the three real deposits are like this — so
+        # rather than ship a header-only table the design is PROPOSED from what
+        # the crate already states (#438): compound identity, cell line and assay
+        # are entities, so restating them asserts nothing new. Anything the crate
+        # never states stays blank and comes back as a question for the human; no
+        # concentration is ever invented.
+        #
+        # Routed through the same fallback as every other unusable outcome so the
+        # provenance survives either way (#422): on success the rows carry
+        # `fallback_from`, and if the proposal ALSO fails this reason survives as
+        # the primary with the proposal's own alongside it.
+        if unreadable:
+            # A table that could not be OPENED is a different fact from one that
+            # read fine and simply is not per-condition, and #422 exists because
+            # the two used to be indistinguishable while the crate shipped a
+            # header-only table either way. Name the files, loudly.
+            names = ", ".join(sorted(PurePath(path).name for path, _ in unreadable))
+            logger.warning(
+                "Condition table: %d scanned table(s) could not be READ (%s); "
+                "proposing from crate entities instead (#422).",
+                len(unreadable),
+                names,
+            )
+            return _fall_back_to_proposal(
+                engine,
+                exposure_id,
+                {
+                    "populated": False,
+                    "reason": f"{len(unreadable)} table(s) could not be read ({names})",
+                    "read_failed": True,
+                },
+            )
         return _fall_back_to_proposal(
             engine,
             exposure_id,
             {
                 "populated": False,
-                "reason": f"{named!r} matches no scanned file inside the approved scan roots",
+                "reason": "no scanned table carries per-condition rows "
+                "(a well key and a column that maps onto the schema)",
             },
         )
+
+    if len(candidates) > 1:
+        # Deliberately NO proposal fallback here (#422): several tables that each
+        # read as the design is genuine ambiguity a human must settle —
+        # synthesizing rows while real design tables sit unread would paper over
+        # the question. Measured over the three real deposits this does not fire:
+        # svhps22 has exactly one such table and the other two have none.
+        names = ", ".join(sorted(PurePath(c[2]).name for c in candidates))
+        return {
+            "populated": False,
+            "reason": f"{len(candidates)} design-table candidates ({names}) — refusing to guess",
+        }
+
+    _wells, _mapped, path = candidates[0]
+    named = PurePath(path).name
 
     try:
         outcome = engine.run_tool(
@@ -1508,14 +1593,13 @@ def _materialize_plan(
       ``process_chain``, each plan step's ``name`` is overlaid onto the matching
       ``process_type`` so the two paths share ONE chain (no duplicate processes).
       This runs even with NO provider, so the crate is never structurally hollow.
-    * **condition table (#408).** The ONE plan file classified
-      ``role == "condition_table"`` is written into the Exposure's typed CSVW table
-      via ``populate_condition_table``
-      (:func:`_populate_condition_table_from_plan`) — the leaf already emits that
-      role and the spine used to discard it, so every crate declared a ten-column
-      ``csvw:Table`` and shipped it header-only. Zero or several candidates → the
-      spine records why and writes nothing rather than guess. The outcome is
-      surfaced on this function's result.
+    * **condition table (#408, #594).** The ONE scanned table whose rows carry a
+      well key and map onto the canonical schema is written into the Exposure's
+      typed CSVW table via ``populate_condition_table``
+      (:func:`_populate_condition_table_from_deposit`). Several such tables → the
+      spine records why and writes nothing rather than guess; none → the design is
+      proposed from what the crate already states (#438). The outcome is surfaced
+      on this function's result.
     * **scanned files — ALWAYS, regardless of provider (#262).** Every
       ``engine.state.scanned_files`` entry is added as a ``File`` entity and placed
       under the scaffolded Assay (else Study) ``hasPart`` via the idempotent
@@ -1760,8 +1844,8 @@ def _materialize_plan(
     # no compound resolved. ---
     exposure_for_table = (chain_by_type.get("Exposure") or {}).get("process_id")
     if exposure_for_table:
-        result["condition_table"] = _populate_condition_table_from_plan(
-            engine, plan, str(exposure_for_table)
+        result["condition_table"] = _populate_condition_table_from_deposit(
+            engine, str(exposure_for_table)
         )
     else:
         result["condition_table"] = {

--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -622,7 +622,63 @@ def reference_cell_allowlist(state: CrateState, entity_type: str) -> list[str]:
 # rather than failing in a way that reads like "the plate map was unusable".
 
 _TEXT_TABLE_SUFFIXES: dict[str, str] = {".csv": ",", ".tsv": "\t", ".tab": "\t"}
+
+# A workbook that opened fine and simply holds no per-condition sheet. Reported
+# through the same `error` channel as a genuine read failure because
+# `populate_condition_table`'s caller asked for ONE named file and either way got
+# nothing — but the two are not the same fact, and #594's search over every
+# scanned table has to tell them apart or it calls a deposit's whole workbook
+# collection unreadable (20 of svhps22's tables, every one of them fine).
+_NO_QUALIFYING_SHEET = "no sheet has both a mapped condition-table column and a well_id"
 _EXCEL_SUFFIXES: frozenset[str] = frozenset({".xlsx", ".xlsm"})
+
+
+def condition_table_fit(rows: Sequence[Mapping[str, Any]]) -> tuple[int, int]:
+    """How well *rows* serve as a condition table: ``(wells, mapped_columns)``.
+
+    ``(0, 0)`` means they do not. A design table is one that carries a well key
+    AND columns that map onto the canonical schema — a table with wells but no
+    mapped column describes nothing, and one with mapped columns but no well key
+    is not per-condition.
+
+    This is the ONE plate-map test (#594). It is the same predicate
+    :func:`populate_condition_table` has to satisfy to write anything, so
+    "this file is the design table" and "this file can be written" cannot
+    disagree — which a separate filename-and-header heuristic would eventually
+    let them do, in the way the four file vocabularies #591 replaced did.
+
+    Sorting by the pair prefers the table describing more wells, and breaks a tie
+    on how much of the schema it fills.
+    """
+    projection = project_condition_rows(rows)
+    wells = sum(1 for r in projection["rows"] if _has_value(r.get("well_id")))
+    mapped = len(projection["mapped_columns"])
+    return (wells, mapped) if wells and mapped else (0, 0)
+
+
+def condition_table_fit_of(src: Path) -> tuple[int, int, str | None]:
+    """:func:`condition_table_fit` for a file on disk, plus any READ error.
+
+    Returns ``(wells, mapped, error)``. The error is reported separately from the
+    fit because the two are different facts about a deposit: a table that reads
+    fine and simply is not per-condition is the ordinary case — most tables in a
+    submission are measurements — while one that cannot be OPENED is a problem
+    the depositor should hear about, and #422 exists because those two used to be
+    indistinguishable.
+
+    Never raises: a deposit holds workbooks no reader can open, and one of them
+    must not stop the search.
+    """
+    try:
+        rows, _reader, error, _sheet = _rows_from_file(src)
+    except Exception as exc:  # noqa: BLE001 - an unreadable file is not the table
+        return (0, 0, str(exc))
+    if error:
+        # "Opened fine, holds no per-condition sheet" is an ordinary answer to
+        # this search, not a failure to report — most tables in a submission are
+        # measurements.
+        return (0, 0, None) if error.startswith(_NO_QUALIFYING_SHEET) else (0, 0, error)
+    return (*condition_table_fit(rows), None) if rows else (0, 0, None)
 
 
 def _rows_from_file(
@@ -663,20 +719,16 @@ def _rows_from_file(
             tried.append(f"{name} ({', '.join(list(rows[0])[:6]) if rows else 'empty'})")
             if not rows:
                 continue
-            projection = project_condition_rows(rows)
-            wells = sum(1 for r in projection["rows"] if _has_value(r.get("well_id")))
-            mapped = len(projection["mapped_columns"])
-            if not mapped or not wells:
+            wells, mapped = condition_table_fit(rows)
+            if not wells:
                 continue
-            score = (wells, mapped)
-            if best is None or score > (best[0], best[1]):
+            if best is None or (wells, mapped) > (best[0], best[1]):
                 best = (wells, mapped, name, rows)
         if best is None:
             return (
                 [],
                 reader_name,
-                "no sheet has both a mapped condition-table column and a well_id; "
-                "tried " + "; ".join(tried),
+                _NO_QUALIFYING_SHEET + "; tried " + "; ".join(tried),
                 None,
             )
         return list(best[3]), reader_name, None, best[2]

--- a/tests/agents/test_leaves.py
+++ b/tests/agents/test_leaves.py
@@ -138,27 +138,41 @@ class TestDrafterTier:
         assert rec["calls"][0].get("model") == "gpt-4o-mini"
 
 
-class TestConditionTableRoleGuidance:
-    """#422: the plan schema must define what a ``condition_table`` IS.
+def _plan_schema_properties() -> dict[str, Any]:
+    from builder.agents.pipeline.leaves import _plan_schema
 
-    The real S-VHPS26 mislabel: with the role described only as "What kind of
-    data file this is.", the leaf labelled a Parameter|Value assay-metadata
-    template ``condition_table``, and the populator was handed a file that can
-    never map. The enum description is the leaf's ONLY definition of the term —
-    it must say per-well design/plate map and steer templates to ``other``.
+    return _plan_schema()["properties"]
+
+
+class TestTheLeafIsNotAskedToLabelFiles:
+    """The plan cannot mislabel a file it is never asked about (#594).
+
+    #422 came from the real S-VHPS26 mislabel: the leaf called a Parameter|Value
+    assay-metadata template a ``condition_table`` and the populator was handed a
+    file that can never map. The fix then was to DEFINE the term better in the
+    enum's description, and a test pinned that wording — a prompt guard against a
+    model's judgement, which is the weakest kind there is.
+
+    The question is gone instead. Which file is the design table is decided by
+    reading rows (``data_content.condition_table_fit``), so there is no label to
+    get wrong. This asserts the schema stays that way: re-adding a files array
+    would restore the failure mode the wording was defending against.
     """
 
-    def test_role_description_defines_condition_table_and_steers_templates(self) -> None:
+    def test_the_plan_schema_asks_for_no_files(self) -> None:
         from builder.agents.pipeline.leaves import _plan_schema
 
-        role = _plan_schema()["properties"]["files"]["items"]["properties"]["role"]
-        desc = str(role.get("description") or "").lower()
-        assert "per-well" in desc or "per well" in desc, (
-            "the description must define condition_table as a per-well design table"
+        assert "files" not in _plan_schema()["properties"], (
+            "the plan must not ask the leaf to classify files — the deposit's "
+            "rows answer that (#594)"
         )
-        assert "template" in desc and "other" in desc, (
-            "metadata/parameter templates must be steered to the `other` role"
-        )
+
+    def test_the_leaf_still_proposes_the_entities_it_is_for(self) -> None:
+        """Control: removing `files` must not have emptied the schema."""
+        properties = _plan_schema_properties()
+
+        for expected in ("study", "compounds", "cell_lines", "publications"):
+            assert expected in properties, f"the plan lost {expected!r}"
 
 
 class TestStructuredOutput:

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -3617,6 +3617,52 @@ class TestConditionTableFromPlan:
         assert "Thyroxine" in "\n".join(rows)
         assert result.get("condition_table")
 
+    def test_the_plate_map_is_found_when_the_plan_never_names_it(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The deposit answers, not the plan (#594).
+
+        The plan role is a label a model assigned in advance from a filename it
+        was shown; whether a file IS the design table is a question its content
+        answers. Here the plan names no file at all — as a real extraction
+        routinely leaves it — and the table is still populated, from the one
+        scanned table whose rows carry well ids and map onto the canonical
+        columns.
+
+        ``Thyroxine`` is the discriminator: it appears only in the CSV on disk.
+        The #438 proposal builds rows from what the crate already knows, and this
+        plan states no compound, so a proposal cannot produce that name.
+        """
+        state, _ = self._state(tmp_path)
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(monkeypatch, state, [])
+
+        table = self._table_path(engine)
+        assert table is not None and table.is_file(), "no condition table was written"
+        body = table.read_text(encoding="utf-8")
+        assert len(body.strip().splitlines()) > 1, "still header-only"
+        assert "Thyroxine" in body, (
+            "the rows did not come from the deposit's table — a proposal cannot "
+            "know that compound"
+        )
+        assert not (result.get("condition_table") or {}).get("proposed")
+
+    def test_a_deposit_with_no_design_table_still_falls_back_to_the_proposal(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Zero candidates keeps the #438 behaviour, not a new refusal.
+
+        Two of the three real deposits carry no table that maps onto the
+        condition-table columns at all, so this is the common path, not the edge.
+        """
+        state, _ = self._state(tmp_path, name="notes.csv", body="a,b\n1,2\n")
+        state.metadata.output_path = str(tmp_path / "crate")
+        engine, result = self._run(monkeypatch, state, [])
+
+        assert not (result.get("condition_table") or {}).get("populated"), (
+            "a table with no well ids must not be read as the design table"
+        )
+
     def test_the_model_can_only_return_a_basename_so_an_exact_path_would_never_fire(
         self, monkeypatch, tmp_path: Path
     ) -> None:
@@ -3686,13 +3732,26 @@ class TestConditionTableFromPlan:
         assert not outcome.get("populated"), "two candidates — the spine must not guess"
         assert outcome.get("reason"), "the refusal must be recorded, not silent"
 
-    def test_no_condition_table_role_records_a_reason(self, monkeypatch, tmp_path: Path) -> None:
+    def test_a_wrong_plan_role_no_longer_suppresses_a_real_design_table(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """The inversion #594 is for: the plan is wrong and the deposit wins.
+
+        This file IS a per-condition design table — well ids, compound,
+        concentration. The plan calls it ``raw``, which is exactly the mistake a
+        model makes when it is shown filenames and asked to label them in
+        advance. That label used to be the whole answer, so one bad guess shipped
+        a header-only table while the rows sat on disk.
+        """
         state, _ = self._state(tmp_path)
         state.metadata.output_path = str(tmp_path / "crate")
         engine, result = self._run(monkeypatch, state, [{"path": self._PLATE, "role": "raw"}])
+
         outcome = result.get("condition_table") or {}
-        assert not outcome.get("populated")
-        assert outcome.get("reason")
+        assert outcome.get("populated"), f"the plan's wrong label still won: {outcome}"
+        assert not outcome.get("proposed"), "these rows must come from the file, not a proposal"
+        table = self._table_path(engine)
+        assert table is not None and "Thyroxine" in table.read_text(encoding="utf-8")
 
     # -- #422: an unusable candidate must not beat having no candidate at all --
 

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -1032,3 +1032,69 @@ class TestPayloadLayerRunsOnThePipelineArm:
         assert issues
         assert all(i["profile"] == "data" for i in issues)
         assert all(i["profile"] not in {"base", "isa", "tox"} for i in issues)
+
+
+class TestAWorkbookThatIsSimplyNotTheDesignTable:
+    """"Opened fine, holds no per-condition sheet" is not a read failure (#594).
+
+    ``_rows_from_file`` reports both through its ``error`` channel, which was
+    harmless while a caller named ONE file and either way got nothing. Searching
+    every scanned table for the design table makes the difference load-bearing:
+    read as failures, svhps22's twenty perfectly good workbooks would fire the
+    #422 "could not READ" warning and put a false ``read_failed`` on the result.
+    """
+
+    @staticmethod
+    def _measurements(path) -> None:
+        import openpyxl
+
+        book = openpyxl.Workbook()
+        sheet = book.active
+        sheet.title = "Readings"
+        sheet.append(["timepoint", "absorbance", "operator"])
+        sheet.append([0, 0.412, "AB"])
+        sheet.append([30, 0.688, "AB"])
+        book.save(path)
+
+    def test_it_reports_no_error(self, tmp_path) -> None:
+        from builder.tools.data_content import condition_table_fit_of
+
+        book = tmp_path / "readings.xlsx"
+        self._measurements(book)
+
+        wells, mapped, error = condition_table_fit_of(book)
+
+        assert (wells, mapped) == (0, 0), "a measurement sheet is not a design table"
+        assert error is None, f"a readable workbook must not be reported as failed: {error}"
+
+    def test_a_workbook_that_cannot_be_opened_still_does(self, tmp_path) -> None:
+        """The control: the #422 signal must survive the distinction above."""
+        from builder.tools.data_content import condition_table_fit_of
+
+        broken = tmp_path / "plate_map.xlsx"
+        broken.write_text("this is not a workbook", encoding="utf-8")
+
+        wells, mapped, error = condition_table_fit_of(broken)
+
+        assert (wells, mapped) == (0, 0)
+        assert error, "an unopenable workbook must still be reported"
+
+    def test_a_real_plate_map_still_wins(self, tmp_path) -> None:
+        """The other control: the predicate still finds the design table."""
+        import openpyxl
+
+        from builder.tools.data_content import condition_table_fit_of
+
+        book = tmp_path / "design.xlsx"
+        wb = openpyxl.Workbook()
+        wb.active.title = "Cover"
+        wb.active.append(["Depositor", "Lab X"])
+        plate = wb.create_sheet("Plate map")
+        plate.append(["well_id", "compound", "concentration_value", "concentration_unit"])
+        plate.append(["A1", "BPA", 10.0, "uM"])
+        wb.save(book)
+
+        wells, mapped, error = condition_table_fit_of(book)
+
+        assert error is None
+        assert wells == 1 and mapped >= 3

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -573,31 +573,25 @@ class TestRealInputPipeline:
             "the LabProtocol must be linked to a LabProcess"
         )
 
-    def test_a_mislabelled_metadata_workbook_still_yields_a_populated_table(
+    def test_a_deposit_with_no_design_table_still_yields_a_populated_one(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """#422 acceptance, on the genuine fixture: the real leaf labels the
-        assay-metadata workbook ``condition_table``. The tool reads it (#469's
-        Excel intake) and correctly refuses — it is a Parameter|Value template
-        with no per-well rows — and the spine must then fall back to the #438
-        proposal built from the entities the SAME plan materialized, landing
-        real rows: ``condition_table.populated is True`` on the real deposit."""
-        import builder.agents.pipeline.pipeline as pipeline_mod
+        """#422/#438 acceptance on the genuine fixture: S-VHPS26 ships no plate map.
+
+        Its only workbook is a Parameter|Value assay-metadata template — no
+        per-well rows — so nothing in the deposit reads as a design table and the
+        spine must PROPOSE one from the entities the same run materialized,
+        landing real rows rather than a header-only export.
+
+        This used to inject a plan entry labelling that workbook
+        ``condition_table``, reproducing the leaf's real mislabel, because the
+        label was what selected the file. Since #594 nothing reads it — the rows
+        decide — so the injection is gone rather than kept as inert scaffolding
+        that would make this pass for a reason that no longer exists.
+        """
         from builder.agents.pipeline.pipeline import run_pipeline
 
         _install_offline_seams(monkeypatch)
-        base = pipeline_mod.extract_plan
-
-        def plan_with_the_real_mislabel(
-            context: str, *, overrides: Any = None, usage_sink: Any = None
-        ) -> dict[str, Any]:
-            plan = base(context, overrides=overrides, usage_sink=usage_sink)
-            plan.setdefault("files", []).append(
-                {"path": _METADATA_XLSX_NAME, "role": "condition_table"}
-            )
-            return plan
-
-        monkeypatch.setattr(pipeline_mod, "extract_plan", plan_with_the_real_mislabel)
         engine = _scanning_engine(FIXTURE_DIR)
         result = run_pipeline(engine)
 

--- a/tests/test_process_chain_deposited_outputs.py
+++ b/tests/test_process_chain_deposited_outputs.py
@@ -22,7 +22,7 @@ fixtures do not share one convention:
 
 A folder-name rule that only reads "raw" would hand every processed file in
 those two deposits to the EndpointReadout. So a directory naming both tiers
-resolves to neither, on the ``_populate_condition_table_from_plan`` precedent
+resolves to neither, on the ``_populate_condition_table_from_deposit`` precedent
 (#408) of refusing to guess between ambiguous candidates.
 """
 


### PR DESCRIPTION
…(#594)

Which scanned file holds the experiment's design was decided by a `role` the extraction leaf assigned from a listing of FILENAMES, before anything was read. `condition_table` won; `raw`, `processed` and `other` lost. A file mislabelled `raw` shipped a header-only table while its per-well payload sat on disk one directory away — and the label was a guess made from a name, which is the one thing about a table that tells you nothing about its rows.

Every scanned table is now tried against `data_content.condition_table_fit`: does it carry a well key AND columns that map onto the canonical schema? That is the same predicate `populate_condition_table` has to satisfy to write anything, so what is DETECTED and what is WRITABLE cannot disagree. A separate filename and header heuristic would eventually let them, the way the four file vocabularies #591 replaced did — that lesson, applied to the holdout #591 left behind.

THE CLASS CANNOT SCOPE THE SEARCH, though #594 was filed saying it would. Over the three real deposits the only table that qualifies is svhps22's tidy per-condition export, classified `processed_data_file` because it carries the measured value alongside the design. The same content is `metadata` as `plate_map.csv` and `raw_data_file` as `conditions.csv`: the name decides the class, only the rows decide this. A `metadata`-scoped search finds nothing at all on any deposit we have.

Measured: svhps22 resolves to one candidate (1048 wells, 7 mapped columns) and populates; svhps21 and svhps26 have none and propose from crate entities (#438). The several-candidates refusal (#408) never fires spuriously, because ambiguity at this level is not what real deposits look like.

READ FINE BUT NOT PER-CONDITION is not a read failure. `_rows_from_file` reports both through one `error` channel, which was harmless while a caller named ONE file and either way got nothing. Searching every table makes it load-bearing: twenty of svhps22's perfectly good workbooks came back "unreadable", which would have fired the #422 loud warning and put a false `read_failed` on the result of every run. The two are named apart now, and 0 of 66 files across the three deposits reports a read failure.

RETIRED: the plan's whole `files` array, not just its `role`. Nothing read `path` once the role went, so asking for it was tokens spent inviting a model to invent paths. `_populate_condition_table_from_plan` becomes `_populate_condition_table_from_deposit` and no longer takes the plan.

A test that pinned the WORDING of the retired enum's description goes with it, replaced by the structural claim it was reaching for: the plan must not ask the leaf to classify files at all. Guarding a prompt against a model's judgement is the weakest guard there is, and there is now nothing to misjudge. A real-input test that injected the S-VHPS26 mislabel is stripped of that injection rather than left as scaffolding — nothing reads the label now, so it would have passed identically with its whole setup deleted, which is a green test measuring nothing.

Every invariant survives. Zero candidates falls back to the #438 proposal, several refuses and says so (#408), a table that cannot be opened falls back loudly (#422), and `populate_condition_table` stays the only writer — the zero-candidate path is routed through `_fall_back_to_proposal` rather than straight to the proposal, so `fallback_from` and `proposal_reason` keep meaning what they meant. One test is inverted rather than deleted: it asserted that a plan role of `raw` suppresses the table, which is precisely what this retires.