### PR TITLE
fix(report): the explorer legend names the crate's own types (#623)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1998,6 +1998,17 @@ does. This does not make every view framable — a crate with 80 non-leaf entiti
 some 3,400 px tall whatever is done with its leaves, and "all entities" stays a view to navigate
 rather than to take in at once.
 
+**The legend names types, not categories (#623).** A colour key labelled in category prose — "Sample
+/ material", "Term / parameter" — explains the canvas in a vocabulary the reader can see nowhere
+else, while every node on it is captioned with its type. Each key is therefore labelled from the
+crate's own census: the distinct type tags its nodes carry in that category, commonest first, the
+first two spelled out and the rest counted away with the full list on `title`. Derived, never a
+hand-kept map, so a category that gains a type is labelled with it the day it does, and the fallback
+bucket — which has no single type to name — is labelled as honestly as the rest. A refinement folds
+into its base (`Dataset · Assay` counts as `Dataset`): the colour is the base type's, and the
+refinement is what the node itself spells out. The one key the census cannot supply is the off-crate
+reference, which keeps its wording because it names a provenance status rather than a type.
+
 **Script, but nothing loaded.** The report's contract was "carries no script"; it is now *loads
 nothing*. React, React Flow, dagre and htm are vendored UMD builds under `builder/writers/vendor/`,
 pinned by `manifest.json` (name, version, licence, origin, sha256) and verified against it at render

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -90,7 +90,20 @@
       aria-hidden="true"><path d=${c.glyph} fill=${c.colour} fill-opacity=".18"
       stroke=${c.colour} stroke-width="1.3" stroke-linejoin="round" /></svg>`;
   }
-
+  // How many type names a legend key spells out before it counts the rest. The
+  // legend is one strip across the toolbar, so a bucket holding eight types
+  // would push the rest of the keys off it; the full census rides on `title`.
+  var LEGEND_TYPES = 2;
+  function legendLabel(c) {
+    var types = c.types || [];
+    if (!types.length) return c.label;
+    var shown = types.slice(0, LEGEND_TYPES).join(', ');
+    return types.length > LEGEND_TYPES ? shown + ' +' + (types.length - LEGEND_TYPES) : shown;
+  }
+  function legendTitle(c) {
+    var types = c.types || [];
+    return types.length > LEGEND_TYPES ? c.label + ' — ' + types.join(', ') : c.label;
+  }
 
   /* ---- the state a reader can link to -------------------------------------- */
   function readHash() {
@@ -488,8 +501,9 @@
       <div class="ex-legend">
         ${Object.keys(D.categories).filter(function (k) { return present.has(k); })
           .map(function (k) {
-            return html`<span key=${k} class="ex-key"><${Glyph} k=${k} size=${12} />
-              ${D.categories[k].label}</span>`;
+            var c = D.categories[k];
+            return html`<span key=${k} class="ex-key" title=${legendTitle(c)}>
+              <${Glyph} k=${k} size=${12} />${legendLabel(c)}</span>`;
           })}
         <span class="ex-key"><span class="ex-swatch ex-swatch-orphan"></span>unreachable from the root</span>
         <span class="ex-key"><span class="ex-swatch ex-swatch-outside"></span>outside the crate</span>

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import hashlib
 import html
 import json
+from collections import Counter
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, NamedTuple
@@ -245,18 +246,57 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
 )
 
 
-def _categories() -> dict[str, dict[str, str]]:
+def _categories(nodes: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """The drawing registry, as the browser needs it.
 
-    Generated from :data:`CATEGORY_STYLES` for the same reason the stylesheet is
-    (`category_css`): a second hand-written palette is how the report came to
-    disagree with its own diagrams about what colour a file is.
+    Colours and glyphs are generated from :data:`CATEGORY_STYLES` for the same
+    reason the stylesheet is (`category_css`): a second hand-written palette is
+    how the report came to disagree with its own diagrams about what colour a
+    file is.
+
+    ``types`` is the census the legend labels itself from — the distinct type
+    tags this crate's nodes carry in that category, most common first (#623).
+    Every node on the canvas is captioned with its type, so a legend written in
+    category prose explains the colours in a vocabulary the reader can see
+    nowhere else; naming the tags makes the legend and the nodes say the same
+    words. Derived from the crate rather than kept by hand, so a category that
+    gains a type is labelled with it the day it does — and so the fallback
+    bucket, which has no single type to name, is labelled as honestly as the
+    rest.
+
+    A refinement folds into its base (``Dataset · Assay`` counts as
+    ``Dataset``): the colour is the base type's, and the refinements are what
+    the nodes themselves spell out.
     """
-    out = {
-        key: {"colour": style.colour, "label": style.label, "glyph": style.glyph}
+    census: dict[str, Counter] = {}
+    for node in nodes:
+        tag = str(node.get("type") or "").split(" · ")[0].strip()
+        if not tag:
+            continue
+        census.setdefault(str(node.get("category") or ""), Counter())[tag] += 1
+
+    def types_for(key: str) -> list[str]:
+        # Commonest first, ties by name: the legend spells out only the first
+        # few, and the payload is pinned byte-for-byte, so an unstable tie would
+        # break the crate's reproducibility and not merely the wording.
+        counted = census.get(key) or Counter()
+        return [tag for tag, _ in sorted(counted.items(), key=lambda kv: (-kv[1], kv[0]))]
+
+    out: dict[str, dict[str, Any]] = {
+        key: {
+            "colour": style.colour,
+            "label": style.label,
+            "glyph": style.glyph,
+            "types": types_for(key),
+        }
         for key, style in CATEGORY_STYLES.items()
     }
-    out[_CTX_CATEGORY] = {"colour": _CTX_COLOUR, "label": _CTX_LABEL, "glyph": _CTX_GLYPH}
+    # An off-crate reference has no type because the crate never describes it,
+    # so this key keeps its wording: it names a provenance status, not a
+    # category, and is the one label the census cannot supply.
+    out[_CTX_CATEGORY] = {
+        "colour": _CTX_COLOUR, "label": _CTX_LABEL, "glyph": _CTX_GLYPH, "types": [],
+    }
     return out
 
 
@@ -342,7 +382,7 @@ def build_explorer_payload(
         "version": PAYLOAD_VERSION,
         "root": crate.root,
         "layers": {str(level): name for level, name in _LAYER_NAMES.items()},
-        "categories": _categories(),
+        "categories": _categories(nodes),
         "nodes": nodes,
         "edges": [
             {"src": e["src"], "dst": e["dst"], "label": e["label"]} for e in model["edges"]

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import html
 import json
+from collections import Counter
 import re
 import unicodedata
 import subprocess
@@ -163,6 +164,71 @@ class TestPayloadShape:
         assert by_id["./"]["status"] == "in_crate"
         assert by_id["./"]["orphan"] is False
         assert set(by_id["#sample"]) >= {"layer", "reach", "identifier_backed", "category"}
+
+
+class TestCategoryTypeCensus:
+    """What the legend labels itself from (#623): the type tags a category's
+    nodes actually carry, so the legend and the nodes say the same words."""
+
+    def _cats(self, graph: dict[str, Any] | None = None) -> dict[str, Any]:
+        return build_explorer_payload(graph or tabbed_views_graph())["categories"]
+
+    def test_a_category_names_the_tags_its_own_nodes_show(self) -> None:
+        payload = build_explorer_payload(tabbed_views_graph())
+        cats = payload["categories"]
+
+        for key, category in cats.items():
+            shown = {
+                node["type"].split(" · ")[0]
+                for node in payload["nodes"]
+                if node["category"] == key and node["type"]
+            }
+            assert set(category["types"]) == shown, key
+
+    def test_a_refinement_folds_into_its_base_type(self) -> None:
+        """Nodes are tagged ``Dataset · Assay``; the colour is the base type's,
+        and spelling every refinement out would make the legend the longest
+        thing on the page."""
+        cats = self._cats()
+
+        assert cats["container"]["types"] == ["Dataset"]
+
+    def test_the_census_is_ordered_by_how_much_of_the_crate_it_covers(self) -> None:
+        """Most common first — the legend spells out only the first two and
+        counts the rest away, so the order decides what a reader is told.
+
+        Over the plumbing-heavy crate, whose fallback bucket holds one type
+        three times and five others once each: a fixture where every type
+        appears equally often could not tell an ordering from its reverse.
+        """
+        payload = build_explorer_payload(plumbing_heavy_graph())
+        types = payload["categories"]["annotation"]["types"]
+        counted = Counter(
+            node["type"].split(" · ")[0]
+            for node in payload["nodes"]
+            if node["category"] == "annotation"
+        )
+
+        assert len(set(counted.values())) > 1, "the fixture stopped discriminating"
+        assert types[0] == max(counted, key=lambda t: (counted[t], t))
+        assert [counted[t] for t in types] == sorted(counted.values(), reverse=True)
+
+    def test_two_builds_of_one_crate_order_it_the_same_way(self) -> None:
+        """Ties are broken by name, not by dict order: the payload is pinned
+        byte-for-byte across runs, so an unstable tie would break the crate's
+        reproducibility, not merely the legend's wording."""
+        graph = tabbed_views_graph()
+
+        assert self._cats(graph) == self._cats(graph)
+
+    def test_a_category_with_no_types_keeps_its_wording(self) -> None:
+        """An off-crate reference has no type because the crate never describes
+        it. That key names a provenance status, not a category, and is the one
+        label the census cannot supply."""
+        cats = self._cats()
+
+        assert cats["ctx"]["types"] == []
+        assert cats["ctx"]["label"] == "Referenced outside the crate"
 
 
 class TestViewMembership:


### PR DESCRIPTION
Closes #623. From a review comment on the report artifact.

## The defect

The legend labelled its colours in category prose while every node on the canvas is captioned with its **type**. Two vocabularies for one picture — and the legend's appears nowhere else on the page.

| legend said | the type tags its nodes actually show |
|---|---|
| Investigation / Study / Assay | `Dataset · Investigation`, `Dataset · Study`, `Dataset · Assay` |
| Process | `CellCulture`, `Exposure`, `EndpointReadout`, `DataAnalysis` |
| Sample / material | `Sample`, `Sample · CellLine` |
| File / table | `File`, `Table` |
| Term / parameter | `PropertyValue`, `DefinedTerm`, `Column`, `CreateAction`, +4 |

## The fix

Each key is labelled from the crate: the distinct type tags its own nodes carry in that category, commonest first, the first two spelled out and the rest counted away with the full census on `title`.

Derived rather than kept by hand — so a category that gains a type is labelled with it the day it does, and the fallback bucket, which has no single type to name, is labelled as honestly as the rest. On the real deposit the strip now reads:

`Dataset` · `CellCulture, DataAnalysis +2` · `HowTo` · `Sample` · `MolecularEntity` · `File, Table` · `Person` · `Organization` · `PropertyValue, Column +6`

Two edges of the rule:

- **A refinement folds into its base** — `Dataset · Assay` counts as `Dataset`, since the colour is the base type's and the refinement is what the node itself spells out.
- **The off-crate key keeps its wording.** Those entities have no type because the crate never describes them, so it names a provenance status rather than a category — the one label the census cannot supply.

The process key names its four ISA-Tox discriminators rather than `LabProcess`, because that is what is written on the nodes.

## Testing

Five tests, driving the real payload builder:

- a category names exactly the tags its own nodes show, checked against the payload's nodes rather than a hard-coded list
- a refinement folds into its base
- the census is ordered by coverage — **verified by mutation**: reversing the sort reddens it. The first version of this test did not, because the fixture I used had a single annotation type; it now runs over `plumbing_heavy_graph`, which has one type three times and five singletons, and asserts the fixture still discriminates
- two builds of one crate order it identically (ties break by name — the payload is pinned byte for byte, so an unstable tie would break the crate's reproducibility, not merely the wording)
- a category with no types keeps its wording

`uv run ty check` clean, `uvx ruff check` clean, 59 explorer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3