### PR TITLE
fix(discovery): allocate the prompt slots by what the files are (#595)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,17 +397,41 @@ readable documentation into a bounded context, reusing the previews
 classification already read. It reports `kind` (descriptor / tabular / narrative
 / opaque) alongside the classification, because form decides how a file is
 *rendered* — a data table contributes its shape, prose contributes its text — and
-the two questions have different answers for the same file. Narrative and tabular
-are interleaved by their own rank rather than competing on one scale, and the cap
-is stated in the context rather than applied silently (#587).
+the two questions have different answers for the same file. The cap is stated in
+the context rather than applied silently (#587).
 
 The character budget is split **max-min fair** across the candidates, not spent in
 rank order: rank order let three long READMEs consume the whole ceiling and delete
 every cheaper entry behind them, and a file that is never named is a file the agent
 cannot read. A share too small to carry even the entry's `[kind/class] path` header
 buys nothing, so that entry is dropped and its share returned rather than emitted as
-a fragment. The SLOT allocation is not fair in the same sense yet — the ranking does
-not use the classification to decide which 20 files compete — which is #595.
+a fragment.
+
+**The slots are allocated the same way, over the classification (#595).** The cap is
+the agent's whole view of the submission, and it used to be spent on one axis — "how
+document-like is this?" — over a population #591 can classify into four, so whole
+tiers vanished: svhps26 named 14 interchangeable plate readouts and *none* of its 8
+GraphPad analysis files, each carrying a kilobyte of readable content. Every class
+present now takes a floor, so a tier is never wholly absent, and the surplus goes
+through the same `_fair_shares`. `raw_data_file` takes its floor and stands out of
+the redistribution — #598 established it is the one tier whose members are
+interchangeable, so a sixth gamma-counter printout says nothing the first five did,
+while a sixth protocol is a different experiment — but it still absorbs whatever the
+other classes leave unspent, because an empty slot helps nobody.
+
+Within a class, rank decides and nothing overrides it. This *replaces* the kind
+interleave rather than nesting inside it: interleaving by kind within a class was
+measured and re-created the very defect #587 fixed, with metadata's quota alternating
+so that READMEs scoring 0.578 and 0.521 displaced assay-metadata workbooks scoring
+0.670 and 0.657. #587's concern stands, but **class** is the axis that delivers it,
+because the tiers a deposit floods are also the ones of a single form — measured on
+the real fixture, 50% tabular against 42% narrative, with no kind rule at all.
+
+The cap and the budget moved with it, from 20 slots / 12 000 characters to **40 /
+18 000**. They are one trade, not two: at 40 slots the old budget squeezed the median
+entry from 433 characters to 302, which is exactly the "more files named, each saying
+less" the fix has to avoid. At 18 000 every entry keeps its full size, and the class
+floor is what stops the extra slots going to more of the same instrument output.
 
 #### Entity Drafters (`builder/tools/drafters.py`)
 Generate metadata entities from files, conversation, or existing metadata.

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -313,7 +313,7 @@ def _run_document_discovery(engine: AgentEngine) -> None:
         return
 
     # Classify EVERY scanned file before ranking any of them (#591). The ranking
-    # exists to fill a bounded prompt and shows 20 of them; what the crate is
+    # exists to fill a bounded prompt and shows a capped subset; what the crate is
     # built from must not depend on what fits in a context window. Every file is
     # stamped, but not every file is opened — a folder of interchangeable
     # instrument output is sampled (#598). The previews are handed on so the

--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -22,7 +22,7 @@ _DOCUMENT_SUFFIXES = {
 }
 _TEXT_MIMES = ("text/", "application/json", "application/xml", "application/pdf")
 _MAX_PREVIEW_CHARS = 3_000
-_MAX_CONTEXT_CHARS = 12_000
+_MAX_CONTEXT_CHARS = 18_000
 _JOINER = "\n\n"
 _TRUNCATED = " […]"
 
@@ -538,7 +538,7 @@ def classify_scanned_files(
 ) -> dict[str, str]:
     """Stamp every scanned file with its class, and return the previews read.
 
-    EVERY file, not the ranked subset: :func:`discover_documents` caps at 20
+    EVERY file, not the ranked subset: :func:`discover_documents` caps its
     candidates because its job is filling a bounded prompt, and what gets wired
     into the crate must not depend on what fits in a context window.
 
@@ -609,11 +609,12 @@ def classify_scanned_files(
 # two vocabularies; what #591 collapsed was four lists all answering the SAME
 # question differently.
 #
-# The ranking does NOT yet use the classification to allocate its 20 slots, and
-# should: a `.docx` previews as a paragraph count, so a protocol's score comes
-# almost entirely from which of these words are in its FILENAME, and 7 of
-# svhps22's 13 protocol documents miss the cut while 9 of its 14 metadata files
-# are named. Tracked in #595.
+# These words still decide a NARRATIVE file's score, and for a `.docx` — which
+# previews as a paragraph count — that means its FILENAME decides it. That is
+# survivable now only because the slot allocation no longer lets one class take
+# the listing (#595): the score orders files WITHIN a class, where every
+# candidate is the same kind of thing, rather than deciding which tier is seen
+# at all.
 _STUDY_PROSE_TERMS = (
     "assay", "endpoint", "readout", "cell", "compound", "substance",
     "concentration", "dose", "exposure", "incubat", "replicate", "protocol",
@@ -694,7 +695,7 @@ def discover_documents(
     *,
     input_root: str,
     approved_roots: set[str],
-    max_candidates: int = 20,
+    max_candidates: int = 40,
     max_context_chars: int = _MAX_CONTEXT_CHARS,
     previews: dict[str, str] | None = None,
 ) -> list[DocumentationCandidate]:
@@ -747,43 +748,79 @@ def discover_documents(
             )
         )
     ranked.sort(key=lambda item: (-item.score, item.relative_path.casefold()))
-    return _interleave_kinds(ranked, max_candidates)
+    return _allocate_slots(ranked, max_candidates)
 
 
-# Narrative explains what the study IS; tabular carries the values the crate is
-# built from. A ranking dominated by either is the same defect — the original
-# surfaced seven READMEs and one data file, and scoring tables on their real
-# contents simply inverts it, because a deposit holds far more instrument output
-# than prose. So the two are interleaved by their own rank rather than competing
-# on one scale, and balance follows from the construction rather than from a
-# threshold someone has to keep tuning.
-_INTERLEAVED_KINDS = (KIND_NARRATIVE, KIND_TABULAR)
+# Slots a class present in the deposit is guaranteed before any redistribution.
+# A tier the deposit holds must be NAMED — the agent cannot read a file it was
+# not told exists — and svhps26 spent 14 of its 20 slots on interchangeable
+# plate readouts while naming NONE of its 8 GraphPad analysis files, each
+# carrying a kilobyte of readable content (#595).
+_MIN_SLOTS_PER_CLASS = 2
+
+# The class that takes its floor and no share of the surplus. #598 established
+# instrument output is the one tier whose members are interchangeable: a sixth
+# gamma-counter printout says nothing the first five did not, while a sixth
+# protocol is a different experiment. It still absorbs whatever the other
+# classes leave unspent — an empty slot helps nobody.
+_INTERCHANGEABLE_CLASSES = frozenset({CLASS_RAW_DATA})
 
 
-def _interleave_kinds(
+def _allocate_slots(
     ranked: list[DocumentationCandidate], limit: int
 ) -> list[DocumentationCandidate]:
-    """Fill *limit* slots alternating between narrative and tabular, best first.
+    """Fill *limit* slots so no class the deposit holds can be crowded out (#595).
 
-    The descriptor leads if there is one — a submission record outranks anything
-    else in the deposit, being the only file that states the study's own identity.
-    Whatever remains (opaque formats, and the tail of either kind) fills the slots
-    the alternation does not use, so nothing is excluded merely by its kind.
+    The cap is the agent's whole view of the submission, and it was spent on a
+    single axis — "how document-like is this?" — over a population #591 can
+    classify into four. Whole tiers vanished: svhps26 named 14 interchangeable
+    readouts and none of its processed data at all.
+
+    Slots are allocated the way :func:`format_document_context` already
+    allocates its CHARACTERS, through the same :func:`_fair_shares`, with one
+    difference measurement forced. Every class present takes a floor, so a tier
+    is never wholly absent; :data:`_INTERCHANGEABLE_CLASSES` takes that floor
+    and stands out of the redistribution, because one exemplar of a tier whose
+    files repeat each other says what six would.
+
+    Within a class, RANK decides and nothing overrides it. Interleaving by kind
+    inside a class was measured and re-created the defect #587 fixed: metadata's
+    quota alternated narrative with tabular, so READMEs scoring 0.578 and 0.521
+    displaced assay-metadata workbooks scoring 0.670 and 0.657.
+
+    This replaces the kind interleave rather than nesting inside it. #587's
+    concern stands — narrative explains what the study IS, tabular carries the
+    values the crate is built from, and a listing dominated by either is the
+    same defect — but *class* turns out to be the axis that delivers it, because
+    the tiers a deposit floods are also the ones of a single form. Balance now
+    follows from the construction on the axis that decides what a file is worth
+    naming: measured on the real fixture, 50% tabular against 42% narrative, and
+    the descriptor still leads on score alone.
     """
-    by_kind: dict[str, list[DocumentationCandidate]] = {}
+    by_class: dict[str, list[DocumentationCandidate]] = {}
     for candidate in ranked:
-        by_kind.setdefault(candidate.kind, []).append(candidate)
+        by_class.setdefault(candidate.classification, []).append(candidate)
+    if not by_class:
+        return []
 
-    chosen = list(by_kind.get(KIND_DESCRIPTOR, []))[:limit]
-    queues = [list(by_kind.get(kind, [])) for kind in _INTERLEAVED_KINDS]
-    while len(chosen) < limit and any(queues):
-        for queue in queues:
-            if not queue or len(chosen) >= limit:
-                continue
-            chosen.append(queue.pop(0))
-    if len(chosen) < limit:
-        taken = {id(c) for c in chosen}
-        chosen.extend(c for c in ranked if id(c) not in taken)
+    classes = sorted(by_class)
+    # The floor cannot outrun the budget: a small cap over many classes would
+    # otherwise reserve more slots than there are.
+    ceiling = limit // len(classes)
+    quota = {cls: min(_MIN_SLOTS_PER_CLASS, ceiling, len(by_class[cls])) for cls in classes}
+    demand = [
+        0 if cls in _INTERCHANGEABLE_CLASSES else len(by_class[cls]) - quota[cls]
+        for cls in classes
+    ]
+    for cls, extra in zip(classes, _fair_shares(demand, max(0, limit - sum(quota.values())))):
+        quota[cls] += extra
+
+    chosen = [c for cls in classes for c in by_class[cls][: quota[cls]]]
+    # Whatever the allocation did not spend — every distinct class met in full,
+    # or only interchangeable candidates left — goes by rank, so the listing is
+    # never short while candidates remain.
+    taken = {id(c) for c in chosen}
+    chosen.extend(c for c in ranked if id(c) not in taken)
     chosen = chosen[:limit]
     chosen.sort(key=lambda item: (-item.score, item.relative_path.casefold()))
     return chosen

--- a/tests/test_document_discovery_ranking.py
+++ b/tests/test_document_discovery_ranking.py
@@ -1,7 +1,7 @@
 """Discovery ranks what carries the facts, not what reads like prose (#587).
 
-The ranking decides what the agent sees at all — 20 candidates out of 54 files,
-against a 12 000-character context cap — and it used to award +0.12 for
+The ranking decides what the agent sees at all — a capped subset of the deposit,
+against a bounded context — and it used to award +0.12 for
 "prose-like" text and up to +0.24 for sitting near the root. A spreadsheet can
 never earn the first, so the deposit's 1048-row measurement table scored 0.44
 against a top-level README's 0.65, despite carrying twice the content evidence.
@@ -130,7 +130,7 @@ class TestScoresDiscriminate:
 
 class TestNothingIsDroppedSilently:
     def test_the_context_says_how_much_it_left_out(self, ranked) -> None:
-        # "20 candidates" hid 34 files. Same rule the maturity report follows:
+        # A silent cap hid 34 of the fixture's files. Same rule the report follows:
         # a cap that bites says how many it hid.
         context = format_document_context(ranked, total_scanned=len(_scan()))
         assert "not surfaced" in context or "not listed" in context, context[-400:]
@@ -312,12 +312,21 @@ class TestNoOneFileCrowdsOutTheRest:
             assert block.strip(), f"{candidate.relative_path} was cut entirely"
 
     def test_the_ceiling_still_holds(self, ranked) -> None:
-        """Fitting everything must not be achieved by spending more."""
+        """Fitting everything must not be achieved by spending without limit.
+
+        The ceiling moved from 12 000 to 18 000 with the slot cap (#595): at 40
+        slots the old budget squeezed the median entry from 433 characters to
+        302, and an entry that says less is the cost the issue warned about.
+        18 000 buys twice the files at their full size. What must not change is
+        that there IS a ceiling and the listing respects it.
+        """
+        from builder.tools.document_discovery import _MAX_CONTEXT_CHARS
+
         context = format_document_context(ranked, total_scanned=99)
 
         blocks = context.split("\n\n(")[0]
 
-        assert len(blocks) <= 12_000, len(blocks)
+        assert len(blocks) <= _MAX_CONTEXT_CHARS, len(blocks)
 
     def test_a_block_too_small_to_name_its_file_is_not_written(self, ranked) -> None:
         """Fairness cuts the other way at the bottom of the budget.
@@ -355,3 +364,140 @@ class TestNoOneFileCrowdsOutTheRest:
         )
 
         assert named, "a 2 000-char budget must still name somebody"
+
+
+class TestTheSlotsAreAllocatedByWhatTheFilesAre:
+    """20 slots, four classes, and the ranking used to spend them on one axis (#595).
+
+    The cap is the agent's whole view of the submission — a file that misses it
+    is never named, and the agent cannot read a file it was not told exists. The
+    ranking decided those slots by "how document-like is this?" over a
+    population #591 can classify into four, so on the real deposits whole tiers
+    vanished: svhps26 named 14 interchangeable plate readouts and **zero** of
+    its 8 GraphPad analysis files, each carrying a kilobyte of readable content.
+
+    Slots are now allocated the way `format_document_context` already allocates
+    its CHARACTERS — max-min fair, so no class can crowd out another — with two
+    differences that measurement forced:
+
+    - every class present takes a floor first, so a tier is never wholly absent;
+    - `raw_data_file` takes its floor and stands out of the redistribution.
+      #598 established it is the one tier whose members are interchangeable: a
+      sixth gamma-counter printout says nothing the first five did not, while a
+      sixth protocol is a different experiment.
+
+    Within a class the kind interleave still decides, because form is what makes
+    an entry worth reading and class is what makes it worth naming.
+    """
+
+    from builder.tools.document_discovery import (
+        CLASS_METADATA,
+        CLASS_PROCESSED_DATA,
+        CLASS_PROTOCOL,
+        CLASS_RAW_DATA,
+    )
+
+    def _candidates(self, spec: list[tuple[str, str, float]]):
+        """`(classification, kind, score)` triples as ranked candidates."""
+        from builder.tools.document_discovery import DocumentationCandidate
+
+        return [
+            DocumentationCandidate(
+                path=f"/d/{i}", filename=f"{i}.txt", relative_path=f"{i}.txt",
+                kind=kind, classification=cls, score=score, preview="x",
+            )
+            for i, (cls, kind, score) in enumerate(spec)
+        ]
+
+    def _allocate(self, candidates, limit: int):
+        from builder.tools.document_discovery import _allocate_slots
+
+        return _allocate_slots(candidates, limit)
+
+    def _counts(self, chosen) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for candidate in chosen:
+            counts[candidate.classification] = counts.get(candidate.classification, 0) + 1
+        return counts
+
+    def test_a_tier_is_never_crowded_out_entirely(self) -> None:
+        """svhps26's shape: one tier numerous, another tiny and invisible."""
+        spec = [(self.CLASS_RAW_DATA, "tabular", 0.9 - i * 0.001) for i in range(40)]
+        spec += [(self.CLASS_PROCESSED_DATA, "opaque", 0.3 - i * 0.001) for i in range(8)]
+
+        counts = self._counts(self._allocate(self._candidates(spec), 20))
+
+        assert counts.get(self.CLASS_PROCESSED_DATA, 0) > 0, counts
+
+    def test_the_interchangeable_tier_never_costs_a_distinct_one_a_slot(self) -> None:
+        """Every raw file outranks every protocol, and every protocol is still named.
+
+        Raw takes what is left over rather than what it outranks — leaving a
+        slot empty would help nobody, but taking one from a tier whose files
+        differ from each other loses something no other file says.
+        """
+        spec = [(self.CLASS_RAW_DATA, "tabular", 0.9 - i * 0.001) for i in range(40)]
+        spec += [(self.CLASS_PROTOCOL, "narrative", 0.3 - i * 0.001) for i in range(12)]
+
+        counts = self._counts(self._allocate(self._candidates(spec), 20))
+
+        assert counts[self.CLASS_PROTOCOL] == 12, counts
+        assert counts[self.CLASS_RAW_DATA] == 8, counts
+
+    def test_a_class_with_less_than_its_share_gives_the_rest_back(self) -> None:
+        spec = [(self.CLASS_METADATA, "narrative", 0.9)]
+        spec += [(self.CLASS_PROTOCOL, "narrative", 0.5 - i * 0.001) for i in range(30)]
+
+        counts = self._counts(self._allocate(self._candidates(spec), 20))
+
+        assert counts[self.CLASS_METADATA] == 1
+        assert counts[self.CLASS_PROTOCOL] == 19, counts
+
+    def test_every_slot_is_still_filled(self) -> None:
+        spec = [(self.CLASS_RAW_DATA, "tabular", 0.9 - i * 0.001) for i in range(50)]
+
+        assert len(self._allocate(self._candidates(spec), 20)) == 20
+
+    def test_fewer_candidates_than_slots_names_them_all(self) -> None:
+        spec = [(self.CLASS_METADATA, "narrative", 0.9), (self.CLASS_PROTOCOL, "narrative", 0.5)]
+
+        assert len(self._allocate(self._candidates(spec), 20)) == 2
+
+    def test_within_a_class_rank_decides_and_nothing_overrides_it(self) -> None:
+        """Class balance replaces the kind interleave rather than nesting inside it.
+
+        Interleaving by kind INSIDE a class re-created the defect #587 fixed:
+        metadata's quota alternated, so READMEs scoring 0.578 and 0.521 displaced
+        assay-metadata workbooks scoring 0.670 and 0.657 — a lower-scoring file
+        beating a higher-scoring one in the same class. Kind balance is a
+        property of the whole list, and the measured list holds it: 50% tabular
+        against 42% narrative on the real fixture.
+        """
+        spec = [(self.CLASS_METADATA, "tabular", 0.9 - i * 0.001) for i in range(10)]
+        spec += [(self.CLASS_METADATA, "narrative", 0.4 - i * 0.001) for i in range(10)]
+
+        chosen = self._allocate(self._candidates(spec), 8)
+
+        assert [c.score for c in chosen] == sorted((c.score for c in chosen), reverse=True)
+        assert all(c.kind == "tabular" for c in chosen), [c.kind for c in chosen]
+
+    def test_the_descriptor_still_leads(self, ranked) -> None:
+        assert ranked[0].relative_path.replace("\\", "/") == DESCRIPTOR
+
+
+class TestTheRealDepositIsRepresented:
+    """Measured on the fixture the way #595 requires it reported: per class."""
+
+    def test_no_class_takes_more_than_a_third_of_the_list(self, ranked) -> None:
+        """It was metadata 9 of 20 against protocol 6, raw 1, processed 4."""
+        counts: dict[str, int] = {}
+        for candidate in ranked:
+            counts[candidate.classification] = counts.get(candidate.classification, 0) + 1
+
+        for cls, count in counts.items():
+            assert count <= len(ranked) / 3 + 1, f"{cls} takes {count} of {len(ranked)}: {counts}"
+
+    def test_every_class_the_deposit_holds_is_named(self, ranked) -> None:
+        named = {c.classification for c in ranked}
+
+        assert named == {"metadata", "protocol", "raw_data_file", "processed_data_file"}, named

--- a/tests/test_file_classification.py
+++ b/tests/test_file_classification.py
@@ -381,7 +381,7 @@ class TestTheDefaults:
 class TestClassifyingTheWholeDeposit:
     """What gets wired into the crate must not depend on what fits in a prompt.
 
-    ``discover_documents`` caps at 20 candidates because its job is filling a
+    ``discover_documents`` caps its candidates because its job is filling a
     12 000-character context. Classification runs over everything.
     """
 


### PR DESCRIPTION
Closes #595.

The cap is the agent's whole view of the submission — a file that misses it is
never named, and **the agent cannot read a file it was not told exists**. It was
spent on a single axis ("how document-like is this?") over a population #591 can
classify into four, so whole tiers vanished.

## Named per class, before → after

| deposit | metadata | protocol | raw | processed |
|---|---|---|---|---|
| svhps22 fixture (52 eligible) | 9 → **13** | 6 → **12** | 1 → 2 | 4 → **13** |
| S-VHPS26 (55 eligible) | 5 → 5 | 1 → 1 | 14 → 26 | **0 → 8** |
| S-VHPS22 full (1455 eligible) | 5 → **13** | 6 → **12** | 0 → 2 | 9 → **13** |

svhps26 named **zero** of its 8 GraphPad analysis files — each carrying a
kilobyte of readable content — while spending 14 slots on interchangeable plate
readouts.

## Two changes, and neither is sufficient alone

**The cap and the character budget move together**, 20/12 000 → 40/18 000. One
trade, not two: at 40 slots the old budget squeezes the median entry from 433
characters to 302 — exactly the *"more files named, each saying less"* the issue
warns about. At 18 000 every entry keeps its full size.

**Slots are allocated the way the characters already are**, through the same
`_fair_shares`. Every class present takes a floor, so a tier is never wholly
absent. `raw_data_file` takes that floor and stands out of the redistribution —
#598 established it is the one tier whose members are interchangeable, so a sixth
gamma-counter printout says nothing the first five did, while a sixth protocol is
a different experiment. It still absorbs whatever the other classes leave unspent.

Measured separately:

- **Cap alone does not fix svhps26** — at 40 slots it names 34 raw files and
  *still* zero processed data, because rank puts 41 interchangeable readouts above
  8 distinct analysis files.
- **Class floor alone does not fix svhps22** — 13 protocols and 14 metadata files
  cannot fit 20 slots however they are shared.

## `_interleave_kinds` is deleted

The issue asks whether `kind` and `classification` are both needed. Measured
answer: **no** — class replaces it.

Interleaving by kind *inside* a class re-created the very defect #587 fixed:
metadata's quota alternated narrative with tabular, so READMEs scoring 0.578 and
0.521 displaced assay-metadata workbooks scoring 0.670 and 0.657 — a lower-scoring
file beating a higher-scoring one in the same class.

#587's concern stands, but **class is the axis that delivers it**, because the
tiers a deposit floods are also the ones of a single form. With no kind rule at
all, the real fixture comes out **50% tabular against 42% narrative** (inside
#587's 25–60% band, and better than the 70% skew the old cap produced), the
descriptor still leads, and **all four assay-metadata workbooks are named**.

## On the two #587 contracts

An earlier cut of this had them in conflict — a balanced allocation dropped one
workbook. That conflict **does not exist at 40 slots**: metadata gets 13 of 14, so
both contracts hold unchanged. Two ranking tests were updated: the ceiling test
now reads `_MAX_CONTEXT_CHARS` rather than hardcoding 12 000, and my own
within-class test was inverted once measurement showed rank must win there.

## Verification

Full suite **3282 passed, 0 failed**.

Stale references swept: the `#595` TODO in `_STUDY_PROSE_TERMS`, "caps at 20
candidates" in three places, and the 12 000 figure.

## Noted, not fixed

svhps26's `.pzfx` files classify as `kind == "opaque"` despite carrying ~1KB of
readable content, so they render as "(preview unavailable)" even now that they are
named. That is a `kind` gap rather than a slot gap — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
