### PR TITLE
fix(validation): assert the ISA backbone reaches what the crate mints (#537)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,9 @@ CrateState {
         # whether anything actually looked at the crate's FILES (#530) — the
         # in-memory gate validates a document, where payload checks emit nothing
         payload_checked: bool,
+        # whether anything asked which entities the ISA backbone reaches (#537) —
+        # the profile's own rules cannot, so a detached entity is skipped not failed
+        isa_reachability_checked: bool,
         input_fingerprint: str,
     },
     mit_assessment: { module_scores: { m: { completed, total } }, overall_score },
@@ -1787,6 +1790,23 @@ write could never reach the report shipping inside the crate — and files what 
 issues, so the existing rendering flips the header verdict without knowing this check exists.
 `payload_checked` records that something looked; a verdict where nothing did says so rather than
 implying a clean sheet it did not earn.
+
+**A rule that infers its own target cannot fail on a missing edge (#537).** The ISA shapes mint
+their target class *from* the very edge whose absence is the defect: `FindISAProcesses` stamps
+`isa-ro-crate:Process` only on a `bioschemas:LabProcess` some Dataset already points at, and
+`ProcessMustBeReferencedFromDataset` then targets that inferred class — so a process nothing
+references never earns the label, the rule written to catch exactly this defect has no target, and
+every rule keyed to the class goes silent with it. 11 of the profile's 12 shape files are built this
+way, and our `tox/7_assay_key_event.ttl` rides on `isa-ro-crate:Assay`, so the blind spot is
+general: a missing structural edge switches off the whole rule-set for that layer, and the crate
+reports conformant precisely when its structure is most broken. The upstream shapes are not ours to
+restructure, so `verify_isa_reachability` asserts the invariant on our side, the one way an absent
+edge cannot game — an entity nothing points at is detached, whatever the profile could evaluate.
+Reachability here is **directed**: `provenance_dag.build_crate_graph` already flags orphans, but
+over an *undirected* walk, where a process pointing at the files it produced counts as connected
+though nothing points at it. Entities named by an absolute URI are described here and live
+elsewhere, the same line `verify_payload` draws. `isa_reachability_checked` records that something
+asked.
 
 **Every finding folds out of the severity row it belongs to** (#510). Severity is the primary axis
 because it is the fix order — REQUIRED blocks the build, the advisory tiers do not — so a tier row

--- a/builder/state.py
+++ b/builder/state.py
@@ -671,6 +671,12 @@ class ValidationReport:
             payload — "is every declared Data Entity present?" — emit nothing
             there, and their silence must not be read as a pass (#530). False on
             a verdict that only ever saw the metadata.
+        isa_reachability_checked: Whether anything asked which structural
+            entities the ISA backbone actually reaches. The profile's own rules
+            cannot ask — they target a class that is only minted once the
+            reference exists, so a detached entity is skipped rather than
+            failed, and the silence reads as a pass (#537). False on a verdict
+            that never looked.
         input_fingerprint: :meth:`CrateState.validation_fingerprint` as it was
             when this verdict was recorded — the answer to "does this verdict
             still describe the crate?". Empty means unknown (a report restored
@@ -687,6 +693,7 @@ class ValidationReport:
     stale_tier_counts: dict[str, int] = field(default_factory=dict, repr=False)
     issue_records: list[dict[str, str]] = field(default_factory=list)
     payload_checked: bool = False
+    isa_reachability_checked: bool = False
     input_fingerprint: str = ""
 
     def is_stale_for(self, state: CrateState) -> bool:
@@ -711,6 +718,7 @@ class ValidationReport:
             "assessed_tiers": sorted(self.assessed_tiers),
             "issue_records": [dict(r) for r in self.issue_records],
             "payload_checked": self.payload_checked,
+            "isa_reachability_checked": self.isa_reachability_checked,
             "input_fingerprint": self.input_fingerprint,
         }
 
@@ -726,6 +734,7 @@ class ValidationReport:
             assessed_tiers=set(data.get("assessed_tiers", [])),
             issue_records=data.get("issue_records", []),
             payload_checked=data.get("payload_checked", False),
+            isa_reachability_checked=data.get("isa_reachability_checked", False),
             input_fingerprint=data.get("input_fingerprint", ""),
         )
 

--- a/builder/tools/builder.py
+++ b/builder/tools/builder.py
@@ -725,6 +725,19 @@ def export_crate(
         except Exception as payload_err:  # noqa: BLE001 — never fail the write
             logger.warning("Could not verify the crate payload: %s", payload_err)
 
+        # Answer the one REQUIRED question the ISA profile cannot ask of itself:
+        # does its backbone actually reach the entities the crate mints (#537)?
+        # Its rules target a class inferred from the very edge whose absence is
+        # the defect, so a detached process is skipped rather than failed and the
+        # silence ships as a pass. Runs here for the same reason as the payload
+        # check above: the report is rendered from `state.validation` below.
+        try:
+            from builder.tools.validation import record_isa_reachability_check
+
+            record_isa_reachability_check(state, crate)
+        except Exception as reach_err:  # noqa: BLE001 — never fail the write
+            logger.warning("Could not verify the ISA backbone's reachability: %s", reach_err)
+
         # Embed the standard ro-crate-py preview (ro-crate-preview.html, a
         # CreativeWork about ./) so the written crate is browsable without
         # tooling (#86) — rendered through an autoescaping template so

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -236,6 +236,125 @@ def verify_payload(crate: Any) -> list[dict[str, Any]]:
     return issues
 
 
+# The ISA classes this crate MINTS a structural entity for. Each carries a
+# rule-set in the upstream profile that only applies once something references
+# the entity, so each is a class whose whole rule-set can go silent (#537).
+_ISA_STRUCTURAL_TYPES = frozenset({"LabProcess", "Sample", "LabProtocol"})
+
+# Keys that describe the node rather than point away from it. `@type`'s values
+# are class names, and a class name is not a reference to another entity.
+_NON_REFERENCE_KEYS = frozenset({"@id", "@type", "@context"})
+
+
+def verify_isa_reachability(
+    metadata: dict[str, Any] | list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Report every ISA structural entity the crate mints and then references from nowhere.
+
+    The ISA shapes infer their target class from the very edge whose absence is
+    the defect. ``FindISAProcesses`` mints ``isa-ro-crate:Process`` only for a
+    ``bioschemas:LabProcess`` some Dataset already points at, and
+    ``ProcessMustBeReferencedFromDataset`` targets that inferred class — so a
+    process nothing references never earns the label, and the rule written to
+    catch exactly this defect has no target. Every rule keyed to the class goes
+    silent with it. 11 of the profile's 12 shape files are built this way, so a
+    missing structural edge switches off the whole rule-set for that layer and
+    the crate reports conformant precisely when its structure is most broken.
+
+    The upstream shapes are not ours to restructure, so the invariant is
+    asserted here instead, and asserted the only way that cannot be gamed by an
+    absent edge: an entity nothing points at is detached, whatever the profile
+    was able to evaluate.
+
+    Reachability is DIRECTED. ``provenance_dag.build_crate_graph`` already flags
+    orphans, but over an undirected walk, where a process that points at the
+    files it produced counts as connected even though nothing points at it —
+    which is why it reports 19 orphans for the crate in #537 and none of them
+    are its three detached processes.
+
+    Entities identified by an absolute URI are described here and live
+    elsewhere — a Cellosaurus cell line is a record of an external thing, not a
+    hole in this crate's backbone — so they are not reported, the same line
+    :func:`verify_payload` draws for the payload.
+
+    Args:
+        metadata: The ``crate.metadata.generate()`` document, the parsed
+            ``ro-crate-metadata.json``, or the ``@graph`` list itself.
+
+    Returns:
+        Routable issue dicts in the shape :func:`build_and_validate` returns, so
+        the existing write-back and the maturity report render them unchanged.
+    """
+    from builder.writers.provenance_dag import _refs, _types
+
+    graph = metadata.get("@graph", []) if isinstance(metadata, dict) else metadata
+    nodes = [node for node in graph if isinstance(node, dict) and node.get("@id")]
+
+    referenced: set[str] = set()
+    for node in nodes:
+        keys = tuple(key for key in node if key not in _NON_REFERENCE_KEYS)
+        referenced.update(ref for ref in _refs(node, keys) if ref != node.get("@id"))
+
+    issues: list[dict[str, Any]] = []
+    for node in nodes:
+        entity_id = str(node["@id"])
+        if entity_id.startswith(("http://", "https://")):
+            continue
+        if not (_types(node) & _ISA_STRUCTURAL_TYPES):
+            continue
+        if entity_id in referenced:
+            continue
+        kind = ", ".join(sorted(_types(node) & _ISA_STRUCTURAL_TYPES))
+        issues.append(
+            {
+                "entity_id": entity_id,
+                "property": "about",
+                "message": (
+                    f"Nothing in the crate references the {kind} {entity_id!r}, so it is "
+                    "detached from the ISA backbone and every profile rule for its class "
+                    "is skipped rather than passed"
+                ),
+                "fix": (
+                    f"Reference `{entity_id}` from the entity it belongs to — a process "
+                    "from its Assay's `about`, a protocol or sample from the process that "
+                    "uses it — or drop it so the crate stops describing a step it does "
+                    "not connect."
+                ),
+                "severity": "required",
+                "profile": "isa",
+            }
+        )
+    return issues
+
+
+def record_isa_reachability_check(state: CrateState, crate: Any) -> list[dict[str, Any]]:
+    """Fold :func:`verify_isa_reachability` into ``state.validation`` (#537).
+
+    A detached structural entity is a REQUIRED failure of the ISA profile — the
+    profile simply cannot say so itself — so it is filed through the same shape
+    every other finding uses, and the header verdict flips off "Conformant"
+    without the report needing to know this check exists.
+
+    Marks the verdict ``isa_reachability_checked`` either way: a connected
+    backbone is a result, and the distinction that matters downstream is
+    "looked and found nothing" versus "never looked".
+
+    Returns the issues found, for the caller to log or report.
+    """
+    issues = verify_isa_reachability(crate.metadata.generate())
+    report = state.validation
+    existing = set(report.required_issues)
+    for issue, text in zip(issues, order_issues(issues, "required"), strict=True):
+        if text not in existing:
+            report.required_issues.append(text)
+            report.issue_records.extend(_issue_records([issue], "required"))
+    if issues:
+        report.isa_passed = False
+    report.assessed_tiers.add("required")
+    report.isa_reachability_checked = True
+    return issues
+
+
 def record_payload_check(state: CrateState, crate: Any) -> list[dict[str, Any]]:
     """Fold :func:`verify_payload` into ``state.validation`` (#530).
 

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -724,6 +724,28 @@ def _payload_caveat(val: ValidationReport) -> str:
     )
 
 
+def _backbone_caveat(val: ValidationReport) -> str:
+    """Name the one question the ISA profile cannot answer of itself (#537).
+
+    Whether the backbone reaches the structural entities the crate mints is
+    REQUIRED, and unaskable by the profile: its rules target a class inferred
+    from the very edge whose absence is the defect, so a detached process is
+    skipped rather than failed and the silence reads as a pass. A verdict from
+    the in-memory gate never asked. Export asks and clears it.
+
+    Rendered on the same terms as :func:`_payload_caveat`, and for the same
+    reason: a verdict clean at REQUIRED is exactly where the green pill
+    over-claims hardest.
+    """
+    if val.isa_reachability_checked:
+        return ""
+    return (
+        '<p class="lead payload-note">The crate\'s ISA backbone was not checked for '
+        "detached entities — this verdict cannot say whether every process, protocol "
+        "and sample it describes is connected to anything.</p>"
+    )
+
+
 def _render_profile_section(
     val: ValidationReport, tiers: list[dict[str, str]] | None, *, stale: bool = False
 ) -> str:
@@ -770,6 +792,7 @@ def _render_profile_section(
         f"  {severity_detail}\n"
         f"  {sugg}\n"
         f"  {_payload_caveat(val)}\n"
+        f"  {_backbone_caveat(val)}\n"
         "</section>\n"
     )
 

--- a/tests/test_isa_reachability.py
+++ b/tests/test_isa_reachability.py
@@ -1,0 +1,266 @@
+"""A structural entity nothing references is a defect the ISA profile cannot report (#537).
+
+Same class as #530 — a check that cannot fire being read as a pass — but
+structural, and it spans the whole profile rather than one rule.
+
+The ISA shapes infer their target class from the very edge whose absence is the
+defect. ``FindISAProcesses`` mints ``isa-ro-crate:Process`` only for a
+``bioschemas:LabProcess`` that some Dataset already points at, and
+``ProcessMustBeReferencedFromDataset`` then targets that inferred class. A
+process no Dataset references never earns the label, so the rule written to
+catch exactly this defect has no target and stays silent — along with every
+other rule keyed to the class. 11 of the profile's 12 shape files are built this
+way, so the blind spot is general: when a structural edge is missing, the whole
+rule-set for that layer switches off, and the crate reports conformant precisely
+when its structure is most broken.
+
+The upstream shapes are not ours to restructure, so the invariant is asserted on
+our side instead: a structural entity this crate mints must be referenced by
+something. Local entities only — an entity named by an absolute URI is described
+here but lives elsewhere, the same line #530 draws for the payload.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from builder.state import CrateState, Entity, ValidationReport
+from builder.tools.builder import export_crate
+from builder.tools.validation import verify_isa_reachability
+from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+pytestmark = pytest.mark.timeout(120)
+
+REGRESSION_CRATE = Path("output/svhps26_real_input_crate/ro-crate-metadata.json")
+
+
+def _doc(*entities: dict) -> dict:
+    """A serialized crate document with the descriptor and root already wired."""
+    return {
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "about": {"@id": "./"},
+            },
+            {"@id": "./", "@type": "Dataset", "name": "Investigation"},
+            *entities,
+        ],
+    }
+
+
+def _process(pid: str, **props) -> dict:
+    return {"@id": pid, "@type": "LabProcess", "name": pid, **props}
+
+
+class TestVerifyIsaReachability:
+    """The invariant, stated over the assembled document rather than a rule id."""
+
+    def test_a_process_no_dataset_references_is_reported(self) -> None:
+        issues = verify_isa_reachability(_doc(_process("#proc_exposure")))
+
+        assert [i["entity_id"] for i in issues] == ["#proc_exposure"]
+        assert issues[0]["severity"] == "required"
+        assert issues[0]["profile"] == "isa"
+        assert "#proc_exposure" in issues[0]["message"]
+
+    def test_a_process_an_assay_is_about_is_not_reported(self) -> None:
+        doc = _doc(
+            {
+                "@id": "#assay_1",
+                "@type": "Dataset",
+                "name": "Assay",
+                "about": [{"@id": "#proc_exposure"}],
+            },
+            _process("#proc_exposure"),
+        )
+
+        assert verify_isa_reachability(doc) == []
+
+    def test_a_detached_protocol_is_reported(self) -> None:
+        """Measured on `output/svhps22_real_input_crate_v2`, which carries four."""
+        doc = _doc({"@id": "#proto_uptake", "@type": "LabProtocol", "name": "Uptake SOP"})
+
+        assert [i["entity_id"] for i in verify_isa_reachability(doc)] == ["#proto_uptake"]
+
+    def test_a_protocol_a_process_uses_is_not_reported(self) -> None:
+        doc = _doc(
+            {
+                "@id": "#assay_1",
+                "@type": "Dataset",
+                "about": [{"@id": "#proc_exposure"}],
+            },
+            _process("#proc_exposure", agent={"@id": "#proto_uptake"}),
+            {"@id": "#proto_uptake", "@type": "LabProtocol", "name": "Uptake SOP"},
+        )
+
+        assert verify_isa_reachability(doc) == []
+
+    def test_a_sample_a_process_consumed_is_not_reported(self) -> None:
+        doc = _doc(
+            {"@id": "#assay_1", "@type": "Dataset", "about": [{"@id": "#proc_exposure"}]},
+            _process("#proc_exposure", object={"@id": "#sample_h4"}),
+            {"@id": "#sample_h4", "@type": "Sample", "name": "H4"},
+        )
+
+        assert verify_isa_reachability(doc) == []
+
+    def test_an_entity_named_by_an_absolute_uri_is_not_reported(self) -> None:
+        """A Cellosaurus cell line is described here and lives elsewhere.
+
+        Four of the crates in `output/` carry such a Sample with nothing
+        pointing at it. That is a record of an external thing, not a hole in
+        this crate's backbone — the same line #530 draws for the payload.
+        """
+        doc = _doc(
+            {
+                "@id": "https://www.cellosaurus.org/CVCL_D357",
+                "@type": "Sample",
+                "name": "MO3.13",
+            }
+        )
+
+        assert verify_isa_reachability(doc) == []
+
+    def test_a_file_is_not_this_checks_business(self) -> None:
+        """Files are #530's question. This one is about the ISA backbone."""
+        doc = _doc({"@id": "data/orphan.csv", "@type": "File", "name": "orphan"})
+
+        assert verify_isa_reachability(doc) == []
+
+    def test_every_orphan_is_reported_not_just_the_first(self) -> None:
+        doc = _doc(_process("#proc_a"), _process("#proc_b"), _process("#proc_c"))
+
+        assert [i["entity_id"] for i in verify_isa_reachability(doc)] == [
+            "#proc_a",
+            "#proc_b",
+            "#proc_c",
+        ]
+
+    def test_the_fix_says_what_to_wire(self) -> None:
+        issues = verify_isa_reachability(_doc(_process("#proc_exposure")))
+
+        assert "#proc_exposure" in issues[0]["fix"]
+
+
+class TestTheCrateThatPassedClean:
+    """`output/svhps26_real_input_crate` — three orphaned processes, ISA green."""
+
+    def test_its_three_orphaned_processes_are_reported(self) -> None:
+        if not REGRESSION_CRATE.exists():  # pragma: no cover - crate not built
+            pytest.skip(f"{REGRESSION_CRATE} not available")
+
+        issues = verify_isa_reachability(json.loads(REGRESSION_CRATE.read_text()))
+
+        assert sorted(i["entity_id"] for i in issues) == sorted(
+            [
+                "#LabProcess_proc_culture_and_seed_cho_k1_oatp1c1_cells",
+                "#LabProcess_proc_30_minute_co_exposure_for_oatp1c1_t4_uptake_assay",
+                "#LabProcess_proc_normalize_uptake_and_viability_and_fit_"
+                "concentration_response_curves",
+            ]
+        )
+        assert all(i["severity"] == "required" for i in issues)
+
+
+class TestVerdictRecordsWhetherReachabilityWasSeen:
+    """A verdict that never asked must not be read as one that asked and found nothing."""
+
+    def test_defaults_to_unchecked_and_round_trips(self) -> None:
+        assert ValidationReport().isa_reachability_checked is False
+        report = ValidationReport(isa_reachability_checked=True)
+        restored = ValidationReport.from_dict(report.to_dict())
+        assert restored.isa_reachability_checked is True
+        # A checkpoint written before the field existed still loads.
+        legacy = report.to_dict()
+        del legacy["isa_reachability_checked"]
+        assert ValidationReport.from_dict(legacy).isa_reachability_checked is False
+
+    def test_a_verdict_that_never_looked_says_so(self) -> None:
+        """The green pill over-claims hardest on a verdict clean at REQUIRED."""
+        from builder.writers.maturity_report import build_maturity_html
+
+        state = vhps_fixture_state("S-VHPS21")
+        val = ValidationReport(
+            base_passed=True,
+            isa_passed=True,
+            tox_passed=True,
+            assessed_tiers={"required", "recommended", "optional"},
+        )
+
+        assert "not checked for detached entities" in build_maturity_html(state, validation=val)
+
+        val.isa_reachability_checked = True
+        page = build_maturity_html(state, validation=val)
+        assert "not checked for detached entities" not in page
+
+
+class TestExportRefusesToCallADetachedBackboneClean:
+    """The end-to-end regression: the shipped report must not say Conformant."""
+
+    @staticmethod
+    def _state_with_a_detached_process(tmp_path: Path) -> CrateState:
+        """A crate carrying a step no Assay is ``about``.
+
+        The generic shape of the defect, not one deposit's: any process that
+        loses its container — created and then cascade-deleted mid-run, as in
+        the session behind #537 — assembles into exactly this.
+        """
+        state = vhps_fixture_state("S-VHPS21")
+        state.metadata.output_path = str(tmp_path / "crate")
+        state.add_entity(
+            Entity(
+                entity_id="proc_orphan",
+                type="LabProcess",
+                fields={"name": "Orphaned step", "description": "nothing points here"},
+            )
+        )
+        return state
+
+    def test_export_records_the_detached_process_as_a_required_issue(
+        self, tmp_path: Path
+    ) -> None:
+        state = self._state_with_a_detached_process(tmp_path)
+
+        result = export_crate(state, str(tmp_path / "crate"))
+
+        assert result["success"], result["error"]
+        assert any("proc_orphan" in issue for issue in state.validation.required_issues), (
+            state.validation.required_issues
+        )
+        assert state.validation.isa_passed is False
+
+    def test_the_embedded_report_does_not_headline_conformant(self, tmp_path: Path) -> None:
+        state = self._state_with_a_detached_process(tmp_path)
+
+        export_crate(state, str(tmp_path / "crate"))
+
+        page = (tmp_path / "crate" / "ro-crate-metadata-maturity.html").read_text(encoding="utf-8")
+        body = page.split("</style>", 1)[-1]
+        assert "Not conformant" in body
+        assert '<span class="vpill good">' not in body
+
+    def test_a_crate_whose_backbone_is_whole_still_passes(self, tmp_path: Path) -> None:
+        """Paired with the test above.
+
+        Without it, "Not conformant appears" would pass just as well on a
+        fixture that was never conformant, and the assertion would pin nothing.
+        """
+        state = vhps_fixture_state("S-VHPS21")
+        state.metadata.output_path = str(tmp_path / "crate")
+
+        export_crate(state, str(tmp_path / "crate"))
+
+        assert state.validation.isa_reachability_checked is True
+        assert state.validation.required_issues == []
+        body = (
+            (tmp_path / "crate" / "ro-crate-metadata-maturity.html")
+            .read_text(encoding="utf-8")
+            .split("</style>", 1)[-1]
+        )
+        assert '<span class="vpill good">' in body
+        assert "Not conformant" not in body


### PR DESCRIPTION
Closes #537.

`output/svhps26_real_input_crate` has three `LabProcess` entities nothing
references and no Assay container at all. Both profiles report
`passed_required=True`, zero REQUIRED issues. The crate is at its most broken and
the report is at its cleanest.

## Mechanism

The ISA shapes infer their target class **from the very edge whose absence is the
defect**:

```turtle
isa-ro-crate:FindISAProcesses               # mints isa-ro-crate:Process ONLY for a
    sh:targetClass bioschemas:LabProcess ;  # LabProcess something already points at
    sh:rule [ … sh:object isa-ro-crate:Process ; sh:condition [ … ] ]

isa-ro-crate:ProcessMustBeReferencedFromDataset
    sh:targetClass isa-ro-crate:Process ;   # <- the inferred class
    sh:message "Process MUST be directly referenced in about on a Dataset" ;
```

A process nothing references never earns the label, so the rule written to catch
exactly this defect **has no target**. Every rule keyed to the class — name,
object, result, protocol, parameter values — goes silent with it. 11 of the
profile's 12 shape files are built this way, and our
`tox/7_assay_key_event.ttl` rides on `isa-ro-crate:Assay`, so a missing
structural edge switches off the whole rule-set for that layer.

## What changed

The upstream shapes are not ours to restructure, so `verify_isa_reachability`
asserts the invariant here, the one way an absent edge cannot game: **an entity
nothing points at is detached**, whatever the profile could evaluate. Findings
file as REQUIRED through the same shape `verify_payload` uses (#530), so the
header verdict flips off "Conformant" without the report knowing this check
exists.

## The trap I fell into first, now documented

#537 says the fact is already computed, and `provenance_dag.build_crate_graph`
does flag orphans — so I reached for it. It reports **19 orphans for this crate
and none of them are the three detached processes**, because that walk is
*undirected*: a process pointing at the files it produced counts as connected
even though nothing points at it. This check had to be directed. Stated in the
docstring and AGENTS.md so the next reader does not repeat it.

## Measured over every crate in `output/`

| crate | findings |
|---|---|
| `svhps26_real_input_crate` | **3** `LabProcess` — the reported defect |
| `svhps22_real_input_crate_v2` | **4** detached `LabProtocol` |
| `svhps22_real_input_crate_v3` | **4** detached `LabProtocol` |
| the other 7 | 0 |

No false positives. The Cellosaurus `Sample` URIs in v4/v6/v8/v9 are excluded —
an absolute URI is described here and lives elsewhere, the same line
`verify_payload` already draws for the payload.

## Not assessed is not clean

`isa_reachability_checked` records that something asked, and the maturity report
says so when nothing did. A flag nothing reads would be dead weight, and #537's
own fix direction is "treat a zero count as suspicious, not clean" (#306).

## Verification

Full suite **3241 passed, 0 failed**. 15 new tests; four mutations of the
implementation each break them:

| mutation | tests failing |
|---|---|
| drop the absolute-URI exclusion | 1 |
| drop the structural-type filter | 11 |
| don't flip `isa_passed` | 1 |
| report only the first orphan | 2 |

## Follow-up worth filing

Two older crates carry four detached `LabProtocol` entities each — real findings
this check now surfaces, but they say something about how protocols get wired
that is worth its own issue rather than a fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
