### PR TITLE
fix(report): the Assays view says what an assay is for (#627)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1973,7 +1973,15 @@ that describes it, which is the `annotation` category (parameters, csvw columns 
 ontology terms, licences, profiles, the build's own action and software) plus every off-crate stub.
 The rule is by category and never by layer: Persons, Organisations and articles sit in the base
 packaging layer beside the plumbing, so a layer-based rule would drop exactly the credit a reader
-looks for; the root is kept whatever its category. **LabProcesses** draws the derivation chain plus what each step *is*: the protocol a visible
+looks for; the root is kept whatever its category. **Assays** draws the ISA backbone plus what its assays are *for*: the adverse outcome pathway a
+study serves and the key events an assay measures, which the ISA-Tox profile hangs off
+`schema:mentions` (`7_assay_key_event.ttl`, `6_study_aop.ttl`). Followed from the backbone rather
+than swept from the crate, and filtered by type — `mentions` is general enough to carry the
+build's own action, and a key event nothing in the backbone claims is not one this crate's assays
+measure (#627). A domain type also outranks the generic one it refines when a node is captioned,
+so a key event reads as a key event rather than as the `DefinedTerm` it also is.
+
+**LabProcesses** draws the derivation chain plus what each step *is*: the protocol a visible
 process executes and the assay whose `about` points at one. Neither edge lies on the material chain
 the derivation walk follows, and the two point in opposite directions — outward to the protocol,
 inward from the assay — so the view showed every step and every file it touched while never saying

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -44,6 +44,7 @@ from builder.writers.provenance_dag import (
     _derivation_edges,
     _graph_nodes,
     _route_hop_ids,
+    _types,
     build_cellline_inventory,
     build_chemical_inventory,
     build_citation_inventory,
@@ -123,9 +124,40 @@ def _select_files(crate: _Crate) -> set[str]:
     return {n["id"] for n in crate.model["nodes"] if n["category"] in ("data", "container")}
 
 
+# What an assay is FOR. The ISA-Tox profile hangs both off `schema:mentions`
+# (`profiles/shapes/tox/7_assay_key_event.ttl`, `6_study_aop.ttl`), so the
+# relation alone does not identify them — a crate mentions its own build action
+# through it too. The type does (#627).
+_PATHWAY_TYPES = frozenset({"AdverseOutcomePathway", "KeyEvent"})
+
+
 def _select_assays(crate: _Crate) -> set[str]:
-    """The ISA backbone: Investigation → Study → Assay."""
-    return {n["id"] for n in crate.inventory("isa")["nodes"]}
+    """The ISA backbone, and what its assays are for.
+
+    Investigation → Study → Assay, plus the adverse outcome pathway a study
+    serves and the key events an assay measures. Those are the one thing in the
+    crate that says what an assay is *for*, and the view named after assays used
+    to select the backbone alone (#627).
+
+    Followed, never collected: a pathway reaches the canvas only through an ISA
+    entity that mentions it, so an ontology term nothing points at stays out.
+    ``mentions`` is a general relation, so what is mentioned is filtered by
+    type — the science joins the view, the build's own action does not.
+    """
+    backbone = {n["id"] for n in crate.inventory("isa")["nodes"]}
+    described = {
+        str(entity["@id"]): entity
+        for entity in crate.document.get("@graph", [])
+        if isinstance(entity, dict) and entity.get("@id")
+    }
+    pathway = {
+        edge["dst"]
+        for edge in crate.model["edges"]
+        if edge["label"] == "mentions"
+        and edge["src"] in backbone
+        and _types(described.get(edge["dst"], {})) & _PATHWAY_TYPES
+    }
+    return backbone | pathway
 
 
 # What a step *is*, as opposed to what it handled. Each is keyed by the edge the

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -439,7 +439,19 @@ def _tag(node: dict[str, Any]) -> str:
     if _is_process(node):
         return _additional_type(node) or "LabProcess"
     types = _types(node)
-    for preferred in ("MolecularEntity", "Table", "File", "Sample"):
+    # A domain type outranks the generic one it refines. Without this the tag is
+    # whichever type sorts first, so a key event — typed `["KeyEvent",
+    # "DefinedTerm"]` — reached the canvas captioned "DefinedTerm", telling the
+    # reader it was a piece of vocabulary rather than the effect the assay
+    # measures (#627).
+    for preferred in (
+        "AdverseOutcomePathway",
+        "KeyEvent",
+        "MolecularEntity",
+        "Table",
+        "File",
+        "Sample",
+    ):
         if preferred in types:
             tag = preferred
             break

--- a/tests/fixtures/crate_graphs.py
+++ b/tests/fixtures/crate_graphs.py
@@ -289,3 +289,77 @@ def process_context_graph() -> dict[str, Any]:
             },
         ]
     }
+
+
+def aop_linked_graph() -> dict[str, Any]:
+    """A crate whose assays say what they are *for*.
+
+    The shape #627 is about. The ISA-Tox profile links an Assay to the key
+    events it measures and a Study to the adverse outcome pathway it serves,
+    both through ``schema:mentions`` (``profiles/shapes/tox/7_assay_key_event.ttl``
+    and ``6_study_aop.ttl``). The Assays view selected the ISA backbone alone, so
+    the one thing that says what an assay is for was missing from the view named
+    after assays.
+
+    ``mentions`` is a general relation, so the crate also mentions something that
+    is neither — the build's own action, exactly as a real crate does — and it
+    must stay out of a view about the science. A second key event is mentioned
+    only by an entity outside the ISA backbone, so a rule that followed every
+    ``mentions`` edge in the crate rather than the ones leaving an assay or study
+    would draw a pathway no assay claims.
+    """
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                "name": "An investigation",
+                "hasPart": [{"@id": "#study"}],
+                "mentions": [{"@id": "#build"}],
+            },
+            {
+                "@id": "#study",
+                "@type": "Dataset",
+                "additionalType": "Study",
+                "name": "A study",
+                "hasPart": [{"@id": "#assay"}],
+                "mentions": [{"@id": "https://aopwiki.org/aops/610"}],
+            },
+            {
+                "@id": "#assay",
+                "@type": "Dataset",
+                "additionalType": "Assay",
+                "name": "Transport assay",
+                "mentions": [{"@id": "https://aopwiki.org/events/2258"}],
+            },
+            {
+                "@id": "https://aopwiki.org/aops/610",
+                "@type": ["AdverseOutcomePathway", "schema:DefinedTerm"],
+                "name": "Decreased thyroid hormone levels in the brain",
+            },
+            {
+                "@id": "https://aopwiki.org/events/2258",
+                "@type": ["KeyEvent", "schema:DefinedTerm"],
+                "name": "Inhibition, monocarboxylate transporter 8",
+            },
+            {
+                "@id": "#term",
+                "@type": "DefinedTerm",
+                "name": "An ontology term no assay mentions",
+            },
+            {
+                "@id": "#note",
+                "@type": "CreativeWork",
+                "name": "A note outside the ISA backbone",
+                "mentions": [{"@id": "https://aopwiki.org/events/9999"}],
+            },
+            {
+                "@id": "https://aopwiki.org/events/9999",
+                "@type": ["KeyEvent", "schema:DefinedTerm"],
+                "name": "A key event no assay measures",
+            },
+            {"@id": "#build", "@type": "CreateAction", "name": "vitro-crate build"},
+        ]
+    }

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -49,6 +49,7 @@ from builder.writers.provenance_dag import (
     build_people_inventory,
 )
 from tests.fixtures.crate_graphs import (
+    aop_linked_graph,
     plumbing_heavy_graph,
     process_context_graph,
     tabbed_views_graph,
@@ -325,6 +326,66 @@ class TestViewMembership:
 
         assert views["assays"] == {n["id"] for n in build_isa_inventory(graph)["nodes"]}
         assert views["assays"] == {"./"}  # the fixture declares one Investigation
+
+    def test_assays_hold_the_key_events_an_assay_measures(self) -> None:
+        """What an assay is *for*. The profile links it through
+        ``schema:mentions`` (``7_assay_key_event.ttl``), and the view used to
+        select the ISA backbone alone (#627)."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert "https://aopwiki.org/events/2258" in views["assays"]
+
+    def test_assays_hold_the_pathway_a_study_serves(self) -> None:
+        """The AOP hangs off the Study rather than the Assay
+        (``6_study_aop.ttl``), so a rule keyed to assays alone would miss it."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert "https://aopwiki.org/aops/610" in views["assays"]
+
+    def test_assays_do_not_hold_whatever_else_the_crate_mentions(self) -> None:
+        """``mentions`` is a general relation: a crate mentions its own build
+        action through it. The view is about the science, so the rule is keyed
+        to what is mentioned, not merely to the relation."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert "#build" not in views["assays"]
+
+    def test_a_key_event_is_captioned_as_one(self) -> None:
+        """A key event is typed ``["KeyEvent", "schema:DefinedTerm"]``, and the
+        node caption used to take whichever came first alphabetically — so the
+        crate's key events reached the canvas labelled "DefinedTerm",
+        indistinguishable from a csvw column's ontology term. Drawing them in
+        the Assays view (#627) is worth nothing if the canvas will not name
+        them: a domain type outranks the generic one it refines, the way
+        MolecularEntity and Sample already do."""
+        payload = build_explorer_payload(aop_linked_graph())
+        tags = {n["id"]: n["type"] for n in payload["nodes"]}
+
+        assert tags["https://aopwiki.org/events/2258"] == "KeyEvent"
+        assert tags["https://aopwiki.org/aops/610"] == "AdverseOutcomePathway"
+        assert tags["#term"] == "DefinedTerm", "a plain term is still a plain term"
+
+    def test_assays_do_not_hold_a_pathway_no_assay_claims(self) -> None:
+        """Followed from the backbone, not swept from the crate. The fixture's
+        second key event is mentioned only by a note outside the ISA entities,
+        so no assay claims it and the view must not show it as though one did."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert "https://aopwiki.org/events/9999" not in views["assays"]
+
+    def test_assays_do_not_hold_an_unmentioned_term(self) -> None:
+        """Followed, not collected: an ontology term no ISA entity points at
+        stays out, whatever its type."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert "#term" not in views["assays"]
+
+    def test_assays_still_hold_the_isa_backbone(self) -> None:
+        """The pathway is added to the backbone, never in place of it."""
+        graph = aop_linked_graph()
+        views = _views(build_explorer_payload(graph))
+
+        assert {n["id"] for n in build_isa_inventory(graph)["nodes"]} <= views["assays"]
 
     def test_labprocesses_holds_the_derivation_chain(self) -> None:
         """The chain is the spine of the view, and every link of it is drawn.


### PR DESCRIPTION
Closes #627. From a review comment on the report artifact: *"the assays view should also show linked aop and ke events"*.

## The defect

`_select_assays` returned the ISA backbone and nothing else — six Datasets on `svhps22_real_input_crate_v19`. The crate also carries the adverse outcome pathway its study serves and the key events its assays measure, and the view drew neither. The one thing that says what an assay is *for* was missing from the view named after assays.

## The fix

The ISA-Tox profile hangs both off `schema:mentions` (`profiles/shapes/tox/7_assay_key_event.ttl` for assay → key event, `6_study_aop.ttl` for study → AOP), so this is a graph walk, not a guess.

Two guards, both mutation-verified:

- **Followed from the backbone, not swept from the crate.** A key event mentioned only by something outside the ISA entities is not one this crate's assays measure. Dropping this reddens `test_assays_do_not_hold_a_pathway_no_assay_claims`.
- **Filtered by type.** `mentions` is general enough to carry the build's own `CreateAction`. Dropping this reddens `test_assays_do_not_hold_whatever_else_the_crate_mentions`.

My first version of the first guard's test did **not** catch its mutation — the fixture had nothing outside the backbone mentioning a pathway, so "follow from the backbone" and "sweep every mentions edge" gave the same answer. The fixture now carries a note that mentions a key event no assay claims.

## The caption, which turned out to matter

A key event is typed `["KeyEvent", "schema:DefinedTerm"]`, and `_tag` took whichever type sorted first — so every key event reached the canvas labelled **`DefinedTerm`**, indistinguishable from a csvw column's ontology term. Drawing them in this view is worth nothing if the canvas will not name them, so a domain type now outranks the generic one it refines, exactly as `MolecularEntity`, `Table`, `File` and `Sample` already did.

The AOP was only ever captioned correctly by alphabetical luck.

## Result on the real crate

The view goes from 6 members to **11**:

    AdverseOutcomePathway    Decreased thyroid hormone levels in the brain regulating…
    Dataset · Investigation  Neural cell in vitro toxicology assays for thyroid hormone…
    Dataset · Study          Neural cell screening models – thyroid hormone signalling
    Dataset · Assay          Deiodinase Assay
    Dataset · Assay          Thyroid Hormone Receptor Activation
    Dataset · Assay          Thyroid Hormone Transport Assay
    Dataset · Assay          Whole-cell metabolism assay
    KeyEvent                 Inhibition, Deiodinase 2
    KeyEvent                 Antagonism, Thyroid Receptor
    KeyEvent                 Inhibition, monocarboxylate transporter 8 (MCT8)
    KeyEvent                 Inhibition, organic anion-transporting polypeptide 1

## Deliberately not decided here

Those entities keep the `annotation` colour — the bucket for things that *qualify* the work rather than take part in it. In a toxicology crate a key event is a domain object, and giving it a category of its own touches the colour registry and the stylesheet, with its own blast radius. Worth a decision on its own; the caption fix means they are at least legible in the meantime.

`uv run ty check` clean, `uvx ruff check` clean, the JS name probe reports no free names, 349 graph and report tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3