### PR TITLE
feat(metadata): read the declared licence in whatever convention states it (#535)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1693,6 +1693,45 @@ warning, so the heaviest payloads are still removed.
 The Investigation **is** the Root Data Entity (`./`); the ISA RO-Crate profile mandates this and
 the SHACL shapes forbid alternatives (a Study carrying `additionalType "Study"` MUST be `hasPart`
 of the root via `StudyMustBeReferencedFromInvestigation`, so the root cannot itself be a Study).
+**A declared licence is read, in whatever convention the deposit states it (#535).** Nothing used
+to read it: `set_crate_metadata` — an LLM-callable tool — was its only writer, so the licence was
+whatever the model supplied, and on S-VHPS26 the guess inverted the depositor's (CC-BY-4.0 declared,
+all-rights-reserved asserted) in the one direction that suppresses reuse. `extract_deposit_licence`
+reads a NAMED field, which is not guessing, across the two conventions deposits actually use: the
+BioStudies *attribute* (a node naming the field, usually qualified with a canonical URL) and the
+*field* every other record uses — RO-Crate `license`, CodeMeta, Frictionless `licenses[].path`,
+DataCite `rightsList[].rightsUri`. Gating on the BioStudies shape, as it first did, answered for one
+repository's export and left every other deposit on the fabricated fallback. An IRI wins wherever it
+sits; without one the declared value is returned **verbatim**, because mapping "CC-BY" onto a 4.0
+URI states a version the depositor did not (D5).
+
+Two conventions live outside a metadata record and are read as well. `SPDX-License-Identifier:` is a
+formal declaration that can sit in any text, so it is honoured wherever it appears; and a file *named*
+`LICENSE` / `LICENCE` / `COPYING` declares by its name that its whole content is the licence, which is
+what permits reading a URI out of it — in any other file that would be a URL appearing in prose. The
+document formats widen with them: `.json`, `.jsonld`, `.yaml`, `.yml`, `.cff` (CITATION.cff is YAML,
+and `license` is one of its standard keys) and `.xml`.
+
+XML carries the same field convention in element form — DataCite keeps the machine-actionable value
+in an attribute (`<rights rightsURI="…">CC BY 4.0</rights>`) and the label in the text, Dublin Core
+puts the whole thing in `<dc:rights>` — so tags and attributes are matched on their **local** name,
+namespace stripped. It is parsed through `defusedxml`, not stdlib `ElementTree`: a deposit is
+untrusted input, and one crafted file would otherwise expand a billion-laughs entity during a scan.
+A refused or malformed document is simply not a declaration.
+
+Prose is never a source, and the guard is load-bearing rather than defensive: YAML parses a README's
+bullets into a list of mappings, so `- License: see the LICENSE file` would otherwise be filed as
+legal terms, and every real deposit's README ships the unfilled placeholder `[Default CC-BY 4.0 for
+data, CC0 for metadata unless specified otherwise]` — two licences named, neither declared. Only a
+document whose top level is a **mapping** is a metadata record, and a `LICENSE` holding only legal
+text names no identifier: reading "Creative Commons Attribution 4.0 International Public License" off
+its first line would invent a machine-actionable claim out of a heading. Which file is the DEPOSIT's is
+decided rather than left to directory order: shallowest first (a root descriptor describes the
+deposit, a bundled `package.json` four levels down describes itself), then a machine-actionable IRI,
+then the path. Depth outranks the IRI preference deliberately — a nested SPDX URI must not beat the
+root descriptor's own label. `license_from_deposit` marks the value as read, and `set_crate_metadata`
+cannot overwrite one that was.
+
 **An unstated licence says so, and claims nothing (#540).** `license` is a base MUST, so the field
 cannot be left empty — but answering it with `ALL RIGHTS RESERVED BY THE AUTHORS`, as it once did,
 converts an unanswered question into the most restrictive claim available, asserted by machine over

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -353,6 +353,24 @@ def _run_document_discovery(engine: AgentEngine) -> None:
         )
 
 
+# Formats that carry a NAMED licence field, and the filenames whose whole
+# content is one. Prose is deliberately absent: every real deposit's README
+# ships the unfilled placeholder "[Default CC-BY 4.0 for data, CC0 for metadata
+# unless specified otherwise]", which names two licences and declares neither
+# (#535). Any other text is still read for an `SPDX-License-Identifier:`, which
+# is a formal declaration rather than prose.
+_LICENCE_DOCUMENT_SUFFIXES = (".json", ".jsonld", ".yaml", ".yml", ".cff", ".xml")
+_LICENCE_FILE_STEMS = frozenset({"license", "licence", "copying", "copyright"})
+
+
+def _may_declare_a_licence(path: str) -> bool:
+    """Whether *path* is a document a licence can be READ from, by name alone."""
+    name = Path(path)
+    return name.suffix.lower() in _LICENCE_DOCUMENT_SUFFIXES or (
+        name.stem.casefold() in _LICENCE_FILE_STEMS
+    )
+
+
 def _read_declared_licence(engine: AgentEngine) -> None:
     """Read the licence the deposit declares, before anyone drafts one (#535).
 
@@ -368,26 +386,47 @@ def _read_declared_licence(engine: AgentEngine) -> None:
     a licence nobody has set yet is filled — a resumed session that already
     carries one is left alone — and the value is marked as read from the deposit
     so a later draft cannot overwrite it.
+
+    More than one file can name a licence, so which one is the DEPOSIT's is
+    decided rather than left to directory order: the shallowest declaration
+    wins, because a file at the deposit root describes the deposit while a
+    bundled manifest four directories down describes itself. Depth outranks
+    everything — a nested SPDX URI must not beat the root descriptor's own
+    label — then a machine-actionable IRI, then the path, so the answer is the
+    same on every run.
     """
     from builder.tools.file_readers import extract_deposit_licence, read_file
 
     metadata = engine.state.metadata
     if metadata.license:
         return
+
+    root = metadata.input_path or ""
+    found: list[tuple[int, int, str, str]] = []
     for candidate in engine.state.scanned_files:
         path = str(getattr(candidate, "path", "") or "")
-        if not path.lower().endswith(".json"):
+        if not _may_declare_a_licence(path):
             continue
         try:
             text = read_file(path)
         except Exception:  # noqa: BLE001 — an unreadable file is simply not the one
             continue
-        licence = extract_deposit_licence(text or "")
-        if licence:
-            metadata.license = licence
-            metadata.license_from_deposit = True
-            logger.info("Read the licence the deposit declares: %s", licence)
-            return
+        licence = extract_deposit_licence(text or "", filename=Path(path).name)
+        if not licence:
+            continue
+        try:
+            depth = len(Path(path).resolve().relative_to(Path(root).resolve()).parts)
+        except (ValueError, OSError):
+            depth = len(Path(path).parts)
+        actionable = 0 if licence.startswith(("http://", "https://")) else 1
+        found.append((depth, actionable, path, licence))
+
+    if not found:
+        return
+    depth, _, path, licence = min(found)
+    metadata.license = licence
+    metadata.license_from_deposit = True
+    logger.info("Read the licence the deposit declares from %s: %s", path, licence)
 
 
 class AgentEngine:

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -15,6 +15,8 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 logger = logging.getLogger(__name__)
 
 
@@ -986,14 +988,152 @@ def compact_attribute_json(text: str) -> str:
     return "\n".join(out).strip()
 
 
+# The two conventions a deposit states its licence in. BioStudies writes it as an
+# ATTRIBUTE — a node that names the field and carries the value beside it — while
+# RO-Crate, CodeMeta, Frictionless and DataCite write it as a FIELD, the key
+# itself. Both are the depositor naming a licence. Neither is prose.
 _LICENCE_NAMES = {"license", "licence"}
+_LICENCE_KEYS = {"license", "licence", "licenses", "licences", "rightsuri"}
+# Where an object-valued licence keeps the thing itself, best first: an IRI is
+# machine-actionable, a label is only a name.
+_LICENCE_VALUE_KEYS = ("@id", "url", "path", "identifier", "name", "value")
 
 
-def extract_deposit_licence(text: str) -> str | None:
-    """The licence a BioStudies descriptor declares, as the deposit states it (#535).
+def _is_iri(value: str) -> bool:
+    return value.startswith(("http://", "https://"))
 
-    Reading this is not guessing: the descriptor carries it as an attribute, and
-    usually qualifies it with a canonical URL —
+
+def _licence_candidates(value: Any) -> list[str]:
+    """Every licence a value states, in document order.
+
+    A licence is a string, an object keeping it under one of
+    :data:`_LICENCE_VALUE_KEYS`, or a list of either — the shapes RO-Crate
+    (``{"@id": …}``), CodeMeta, Frictionless (``{"path": …}``) and DataCite use
+    between them.
+    """
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, list):
+        return [found for item in value for found in _licence_candidates(item)]
+    if isinstance(value, dict):
+        for key in _LICENCE_VALUE_KEYS:
+            if (found := str(value.get(key) or "").strip()):
+                return [found]
+    return []
+
+
+# The formal, machine-readable way to declare a licence in any text at all. It
+# names the field, so reading it is no more a guess than reading a JSON key.
+_SPDX_DECLARATION = re.compile(r"SPDX-License-Identifier:\s*([^\s*/#<>\"\']+)", re.IGNORECASE)
+# Filenames whose whole content IS the licence. The name is itself the
+# declaration, which is what lets a URI be read out of the text — in any other
+# file that would be a URL that happens to appear in prose.
+_LICENCE_FILENAMES = {"license", "licence", "copying", "copyright"}
+_URI_IN_TEXT = re.compile(r"https?://[^\s\"\'<>)\]]+")
+# The XML analogue of the field convention. DataCite keeps the machine-actionable
+# form in an ATTRIBUTE (`<rights rightsURI="…">CC BY 4.0</rights>`) and the label
+# in the element text, while Dublin Core puts the whole thing in the text.
+_LICENCE_XML_TAGS = {"license", "licence", "rights", "rightsuri"}
+_LICENCE_XML_ATTRS = {"rightsuri", "href", "resource", "about", "url"}
+
+
+def _local_tag(name: Any) -> str:
+    """An XML tag or attribute without its namespace: ``{ns}rights`` -> ``rights``."""
+    return str(name).rsplit("}", 1)[-1].strip().casefold()
+
+
+def _prefer_iri(found: list[str]) -> str | None:
+    """The first machine-actionable value, else the first stated one."""
+    return next((value for value in found if _is_iri(value)), found[0] if found else None)
+
+
+def _parse_structured(text: str) -> dict[str, Any] | None:
+    """*text* as a mapping, read as JSON then as YAML, or ``None``.
+
+    A mapping is required rather than any YAML value, because YAML parses prose
+    into something: every real deposit's README carries the unfilled placeholder
+    ``[Default CC-BY 4.0 for data, CC0 for metadata unless specified
+    otherwise]``, which is a valid flow sequence naming two licences and
+    declaring neither.
+    """
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        try:
+            parsed = yaml.safe_load(text)
+        except Exception:  # noqa: BLE001 — anything unparseable is simply not a declaration
+            return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _licence_from_structured(text: str) -> str | None:
+    """The licence a JSON/YAML mapping declares, in either convention."""
+    parsed = _parse_structured(text)
+    if parsed is None:
+        return None
+
+    found: list[str] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            # The attribute convention: this node NAMES the licence field, and
+            # a qualifier beside it may carry the canonical URL.
+            if str(node.get("name") or "").strip().casefold() in _LICENCE_NAMES:
+                for qualifier in node.get("valqual") or []:
+                    url = str((qualifier or {}).get("value") or "").strip()
+                    if _is_iri(url):
+                        found.append(url)
+                        return
+                if value := str(node.get("value") or "").strip():
+                    found.append(value)
+                return
+            for key, child in node.items():
+                if str(key).strip().casefold() in _LICENCE_KEYS:
+                    found.extend(_licence_candidates(child))
+                else:
+                    _walk(child)
+        elif isinstance(node, list):
+            for child in node:
+                _walk(child)
+
+    _walk(parsed)
+    return _prefer_iri(found)
+
+
+def _licence_from_xml(text: str) -> str | None:
+    """The licence an XML record declares — DataCite, Dublin Core, METS.
+
+    Parsed through ``defusedxml``: a deposit is untrusted input, and stdlib
+    ElementTree expands a billion-laughs entity out of one crafted file. A
+    refused or malformed document is simply not a declaration.
+    """
+    if "<" not in text:
+        return None
+    from defusedxml.ElementTree import fromstring
+
+    try:
+        root = fromstring(text)
+    except Exception:  # noqa: BLE001 — unparseable or refused is not a declaration
+        return None
+
+    found: list[str] = []
+    for element in root.iter():
+        if _local_tag(element.tag) not in _LICENCE_XML_TAGS:
+            continue
+        for name, value in (element.attrib or {}).items():
+            if _local_tag(name) in _LICENCE_XML_ATTRS and str(value).strip():
+                found.append(str(value).strip())
+        if label := (element.text or "").strip():
+            found.append(label)
+    return _prefer_iri(found)
+
+
+def extract_deposit_licence(text: str, *, filename: str = "") -> str | None:
+    """The licence a structured metadata document declares (#535).
+
+    Reading this is not guessing: the depositor named the field. A BioStudies
+    descriptor states it as an attribute, usually qualified with a canonical
+    URL —
 
     .. code-block:: json
 
@@ -1001,43 +1141,40 @@ def extract_deposit_licence(text: str) -> str | None:
          "valqual": [{"name": "URL",
                       "value": "https://creativecommons.org/licenses/by/4.0/legalcode"}]}
 
-    A URL is preferred because it is machine-actionable and the depositor chose
-    it. Without one the declared value is returned **verbatim**: "CC-BY" does
-    not say which version, and mapping it onto a 4.0 URI would state something
-    the depositor did not (D5).
+    — while an RO-Crate, CodeMeta record, Frictionless datapackage or DataCite
+    payload states it as a field. Gating on the BioStudies shape answered for
+    exactly one repository's export and left every other deposit with the
+    fabricated all-rights-reserved fallback, so both conventions are read.
 
-    Applied blindly to any scanned file, so anything that is not a BioStudies
-    attribute tree — or carries no licence — yields ``None`` rather than raising.
+    An IRI wins wherever it sits, being machine-actionable and the depositor's
+    own choice. Without one the declared value is returned **verbatim**:
+    "CC-BY" does not say which version, and mapping it onto a 4.0 URI would
+    state something the depositor did not (D5).
+
+    Two conventions live outside a metadata record and are read as well.
+    ``SPDX-License-Identifier:`` is a formal declaration that can sit in any
+    text, and a file *named* ``LICENSE`` / ``COPYING`` declares by its name that
+    its whole content is the licence — which is what lets a URI be read out of
+    it, where in any other file that would be a URL appearing in prose. Pass
+    *filename* to enable that reading; without it the strict rules apply.
+
+    Legal prose is still never mined. A ``LICENSE`` holding only the text of a
+    licence names no identifier, and reading "Creative Commons Attribution 4.0
+    International Public License" off its first line would invent a
+    machine-actionable claim out of a heading.
+
+    Applied blindly to any scanned file, so anything carrying no licence — or
+    naming one only in prose — yields ``None`` rather than raising.
     """
-    try:
-        parsed = json.loads(text)
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(parsed, dict) or not ("attributes" in parsed or "section" in parsed):
-        return None
-
-    found: list[str] = []
-
-    def _walk(node: Any) -> None:
-        if isinstance(node, dict):
-            if str(node.get("name") or "").strip().casefold() in _LICENCE_NAMES:
-                for qualifier in node.get("valqual") or []:
-                    url = str((qualifier or {}).get("value") or "").strip()
-                    if url.startswith(("http://", "https://")):
-                        found.append(url)
-                        return
-                value = str(node.get("value") or "").strip()
-                if value:
-                    found.append(value)
-                return
-            for child in node.values():
-                _walk(child)
-        elif isinstance(node, list):
-            for child in node:
-                _walk(child)
-
-    _walk(parsed)
-    return found[0] if found else None
+    for read in (_licence_from_structured, _licence_from_xml):
+        if found := read(text):
+            return found
+    if spdx := _SPDX_DECLARATION.search(text):
+        return spdx.group(1).strip()
+    if Path(filename).stem.casefold() in _LICENCE_FILENAMES:
+        if uri := _URI_IN_TEXT.search(text):
+            return uri.group(0)
+    return None
 
 
 def read_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     # ceiling only once roc-validator supports 0.40 (upstream declares no bound,
     # so nothing else will stop this recurring).
     "pyshacl>=0.26,<0.40",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_deposit_licence.py
+++ b/tests/test_deposit_licence.py
@@ -63,9 +63,9 @@ class TestExtractDepositLicence:
     def test_a_descriptor_without_a_licence_yields_nothing(self) -> None:
         assert extract_deposit_licence(_descriptor(None)) is None
 
-    def test_non_biostudies_input_yields_nothing(self) -> None:
+    def test_a_document_that_declares_none_yields_nothing(self) -> None:
         # Applied blindly to any scanned file, so it must be quiet on the rest.
-        assert extract_deposit_licence("not json at all") is None
+        assert extract_deposit_licence("not structured at all") is None
         assert extract_deposit_licence(json.dumps({"unrelated": True})) is None
         assert extract_deposit_licence("") is None
 
@@ -271,3 +271,366 @@ class TestAnUnstatedLicenceSaysSo:
 
         assert not _nonempty({"@id": LICENCE_NOT_STATED_ID})
         assert LICENCE_NOT_STATED_ID.lower() in {v.lower() for v in _placeholder_values()}
+
+
+class TestAnyStructuredMetadataFileCanDeclareIt:
+    """BioStudies is one convention among several, and deposits use the others.
+
+    Gating on a BioStudies attribute tree made the reader answer for exactly one
+    repository's export. A deposit that ships an RO-Crate, a CodeMeta record, a
+    Frictionless datapackage or a DataCite payload states its licence just as
+    plainly, in a field rather than an attribute — and got the fabricated
+    fallback instead. Reading a NAMED field is still not guessing; what stays
+    forbidden is inferring one from prose.
+    """
+
+    def test_an_ro_crate_declares_it_by_reference(self) -> None:
+        doc = json.dumps(
+            {
+                "@context": "https://w3id.org/ro/crate/1.2/context",
+                "@graph": [
+                    {
+                        "@id": "./",
+                        "@type": "Dataset",
+                        "license": {"@id": "https://creativecommons.org/licenses/by/4.0/"},
+                    }
+                ],
+            }
+        )
+
+        assert extract_deposit_licence(doc) == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_a_codemeta_record_declares_it_as_a_string(self) -> None:
+        doc = json.dumps({"@type": "SoftwareSourceCode", "license": "https://spdx.org/licenses/MIT"})
+
+        assert extract_deposit_licence(doc) == "https://spdx.org/licenses/MIT"
+
+    def test_a_frictionless_datapackage_declares_it_in_a_list(self) -> None:
+        doc = json.dumps(
+            {
+                "name": "deposit",
+                "licenses": [
+                    {"name": "CC-BY-4.0", "path": "https://creativecommons.org/licenses/by/4.0/"}
+                ],
+            }
+        )
+
+        assert extract_deposit_licence(doc) == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_a_datacite_payload_declares_it_as_a_rights_uri(self) -> None:
+        doc = json.dumps(
+            {
+                "rightsList": [
+                    {
+                        "rights": "Creative Commons Attribution 4.0",
+                        "rightsUri": "https://creativecommons.org/licenses/by/4.0/legalcode",
+                    }
+                ]
+            }
+        )
+
+        assert extract_deposit_licence(doc) == (
+            "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )
+
+    def test_a_yaml_metadata_file_declares_it(self) -> None:
+        assert extract_deposit_licence(
+            "title: A study\nlicense: https://creativecommons.org/licenses/by/4.0/\n"
+        ) == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_a_uri_is_preferred_over_a_bare_label(self) -> None:
+        """Machine-actionable beats a label, wherever in the document it sits."""
+        doc = json.dumps(
+            {
+                "license": "CC-BY-4.0",
+                "distribution": {"license": {"@id": "https://creativecommons.org/licenses/by/4.0/"}},
+            }
+        )
+
+        assert extract_deposit_licence(doc) == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_a_bare_label_is_still_returned_verbatim(self) -> None:
+        """Mapping "CC-BY" onto a 4.0 URI would state a version nobody did (D5)."""
+        assert extract_deposit_licence(json.dumps({"license": "CC-BY"})) == "CC-BY"
+
+    def test_prose_is_never_a_source(self) -> None:
+        """Every real deposit's README carries an unfilled template placeholder.
+
+        `## License` / `[Default CC-BY 4.0 for data, CC0 for metadata unless
+        specified otherwise]` — a bracketed instruction naming two licences and
+        declaring neither. Reading a named field is not guessing; reading this
+        would be.
+        """
+        readme = (
+            "# Study README Template\n\n## License\n"
+            "[Default CC-BY 4.0 for data, CC0 for metadata unless specified otherwise]\n"
+        )
+
+        assert extract_deposit_licence(readme) is None
+
+    def test_a_markdown_bullet_list_is_not_a_declaration(self) -> None:
+        """Prose parses as YAML, which is the trap.
+
+        `- License: see the LICENSE file` is a valid YAML sequence of mappings,
+        so a reader that accepted any YAML value would file "see the LICENSE
+        file" as this deposit's legal terms. Only a document whose top level is
+        a MAPPING is a metadata record; a list of bullets is a README.
+        """
+        readme = "- License: see the LICENSE file\n- Contact: someone@example.org\n"
+
+        assert extract_deposit_licence(readme) is None
+
+    def test_an_empty_declaration_is_not_a_declaration(self) -> None:
+        assert extract_deposit_licence(json.dumps({"license": ""})) is None
+        assert extract_deposit_licence(json.dumps({"license": {"@id": ""}})) is None
+
+
+class TestWhichFileTheLicenceIsReadFrom:
+    """Several files in a deposit can name a licence. Which one is the deposit's.
+
+    Reading the first `.json` the scan happened to reach made the answer depend
+    on directory order, and admitted any bundled manifest as the deposit's own
+    terms.
+    """
+
+    CC_BY = "https://creativecommons.org/licenses/by/4.0/legalcode"
+
+    def _engine_over(self, tmp_path: Path):
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        engine.initialize(input_path=str(tmp_path))
+        return engine
+
+    def test_a_yaml_metadata_file_is_read(self, tmp_path: Path) -> None:
+        (tmp_path / "dataset_description.yaml").write_text(
+            f"title: A study\nlicense: {self.CC_BY}\n", encoding="utf-8"
+        )
+
+        engine = self._engine_over(tmp_path)
+
+        assert engine.state.metadata.license == self.CC_BY
+        assert engine.state.metadata.license_from_deposit is True
+
+    def test_a_bundled_manifest_does_not_become_the_deposits_terms(
+        self, tmp_path: Path
+    ) -> None:
+        """A vendored `package.json` states its own licence, not the data's."""
+        (tmp_path / "S-TEST1.json").write_text(
+            _descriptor(
+                {
+                    "name": "License",
+                    "value": "CC-BY",
+                    "valqual": [{"name": "URL", "value": self.CC_BY}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        nested = tmp_path / "code" / "vendor" / "lib"
+        nested.mkdir(parents=True)
+        (nested / "package.json").write_text(
+            json.dumps({"name": "lib", "license": "MIT"}), encoding="utf-8"
+        )
+
+        assert self._engine_over(tmp_path).state.metadata.license == self.CC_BY
+
+    def test_the_answer_does_not_depend_on_directory_order(self, tmp_path: Path) -> None:
+        """Two declarations at the same depth resolve the same way every run."""
+        for name in ("zzz_meta.json", "aaa_meta.json"):
+            (tmp_path / name).write_text(
+                json.dumps({"license": self.CC_BY}), encoding="utf-8"
+            )
+
+        assert self._engine_over(tmp_path).state.metadata.license == self.CC_BY
+
+    def test_a_machine_actionable_uri_beats_a_label_in_another_file(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "a_label.json").write_text(
+            json.dumps({"license": "CC-BY"}), encoding="utf-8"
+        )
+        (tmp_path / "b_uri.json").write_text(
+            json.dumps({"license": self.CC_BY}), encoding="utf-8"
+        )
+
+        assert self._engine_over(tmp_path).state.metadata.license == self.CC_BY
+
+
+class TestTheConventionsOutsideAMetadataRecord:
+    """Not every deposit ships a metadata record, and most ship a LICENSE file.
+
+    A named field in a JSON document is one way to declare terms. The two that
+    cover everything else are the SPDX identifier — a formal, machine-readable
+    declaration that can sit in any text — and a file whose NAME says its whole
+    content is the licence.
+    """
+
+    CC_BY = "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_an_spdx_identifier_is_a_declaration_wherever_it_sits(self) -> None:
+        """`SPDX-License-Identifier:` is a standard, not a guess."""
+        assert extract_deposit_licence("# SPDX-License-Identifier: CC-BY-4.0\n") == "CC-BY-4.0"
+        assert extract_deposit_licence("<!-- SPDX-License-Identifier: MIT -->") == "MIT"
+
+    def test_a_citation_file_declares_it(self) -> None:
+        """CITATION.cff is YAML, and `license` is one of its standard keys."""
+        cff = "cff-version: 1.2.0\ntitle: A study\nlicense: CC-BY-4.0\n"
+
+        assert extract_deposit_licence(cff) == "CC-BY-4.0"
+
+    def test_a_license_file_naming_a_url_is_read(self) -> None:
+        """The filename declares that the content IS the licence, so a URI in it
+        is the depositor's statement rather than a URL found in prose."""
+        text = f"Creative Commons Attribution 4.0 International\n\n{self.CC_BY}\n"
+
+        assert extract_deposit_licence(text, filename="LICENSE") == self.CC_BY
+
+    def test_a_license_file_carrying_an_spdx_id_is_read(self) -> None:
+        assert extract_deposit_licence("CC0-1.0\n", filename="COPYING") is None
+        assert (
+            extract_deposit_licence("SPDX-License-Identifier: CC0-1.0\n", filename="COPYING")
+            == "CC0-1.0"
+        )
+
+    def test_legal_prose_alone_is_still_not_mined(self) -> None:
+        """A LICENSE file holding only the legal text names no identifier.
+
+        Reading "Creative Commons Attribution 4.0 International Public License"
+        off the first line would be inventing a machine-actionable claim from a
+        heading. Absent is honest (D5).
+        """
+        text = (
+            "Creative Commons Attribution 4.0 International Public License\n\n"
+            "By exercising the Licensed Rights, You accept and agree to be bound by\n"
+            "the terms and conditions of this Public License.\n"
+        )
+
+        assert extract_deposit_licence(text, filename="LICENSE") is None
+
+    def test_the_permissive_read_needs_the_filename(self) -> None:
+        """The same URI in an unnamed text file is just a URL in prose."""
+        text = f"See {self.CC_BY} for details.\n"
+
+        assert extract_deposit_licence(text) is None
+        assert extract_deposit_licence(text, filename="LICENCE.txt") == self.CC_BY
+
+
+class TestXmlMetadataDeclaresItToo:
+    """DataCite, OAI-DC and METS are XML, and repositories export them.
+
+    Parsed through `defusedxml`: a deposit is untrusted input, and stdlib
+    ElementTree will happily expand a billion-laughs entity out of one.
+    """
+
+    CC_BY = "https://creativecommons.org/licenses/by/4.0/legalcode"
+
+    def test_a_datacite_record_declares_it_as_a_rights_uri_attribute(self) -> None:
+        xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+        <resource xmlns="http://datacite.org/schema/kernel-4">
+          <identifier identifierType="DOI">10.1234/abcd</identifier>
+          <rightsList>
+            <rights rightsURI="{self.CC_BY}">Creative Commons Attribution 4.0</rights>
+          </rightsList>
+        </resource>"""
+
+        assert extract_deposit_licence(xml) == self.CC_BY
+
+    def test_a_namespaced_dublin_core_rights_element_is_read(self) -> None:
+        xml = f"""<?xml version="1.0"?>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/">
+          <dc:title>A study</dc:title>
+          <dc:rights>{self.CC_BY}</dc:rights>
+        </oai_dc:dc>"""
+
+        assert extract_deposit_licence(xml) == self.CC_BY
+
+    def test_a_license_element_is_read(self) -> None:
+        xml = f'<metadata><license>{self.CC_BY}</license></metadata>'
+
+        assert extract_deposit_licence(xml) == self.CC_BY
+
+    def test_a_uri_attribute_beats_the_elements_label(self) -> None:
+        xml = f'<rightsList><rights rightsURI="{self.CC_BY}">CC BY 4.0</rights></rightsList>'
+
+        assert extract_deposit_licence(xml) == self.CC_BY
+
+    def test_a_label_with_no_uri_is_returned_verbatim(self) -> None:
+        assert extract_deposit_licence("<resource><rights>CC-BY-4.0</rights></resource>") == (
+            "CC-BY-4.0"
+        )
+
+    def test_xml_that_declares_nothing_yields_nothing(self) -> None:
+        assert extract_deposit_licence("<resource><title>A study</title></resource>") is None
+
+    def test_malformed_xml_is_not_a_declaration(self) -> None:
+        assert extract_deposit_licence("<resource><rights>oops") is None
+
+    def test_an_entity_bomb_is_refused_rather_than_expanded(self) -> None:
+        """The reason this goes through defusedxml at all.
+
+        Stdlib ElementTree expands these; a deposit is untrusted input, and one
+        crafted file must not be able to exhaust memory during a scan.
+        """
+        bomb = """<?xml version="1.0"?>
+        <!DOCTYPE lolz [
+          <!ENTITY lol "lol">
+          <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+          <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+        ]>
+        <resource><rights>&lol3;</rights></resource>"""
+
+        assert extract_deposit_licence(bomb) is None
+
+
+class TestTheEngineReadsThoseToo:
+    CC_BY = "https://creativecommons.org/licenses/by/4.0/"
+
+    def _licence_over(self, tmp_path: Path) -> str | None:
+        from builder.engine import AgentEngine
+
+        engine = AgentEngine()
+        engine.initialize(input_path=str(tmp_path))
+        return engine.state.metadata.license
+
+    def test_a_standalone_license_file_is_read(self, tmp_path: Path) -> None:
+        (tmp_path / "LICENSE").write_text(
+            f"Creative Commons Attribution 4.0\n{self.CC_BY}\n", encoding="utf-8"
+        )
+
+        assert self._licence_over(tmp_path) == self.CC_BY
+
+    def test_a_citation_file_is_read(self, tmp_path: Path) -> None:
+        (tmp_path / "CITATION.cff").write_text(
+            "cff-version: 1.2.0\nlicense: CC-BY-4.0\n", encoding="utf-8"
+        )
+
+        assert self._licence_over(tmp_path) == "CC-BY-4.0"
+
+    def test_a_datacite_xml_export_is_read(self, tmp_path: Path) -> None:
+        (tmp_path / "datacite.xml").write_text(
+            '<resource><rightsList><rights rightsURI="'
+            + self.CC_BY
+            + '">CC BY 4.0</rights></rightsList></resource>',
+            encoding="utf-8",
+        )
+
+        assert self._licence_over(tmp_path) == self.CC_BY
+
+    def test_a_metadata_record_still_outranks_a_deeper_license_file(
+        self, tmp_path: Path
+    ) -> None:
+        """Depth decides, so a root descriptor beats a nested LICENSE."""
+        (tmp_path / "S-TEST1.json").write_text(
+            _descriptor({"name": "License", "value": "CC-BY", "valqual": [
+                {"name": "URL", "value": "https://creativecommons.org/licenses/by/4.0/legalcode"}
+            ]}),
+            encoding="utf-8",
+        )
+        nested = tmp_path / "code"
+        nested.mkdir()
+        (nested / "LICENSE").write_text("SPDX-License-Identifier: MIT\n", encoding="utf-8")
+
+        assert self._licence_over(tmp_path) == (
+            "https://creativecommons.org/licenses/by/4.0/legalcode"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -575,6 +575,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3008,6 +3017,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "frictionless" },
     { name = "langchain" },
     { name = "langgraph" },
@@ -3051,6 +3061,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cryptography", specifier = ">=41" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "frictionless", specifier = ">=5.19.0" },
     { name = "langchain", specifier = ">=1.3.10" },
     { name = "langchain-anthropic", marker = "extra == 'langchain'", specifier = ">=1" },


### PR DESCRIPTION
Closes #535.

## The reported defect was already fixed

S-VHPS26 declares CC-BY-4.0 and its crate asserted all-rights-reserved. All three
of the issue's fix directions had landed separately: `extract_deposit_licence`
reads it, `license_from_deposit` stops `set_crate_metadata` overwriting it, and
the hardcoded `ALL RIGHTS RESERVED BY THE AUTHORS` fallback is gone. The crate
under `output/` still shows the old value because it is a **pre-fix artifact**,
not because the bug is live — re-running the extractor over all three real
deposits resolves each to `https://creativecommons.org/licenses/by/4.0/legalcode`.

So this PR closes the issue, and what it actually changes is **reach**.

## What was too narrow

The reader was gated on a BioStudies attribute tree
(`if not ("attributes" in parsed or "section" in parsed): return None`) and the
engine opened only `.json`. It answered for exactly one repository's export
format; every other deposit fell straight through to the model guessing.

## What it reads now

Still a **named field** — that is what keeps this reading rather than guessing.

| convention | shape |
|---|---|
| BioStudies attribute | `{"name":"License","valqual":[{"value":URL}]}` |
| RO-Crate | `"license": {"@id": …}` |
| CodeMeta / Zenodo | `"license": "https://…"` |
| Frictionless | `"licenses": [{"path": …}]` |
| DataCite JSON | `"rightsList": [{"rightsUri": …}]` |
| DataCite XML | `<rights rightsURI="…">CC BY 4.0</rights>` |
| Dublin Core / OAI | `<dc:rights>https://…</dc:rights>` |
| CITATION.cff | YAML `license:` |
| SPDX | `SPDX-License-Identifier:` in any text |
| LICENSE / COPYING | URI read from the content |

Formats: `.json`, `.jsonld`, `.yaml`, `.yml`, `.cff`, `.xml`, plus any file named
LICENSE / LICENCE / COPYING / COPYRIGHT.

XML tags and attributes match on their **local** name, namespace stripped —
otherwise every namespaced record slips past. DataCite splits the URI (attribute)
from the label (element text); both are collected and the URI wins, the same rule
used everywhere else.

## defusedxml is pinned by a test, not by a comment

A deposit is untrusted input, and stdlib `ElementTree` expands a billion-laughs
entity out of one crafted file. `test_an_entity_bomb_is_refused_rather_than_expanded`
fails if you swap `defusedxml` for `xml.etree` — I verified that mutation.

## Three boundaries drawn deliberately

- **Prose is never a source, and the guard is load-bearing.** YAML parses a
  README's bullets into a list of mappings, so `- License: see the LICENSE file`
  would be filed as legal terms. Only a document whose top level is a **mapping**
  is a metadata record. I nearly dropped this as defensive before checking.
- **A LICENSE file gets a permissive read; anything else does not.** The filename
  is itself the declaration that the content is the licence, which is what lets a
  URI be read out of it. The same URI in an unnamed `.txt` is a URL in prose.
- **Legal prose still yields nothing.** Taking "Creative Commons Attribution 4.0
  International Public License" off line one would manufacture a
  machine-actionable claim from a heading (D5).

## Which file is the deposit's

Decided rather than left to directory order: **shallowest first**, then a
machine-actionable IRI, then the path. Depth outranks the IRI preference
deliberately — a nested SPDX URI must not beat the root descriptor's own label,
and a vendored `package.json` is not the data's terms.

## Verification

Full suite **3273 passed, 0 failed**. 49 tests in `tests/test_deposit_licence.py`.

Re-verified on the three real deposits after *each* widening: exactly one
declaration each, at depth 1, the correct URI — no greediness introduced.

Eleven mutations each break at least one test:

| mutation | tests failing |
|---|---|
| restore the BioStudies gate | 10 |
| no YAML fallback | 2 |
| first candidate wins, no IRI preference | 1 |
| accept any YAML value (prose becomes a source) | 1 |
| engine takes the first match, not the shallowest | 1 |
| engine reads `.json` only | 1 |
| no SPDX support | 2 |
| mine a URI from any text | 1 |
| mine a LICENSE file's first prose line | 2 |
| engine ignores LICENSE-named files | 1 |
| stdlib ElementTree instead of defusedxml | 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
