### PR TITLE
fix(report): a tier a profile defines no checks at is not a green tick (#620)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1843,7 +1843,14 @@ the crate's own `vitro-crate build` CreateAction, plus a provenance note carryin
 render cannot claim its figures come from the crate's metadata). Then a **KPI grid**: a profile ×
 requirement-level conformance **matrix** (rows the three layers linked to their specs — IRIs pinned
 to `_crate_mapping`'s `conformsTo` constants by test — cells ✓/✗/– with counts on `title`; the
-Required column is the report's one headline verdict), the FAIR ladder (the *next* rung dashed red
+Required column is the report's one headline verdict). A `–` carries two different sentences:
+*not assessed* where the sweep did not reach that tier, and *no checks defined at this level*
+where the profile has no rule there at all — the ISA and ISA-Tox profiles declare no `sh:Info`
+shape, so their Optional column can only ever come back empty, and an empty result is the
+profile's silence rather than the crate's cleanliness. Which tiers a layer can report at is
+read from the validator's own requirement registry (`profiles.validator.tiers_defined`), never
+from a list kept by hand, so only a tier that could have failed is allowed to pass. A finding
+outranks that state: one filed at a tier the profile defines no check at still reads ✗, the FAIR ladder (the *next* rung dashed red
 and filled to the ratio of indicators met, so a gated 0 never reads as "nothing done"), the **FAIR
 principle 1.3** rose (one wedge per MIT module: angle = share of the checklist, radius = fill;
 faint full wedges carry the share), a graph tile (linked / total entities) and reproducibility.

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -710,6 +710,31 @@ _PROFILE_SPEC_URLS: dict[str, str] = {
 
 _TIER_KEYS: tuple[str, ...] = ("required", "recommended", "optional")
 
+# Cell state -> the mark it paints, and the words that carry it to a screen
+# reader. "none" paints the same neutral mark as "na" but says something else:
+# not "nobody looked here" but "there is nothing here to look at".
+_CELL_MARK: dict[str, str] = {"ok": "ok", "no": "no", "na": "na", "none": "na"}
+_CELL_WORDS: dict[str, str] = {**_MK_LABEL, "none": "no checks defined"}
+
+
+@lru_cache(maxsize=1)
+def _tier_capability() -> dict[str, frozenset[str]]:
+    """Which tiers each profile layer defines checks at — see
+    :func:`profiles.validator.tiers_defined`.
+
+    Imported lazily and cached for the process: importing the validator runs its
+    upstream-bootstrap patching, and a report rendered from a verdict-less
+    checkpoint never needs the answer. A validator that will not import leaves
+    every layer unknown, and an unknown tier reads as unverified rather than as
+    a pass.
+    """
+    try:
+        from profiles.validator import tiers_defined
+    except ImportError:  # no validator installed: nothing could have been checked
+        logger.warning("The validator is not importable; profile tier capability is unknown")
+        return {}
+    return {key: tiers_defined(key) for key, _ in _PROFILE_LAYERS}
+
 
 def _profile_tier_counts(val: ValidationReport | None) -> dict[str, dict[str, int]]:
     """``{profile: {tier: findings}}`` from the verdict's records — or, for a
@@ -746,7 +771,11 @@ def _profile_matrix_tile(
     """Profile conformance as a profile × requirement-level matrix: rows the
     three layers (each linked to its spec), columns the severity tiers, cells a
     mark with the finding count on its ``title``. An unassessed tier — and every
-    cell of a stale or never-run verdict — is the neutral mark, never a green."""
+    cell of a stale or never-run verdict — is the neutral mark, never a green.
+
+    So is a tier the profile defines no check at (:func:`_tier_capability`): a
+    green there would report the profile's silence as the crate's cleanliness.
+    Only a tier that could have failed is allowed to pass."""
     heads = "".join(f'<span class="pmx-h">{t.capitalize()}</span>' for t in _TIER_KEYS)
     rows = ""
     counts = _profile_tier_counts(val if tiers is not None else None)
@@ -775,17 +804,24 @@ def _profile_matrix_tile(
                 )
             elif n:
                 state, title = "no", f"{n} finding{'s' if n != 1 else ''} at this level"
+            elif tier not in _tier_capability().get(key, frozenset()):
+                # The profile has no rule at this level, so an empty result here
+                # is the profile's silence, not the crate's cleanliness (#620).
+                # Ranked below the count: a finding filed at such a tier — by a
+                # local checker, or by a checkpoint from a profile version that
+                # did have rules here — is still a finding, and still shows.
+                state, title = "none", "no checks defined at this level"
             else:
                 state, title = "ok", "no findings at this level"
             # The cell carries the whole sentence for AT — the grid has no
             # table semantics, so an unassociated "met / not met" stream would
             # say nothing about which profile or tier it belongs to.
-            words = {"ok": "met", "no": "not met", "na": "not assessed"}[state]
+            mark, words = _CELL_MARK[state], _CELL_WORDS[state]
             plain = title.replace("&rsquo;", "'")
             cells += (
                 f'<span class="pmx-c" data-cell="{key}-{tier}" title="{title}" role="img" '
                 f'aria-label="{label}, {tier}: {words} — {plain}">'
-                f'<span class="mk {state}" aria-hidden="true">{_GLYPH[state]}</span></span>'
+                f'<span class="mk {mark}" aria-hidden="true">{_GLYPH[mark]}</span></span>'
             )
         rows += f'<span class="pmx-p">{_lk(_PROFILE_SPEC_URLS[key], label)}</span>{cells}'
     # Findings the validator did not attribute to a layer are reported, never
@@ -801,7 +837,7 @@ def _profile_matrix_tile(
                 if n
                 else ("no findings at this level" if tier in assessed else "not assessed")
             )
-            words = {"ok": "met", "no": "not met", "na": "not assessed"}[state]
+            words = _CELL_WORDS[state]
             cells += (
                 f'<span class="pmx-c" data-cell="unattributed-{tier}" title="{title}" '
                 f'role="img" aria-label="unattributed, {tier}: {words} — {title}">'

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -39,6 +39,7 @@ import os
 # [tool][poetry] lookup is never reached.
 import sys as _sys
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 
 _rv_ver = _metadata.version("roc-validator")
@@ -490,6 +491,56 @@ _SEVERITY_BY_NAME = {
     "optional": models.Severity.OPTIONAL,
 }
 _SEVERITY_NAME = {v: k for k, v in _SEVERITY_BY_NAME.items()}
+
+
+@lru_cache(maxsize=None)
+def tiers_defined(layer: str) -> frozenset[str]:
+    """The severity tiers *layer*'s validation pass can actually report at.
+
+    A profile with no checks at a tier can never produce a finding there, so an
+    empty result at that tier says nothing about the crate. The bundled
+    ``isa-ro-crate`` profile and our tox profile declare no ``sh:Info`` shape at
+    all, and their OPTIONAL column therefore came back clean for every crate ever
+    built (#620); callers use this to tell "clean" apart from "never checked".
+
+    Read from the validator's own profile registry — the same objects the pass
+    runs — rather than from a hand-kept list, so a profile that gains a MAY rule
+    is honoured the day it does. Inherited requirements count only where the pass
+    reports them: ``isa`` and ``tox`` run with
+    ``disable_inherited_profiles_issue_reporting``, so an inherited MAY rule could
+    not surface under those layers.
+
+    Args:
+        layer: A key of :data:`_PROFILE_PASSES` ("base" | "isa" | "tox").
+
+    Returns:
+        The tier names ("required" | "recommended" | "optional") the layer
+        defines at least one check at. An unknown layer, or a registry that will
+        not load, yields the empty set: every tier then reads as unverified,
+        which is the honest answer when we cannot say what was checked.
+    """
+    pass_config = _PROFILE_PASSES.get(layer)
+    if pass_config is None:
+        return frozenset()
+    identifier, extra = pass_config
+    kwargs = {
+        key: extra[key] for key in ("profiles_path", "extra_profiles_path") if key in extra
+    }
+    try:
+        profile = services.get_profile(profile_identifier=identifier, **kwargs)
+        reporting = [profile]
+        if not extra.get("disable_inherited_profiles_issue_reporting"):
+            reporting.extend(profile.inherited_profiles)
+        return frozenset(
+            _SEVERITY_NAME[check.severity]
+            for reported in reporting
+            for requirement in reported.get_requirements(severity=models.Severity.OPTIONAL)
+            for check in requirement.get_checks()
+            if check.severity in _SEVERITY_NAME
+        )
+    except Exception as e:  # noqa: BLE001 — a broken registry must not fail a report
+        logger.warning("Could not read the %s profile's requirement levels: %s", layer, e)
+        return frozenset()
 
 
 @dataclass

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -551,6 +551,37 @@ class TestProfileConformanceMatrix:
         for profile in ("base", "isa", "tox"):
             assert cells[f"{profile}-optional"][0] == "na"
 
+    def test_a_tier_the_profile_defines_no_checks_at_is_neutral_not_green(self) -> None:
+        """ISA and ISA-Tox declare no MAY (``sh:Info``) shape at all, so their
+        OPTIONAL column can only ever come back empty. Reading that emptiness as
+        "no findings at this level" reports the profile's own silence as the
+        crate's clean bill of health (#620): the cell says "no checks defined"
+        instead, and only the base profile — which does define MAY checks — can
+        earn a green there."""
+        val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+        assert cells["base-optional"] == ("ok", "no findings at this level")
+        assert cells["isa-optional"] == ("na", "no checks defined at this level")
+        assert cells["tox-optional"] == ("na", "no checks defined at this level")
+        # A tier all three DO define checks at is untouched: a clean sweep there
+        # is a real result, and still reads as one.
+        assert cells["isa-recommended"] == ("ok", "no findings at this level")
+        assert cells["tox-required"] == ("ok", "no findings at this level")
+
+    def test_a_finding_outranks_the_no_checks_state(self) -> None:
+        """A finding filed at a tier the profile defines no checks at — a
+        checkpoint written against a profile version that had MAY rules, a local
+        checker filing there — still reads as a failure. "No checks defined" may
+        never swallow a finding somebody has to act on."""
+        val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        val.issue_records = [
+            {"profile": "isa", "severity": "optional", "entity_id": "#a", "message": "m"},
+        ]
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+        assert cells["isa-optional"] == ("no", "1 finding at this level")
+
     def test_a_stale_verdict_turns_every_cell_neutral(self) -> None:
         state = vhps_fixture_state("S-VHPS21")
         val = self._verdict()

--- a/tests/test_profile_lineage.py
+++ b/tests/test_profile_lineage.py
@@ -60,3 +60,50 @@ def test_validator_base_pass_is_1_2_by_design():
     from profiles.validator import _PROFILE_PASSES
 
     assert _PROFILE_PASSES["base"][0] == "ro-crate-1.2"
+
+
+# SHACL's own severity vocabulary — the oracle this file checks the validator's
+# profile registry against.
+_SH_SEVERITY_TIER = {"Violation": "required", "Warning": "recommended", "Info": "optional"}
+
+
+def _tiers_declared(shape_dir: pathlib.Path) -> set[str]:
+    """The tiers a profile's shape files themselves declare a severity at."""
+    found: set[str] = set()
+    for ttl in shape_dir.rglob("*.ttl"):
+        for name in re.findall(r"sh:severity\s+sh:(\w+)", ttl.read_text(encoding="utf-8")):
+            found.add(_SH_SEVERITY_TIER[name])  # an unknown severity fails loudly
+    return found
+
+
+def test_tier_capability_matches_the_severities_the_shapes_declare():
+    """Issue #620: ``tiers_defined`` reads the validator's profile registry;
+    this reads the shape files. They must agree — the day upstream gives
+    ``isa-ro-crate`` an ``sh:Info`` shape, the ISA row's OPTIONAL cell has to go
+    back to reporting findings instead of "no checks defined".
+
+    Every profile here declares at least one severity explicitly on every tier it
+    uses, so the declared set is the whole set. A profile leaning on SHACL's
+    ``sh:Violation`` default alone would trip this test — which is the point at
+    which somebody re-reads it rather than trusts it.
+    """
+    import rocrate_validator
+
+    from profiles.validator import SHAPES_DIR, tiers_defined
+
+    bundled = pathlib.Path(rocrate_validator.__file__).parent / "profiles"
+    for layer, shape_dir in (
+        ("base", bundled / "ro-crate" / "1.2"),
+        ("isa", bundled / "isa-ro-crate"),
+        ("tox", SHAPES_DIR / "tox"),
+    ):
+        assert tiers_defined(layer) == _tiers_declared(shape_dir), (
+            f"the {layer} profile's registry and its shape files disagree about "
+            "which requirement levels it defines checks at"
+        )
+
+    # The asymmetry the capability map exists for: only the base profile has
+    # MAY-level checks, so only its OPTIONAL cell can be earned.
+    assert tiers_defined("base") == {"required", "recommended", "optional"}
+    assert tiers_defined("isa") == {"required", "recommended"}
+    assert tiers_defined("tox") == {"required", "recommended"}


### PR DESCRIPTION
Closes #620.

## The defect

The **Profile conformance** matrix showed ISA and ISA-Tox with a green ✓ in the **Optional** column (*"no findings at this level"*) beside a red ✗ in **Recommended** — which is what made it visible.

Those zeros are structural. Severity comes from each shape's `sh:severity`, and only the base profile ships `sh:Info` shapes:

| profile | REQUIRED | RECOMMENDED | OPTIONAL |
|---|---|---|---|
| `ro-crate-1.2` | 72 checks | 104 | **16** |
| `isa-ro-crate` | 97 | 33 | **none** |
| `tox-ro-crate` | 35 | 17 | **none** |

No local checker files at optional severity either (`verify_payload`, `verify_isa_reachability` both file as `required`). So the ISA and ISA-Tox optional cells could never be anything but green: "nothing was checked here" rendered identically to "we checked and you are clean" — the false green `_profile_matrix_tile` exists to refuse. The cause is that `assessed_tiers` is global per tier, not per profile.

## The fix

`profiles.validator.tiers_defined(layer)` returns the tiers a layer's pass can actually report at, read from the validator's **own requirement registry** — the same objects the pass runs — rather than a list kept by hand. Inherited requirements count only where the pass reports them (`isa` and `tox` run with `disable_inherited_profiles_issue_reporting`).

The matrix gains a fourth cell state: the neutral mark with the title *"no checks defined at this level"*, ranked **below** the finding count so a finding filed at such a tier (a local checker, a checkpoint from a profile version that had MAY rules) still reads ✗.

Rendered against the real verdict from the screenshot that started this:

```
base-required     ok  no findings at this level
base-recommended  no  56 findings at this level
base-optional     no  210 findings at this level
isa-required      ok  no findings at this level
isa-recommended   no  33 findings at this level
isa-optional      na  no checks defined at this level   <- was: ok, "no findings at this level"
tox-required      ok  no findings at this level
tox-recommended   no  7 findings at this level
tox-optional      na  no checks defined at this level   <- was: ok, "no findings at this level"
```

## Tests

- `test_a_tier_the_profile_defines_no_checks_at_is_neutral_not_green` — the red test: ISA/ISA-Tox optional go neutral, base optional still earns its green, tiers all three define checks at are untouched.
- `test_a_finding_outranks_the_no_checks_state` — precedence guard; verified by mutation (ranking the new branch above the count reddens it).
- `test_tier_capability_matches_the_severities_the_shapes_declare` — anti-drift: reads `sh:severity` out of the shape files and holds the registry to it, so the day upstream gives `isa-ro-crate` an `sh:Info` shape the ISA row goes back to reporting findings.

`uv run ty check` clean; `uvx ruff check` clean on the changed files (the 7 pre-existing errors in `tests/test_maturity_report.py` are on `main` too). Report-touching modules pass: `test_maturity_report`, `test_profile_lineage`, `test_validator_wiring`, `test_html_xss`, `test_entity_explorer`, `test_generated_artifacts`, `test_isa_reachability`, `test_payload_verification`, `test_provenance_dag`, `test_report_shows_every_finding`.

AGENTS.md states the contract: a `–` carries two sentences, and only a tier that could have failed is allowed to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3