### PR TITLE
fix(report): the LabProcesses view says what each step is (#626)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1973,7 +1973,12 @@ that describes it, which is the `annotation` category (parameters, csvw columns 
 ontology terms, licences, profiles, the build's own action and software) plus every off-crate stub.
 The rule is by category and never by layer: Persons, Organisations and articles sit in the base
 packaging layer beside the plumbing, so a layer-based rule would drop exactly the credit a reader
-looks for; the root is kept whatever its category. The other toggles are the tabbed section's own
+looks for; the root is kept whatever its category. **LabProcesses** draws the derivation chain plus what each step *is*: the protocol a visible
+process executes and the assay whose `about` points at one. Neither edge lies on the material chain
+the derivation walk follows, and the two point in opposite directions — outward to the protocol,
+inward from the assay — so the view showed every step and every file it touched while never saying
+how a step was done or which assay it served (#626). Followed, never collected: context reaches the
+canvas only through a step the view already draws. The other toggles are the tabbed section's own
 selections, reused rather than re-derived — `_derivation_edges` and `_route_hop_ids` are shared with
 the SVG renderers for that reason, and tests hold each toggle to what its panel draws. A view no
 entity satisfies is not offered, the way an empty tab is not shown. Selecting an entity opens a side

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -128,10 +128,42 @@ def _select_assays(crate: _Crate) -> set[str]:
     return {n["id"] for n in crate.inventory("isa")["nodes"]}
 
 
+# What a step *is*, as opposed to what it handled. Each is keyed by the edge the
+# crate draws and the direction it points, because the two disagree: a process
+# reaches its protocol, and an assay reaches its process (#626).
+_PROCESS_CONTEXT: tuple[tuple[str, bool], ...] = (
+    ("executes", True),  # process → the protocol it runs
+    ("about", False),  # assay → the process it is about
+)
+
+
 def _select_processes(crate: _Crate) -> set[str]:
-    """The derivation chain: every process and what it consumes and produces."""
+    """The derivation chain, and what each step is and belongs to.
+
+    :func:`_derivation_edges` walks the **material** chain — what a process
+    consumed and produced. Neither edge that says what a step *is* travels that
+    way, so the view used to show every step and every file it touched while
+    never saying how a step was done or which assay it served (#626).
+
+    Both are followed here, and followed rather than collected: only the
+    protocol a visible process executes and the assay whose ``about`` points at
+    a visible process join the selection, so a protocol belonging to no drawn
+    step stays out. The two point in opposite directions, which is why this
+    reads the model's edges instead of extending the derivation walk.
+    """
     edges = _derivation_edges(crate.nodes)
-    return {e[0] for e in edges} | {e[1] for e in edges}
+    chain = {e[0] for e in edges} | {e[1] for e in edges}
+    processes = {
+        n["id"] for n in crate.model["nodes"] if n["category"] == "process" and n["id"] in chain
+    }
+    context = {
+        edge["dst"] if outgoing else edge["src"]
+        for edge in crate.model["edges"]
+        for label, outgoing in _PROCESS_CONTEXT
+        if edge["label"] == label
+        and (edge["src"] if outgoing else edge["dst"]) in processes
+    }
+    return chain | context
 
 
 def _routed(crate: _Crate, inventory: str, members: str) -> set[str]:

--- a/tests/fixtures/crate_graphs.py
+++ b/tests/fixtures/crate_graphs.py
@@ -220,3 +220,72 @@ def wide_fanout_graph(files: int = 60) -> dict[str, Any]:
         for i in range(files)
     ]
     return {"@graph": graph}
+
+
+def process_context_graph() -> dict[str, Any]:
+    """A crate where each step says what it is and what it belongs to.
+
+    The shape #626 is about. A LabProcess is reached from its Assay's ``about``
+    — an edge pointing *into* the process — and reaches its protocol through
+    ``executesLabProtocol``, an edge pointing *out*. Neither is part of the
+    material chain the derivation walk follows, so a selection built from that
+    walk alone shows the step and its files and never says how it was done or
+    which assay it serves.
+
+    Carries a second step that is off the material chain entirely — no inputs,
+    no outputs — with a protocol of its own and an assay pointing at it. That
+    step is not drawn, so neither is its context; a selector that swept up every
+    ``executes`` and ``about`` edge in the crate would draw both and pass a test
+    written with only an unreferenced protocol to exclude.
+    """
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                "name": "An investigation",
+                "hasPart": [{"@id": "#assay"}, {"@id": "result.csv"}],
+            },
+            {
+                "@id": "#assay",
+                "@type": "Dataset",
+                "additionalType": "Assay",
+                "name": "Uptake assay",
+                "about": [{"@id": "#exposure"}],
+            },
+            {
+                "@id": "#exposure",
+                "@type": "LabProcess",
+                "additionalType": "Exposure",
+                "name": "Exposure",
+                "object": {"@id": "#cells"},
+                "result": {"@id": "result.csv"},
+                "executesLabProtocol": {"@id": "#protocol"},
+            },
+            {"@id": "#protocol", "@type": "LabProtocol", "name": "Exposure protocol"},
+            {
+                "@id": "#orphan-step",
+                "@type": "LabProcess",
+                "additionalType": "DataAnalysis",
+                "name": "A step on no chain",
+                "executesLabProtocol": {"@id": "#unused-protocol"},
+            },
+            {
+                "@id": "#orphan-assay",
+                "@type": "Dataset",
+                "additionalType": "Assay",
+                "name": "An assay for the undrawn step",
+                "about": [{"@id": "#orphan-step"}],
+            },
+            {"@id": "#unused-protocol", "@type": "LabProtocol", "name": "A protocol nothing draws"},
+            {"@id": "#cells", "@type": "Sample", "name": "Cultured cells"},
+            {
+                "@id": "result.csv",
+                "@type": "File",
+                "name": "result.csv",
+                "encodingFormat": "text/csv",
+            },
+        ]
+    }

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -45,7 +45,11 @@ from builder.writers.provenance_dag import (
     build_isa_inventory,
     build_people_inventory,
 )
-from tests.fixtures.crate_graphs import plumbing_heavy_graph, tabbed_views_graph
+from tests.fixtures.crate_graphs import (
+    plumbing_heavy_graph,
+    process_context_graph,
+    tabbed_views_graph,
+)
 
 _VENDOR_BANNER = "@xyflow/react (styles) 12.11.3"
 """A string only React Flow's vendored stylesheet puts in the page."""
@@ -320,14 +324,59 @@ class TestViewMembership:
         assert views["assays"] == {"./"}  # the fixture declares one Investigation
 
     def test_labprocesses_holds_the_derivation_chain(self) -> None:
+        """The chain is the spine of the view, and every link of it is drawn.
+
+        It used to be the WHOLE of the view, and this test pinned that — down to
+        asserting the protocol stayed out as "executed, not derived". #626
+        reverses that judgment: a step's protocol is what the reader asking how
+        it was done is looking for. The chain is still asserted whole; it is no
+        longer asserted alone.
+        """
         graph = tabbed_views_graph()
         edges = _derivation_edges(_graph_nodes(graph))
 
         views = _views(build_explorer_payload(graph))
 
-        assert views["processes"] == {e[0] for e in edges} | {e[1] for e in edges}
+        assert {e[0] for e in edges} | {e[1] for e in edges} <= views["processes"]
         assert {"#culture", "#exposure", "#line", "#cells", "#table"} <= views["processes"]
-        assert "#protocol" not in views["processes"]  # executed, not derived
+        assert "#protocol" in views["processes"]  # executed by #exposure (#626)
+
+    def test_labprocesses_holds_the_protocol_a_step_executes(self) -> None:
+        """A step's protocol is how it was done — the thing a reader asking
+        "how was this made" most wants — and it is not on the material chain the
+        derivation walk follows, so it used to be absent from the one view named
+        after the steps (#626)."""
+        views = _views(build_explorer_payload(process_context_graph()))
+
+        assert "#protocol" in views["processes"]
+
+    def test_labprocesses_holds_the_assay_a_step_belongs_to(self) -> None:
+        """The assay reaches its process through `about`, an edge pointing INTO
+        the process, so a walk that only follows a process's own outgoing
+        relations cannot find it."""
+        views = _views(build_explorer_payload(process_context_graph()))
+
+        assert "#assay" in views["processes"]
+
+    def test_labprocesses_leaves_out_the_context_of_a_step_it_does_not_draw(self) -> None:
+        """Followed, not collected.
+
+        The fixture's second step is off the material chain, so the view does
+        not draw it — and must not draw its protocol or its assay either. A
+        selector that swept up every ``executes`` and ``about`` edge in the
+        crate would pass the two tests above and fail this one.
+        """
+        views = _views(build_explorer_payload(process_context_graph()))
+
+        assert "#orphan-step" not in views["processes"]
+        assert "#unused-protocol" not in views["processes"]
+        assert "#orphan-assay" not in views["processes"]
+
+    def test_labprocesses_still_holds_the_whole_derivation_chain(self) -> None:
+        """The context is added to the chain, never in place of it."""
+        views = _views(build_explorer_payload(process_context_graph()))
+
+        assert {"#exposure", "#cells", "result.csv"} <= views["processes"]
 
     def test_molecularentities_brings_the_route_that_links_a_compound(self) -> None:
         """A compound is linked to its process through the condition table. The


### PR DESCRIPTION
Closes #626. From two review comments on the report artifact — *"labprocesses is not showing any protocols"* and *"this view should also show the assay a given labprocess is part of"*. They are one defect.

## The defect

`_select_processes` walked `_derivation_edges` — the **material** chain, what a process consumed and produced. Neither edge that says what a step *is* travels that way. On `svhps22_real_input_crate_v19` the view held 52 entities:

    16 LabProcess, 27 File, 4 Table, 5 Sample — 0 protocols, 0 assays

So it showed every step and every file it touched, and never said how a step was done or which assay it served.

## The fix

Both edges are followed. **They point in opposite directions**, which is the part worth knowing and probably why neither was picked up:

| edge | direction | count in that crate |
|---|---|---|
| `executes` | process → protocol | 16 |
| `about` | assay → process | 16 |

That is why this reads the model's edges instead of extending the derivation walk, which only ever looks one way.

**Followed, never collected.** A protocol or assay reaches the canvas only through a step the view already draws, so a detached step's context stays off it.

After: **60 members** — the four protocols and four assays it had been leaving out.

    4 Dataset, 16 LabProcess, 4 HowTo, 5 Sample, 27 File, 4 Table

## Testing

Four new tests over a fixture built for this shape, and both halves of the rule are mutation-verified:

- dropping the "only for a drawn step" condition reddens `test_labprocesses_leaves_out_the_context_of_a_step_it_does_not_draw`
- mistaking `about` for an outgoing edge reddens `test_labprocesses_holds_the_assay_a_step_belongs_to`

My first version of the exclusion test did **not** catch the first mutation — the fixture only had an unreferenced protocol, which nothing would draw either way. It now carries a step off the material chain with a protocol *and* an assay of its own, so "collect every edge" and "follow from a drawn step" give different answers.

**One existing test changed contract.** `test_labprocesses_holds_the_derivation_chain` asserted the view was *exactly* the chain, down to `assert "#protocol" not in views["processes"]  # executed, not derived`. That judgment is what this reverses. It is restated, not removed: the chain is still asserted whole, it is no longer asserted alone, and the docstring records what changed and why.

Interacts with #625: adding assays and protocols makes the chip count overstate further — more reason to count the view's subject rather than its members.

`uv run ty check` clean, `uvx ruff check` clean, the JS name probe reports no free names, 223 report tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3