### PR TITLE
fix(report): the toolbar tooltips say what pressing the button does (#630)

### DIFF
--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -490,10 +490,10 @@
             placeholder="Search name, @id or type  ( / )"
             onInput=${function (e) { setQuery(e.target.value); }} />
           <button type="button" class="ex-chip" aria-pressed=${showDoc}
-            title="Read the crate's ro-crate-metadata.json"
+            title="Show the crate's whole ro-crate-metadata.json in the side panel, instead of the selected entity"
             onClick=${function () { setShowDoc(!showDoc); }}>JSON</button>
           <button type="button" class="ex-chip"
-            title="Frame the whole of what is shown"
+            title="Zoom out until everything currently on the canvas fits on screen"
             onClick=${function () { flow.fitView({ padding: 0.08, duration: 300 }); }}>Fit</button>
           <span class="ex-count">${summary(graph, hits)}</span>
         </div>


### PR DESCRIPTION
Closes #630. From a review comment on the report artifact.

Both toolbar buttons already carried a `title`, so the tooltips existed — but each named the button rather than the action, and a native tooltip needs about a second of hover, so a reader who does not already know what the control is may never wait long enough to find out.

| | before | after |
|---|---|---|
| JSON | Read the crate's `ro-crate-metadata.json` | Show the crate's whole `ro-crate-metadata.json` in the side panel, instead of the selected entity |
| Fit | Frame the whole of what is shown | Zoom out until everything currently on the canvas fits on screen |

Copy only — no markup or behaviour change. 54 explorer tests pass.

Left open on the issue, and worth a separate decision: if the problem is that a tooltip is never *seen* rather than what it says, the fix is a visible bubble on hover **and keyboard focus** instead of the browser's, which would also make the explanations reachable without a mouse. That is a component, not a string, so it is not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3