### PR TITLE
fix(report): restore three explorer helpers deleted with #619 (regression)

### DIFF
--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -73,6 +73,24 @@
   }
 
   function category(n) { return D.categories[n.category] || D.categories.ctx; }
+  function layerName(n) {
+    return n.layer ? D.layers[String(n.layer)] : 'Referenced, outside the crate';
+  }
+  function shortId(id) {
+    try {
+      var u = new URL(id);
+      return u.hostname.replace(/^www\./, '') + u.pathname;
+    } catch (err) { return decodeURIComponent(id); }
+  }
+
+  function Glyph(props) {
+    var c = D.categories[props.k] || D.categories.ctx;
+    var s = props.size || 14;
+    return html`<svg class="ex-glyph" width=${s} height=${s} viewBox="0 0 14 14"
+      aria-hidden="true"><path d=${c.glyph} fill=${c.colour} fill-opacity=".18"
+      stroke=${c.colour} stroke-width="1.3" stroke-linejoin="round" /></svg>`;
+  }
+
 
   /* ---- the state a reader can link to -------------------------------------- */
   function readHash() {

--- a/tests/fixtures/js_names_probe.js
+++ b/tests/fixtures/js_names_probe.js
@@ -1,0 +1,75 @@
+/*
+ * Reports the names a browser script references but never defines.
+ *
+ * A Python test can read the file but cannot tell a call from a definition;
+ * node can, because it is the thing that will run it. The script's own
+ * functions live inside an IIFE and are never exported, so nothing else can
+ * observe that one of them has gone — until the page throws ReferenceError in
+ * front of a reader.
+ *
+ * argv[2]: the script to check.  argv[3...]: names the page supplies from
+ * elsewhere (the vendored globals).
+ * stdout:  {"free": [name, ...]} — referenced, declared nowhere.
+ */
+var fs = require('fs');
+var vm = require('vm');
+var source = fs.readFileSync(process.argv[2], 'utf8');
+
+// Syntax first: a script that will not parse never reaches the name check.
+new vm.Script(source, { filename: process.argv[2] });
+
+var declared = new Set(process.argv.slice(3));
+var ident = /[A-Za-z_$][\w$]*/g;
+
+// `function NAME(a, b)` — the name, and the parameters it binds.
+var fn = /\bfunction\s*([A-Za-z_$][\w$]*)?\s*\(([^)]*)\)/g;
+var m;
+while ((m = fn.exec(source)) !== null) {
+  if (m[1]) declared.add(m[1]);
+  (m[2].match(ident) || []).forEach(function (n) { declared.add(n); });
+}
+// `var a = …, b = …` and `var [a, b] = …`: every name a var statement binds.
+// Taken greedily — over-declaring costs a false pass on one name, while
+// under-declaring reports a name that is fine, and this file's whole job is to
+// be believed when it says something is missing.
+var vars = /\bvar\s+([^;\n]*(?:\n\s{6,}[^;\n]*)*);?/g;
+while ((m = vars.exec(source)) !== null) {
+  m[1].split('=')[0].split(',').forEach(function (part) {
+    (part.match(ident) || []).forEach(function (n) { declared.add(n); });
+  });
+  // Names bound after the first `=` are still binders in a multi-declarator
+  // list: `var a = 1, b = 2` binds b too.
+  m[1].split(',').slice(1).forEach(function (part) {
+    var head = part.split('=')[0];
+    (head.match(ident) || []).forEach(function (n) { declared.add(n); });
+  });
+}
+// `catch (err)`
+var caught = /\bcatch\s*\(\s*([A-Za-z_$][\w$]*)/g;
+while ((m = caught.exec(source)) !== null) declared.add(m[1]);
+
+// A reference: called as a bare name, or used as an htm component. Prose is
+// not a reference — "the entity explorer (#615)" reads as a call to anything
+// scanning for `name(` — so comments come out first. Whole-line and block
+// comments only: a `//` inside a string is part of a URL, not a comment.
+var code = source
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .split('\n')
+  .filter(function (line) { return !/^\s*(\/\/|\*)/.test(line); })
+  .join('\n');
+var used = new Set();
+var calls = /(?:^|[^.\w$'"`])([A-Za-z_$][\w$]*)\s*\(/gm;
+while ((m = calls.exec(code)) !== null) used.add(m[1]);
+var components = /<\/?\$\{([A-Za-z_$][\w$]*)\}/g;
+while ((m = components.exec(code)) !== null) used.add(m[1]);
+
+var KEYWORDS = new Set([
+  'function', 'if', 'for', 'while', 'switch', 'catch', 'return', 'typeof',
+  'new', 'delete', 'void', 'in', 'of', 'do', 'else', 'try', 'throw', 'case',
+  'true', 'false', 'null', 'undefined', 'this'
+]);
+var free = [];
+used.forEach(function (name) {
+  if (!declared.has(name) && !KEYWORDS.has(name) && !(name in globalThis)) free.push(name);
+});
+process.stdout.write(JSON.stringify({ free: free.sort() }));

--- a/tests/test_explorer_js_integrity.py
+++ b/tests/test_explorer_js_integrity.py
@@ -1,0 +1,87 @@
+"""The browser half of the explorer, checked by something that can run it.
+
+The Python suite renders the page and reads its markup, so it sees the scripts
+as text. It cannot see that a function the app calls is no longer defined —
+the app's functions live inside an IIFE and are never exported, so nothing
+observes the hole until the page throws in front of a reader. That is exactly
+how three helpers (``Glyph``, ``shortId``, ``layerName``) were deleted by a
+careless edit and shipped: every Python test stayed green.
+
+These run node over the shipped files: it parses them the way the browser will,
+and reports any name they reference but never define.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_PROBE = _REPO / "tests" / "fixtures" / "js_names_probe.js"
+
+# What the page supplies to the app from somewhere other than the app: the
+# vendored bundles and the two DOM globals it reads. A name resolved here is
+# resolved because the page really provides it — the list is the contract, so
+# adding to it is a deliberate act and not a way to quiet the check.
+_PAGE_GLOBALS = ("React", "ReactDOM", "htm", "dagre", "window", "document", "console")
+
+_SCRIPTS = ("entity_explorer.js", "entity_explorer_layout.js")
+
+
+def _node() -> str:
+    exe = shutil.which("node")
+    if exe is None:  # pragma: no cover — depends on the machine, not the code
+        pytest.skip("node is not installed; the explorer's scripts cannot be parsed")
+    return exe
+
+
+def _free_names(script: Path) -> list[str]:
+    result = subprocess.run(
+        [_node(), str(_PROBE), str(script), *_PAGE_GLOBALS],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)["free"]
+
+
+@pytest.mark.skipif(not os.environ.get("CI"), reason="only CI must have node")
+def test_ci_can_parse_the_scripts() -> None:
+    """Locally these skip without node. In CI they must not: a skipped guard
+    protects nothing, and this one guards against a page that cannot run."""
+    assert shutil.which("node"), "CI needs node to parse the explorer's scripts"
+
+
+@pytest.mark.parametrize("name", _SCRIPTS)
+def test_the_script_parses(name: str) -> None:
+    """Node's own parser, so a syntax error is caught here rather than by the
+    first reader to open a crate."""
+    _free_names(_REPO / "builder" / "writers" / name)  # the probe parses before it reports
+
+
+@pytest.mark.parametrize("name", _SCRIPTS)
+def test_it_defines_every_name_it_calls(name: str) -> None:
+    free = _free_names(_REPO / "builder" / "writers" / name)
+
+    assert free == [], f"{name} calls names nothing defines: {', '.join(free)}"
+
+
+def test_the_check_can_fail(tmp_path: Path) -> None:
+    """The control. A guard against deleted code is worth only as much as its
+    ability to notice one, so delete one and watch it notice.
+
+    Cuts a whole function, so the file still parses — this proves the *name*
+    check works, not merely that node rejects broken syntax.
+    """
+    source = (_REPO / "builder" / "writers" / "entity_explorer.js").read_text(encoding="utf-8")
+    start = source.index("  function layerName(n) {")
+    end = source.index("\n  }\n", start) + len("\n  }\n")
+    wounded = tmp_path / "entity_explorer.js"
+    wounded.write_text(source[:start] + source[end:], encoding="utf-8")
+
+    assert _free_names(wounded) == ["layerName"]


### PR DESCRIPTION
**Merge this first.** `main` currently ships a maturity report whose entity explorer throws on first render.

## What happened

`Glyph`, `shortId` and `layerName` were deleted from `entity_explorer.js` in 59e8198 (#631) with every call site left intact:

| function | defined on `main` | referenced on `main` |
|---|---|---|
| `Glyph` | **0** | 5 |
| `shortId` | **0** | 3 |
| `layerName` | **0** | 1 |

`Glyph` draws every node's category icon and every legend key, so the failure is immediate and total: `ReferenceError` on first render, and the section cannot draw. Every report built from that commit carries it, inside the crate.

My fault, and worth naming precisely: while splitting three lanes into separate branches I removed a block with an index slice that ran from one anchor to the next section marker, and it swallowed the three functions sitting in between. The same failure this repo has been bitten by in its test modules, this time in shipped source.

## Why nothing caught it

Nothing runs the JavaScript. The Python suite renders the page and reads its markup, so it sees the scripts as text; the app's functions live inside an IIFE and are never exported, so no test can observe that one has gone. Every Python test stayed green, including the one that scans the script for CSS classes — losing `Glyph` removed the `ex-glyph` class from the scanned set, which only made that check pass more easily.

## The fix, and the missing guard

The three functions are restored verbatim, one definition each.

Added with them: `tests/test_explorer_js_integrity.py`, which runs a node probe over each shipped script. Node parses them the way the browser will, and the probe reports every name a script references but never defines, resolving only against the globals the page actually supplies (`React`, `ReactDOM`, `htm`, `dagre`, `window`, `document`, `console`) — that list is the contract, so widening it is a deliberate act rather than a way to quiet the check.

The suite includes its own control: it cuts a whole function out of a copy — leaving the file parseable, so the *name* check is what is being tested and not node's syntax error — and asserts the probe names it. Run against the broken commit, the probe reports exactly `Glyph, layerName, shortId`.

Node is skipped-if-absent locally and required in CI, so the coverage cannot go quiet.

`uvx ruff check` clean; 69 explorer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3