### PR TITLE
fix(report): pack a wide rank of leaves into a grid (#619)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1982,6 +1982,22 @@ toggle swaps that for the whole `ro-crate-metadata.json`. Every `@id` in either 
 moves the selection — **never a link**: the payload carries the crate verbatim, `javascript:` URLs
 and all, so the absence of anchors is load-bearing and pinned by test.
 
+**Where the nodes go (`entity_explorer_layout.js`, #619).** Layout is its own module and its own
+`<script>`, holding pure geometry — no DOM, no React, no payload — so a test can run the shipped code
+over a crate's graph rather than a Python restatement of it. A layered pass gives every node in a
+rank its own row, which a crate defeats by construction: the root `hasPart` every file it carries,
+so one rank holds the whole file list and the layout is as tall as the deposit is long (a real
+293-entity crate laid out 12,100 px inside a 620 px canvas). Leaves are what makes a rank wide and
+they are also what a row says nothing about — nothing hangs off them — so a rank holding more than
+`RANK_CAP` leaves is packed into a near-square grid. The packing is expressed to dagre rather than
+around it: each block enters the second pass as ONE stand-in node the size of the grid it will hold,
+with its members' edges redirected to the stand-in, so rank order, rank spacing and the room a block
+needs stay the layered algorithm's answers; the members are dealt into the box afterwards. A rank at
+or below the cap keeps its column, because a column is a rank and that reads better than a grid
+does. This does not make every view framable — a crate with 80 non-leaf entities over nine ranks is
+some 3,400 px tall whatever is done with its leaves, and "all entities" stays a view to navigate
+rather than to take in at once.
+
 **Script, but nothing loaded.** The report's contract was "carries no script"; it is now *loads
 nothing*. React, React Flow, dagre and htm are vendored UMD builds under `builder/writers/vendor/`,
 pinned by `manifest.json` (name, version, licence, origin, sha256) and verified against it at render
@@ -2129,6 +2145,7 @@ vitro-crate/
 │   │   ├── maturity_report.py    Maturity / FAIR HTML report
 │   │   ├── entity_explorer.py   Interactive React Flow entity graph (#615)
 │   │   ├── entity_explorer.js   …its browser half (no build step)
+│   │   ├── entity_explorer_layout.js  …where its nodes go (#619)
 │   │   └── vendor/              Pinned UMD builds inlined into the report
 │   └── agents/                  Orchestration + LLM config
 │       ├── build.py             BuildMode switch + run_build dispatch; pipeline entrypoint (run_interactive_build)

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -53,7 +53,8 @@
   // those alongside the derivation is what made the whole-crate picture a
   // hairball on paper.
   var DERIVATION = new Set(['input', 'object', 'result', 'output']);
-  var NODE_W = 200, NODE_H = 44;
+  var layout = window.ExplorerLayout.layout;
+  var NODE_W = window.ExplorerLayout.NODE_W, NODE_H = window.ExplorerLayout.NODE_H;
   // How far the opening view is allowed to pull back. A crate's whole graph is
   // thousands of pixels tall — the researcher view of a real deposit lays out
   // around 2300x4000 — so "fit everything" means a field of 14px slivers with
@@ -72,23 +73,6 @@
   }
 
   function category(n) { return D.categories[n.category] || D.categories.ctx; }
-  function layerName(n) {
-    return n.layer ? D.layers[String(n.layer)] : 'Referenced, outside the crate';
-  }
-  function shortId(id) {
-    try {
-      var u = new URL(id);
-      return u.hostname.replace(/^www\./, '') + u.pathname;
-    } catch (err) { return decodeURIComponent(id); }
-  }
-
-  function Glyph(props) {
-    var c = D.categories[props.k] || D.categories.ctx;
-    var s = props.size || 14;
-    return html`<svg class="ex-glyph" width=${s} height=${s} viewBox="0 0 14 14"
-      aria-hidden="true"><path d=${c.glyph} fill=${c.colour} fill-opacity=".18"
-      stroke=${c.colour} stroke-width="1.3" stroke-linejoin="round" /></svg>`;
-  }
 
   /* ---- the state a reader can link to -------------------------------------- */
   function readHash() {
@@ -146,21 +130,6 @@
       if (merged.get(key).labels.indexOf(e.label) < 0) merged.get(key).labels.push(e.label);
     });
     return { visible: visible, edges: Array.from(merged.values()) };
-  }
-
-  function layout(visible, edges) {
-    var g = new dagre.graphlib.Graph();
-    g.setGraph({ rankdir: 'LR', nodesep: 12, ranksep: 90, marginx: 24, marginy: 24 });
-    g.setDefaultEdgeLabel(function () { return {}; });
-    visible.forEach(function (id) { g.setNode(id, { width: NODE_W, height: NODE_H }); });
-    edges.forEach(function (e) { g.setEdge(e.src, e.dst); });
-    dagre.layout(g);
-    var pos = new Map();
-    visible.forEach(function (id) {
-      var p = g.node(id);
-      pos.set(id, { x: p.x - NODE_W / 2, y: p.y - NODE_H / 2 });
-    });
-    return pos;
   }
 
   /* ---- node ---------------------------------------------------------------- */

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -362,6 +362,7 @@ def build_explorer_payload(
 _ASSET_DIR = Path(__file__).resolve().parent
 _VENDOR_DIR = _ASSET_DIR / "vendor"
 _APP_PATH = _ASSET_DIR / "entity_explorer.js"
+_LAYOUT_PATH = _ASSET_DIR / "entity_explorer_layout.js"
 _MANIFEST_PATH = _VENDOR_DIR / "manifest.json"
 
 _APP_ID = "ex-app"
@@ -372,10 +373,11 @@ VENDOR_MANIFEST: tuple[dict[str, Any], ...] = tuple(
 )
 """Every third-party file the page inlines: name, version, licence, origin, digest."""
 
-# react, react-dom, the jsx-runtime shim, React Flow, dagre, htm, the data
-# island, the app. Named so a test can state the count without recounting the
-# implementation, and so an accidental extra <script> is a failure, not a habit.
-EXPLORER_SCRIPT_COUNT = 8
+# react, react-dom, the jsx-runtime shim, React Flow, dagre, htm, the layout
+# module, the data island, the app. Named so a test can state the count without
+# recounting the implementation, and so an accidental extra <script> is a
+# failure, not a habit.
+EXPLORER_SCRIPT_COUNT = 9
 
 _JS_BUNDLES = (
     "react.production.min.js",
@@ -435,6 +437,17 @@ def _app_js() -> str:
 
 
 @lru_cache(maxsize=1)
+def _layout_js() -> str:
+    """The layout module the app takes its node positions from.
+
+    Its own file, and its own ``<script>``: the geometry is pure — no DOM, no
+    React, no payload — so a test can run the code the page runs over a real
+    crate's graph, rather than over a second copy of it kept in the test.
+    """
+    return _LAYOUT_PATH.read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
 def explorer_css() -> str:
     """React Flow's stylesheet, for inlining into the report's one stylesheet.
 
@@ -487,6 +500,7 @@ def render_explorer_section(
             scripts.append(f"<script>{_JSX_SHIM}</script>")
             continue
         scripts.append(f"<script>{_banner(filename)}\n{_vendor_text(filename)}</script>")
+    scripts.append(f"<script>{_layout_js()}</script>")
     scripts.append(
         f'<script id="{_DATA_ID}" type="application/json">'
         f"{_data_island(build_explorer_payload(metadata, default_views=default_views))}"

--- a/builder/writers/entity_explorer_layout.js
+++ b/builder/writers/entity_explorer_layout.js
@@ -1,0 +1,164 @@
+/*
+ * Where the entity explorer's nodes go (#615, #619).
+ *
+ * Pure geometry: it takes a set of node ids and the edges between them and
+ * returns a position per id. No DOM, no React, no payload — which is what lets
+ * a test run the shipped code over a real crate's graph instead of a copy of
+ * it, and what keeps `entity_explorer.js` about the canvas rather than about
+ * arithmetic.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('./vendor/dagre.min.js'));
+  } else {
+    root.ExplorerLayout = factory(root.dagre);
+  }
+}(typeof self !== 'undefined' ? self : this, function (dagre) {
+  'use strict';
+
+  var NODE_W = 200, NODE_H = 44;
+  var GAP_X = 12, GAP_Y = 12, RANK_GAP = 90, MARGIN = 24;
+
+  // How many leaves a rank may hold before its column becomes a block. A
+  // layered layout gives every node in a rank its own row, so a crate root that
+  // `hasPart` sixty files lays out sixty rows tall however small the rest of the
+  // graph is — 12,100px on a real deposit, in a 620px canvas (#619). Above this
+  // many, the column is packed into a grid; at or below it the column is left
+  // alone, because a column IS a rank and that is worth more than the pixels.
+  var RANK_CAP = 12;
+
+  function newGraph() {
+    var g = new dagre.graphlib.Graph();
+    g.setGraph({
+      rankdir: 'LR', nodesep: GAP_Y, ranksep: RANK_GAP, marginx: MARGIN, marginy: MARGIN
+    });
+    g.setDefaultEdgeLabel(function () { return {}; });
+    return g;
+  }
+
+  function positionsOf(g, ids) {
+    var pos = new Map();
+    ids.forEach(function (id) {
+      var p = g.node(id);
+      pos.set(id, { x: p.x - NODE_W / 2, y: p.y - NODE_H / 2 });
+    });
+    return pos;
+  }
+
+  /* The ranks worth packing, and the order their members keep.
+   *
+   * A leaf is a node nothing on the canvas hangs off: its row carries no
+   * structure, only which entity it belongs to, and the edge already says that.
+   * Members keep the order the layered pass gave them, so siblings the layout
+   * put together stay together in the block.
+   */
+  function wideLeafRanks(g, ids) {
+    var byRank = new Map();
+    ids.forEach(function (id) {
+      var rank = g.node(id).rank;
+      if (!byRank.has(rank)) byRank.set(rank, []);
+      if ((g.outEdges(id) || []).length === 0) byRank.get(rank).push(id);
+    });
+    var blocks = [];
+    Array.from(byRank.keys()).sort(function (a, b) { return a - b; }).forEach(function (rank) {
+      var leaves = byRank.get(rank);
+      if (leaves.length <= RANK_CAP) return;
+      leaves.sort(function (a, b) { return g.node(a).y - g.node(b).y; });
+      blocks.push({ rank: rank, members: leaves });
+    });
+    return blocks;
+  }
+
+  /* The grid a block of *n* nodes is laid out on: as near square in pixels as a
+   * whole number of columns allows, which is the shape that buys the most
+   * height back for the least width. */
+  function blockShape(n) {
+    var cols = Math.max(1, Math.round(Math.sqrt(n * (NODE_H + GAP_Y) / (NODE_W + GAP_X))));
+    var rows = Math.ceil(n / cols);
+    return {
+      cols: cols,
+      width: cols * NODE_W + (cols - 1) * GAP_X,
+      height: rows * NODE_H + (rows - 1) * GAP_Y
+    };
+  }
+
+  function blockKey(index, taken) {
+    // A stand-in is a graph key, not an entity: it must not be an id the crate
+    // could also carry. Widened rather than trusted, so nothing can shadow it.
+    var key = '(block ' + index + ')';
+    while (taken.has(key)) key += ' ';
+    return key;
+  }
+
+  /**
+   * Position every id in *visible*, with wide ranks of leaves packed into grids.
+   *
+   * Runs the layered pass twice. The first says which rank each node is in and
+   * which of them are leaves; every rank holding more than `RANK_CAP` leaves
+   * becomes a block. The second pass then lays out the graph with each block
+   * standing in as ONE node the size of the grid it will hold, and its members'
+   * edges redirected to that stand-in — so rank order, the gap between ranks and
+   * the room a block needs are still dagre's answers rather than arithmetic here
+   * trying to reproduce them. The members are dealt into the box afterwards.
+   *
+   * @param {Set<string>|Array<string>} visible ids to place.
+   * @param {Array<{src: string, dst: string}>} edges links between them.
+   * @returns {Map<string, {x: number, y: number}>} top-left corner per id.
+   */
+  function layout(visible, edges) {
+    var ids = Array.from(visible);
+    var present = new Set(ids);
+    var full = newGraph();
+    ids.forEach(function (id) { full.setNode(id, { width: NODE_W, height: NODE_H }); });
+    edges.forEach(function (e) {
+      if (present.has(e.src) && present.has(e.dst)) full.setEdge(e.src, e.dst);
+    });
+    dagre.layout(full);
+
+    var blocks = wideLeafRanks(full, ids);
+    if (!blocks.length) return positionsOf(full, ids);
+
+    var blockOf = new Map();
+    blocks.forEach(function (b, i) {
+      b.key = blockKey(i, present);
+      b.shape = blockShape(b.members.length);
+      b.members.forEach(function (id) { blockOf.set(id, b.key); });
+    });
+
+    var g = newGraph();
+    ids.forEach(function (id) {
+      if (!blockOf.has(id)) g.setNode(id, { width: NODE_W, height: NODE_H });
+    });
+    blocks.forEach(function (b) {
+      g.setNode(b.key, { width: b.shape.width, height: b.shape.height });
+    });
+    var drawn = new Set();
+    edges.forEach(function (e) {
+      if (!present.has(e.src) || !present.has(e.dst)) return;
+      var src = blockOf.get(e.src) || e.src, dst = blockOf.get(e.dst) || e.dst;
+      // Two members of one block, or a member and its own block: that link is
+      // inside the box, and a self-edge is not a layout constraint.
+      if (src === dst) return;
+      var key = src + ' ' + dst;
+      if (drawn.has(key)) return;
+      drawn.add(key);
+      g.setEdge(src, dst);
+    });
+    dagre.layout(g);
+
+    var pos = positionsOf(g, ids.filter(function (id) { return !blockOf.has(id); }));
+    blocks.forEach(function (b) {
+      var box = g.node(b.key);
+      var left = box.x - b.shape.width / 2, top = box.y - b.shape.height / 2;
+      b.members.forEach(function (id, i) {
+        pos.set(id, {
+          x: left + (i % b.shape.cols) * (NODE_W + GAP_X),
+          y: top + Math.floor(i / b.shape.cols) * (NODE_H + GAP_Y)
+        });
+      });
+    });
+    return pos;
+  }
+
+  return { layout: layout, NODE_W: NODE_W, NODE_H: NODE_H, RANK_CAP: RANK_CAP };
+}));

--- a/tests/fixtures/crate_graphs.py
+++ b/tests/fixtures/crate_graphs.py
@@ -166,3 +166,57 @@ def plumbing_heavy_graph() -> dict[str, Any]:
             {"@id": "#tool", "@type": "SoftwareApplication", "name": "vitro-crate"},
         ],
     }
+
+
+def wide_fanout_graph(files: int = 60) -> dict[str, Any]:
+    """A crate shaped like a real deposit's file list: one root, many leaves.
+
+    The shape #619 is about. A deposit's root Dataset ``hasPart`` every file it
+    carries, and none of those files points anywhere, so a layered layout puts
+    the whole list on one rank — a column *files* nodes tall, whatever the rest
+    of the crate looks like. Measured on a real 293-entity crate, that is a
+    12,100 px layout inside a 620 px canvas.
+
+    Carries a small ISA backbone besides, so the packing has non-leaf nodes on
+    the same ranks to keep out of the way of.
+
+    Args:
+        files: How many files hang off the root.
+    """
+    graph: list[dict[str, Any]] = [
+        {"@id": "ro-crate-metadata.json", "@type": "CreativeWork", "about": {"@id": "./"}},
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "A deposit with a long file list",
+            "hasPart": [{"@id": f"data/f{i}.csv"} for i in range(files)]
+            + [{"@id": "#assay"}],
+            "mentions": [{"@id": "#process"}],
+        },
+        {
+            "@id": "#assay",
+            "@type": "Dataset",
+            "additionalType": "Assay",
+            "name": "Uptake assay",
+            "about": [{"@id": "#process"}],
+        },
+        {
+            "@id": "#process",
+            "@type": "LabProcess",
+            "name": "Exposure",
+            "object": [{"@id": "data/f0.csv"}],
+            "result": [{"@id": "data/f1.csv"}],
+            "agent": [{"@id": "#lab"}],
+        },
+        {"@id": "#lab", "@type": "Organization", "name": "A lab"},
+    ]
+    graph += [
+        {
+            "@id": f"data/f{i}.csv",
+            "@type": "File",
+            "name": f"f{i}.csv",
+            "encodingFormat": "text/csv",
+        }
+        for i in range(files)
+    ]
+    return {"@graph": graph}

--- a/tests/fixtures/layout_probe.js
+++ b/tests/fixtures/layout_probe.js
@@ -1,0 +1,17 @@
+/*
+ * Runs the explorer's shipped layout module over a graph handed in on stdin and
+ * prints the positions it computed. The tests measure the real code this way
+ * rather than keeping a second copy of the geometry in Python.
+ *
+ * argv[2]: path to builder/writers/entity_explorer_layout.js
+ * stdin:   {"nodes": [id, ...], "edges": [{"src": id, "dst": id}, ...]}
+ * stdout:  {"positions": {id: {x, y}}, "nodeW": n, "nodeH": n}
+ */
+var L = require(process.argv[2]);
+var input = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+var pos = L.layout(new Set(input.nodes), input.edges);
+var positions = {};
+pos.forEach(function (p, id) { positions[id] = p; });
+process.stdout.write(JSON.stringify({
+  positions: positions, nodeW: L.NODE_W, nodeH: L.NODE_H
+}));

--- a/tests/test_entity_explorer_layout.py
+++ b/tests/test_entity_explorer_layout.py
@@ -1,0 +1,220 @@
+"""Where the explorer puts the nodes it draws (#619).
+
+The layout is JavaScript, and it is the shipped file these tests run: a node
+probe (``tests/fixtures/layout_probe.js``) requires
+``builder/writers/entity_explorer_layout.js`` and prints the positions it
+computed, so what is measured here is the code the report carries rather than a
+Python restatement of it.
+
+The defect these pin: a layered layout gives every node in a rank its own row,
+so a root that ``hasPart`` sixty files lays out as a column sixty nodes tall —
+12,100 px on a real deposit, inside a 620 px canvas, which is a fit zoom of 0.05
+and a field of unreadable slivers. Leaves carry no downstream structure, so
+their row says nothing that a grid cell does not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from builder.writers.entity_explorer import build_explorer_payload
+from tests.fixtures.crate_graphs import tabbed_views_graph, wide_fanout_graph
+
+_REPO = Path(__file__).resolve().parents[1]
+_MODULE = _REPO / "builder" / "writers" / "entity_explorer_layout.js"
+_PROBE = _REPO / "tests" / "fixtures" / "layout_probe.js"
+
+# The report's canvas, in CSS pixels — the box a view has to be legible inside.
+CANVAS_W, CANVAS_H = 1200, 620
+
+
+def _module_constant(name: str) -> float:
+    """A number the layout module declares, read from it rather than copied."""
+    match = re.search(rf"var {name} = ([\d.]+)", _MODULE.read_text(encoding="utf-8"))
+    assert match, f"the layout module no longer declares {name}"
+    return float(match.group(1))
+
+
+def _app_constant(name: str) -> float:
+    """A number the shipped explorer declares, read from it rather than copied.
+
+    The threshold these tests measure against is the app's own: a layout that
+    cannot be framed above ``FIT_FLOOR`` opens cropped, because that is as far
+    as the opening ``fitView`` is allowed to pull back.
+    """
+    from builder.writers.entity_explorer import _app_js
+
+    match = re.search(rf"var {name} = ([\d.]+);", _app_js())
+    assert match, f"the explorer no longer declares {name}"
+    return float(match.group(1))
+
+
+def _node() -> str:
+    exe = shutil.which("node")
+    if exe is None:  # pragma: no cover — depends on the machine, not the code
+        pytest.skip("node is not installed; the layout module cannot be run")
+    return exe
+
+
+def _positions(nodes: list[str], edges: list[dict[str, str]]) -> dict[str, Any]:
+    """Run the shipped layout over *nodes*/*edges* and return what it produced."""
+    result = subprocess.run(
+        [_node(), str(_PROBE), str(_MODULE)],
+        input=json.dumps({"nodes": nodes, "edges": edges}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _canvas(graph: dict[str, Any]) -> dict[str, Any]:
+    """Lay out everything a crate's payload can draw.
+
+    Uses the ``all`` view deliberately: its edge rule is "every link the payload
+    holds", so the test states the graph rather than re-implementing the app's
+    view filtering.
+    """
+    payload = build_explorer_payload(graph)
+    visible = {
+        member for view in payload["views"] if view["key"] == "all" for member in view["members"]
+    }
+    seen, edges = set(), []
+    for edge in payload["edges"]:
+        pair = (edge["src"], edge["dst"])
+        if pair[0] == pair[1] or pair in seen or not visible >= set(pair):
+            continue
+        seen.add(pair)
+        edges.append({"src": pair[0], "dst": pair[1]})
+    return _positions(sorted(visible), edges) | {"edges": edges}
+
+
+def _extent(out: dict[str, Any]) -> tuple[float, float]:
+    xs = [p["x"] for p in out["positions"].values()]
+    ys = [p["y"] for p in out["positions"].values()]
+    return (
+        max(xs) + out["nodeW"] - min(xs),
+        max(ys) + out["nodeH"] - min(ys),
+    )
+
+
+def _fit(out: dict[str, Any]) -> float:
+    """The zoom that frames the whole layout in the report's canvas."""
+    width, height = _extent(out)
+    return min(CANVAS_W / width, CANVAS_H / height)
+
+
+def _columns(out: dict[str, Any], ids: list[str]) -> set[float]:
+    return {out["positions"][i]["x"] for i in ids}
+
+
+class TestTheProbeRunsTheShippedModule:
+    """If these two go quiet the suite would pass while measuring nothing."""
+
+    def test_the_module_the_probe_loads_is_the_one_the_report_inlines(self) -> None:
+        from builder.writers.entity_explorer import _layout_js
+
+        assert _MODULE.read_text(encoding="utf-8") == _layout_js()
+
+    @pytest.mark.skipif(not os.environ.get("CI"), reason="only CI must have node")
+    def test_ci_can_run_the_layout(self) -> None:
+        """Locally the layout tests skip without node. In CI they must not:
+        a skipped guard protects nothing."""
+        assert shutil.which("node"), "CI needs node to run the explorer's layout"
+
+
+class TestAWideFanOutIsGridded:
+    """A rank of leaves is packed into a block instead of a column."""
+
+    def _fanout(self, files: int = 60) -> tuple[dict[str, Any], list[str]]:
+        out = _canvas(wide_fanout_graph(files=files))
+        # f0 and f1 hang off the process, so they are not part of the root's
+        # flat list; everything else is a leaf of it.
+        return out, [f"data/f{i}.csv" for i in range(2, files)]
+
+    def test_the_leaves_are_not_stacked_in_one_column(self) -> None:
+        out, leaves = self._fanout()
+
+        assert len(_columns(out, leaves)) > 1, f"{len(leaves)} leaves still one per row"
+
+    def test_the_layout_opens_inside_the_zoom_the_app_allows(self) -> None:
+        """The measurement from the issue, as a bound. ``fitView`` will not pull
+        back further than ``FIT_FLOOR``, so a view that cannot be framed at that
+        zoom opens cropped — the reader lands on a corner of a graph they asked
+        to see whole."""
+        out, _ = self._fanout()
+
+        assert _fit(out) >= _app_constant("FIT_FLOOR"), f"opens at {_fit(out):.2f}"
+
+    def test_the_block_is_nearer_square_than_the_column_it_replaces(self) -> None:
+        """Not merely "shorter": the point of a grid is that height falls as
+        width rises. The bound is the geometry — a column of *n* leaves is at
+        least ``n * NODE_H`` tall — not a number read off the current output."""
+        out, leaves = self._fanout()
+        _, height = _extent(out)
+
+        assert height < len(leaves) * out["nodeH"] / 2
+
+    def test_no_two_nodes_overlap(self) -> None:
+        """The invariant packing can break: a grid laid over the nodes that were
+        already there draws two entities on top of each other."""
+        out, _ = self._fanout()
+        boxes = [
+            (p["x"], p["y"], p["x"] + out["nodeW"], p["y"] + out["nodeH"])
+            for p in out["positions"].values()
+        ]
+        for i, a in enumerate(boxes):
+            for b in boxes[i + 1 :]:
+                apart = a[2] <= b[0] or b[2] <= a[0] or a[3] <= b[1] or b[3] <= a[1]
+                assert apart, f"{a} overlaps {b}"
+
+    def test_every_edge_still_points_forward(self) -> None:
+        """Left-to-right is what the canvas means by "derived from". A packed
+        leaf that lands left of the entity it hangs off reverses that."""
+        out, _ = self._fanout()
+        pos = out["positions"]
+
+        for edge in out["edges"]:
+            assert pos[edge["src"]]["x"] < pos[edge["dst"]]["x"], edge
+
+    def test_an_entity_something_hangs_off_keeps_its_column(self) -> None:
+        """Only leaves are packed. A node with an outgoing edge holds structure
+        the reader follows, so the chain through it still reads left to right."""
+        out, _ = self._fanout()
+        pos = out["positions"]
+
+        assert pos["#process"]["x"] > pos["#assay"]["x"]
+        assert pos["data/f1.csv"]["x"] > pos["#process"]["x"]
+
+
+class TestPackingIsForTheRanksThatNeedIt:
+    """Everything narrow enough to read keeps the layered layout, which says
+    more than a grid does: a column is a rank, and a rank is a step."""
+
+    def test_a_fan_out_at_the_cap_keeps_its_column(self) -> None:
+        cap = int(_module_constant("RANK_CAP"))
+        out, leaves = TestAWideFanOutIsGridded()._fanout(files=cap + 2)
+
+        assert len(leaves) == cap
+        assert len(_columns(out, leaves)) == 1, "a rank at the cap was gridded anyway"
+
+    def test_one_more_than_the_cap_is_gridded(self) -> None:
+        cap = int(_module_constant("RANK_CAP"))
+        out, leaves = TestAWideFanOutIsGridded()._fanout(files=cap + 3)
+
+        assert len(leaves) == cap + 1
+        assert len(_columns(out, leaves)) > 1, "a rank over the cap kept its column"
+
+    def test_a_small_crate_is_untouched(self) -> None:
+        """No rank in it comes near the cap, so every column is still a rank."""
+        out = _canvas(tabbed_views_graph())
+
+        assert _fit(out) >= _app_constant("FIT_FLOOR")


### PR DESCRIPTION
Closes #619.

## The defect

A crate root `hasPart` every file it carries, so one rank of the explorer's layout holds the whole file list and the graph is as tall as the deposit is long. On `svhps22_real_input_crate_v19` (293 entities) that is **12,100 px inside a 620 px canvas** — a fit zoom of 0.05, a field of unreadable slivers.

## The rule

A leaf is a node nothing on the canvas hangs off. Its row carries no structure — only which entity it belongs to, and the edge already says that. A rank holding more than `RANK_CAP` (12) leaves is packed into a near-square grid; a rank at or below the cap keeps its column, because a column **is** a rank and that reads better than a grid.

The packing is expressed **to** dagre rather than around it: each block enters a second pass as ONE stand-in node the size of the grid it will hold, with its members' edges redirected to the stand-in, so rank order, rank spacing and the room a block needs stay the layered algorithm's answers. The members are dealt into the box afterwards.

## Measured, before → after

| view | entities | before | after | |
|---|---|---|---|---|
| Researcher (opens by default) | 107 | 0.17 | **0.24** | |
| All entities | 293 | 0.05 | **0.11** | 2.2× |
| Files | 65 | 0.19 | **0.70** | 3.7× |
| LabProcesses | 52 | 0.35 | **0.67** | 1.9× |
| Compounds + samples | 20 | 0.94 | 0.94 | untouched — no wide rank |

I swept the block aspect ratio 1 → 8 against the real crate. Wider blocks buy a little on Researcher (0.24 → 0.28) and cost a lot on Files (0.70 → 0.56), because width becomes the binding constraint there. Near-square won on balance.

## What this does not fix

**All entities is still not framable, and cannot be.** Drop every leaf from that crate entirely and the 80 remaining entities still lay out **3,441 px** tall over nine ranks — a floor of about 0.18. Packing leaves cannot go below the skeleton. That view stays one you navigate (search, minimap, selection) rather than one you take in at once.

## Testing

Layout moves into its own module and its own `<script>` — pure geometry, no DOM, no React — so a node probe (`tests/fixtures/layout_probe.js`) runs **the shipped file** over a real graph rather than a Python restatement of it. Eleven tests:

- the wide fan-out is gridded, opens inside the zoom the app allows, and its height falls below half a column's
- **no two nodes overlap** and **every edge still points forward** — the two invariants packing can break
- a rank *at* the cap keeps its column, one *over* it is gridded — the boundary, read from the module's own constant
- a guard that the module the probe loads is the one the report inlines, so the suite cannot pass while measuring nothing

Node is skipped-if-absent locally but required in CI, so the coverage cannot go quiet.

`uv run ty check` clean, `uvx ruff check` clean, 70 explorer + XSS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3