### PR TITLE
fix(report): a view's chip counts what it is named for (#625)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1976,7 +1976,13 @@ packaging layer beside the plumbing, so a layer-based rule would drop exactly th
 looks for; the root is kept whatever its category. The other toggles are the tabbed section's own
 selections, reused rather than re-derived — `_derivation_edges` and `_route_hop_ids` are shared with
 the SVG renderers for that reason, and tests hold each toggle to what its panel draws. A view no
-entity satisfies is not offered, the way an empty tab is not shown. Selecting an entity opens a side
+entity satisfies is not offered, the way an empty tab is not shown. **A chip counts the view's
+subject, not its selection** (#625): a selection carries the context that makes it readable — the
+files a step touched, the process and table that link a compound to the work — so counting the
+members made every chip overstate its own label, LabProcesses by threefold. The subject comes from
+the same source the matching coverage block counts, and a test pins the two numbers to each other
+rather than each to a literal; it is counted *as drawn*, so a subject the view cannot show is never
+a number the reader has no way to look at. A view whose name covers everything it draws — `Researcher`, `All entities` — declares no subject and counts its members. Selecting an entity opens a side
 panel with its properties, its links in and out grouped by relation, and its JSON-LD; a toolbar
 toggle swaps that for the whole `ro-crate-metadata.json`. Every `@id` in either is a button that
 moves the selection — **never a link**: the payload carries the crate verbatim, `javascript:` URLs

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ build embeds a **maturity report** (`ro-crate-metadata-maturity.html`): profile
 conformance, FAIR maturity, OECD MIT coverage, reproducibility readiness — and an
 **interactive entity explorer**. The explorer draws the crate's whole entity graph,
 with views you turn on and off and combine (Researcher, Files, Assays,
-LabProcesses, MolecularEntities, Biological Samples, Persons & Organisations,
+LabProcesses, Chemicals, Biological models, Persons & Organisations,
 Citations), a search box, and a panel that shows any entity's properties, its
 links and its JSON-LD. Open the file in a browser — it is one self-contained
 page with no network access of any kind, so it works from a USB stick, an

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -482,7 +482,7 @@
             return html`<button key=${v.key} type="button" class="ex-chip"
               aria-pressed=${views.has(v.key)} title=${v.hint}
               onClick=${function () { toggle(v.key); }}>${v.label}
-              <span class="ex-chip-count">${v.members.length}</span></button>`;
+              <span class="ex-chip-count">${v.count}</span></button>`;
           })}
         </div>
         <div class="ex-tools">

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -182,14 +182,50 @@ def _select_citations(crate: _Crate) -> set[str]:
     return ids
 
 
+def _of_category(*categories: str) -> Callable[[_Crate], set[str]]:
+    """Every drawn entity in one of *categories* — the subject of a view named
+    after a kind of entity rather than after an inventory."""
+
+    def subject(crate: _Crate) -> set[str]:
+        return {n["id"] for n in crate.model["nodes"] if n["category"] in categories}
+
+    return subject
+
+
+def _of_inventory(
+    name: str, members: str, level: str | None = None
+) -> Callable[[_Crate], set[str]]:
+    """The members of an inventory — the same source the matching coverage block
+    counts, so the chip and the block cannot drift apart (#625)."""
+
+    def subject(crate: _Crate) -> set[str]:
+        inv = crate.inventory(name)
+        return {
+            member["id"]
+            for member in inv[members]
+            if level is None or member.get("level") == level
+        }
+
+    return subject
+
+
 class ExplorerView(NamedTuple):
-    """One toggle: a named selection over the crate's entities."""
+    """One toggle: a named selection over the crate's entities.
+
+    ``select`` is what the toggle *draws*; ``subject`` is what it is *named
+    for*, and the chip counts that. The two differ because a selection carries
+    the context that makes it readable — the files a step touched, the process
+    and table that link a compound to the work — and counting those made every
+    chip overstate its own label, LabProcesses by threefold (#625). A view whose
+    name covers everything it draws leaves ``subject`` unset.
+    """
 
     key: str
     label: str
     hint: str
     default: bool
     select: Callable[[_Crate], set[str]]
+    subject: Callable[[_Crate], set[str]] | None = None
 
 
 # Order matters: "Researcher" opens the section, and the rest follow the tabbed
@@ -206,10 +242,20 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         "all", "All entities", "Everything the crate describes", False, _select_all
     ),
     ExplorerView(
-        "files", "Files", "Data files and the datasets that hold them", False, _select_files
+        "files",
+        "Files",
+        "Data files and the datasets that hold them",
+        False,
+        _select_files,
+        _of_category("data"),
     ),
     ExplorerView(
-        "assays", "Assays", "Investigation, studies and assays", False, _select_assays
+        "assays",
+        "Assays",
+        "Investigation, studies and assays",
+        False,
+        _select_assays,
+        _of_inventory("isa", "nodes", level="Assay"),
     ),
     ExplorerView(
         "processes",
@@ -217,20 +263,23 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         "Processes with what they consumed and produced",
         False,
         _select_processes,
+        _of_category("process"),
     ),
     ExplorerView(
         "chemicals",
-        "MolecularEntities",
+        "Chemicals",
         "Compounds and the work that used them",
         False,
         lambda crate: _routed(crate, "chemical", "chemicals"),
+        _of_inventory("chemical", "chemicals"),
     ),
     ExplorerView(
         "samples",
-        "Biological Samples",
+        "Biological models",
         "Cell lines and samples, and the work that used them",
         False,
         lambda crate: _routed(crate, "cellline", "celllines"),
+        _of_inventory("cellline", "celllines"),
     ),
     ExplorerView(
         "people",
@@ -238,10 +287,15 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         "Who the crate credits",
         False,
         _select_people,
+        _of_inventory("people", "agents"),
     ),
     ExplorerView(
-        "citations", "Citations", "What the crate cites, and who wrote it", False,
+        "citations",
+        "Citations",
+        "What the crate cites, and who wrote it",
+        False,
         _select_citations,
+        _of_inventory("citation", "articles"),
     ),
 )
 
@@ -364,12 +418,16 @@ def build_explorer_payload(
         members = view.select(crate) & crate.known
         if not members:
             continue
+        # The count is the subject *as drawn*: a subject the view cannot show
+        # would be a number the reader has no way to go and look at.
+        counted = members if view.subject is None else (view.subject(crate) & members)
         views.append(
             {
                 "key": view.key,
                 "label": view.label,
                 "hint": view.hint,
                 "default": view.default,
+                "count": len(counted),
                 "members": sorted(members),
             }
         )

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1801,8 +1801,8 @@ _COVERAGE_BLOCKS: tuple[tuple[str, str], ...] = (
     # Files before Assays: the review's "flip dataset and assays".
     ("cov-data", "Files"),
     ("cov-isa", "Assays"),
-    ("cov-chem", "MolecularEntities"),
-    ("cov-cell", "Biological Samples"),
+    ("cov-chem", "Chemicals"),
+    ("cov-cell", "Biological models"),
     ("cov-people", "Persons &amp; Organisations"),
     # Last, and next to People: the two answer the same kind of question about
     # credit, and a reader who has just checked who the crate credits is the one
@@ -2136,7 +2136,7 @@ _CELL_STATE_NOTE = {
 
 
 def _render_celllines_panel(inv: dict[str, Any]) -> tuple[str, str]:
-    """The Biological Samples view: the test system, and whether it is pinned down.
+    """The Biological models view: the test system, and whether it is pinned down.
 
     The reader-facing name is the owner's (review comment on the report
     artifact); the entities are cell lines, and the wording keeps
@@ -2213,7 +2213,7 @@ def _render_celllines_panel(inv: dict[str, Any]) -> tuple[str, str]:
         '<div class="chem-tbl-scroll"><table class="chem-tbl">'
         '<caption class="sr-only">Identification fields carried by each biological sample'
         "</caption>"
-        f'<thead><tr><th scope="col">Biological sample</th>{head}</tr></thead>'
+        f'<thead><tr><th scope="col">Biological model</th>{head}</tr></thead>'
         f"<tbody>{''.join(rows)}</tbody></table></div>"
     )
 

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -19,6 +19,8 @@ import sys
 from html.parser import HTMLParser
 from typing import Any
 
+import pytest
+
 from builder.writers.entity_explorer import (
     EXPLORER_SCRIPT_COUNT,
     EXPLORER_VIEWS,
@@ -39,6 +41,7 @@ from builder.writers.provenance_dag import (
     _derivation_edges,
     _graph_nodes,
     build_cellline_inventory,
+    build_chemical_inventory,
     build_chemical_inventory,
     build_citation_inventory,
     build_crate_graph,
@@ -421,6 +424,123 @@ class TestViewMembership:
         payload = build_explorer_payload(tabbed_views_graph())
 
         assert {v["key"] for v in payload["views"]} <= {v.key for v in EXPLORER_VIEWS}
+
+
+class TestAChipCountsWhatItIsNamedFor:
+    """A view's members include the supporting entities it drags in so the
+    selection has context — the files a step touched, the hops that link a
+    compound to the work. Counting those on the chip makes every count overstate
+    the thing the label names, LabProcesses by threefold (#625).
+    """
+
+    def _counts(self, payload: dict[str, Any]) -> dict[str, int]:
+        return {v["key"]: v["count"] for v in payload["views"]}
+
+    def _members(self, payload: dict[str, Any]) -> dict[str, int]:
+        return {v["key"]: len(v["members"]) for v in payload["views"]}
+
+    def test_a_count_is_the_subject_not_the_selection(self) -> None:
+        """The compound view draws the process and table that link a compound to
+        the work it was used in. Those are context; the chip says how many
+        compounds."""
+        payload = build_explorer_payload(tabbed_views_graph())
+        chemicals = {
+            m["id"] for m in build_chemical_inventory(tabbed_views_graph())["chemicals"]
+        }
+
+        assert self._counts(payload)["chemicals"] == len(chemicals)
+        assert self._counts(payload)["chemicals"] < self._members(payload)["chemicals"]
+
+    def test_a_subject_the_view_cannot_draw_is_not_counted(self) -> None:
+        """The count is the subject *as drawn*.
+
+        A LabProcess with no inputs or outputs is off the derivation chain, so
+        the view does not draw it — and a chip that counted it would promise a
+        step the reader can never find on the canvas. The crate below holds two
+        processes and draws one.
+        """
+        graph = {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Two steps, one drawn",
+                    "hasPart": [{"@id": "out.csv"}],
+                },
+                {
+                    "@id": "#drawn",
+                    "@type": "LabProcess",
+                    "additionalType": "Exposure",
+                    "name": "A step on the chain",
+                    "object": {"@id": "#cells"},
+                    "result": {"@id": "out.csv"},
+                },
+                {
+                    "@id": "#undrawn",
+                    "@type": "LabProcess",
+                    "additionalType": "DataAnalysis",
+                    "name": "A step on no chain",
+                },
+                {"@id": "#cells", "@type": "Sample", "name": "Cells"},
+                {"@id": "out.csv", "@type": "File", "name": "out.csv"},
+            ]
+        }
+        payload = build_explorer_payload(graph)
+        members = next(v["members"] for v in payload["views"] if v["key"] == "processes")
+
+        assert "#undrawn" not in members, "the fixture stopped discriminating"
+        assert self._counts(payload)["processes"] == 1
+
+    def test_no_count_exceeds_what_the_view_can_draw(self) -> None:
+        """The same rule swept over a whole crate."""
+        payload = build_explorer_payload(plumbing_heavy_graph())
+        counts, members = self._counts(payload), self._members(payload)
+
+        for key in counts:
+            assert counts[key] <= members[key], key
+
+    def test_a_view_that_is_its_own_subject_counts_everything(self) -> None:
+        """"All entities" and "Researcher" name no narrower thing than what they
+        draw, so for them the two numbers are the same — and that is a fact
+        about the view, not a special case to exempt."""
+        payload = build_explorer_payload(plumbing_heavy_graph())
+        counts, members = self._counts(payload), self._members(payload)
+
+        for key in ("all", "researcher"):
+            assert counts[key] == members[key], key
+
+
+class TestTheChipAndTheCoverageBlockAgree:
+    """The section further down the report already counts the way the chips
+    should. Two numbers for one crate, from two code paths, so they are pinned
+    to each other rather than each to a literal."""
+
+    def _cov_n(self, page: str, block_id: str) -> int:
+        match = re.search(
+            rf'id="{block_id}"[^>]*><h3 class="cov-h">.*?<span class="cov-n">(\d+)</span>',
+            page,
+            re.S,
+        )
+        assert match, f"{block_id} reported no count"
+        return int(match.group(1))
+
+    @pytest.mark.parametrize(
+        ("block_id", "key"),
+        [
+            ("cov-isa", "assays"),
+            ("cov-chem", "chemicals"),
+            ("cov-cell", "samples"),
+            ("cov-people", "people"),
+        ],
+    )
+    def test_the_chip_says_what_the_block_says(self, block_id: str, key: str) -> None:
+        graph = tabbed_views_graph()
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), graph=graph)
+        payload = build_explorer_payload(graph)
+
+        count = next(v["count"] for v in payload["views"] if v["key"] == key)
+        assert count == self._cov_n(page, block_id)
 
 
 class TestViewsAgreeWithTheirCoverageBlocks:

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1827,7 +1827,7 @@ class TestCellLinesPanel:
     def test_renders_diagram_and_matrix(self) -> None:
         page = self._page()
         assert '<div class="cov" id="cov-cell">' in page
-        assert '<h3 class="cov-h">Biological Samples' in page
+        assert '<h3 class="cov-h">Biological models' in page
         assert "CHO-K1" in page
         assert "CVCL_0214" in page
         for column in ("RRID", "Type", "Organ", "Tissue", "Passage"):
@@ -1837,13 +1837,16 @@ class TestCellLinesPanel:
         """The owner's term for the test system is the checklist's — "biological
         model", as in the MIT module Biological Model Information — so the block
         heading and the table's corner header both say it (the legend and the
-        diagram that also did are gone, #618). "Cell line" survives only where
+        diagram that also did are gone, #618). Until #625 this test's own name
+        and reasoning said "biological model" while its assertions still pinned
+        "Biological Samples"; the rename settles which of the two was right.
+        "Cell line" survives only where
         it names the actual declaration being checked: the Type column's
         tooltip (the entity is typed as a cell line) and ``CellLine`` itself.
         """
         page = self._page()
-        assert '<h3 class="cov-h">Biological Samples' in page
-        assert '<th scope="col">Biological sample</th>' in page
+        assert '<h3 class="cov-h">Biological models' in page
+        assert '<th scope="col">Biological model</th>' in page
         panel = _block(page, "cov-cell")
         rest = panel.replace('title="Typed as a cell line"', "")
         assert "cell line" not in rest.lower(), "a reader-facing 'cell line' survived"


### PR DESCRIPTION
Closes #625. From a review comment on the report artifact.

## The defect

A view's members include the supporting entities it drags in so the selection has context. The chip counted those, so every count overstated its own label — measured on `svhps22_real_input_crate_v19`:

| chip | was | now | the rest of the members |
|---|---|---|---|
| Files | 65 | **59** | 6 Datasets |
| Assays | 6 | **4** | Investigation, Study |
| LabProcesses | 52 | **16** | 27 Files, 4 Tables, 5 Samples |
| Chemicals | 16 | **12** | the route hops |
| Biological models | 4 | **3** | a CellCulture |
| Persons & Organisations | 4 | **3** | a Dataset |
| Researcher / All entities | 107 / 293 | unchanged | they name everything they draw |

## The fix

A view now declares a **subject** beside its selection — what it is named for — and the chip counts that while the canvas keeps drawing the context.

The subject comes from **the same source the matching coverage block counts**, so the two numbers cannot drift, and a test pins them to each other rather than each to a literal. It is counted **as drawn**: a process off the derivation chain is a LabProcess the view does not show, and counting it would promise a step the reader can never find on the canvas.

## Renames

`MolecularEntities` → **Chemicals**, `Biological Samples` → **Biological models**, in the coverage block as well as on the chip so both places say one word.

The second one finishes something already half-applied. The block's own test is called `test_the_view_is_named_biological_models_wherever_a_reader_sees_it`, and its docstring gives the reason — *"the owner's term for the test system is the checklist's — biological model, as in the MIT module Biological Model Information"* — while its assertions still pinned `Biological Samples`. The rename settles which of the two was right; the table's corner header goes with it.

## Testing

Both halves of the counting rule are mutation-verified:

- making the count fall back to the member list reddens 5 tests
- dropping the "as drawn" intersection reddens `test_a_subject_the_view_cannot_draw_is_not_counted`

That second test is the interesting one. My first attempt at it swept a whole fixture asserting `count <= members`, and the mutation **survived** — on that crate every subject already happened to be drawn, so the intersection was a no-op. It now uses a crate with two LabProcesses of which one is off the derivation chain, so "subject" and "subject as drawn" give different answers.

`uv run ty check` clean, `uvx ruff check` clean, the JS name probe reports no free names, 227 report tests pass.

**Independent of #635.** Both merge cleanly into `main` and cleanly with each other (checked by exit code, not by grepping merge-tree's output — which is how I got this wrong earlier today). Merge in either order; if the second does need a rebase I will do it.

#635 makes this change more valuable, not less: adding protocols and assays to LabProcesses widens the gap between its 60 members and its 16 steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3
