### PR TITLE
perf(discovery): sample a folder of instrument output instead of opening it (#598)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,26 @@ is built from must not depend on what fits in a context window.
 before #591, or any caller holding the inventory without the deposit mounted)
 from the record alone, without touching the disk.
 
+Stamping every file does not mean OPENING every file (#598). A deposit is a
+handful of homogeneous folders, not N distinct things — svhps22's 1468 scanned
+files fall into 149 `(directory, extension)` groups, the largest holding 84
+gamma-counter printouts. So files are grouped that way, a spread sample of each
+group is read, and a group whose sample agrees takes that verdict across the
+rest. The sample is spread rather than taken from the front, because a folder
+sorted by run date puts its exception at the end as often as at the start. A
+group is opened in full when it is smaller than four times the sample — below
+that the saving is a rounding error and the cost is not — when its sample
+DISAGREES, which is what says the folder is heterogeneous and cannot be
+summarised at all, or when the sample is anything but `raw_data_file`.
+Instrument output is the only tier whose files are interchangeable, and it is
+92% of the deposit; a propagated file has no preview, and a workbook with no
+preview is ranked on its filename alone, which is the defect #587 fixed. What
+this cannot see is a file whose CONTENT alone makes it an exception in the
+interior of a large uniform folder. On the three real deposits that costs
+nothing — all 1622 files keep the class a full read gives them and every
+top-20 ranking is unchanged — while svhps22's classification pass drops from
+1468 reads to 324, about ten times faster.
+
 This replaced four disagreeing vocabularies. Two of them labelled FORM ("this is
 a table") and two labelled FUNCTION ("this is metadata"), so a tabular metadata
 workbook could only be one and lost the other. Its consumers are

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -314,8 +314,10 @@ def _run_document_discovery(engine: AgentEngine) -> None:
 
     # Classify EVERY scanned file before ranking any of them (#591). The ranking
     # exists to fill a bounded prompt and shows 20 of them; what the crate is
-    # built from must not depend on what fits in a context window. The previews
-    # are handed on so the deposit is read once.
+    # built from must not depend on what fits in a context window. Every file is
+    # stamped, but not every file is opened — a folder of interchangeable
+    # instrument output is sampled (#598). The previews are handed on so the
+    # deposit is read once.
     previews = classify_scanned_files(
         engine.state.scanned_files,
         input_root=root,

--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -486,6 +486,53 @@ def classification_of(file: FileClassification, *, input_root: str = "") -> str:
     return classify_file(file.filename, preview, _relative(file.path, input_root))[0]
 
 
+# How many files of a folder are opened to decide what the folder holds (#598).
+# A deposit is a handful of homogeneous groups, not N distinct things: svhps22's
+# 1468 scanned files fall into 149 `(directory, extension)` groups, the largest
+# holding 84 gamma-counter printouts. Opening one of those says what the other
+# 83 are; opening all 84 costs 84 PDF parses to learn nothing. Three leaves that
+# deposit reading 324 of its 1468 files, and every file of the other two.
+_EXEMPLARS_PER_GROUP = 3
+
+# The one class a folder may be summarised into. Instrument output is what makes
+# a deposit big and what makes its files interchangeable: 1358 of svhps22's 1468
+# files, and a gamma-counter printout says nothing its 83 siblings did not. The
+# other three tiers are read in full however large the folder, because a
+# propagated file has no preview, and a workbook with no preview is ranked on
+# its filename alone — the defect #587 fixed.
+_SUMMARISABLE_CLASSES = frozenset({CLASS_RAW_DATA})
+
+# How big a folder must be before summarising it is worth being blind to the
+# rest of it — four times the sample. Below that the saving is a rounding error
+# and the cost is real: svhps26 files six per-plate workbooks per run directory,
+# and summarising those cost eight of the twenty ranked slots while saving 20
+# reads of 91. Measured across 4..48, the deposits are flat between 4 and 32
+# (svhps22: 292 to 392 reads of 1468) and collapse at 48, where its own
+# printout folders start falling under the floor.
+_MIN_SUMMARISABLE_GROUP = 4 * _EXEMPLARS_PER_GROUP
+
+
+def _group_key(file: FileClassification) -> tuple[str, str]:
+    """What makes two scanned files the same kind of thing: one folder, one format."""
+    name = file.filename or Path(file.path).name
+    return str(Path(file.path).parent), Path(name).suffix.lower()
+
+
+def _exemplar_indexes(size: int, count: int) -> list[int]:
+    """*count* indexes spread evenly across ``range(size)``, both ends included.
+
+    Spread rather than the first *count*: a folder sorted by run date puts its
+    exception at the end as often as at the front, and a sample that never
+    reaches the last file cannot see it.
+    """
+    if size <= count:
+        return list(range(size))
+    if count <= 1:
+        return [0]
+    step = (size - 1) / (count - 1)
+    return sorted({round(i * step) for i in range(count)})
+
+
 def classify_scanned_files(
     files: list[FileClassification], *, input_root: str, approved_roots: set[str]
 ) -> dict[str, str]:
@@ -495,18 +542,61 @@ def classify_scanned_files(
     candidates because its job is filling a bounded prompt, and what gets wired
     into the crate must not depend on what fits in a context window.
 
+    Not every file is OPENED, though (#598). Files are grouped by containing
+    directory and extension, :data:`_EXEMPLARS_PER_GROUP` files spread across
+    each group are read, and a group whose sample agrees takes that verdict
+    across the rest without touching them. A group is opened in full when it is
+    under :data:`_MIN_SUMMARISABLE_GROUP`, when its sample DISAGREES — the
+    folder is heterogeneous and cannot be summarised — or when the sample lands
+    on anything but :data:`_SUMMARISABLE_CLASSES`.
+
+    What this cannot see is a file whose CONTENT alone makes it an exception,
+    sitting in the interior of a large uniform folder: nothing about its name,
+    extension or directory sets it apart, so only opening it would tell. On the
+    three real deposits it costs nothing — every one of 1622 files keeps the
+    class a full read gives it, and every top-20 ranking is unchanged — while
+    svhps22 drops from 1468 reads to 324, about ten times faster.
+
     Returns:
-        ``{path: preview}``, so the ranking that follows reads each file once.
+        ``{path: preview}`` for every file, so the ranking that follows reads
+        none of them again. A file the sample spoke for maps to ``""``: it has
+        no preview, and the empty string is what stops :func:`discover_documents`
+        from opening the deposit a second time to find one.
     """
     previews: dict[str, str] = {}
-    for file in files:
+
+    def read_and_stamp(file: FileClassification) -> str:
         preview = _safe_preview(
             file.path, approved_roots, _MAX_PREVIEW_CHARS, mode=preview_mode_for(file.filename)
         )
         previews[file.path] = preview
-        file.classification = classify_file(
-            file.filename, preview, _relative(file.path, input_root)
-        )[0]
+        decided = classify_file(file.filename, preview, _relative(file.path, input_root))[0]
+        file.classification = decided
+        return decided
+
+    groups: dict[tuple[str, str], list[FileClassification]] = {}
+    for file in files:
+        groups.setdefault(_group_key(file), []).append(file)
+
+    for group in groups.values():
+        group.sort(key=lambda file: file.path)
+        sampled = set(_exemplar_indexes(len(group), _EXEMPLARS_PER_GROUP))
+        verdicts = {read_and_stamp(group[index]) for index in sampled}
+        rest = [file for index, file in enumerate(group) if index not in sampled]
+        if not rest:
+            continue
+        if (
+            len(group) < _MIN_SUMMARISABLE_GROUP
+            or len(verdicts) > 1
+            or not verdicts <= _SUMMARISABLE_CLASSES
+        ):
+            for file in rest:
+                read_and_stamp(file)
+            continue
+        agreed = next(iter(verdicts))
+        for file in rest:
+            previews[file.path] = ""
+            file.classification = agreed
     return previews
 
 
@@ -614,8 +704,11 @@ def discover_documents(
     remain eligible: assay SOPs and publications are often nested.  The result
     is stable for equal scores and contains only bounded previews.
 
-    *previews* are the reads :func:`classify_scanned_files` already made, keyed
-    by path; supplying them keeps the deposit read once rather than twice.
+    *previews* are what :func:`classify_scanned_files` already read, keyed by
+    path; supplying them keeps the deposit read once rather than twice. An entry
+    is present but empty for a file that classification summarised rather than
+    opened (#598) — which is what stops this from opening it after all, and
+    leaves it ranked and rendered like any other file with no readable preview.
     """
     ranked: list[DocumentationCandidate] = []
     for file in files:

--- a/tests/test_file_classification.py
+++ b/tests/test_file_classification.py
@@ -440,3 +440,241 @@ class TestClassifyingTheWholeDeposit:
         file.classification = CLASS_PROCESSED_DATA
 
         assert classification_of(file, input_root="/deposit") == CLASS_PROCESSED_DATA
+
+
+# A derived table, decided by its own headers rather than by where it sits:
+# `_TIDY_TABLE` needs its `_tidy` filename to place it, and these tests are
+# about folders whose files are named only by a run number.
+_SUMMARY_TABLE = (
+    "test_substance,concentration_uM,replicate_mean,replicate_sd,"
+    "normalised_response,ic50\n"
+    "amiodarone,10,0.82,0.04,0.61,3.4"
+)
+# svhps22's SOP prose, which classifies on the procedure vocabulary alone.
+_SOP_PROSE = (
+    "Standard operating procedure for the uptake assay. Materials and methods: "
+    "incubate the plate for 60 minutes at 37 C, then wash twice and pipette "
+    "200 uL of lysis buffer into each well."
+)
+
+
+def _write(root: Path, relative: str, text: str) -> FileClassification:
+    """One scanned file on disk, as the scanner would have inventoried it."""
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return FileClassification(
+        path=str(path), filename=path.name, size=path.stat().st_size, mime_type="text/plain"
+    )
+
+
+def _classify_all(root: Path, files: list[FileClassification]) -> dict[str, str]:
+    classify_scanned_files(
+        files, input_root=str(root), approved_roots={str(root.resolve())}
+    )
+    return {f.path: f.classification or "" for f in files}
+
+
+@pytest.fixture
+def opened(monkeypatch) -> list[str]:
+    """Every path classification actually read off the disk."""
+    import builder.tools.document_discovery as discovery
+
+    seen: list[str] = []
+    real = discovery._safe_preview
+
+    def counting(path, *args, **kwargs):
+        seen.append(path)
+        return real(path, *args, **kwargs)
+
+    monkeypatch.setattr(discovery, "_safe_preview", counting)
+    return seen
+
+
+class TestSamplingAFolderInsteadOfOpeningIt:
+    """A deposit is a handful of homogeneous folders, not N distinct things (#598).
+
+    Classifying svhps22 opened all 1468 scanned files to learn that 1358 of them
+    were the same gamma-counter printout. Those 1468 fall into 149
+    ``(directory, extension)`` groups, the largest holding 84 PDFs: opening one
+    of those tells you what the other 83 are, and opening all 84 costs 84 PDF
+    parses to learn nothing.
+
+    Coverage is what must not change — every file still carries a class (#591).
+    Only how that class is DERIVED does.
+    """
+
+    def test_the_reads_do_not_grow_with_the_folder(self, tmp_path, opened):
+        """The sample is a fixed cost, not a share of the folder."""
+
+        def folder(name: str, count: int) -> int:
+            root = tmp_path / name
+            files = [_write(root, f"raw data/{n:03d}.csv", _COUNTER_EXPORT) for n in range(count)]
+            opened.clear()
+            _classify_all(root, files)
+            return len(opened)
+
+        for_twenty = folder("a", 20)
+
+        assert folder("b", 200) == for_twenty, "ten times the folder cost ten times the reads"
+        assert for_twenty < 20, f"nothing was saved: {for_twenty} reads for 20 files"
+
+    def test_every_file_still_carries_a_class(self, tmp_path):
+        files = [_write(tmp_path, f"raw data/{n:03d}.csv", _COUNTER_EXPORT) for n in range(80)]
+
+        _classify_all(tmp_path, files)
+
+        assert all(f.classification == CLASS_RAW_DATA for f in files)
+
+    def test_a_folder_smaller_than_the_sample_is_opened_in_full(self, tmp_path, opened):
+        files = [_write(tmp_path, f"raw data/{n}.csv", _COUNTER_EXPORT) for n in range(2)]
+
+        _classify_all(tmp_path, files)
+
+        assert len(opened) == 2
+
+    @pytest.mark.parametrize("odd_at", [0, 40, 79], ids=["first", "middle", "last"])
+    def test_a_folder_whose_sample_disagrees_is_opened_in_full(self, tmp_path, opened, odd_at):
+        """Disagreement means the folder is heterogeneous and cannot be summarised.
+
+        The odd file is planted at each end as well as the middle, because a
+        sample taken as "the first three" would never reach the last one — and
+        a deposit sorted by date puts the exception at the end as often as not.
+        """
+        texts = [_COUNTER_EXPORT] * 80
+        texts[odd_at] = _SUMMARY_TABLE
+        files = [_write(tmp_path, f"raw data/{n:03d}.csv", t) for n, t in enumerate(texts)]
+
+        classes = _classify_all(tmp_path, files)
+
+        assert classes[files[odd_at].path] == CLASS_PROCESSED_DATA
+        assert len(opened) == 80, "a folder that disagrees with itself was still sampled"
+
+    def test_a_folder_of_protocols_is_opened_in_full(self, tmp_path, opened):
+        """Only instrument output is summarised, however large the folder.
+
+        The first build steps run on the metadata and the protocols, and a
+        propagated file has no preview to give them — on svhps22 those two
+        classes are 36 files of 1468, so reading every one costs nothing.
+        """
+        files = [_write(tmp_path, f"protocols/sop_{n}.txt", _SOP_PROSE) for n in range(12)]
+
+        classes = _classify_all(tmp_path, files)
+
+        assert set(classes.values()) == {CLASS_PROTOCOL}
+        assert len(opened) == 12
+
+    def test_a_folder_of_derived_workbooks_is_opened_in_full(self, tmp_path, opened):
+        """Only instrument output is summarised.
+
+        svhps26 files six per-plate workbooks in each run directory. Summarising
+        those cost eight of the twenty ranked slots — a propagated file has no
+        preview, and a workbook with no preview is ranked on its filename alone,
+        which is the defect #587 fixed — while saving 20 reads of 91.
+        """
+        files = [_write(tmp_path, f"analysis/{n:03d}.csv", _SUMMARY_TABLE) for n in range(40)]
+
+        classes = _classify_all(tmp_path, files)
+
+        assert set(classes.values()) == {CLASS_PROCESSED_DATA}
+        assert len(opened) == 40
+
+    @pytest.mark.parametrize(
+        ("size", "expect_full"), [(11, True), (12, False)], ids=["under", "at"]
+    )
+    def test_a_folder_too_small_to_be_worth_it_is_opened_in_full(
+        self, tmp_path, opened, size, expect_full
+    ):
+        """Four times the sample, below which the saving is a rounding error."""
+        files = [_write(tmp_path, f"raw data/{n:03d}.csv", _COUNTER_EXPORT) for n in range(size)]
+
+        _classify_all(tmp_path, files)
+
+        assert (len(opened) == size) is expect_full, f"{len(opened)} reads for {size} files"
+
+    def test_two_folders_are_not_one_sample(self, tmp_path):
+        raw = [_write(tmp_path, f"raw data/{n:03d}.csv", _COUNTER_EXPORT) for n in range(40)]
+        derived = [_write(tmp_path, f"analysis/{n:03d}.csv", _SUMMARY_TABLE) for n in range(40)]
+
+        classes = _classify_all(tmp_path, raw + derived)
+
+        assert {classes[f.path] for f in raw} == {CLASS_RAW_DATA}
+        assert {classes[f.path] for f in derived} == {CLASS_PROCESSED_DATA}
+
+    def test_two_extensions_in_one_folder_are_not_one_sample(self, tmp_path):
+        """An extension is what makes a folder's files the same kind of thing."""
+        counters = [_write(tmp_path, f"mixed/{n:03d}.csv", _COUNTER_EXPORT) for n in range(40)]
+        notes = [_write(tmp_path, f"mixed/sop_{n:03d}.txt", _SOP_PROSE) for n in range(40)]
+
+        classes = _classify_all(tmp_path, counters + notes)
+
+        assert {classes[f.path] for f in counters} == {CLASS_RAW_DATA}
+        assert {classes[f.path] for f in notes} == {CLASS_PROTOCOL}
+
+
+class TestSamplingAgreesWithOpeningEverything:
+    """The classes must not move on the real deposits (#598).
+
+    Asserted as a property rather than a frozen list: the same files are
+    classified twice, once sampled and once with the sample large enough to
+    cover every folder, and the two must agree. A committed baseline would
+    answer a narrower question and go stale the first time the classifier
+    learns something.
+    """
+
+    FIXTURES = (
+        Path("tests/fixtures/svhps21_real_input"),
+        Path("tests/fixtures/svhps22_real_input"),
+        Path("tests/fixtures/svhps26_real_input"),
+    )
+
+    def _scan(self, root: Path) -> list[FileClassification]:
+        from builder.tools.scanner import scan_files
+
+        return scan_files(str(root.resolve()), approved_roots={str(root.resolve())})
+
+    @pytest.mark.parametrize("fixture", FIXTURES, ids=lambda p: p.name)
+    def test_the_sample_reaches_the_same_verdict_as_the_full_read(self, fixture, monkeypatch):
+        import builder.tools.document_discovery as discovery
+
+        if not fixture.exists():  # pragma: no cover - fixture not checked out
+            pytest.skip(f"{fixture} not available")
+
+        sampled = _classify_all(fixture, self._scan(fixture))
+        monkeypatch.setattr(discovery, "_EXEMPLARS_PER_GROUP", 10_000)
+        in_full = _classify_all(fixture, self._scan(fixture))
+
+        assert sampled == in_full
+        assert sampled, f"{fixture} scanned nothing"
+
+    def test_a_content_only_exception_in_a_summarised_folder_is_the_accepted_cost(
+        self, tmp_path, monkeypatch
+    ):
+        """The one case sampling cannot see, pinned so it stays deliberate.
+
+        The fixtures above are trimmed and hold no folder large enough to
+        summarise, so their agreement is nearly free. This is the case they
+        cannot cover, and the honest answer is that a full read wins it: a
+        derived table in the interior of 80 identical printouts, whose name,
+        extension and directory all say raw and only whose CONTENT does not.
+
+        Three things keep it narrow — the sample reaches both ends and the
+        middle, a folder under four times the sample is never summarised, and
+        only instrument output ever is. On the three real deposits it costs
+        nothing: all 1622 files keep the class a full read gives them.
+        """
+        import builder.tools.document_discovery as discovery
+
+        texts = [_COUNTER_EXPORT] * 80
+        texts[63] = _SUMMARY_TABLE
+        files = [_write(tmp_path, f"raw data/{n:03d}.csv", t) for n, t in enumerate(texts)]
+
+        sampled = _classify_all(tmp_path, files)
+        monkeypatch.setattr(discovery, "_EXEMPLARS_PER_GROUP", 10_000)
+        in_full = _classify_all(tmp_path, files)
+
+        assert in_full[files[63].path] == CLASS_PROCESSED_DATA
+        assert sampled[files[63].path] == CLASS_RAW_DATA, "the blind spot moved"
+        assert {p: c for p, c in sampled.items() if p != files[63].path} == {
+            p: c for p, c in in_full.items() if p != files[63].path
+        }, "and it is confined to that one file"


### PR DESCRIPTION
Closes #598.

Classification opened **every** scanned file to stamp it. On S-VHPS22 that is
1468 files and ~70s of parsing before the agent has done anything — to learn
that 1358 of them are the same gamma-counter printout.

## What changed

Those 1468 files fall into **149 `(directory, extension)` groups**, the largest
holding 84 printouts. Files are now grouped that way, three spread across each
group are read, and a group whose sample agrees takes that verdict across the
rest without opening them.

A group is still opened in full when:

| rule | why |
|---|---|
| under **4× the sample** | below that the saving is a rounding error and the cost is not |
| its sample **disagrees** | that is what says the folder is heterogeneous and cannot be summarised |
| its sample is anything but **`raw_data_file`** | instrument output is the only tier whose files are interchangeable |

The sample is **spread** across the group rather than taken from the front: a
folder sorted by run date puts its exception at the end as often as at the start.

## Measured against a full read, on the three real deposits

| deposit | files | full | sampled | classes differing | top-20 ranking |
|---|---|---|---|---|---|
| S-VHPS21 | 63 | 63 reads / 0.3s | 63 reads / 0.4s | **0** | identical |
| S-VHPS22 | 1468 | 1468 reads / 82.0s | **324 reads / 8.3s** | **0** | identical |
| S-VHPS26 | 91 | 91 reads / 7.1s | 91 reads / 6.8s | **0** | identical |

Coverage is unchanged (#591): every scanned file still carries a class. Only how
that class is derived moves.

## Two rules came out of measurement, not design

- **Only raw is summarisable.** The first cut summarised any agreeing class. Zero
  classes changed — but four `.xlsx` swapped out of svhps22's top 20, because a
  propagated file has no preview and a workbook with no preview is ranked on its
  filename alone. That is the defect #587 fixed.
- **The 4× floor.** svhps26 files six per-plate workbooks per run directory;
  summarising those cost 8 of 20 ranked slots to save 20 reads of 91. Swept
  4..48: flat from 4 to 32 (svhps22: 292 → 392 reads), collapses at 48 where its
  own printout folders fall under the floor.

## On the baseline

#598 asks for the full-read result as the baseline to diff against. The real
deposits are gitignored, so a baseline derived from them cannot be reproduced in
CI. Instead the test classifies the same files **twice** — sampled, then with the
sample large enough to cover every folder — and asserts the two agree. It runs
everywhere and cannot go stale when the classifier learns something.

## The boundary, stated rather than implied

Sampling cannot see a file whose **content alone** makes it an exception in the
interior of a large uniform folder: nothing about its name, extension or
directory sets it apart. `test_a_content_only_exception_in_a_summarised_folder_is_the_accepted_cost`
pins it, so a change to that trade-off has to be deliberate. It costs nothing on
the three real deposits.

## Verification

Four mutations of the implementation each fail 1–3 of the new tests:

| mutation | tests failing |
|---|---|
| no sampling (exemplars = everything) | 3 |
| no floor | 1 |
| sample the first *n* instead of spreading | 2 |
| any agreeing class may be summarised | 2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
