### PR TITLE
fix(report): a filename slug does not headline the report (#628)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1835,11 +1835,18 @@ coverage (`assess_mit_coverage`), and a derived reproducibility-readiness checkl
 
 The page follows the maturity-report design handoff (PR #607 records it): a header whose headline is the **accession** (subhead: the
 publication's name when the crate has one, else the study title), an **About this study** card
-(contact/affiliation/funder/licence/publication+dataset DOI — every value a fact the crate holds or
+(identifier/contact/affiliation/funder/licence/publication+dataset DOI — every value a fact the crate holds or
 an honest *not stated*, never a guess) and an **About this RO-Crate** card (the build facts behind
 the crate's own `vitro-crate build` CreateAction, plus a provenance note carrying the report id
 `MR-<date>-<hash6>`, rendered only when the report is built with the crate's graph — a state-only
-render cannot claim its figures come from the crate's metadata). Then a **KPI grid**: a profile ×
+render cannot claim its figures come from the crate's metadata). The headline is the accession, because that is what a reader cites — but only while it reads as one
+(`state.looks_like_identifier`: one compact token, no whitespace, no longer than a DOI URL). A crate
+reached this report headlined a filename slug sitting in the root's `identifier` where a registry
+accession belongs (#628), so a value that fails that test is demoted rather than dropped — the title
+leads, and the study card states the identifier, since a reader who cannot see it cannot question
+it. `set_crate_metadata` applies the same test and warns rather than refusing: the crate carries the
+value as `schema:identifier` whatever its shape, and the tool cannot tell a weak identifier from a
+real one it has never heard of. Then a **KPI grid**: a profile ×
 requirement-level conformance **matrix** (rows the three layers linked to their specs — IRIs pinned
 to `_crate_mapping`'s `conformsTo` constants by test — cells ✓/✗/– with counts on `title`; the
 Required column is the report's one headline verdict). A `–` carries two different sentences:

--- a/builder/state.py
+++ b/builder/state.py
@@ -539,6 +539,35 @@ class GeneratorInfo:
         )
 
 
+# How long an identifier may be and still read as one. Long enough for a DOI URL
+# (`https://doi.org/10.1007/s00204-024-03787-2`, 42 characters), far short of a
+# title turned into a slug.
+IDENTIFIER_MAX = 48
+
+
+def looks_like_identifier(value: str | None) -> bool:
+    """Whether *value* reads as something a reader could cite.
+
+    A crate reached its report headlined
+    ``inv_neural_cell_screening_models_for_endocrine_disruption_of_thyroid_hormone_signaling``
+    — a filename slug sitting in the root's ``identifier`` where a registry
+    accession belongs (#628). A slug identifies nothing, and the crate carries
+    it as ``schema:identifier``, where every downstream consumer reads it as one.
+
+    Judged on shape alone, because the two callers cannot know provenance: the
+    report reads a finished crate, and the setter takes whatever the agent
+    extracted. A citable identifier is ONE COMPACT TOKEN — no whitespace, no
+    longer than :data:`IDENTIFIER_MAX`. ``S-VHPS21`` passes, a DOI URL passes, a
+    sentence with its spaces replaced by underscores does not.
+
+    This is a test of shape, never of existence: it cannot tell a real accession
+    from a well-formed invention, so callers use it to decide how much to CLAIM
+    for a value, never to decide that one is true.
+    """
+    text = (value or "").strip()
+    return bool(text) and not any(c.isspace() for c in text) and len(text) <= IDENTIFIER_MAX
+
+
 @dataclass
 class CrateMetadata:
     """Top-level metadata describing the RO-Crate itself.

--- a/builder/tools/management.py
+++ b/builder/tools/management.py
@@ -15,6 +15,7 @@ from builder.state import (
     CrateState,
     Entity,
     FileClassification,
+    looks_like_identifier,
 )
 from builder.tools._crate_mapping import _REF_FIELDS
 from builder.tools.field_kinds import is_reference_field, is_resolvable_reference
@@ -835,6 +836,18 @@ def set_crate_metadata(
     if description not in (None, ""):
         m.description = description
     if accession not in (None, ""):
+        # Recorded either way — refusing it would drop the only identifier the
+        # crate has, and this tool cannot tell a weak one from a real one it has
+        # never heard of. Said out loud, though: the value travels in the crate
+        # as `schema:identifier`, where every consumer reads it as something to
+        # cite, and a title slugged into that field identifies nothing (#628).
+        if not looks_like_identifier(accession):
+            logger.warning(
+                "accession %r does not read as an identifier (an accession is one "
+                "compact token, e.g. S-VHPS21 or a DOI); recording it, but the "
+                "report will lead with the title instead",
+                accession,
+            )
         m.accession = accession
     if release_date not in (None, ""):
         m.release_date = release_date

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -48,7 +48,14 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from builder.state import CrateState, Entity, FAIRReport, MITReport, ValidationReport
+from builder.state import (
+    CrateState,
+    Entity,
+    FAIRReport,
+    MITReport,
+    ValidationReport,
+    looks_like_identifier,
+)
 from builder.tools.document_discovery import (
     CLASS_PROCESSED_DATA,
     CLASS_RAW_DATA,
@@ -350,11 +357,17 @@ def _render_header(title: str, accession: str, subhead: str) -> str:
     """The page header: eyebrow, the accession as the headline, and a subhead —
     the publication's name when the crate has one, else the study title.
 
+    The accession leads because it is what a reader cites — but only while it
+    reads as one (:func:`state.looks_like_identifier`). A crate reached this
+    report headlined a filename slug sitting where a registry accession belongs
+    (#628); the title leads instead, and the study card reports the identifier
+    either way, since a reader who cannot see it cannot question it.
+
     No verdict pill, no chips, no scope caveats: conformance lives in the
     Profile conformance tile and the caveats with the findings they qualify
     (the #607 design handoff)."""
     esc = html.escape
-    h1 = accession or title
+    h1 = accession if looks_like_identifier(accession) else (title or accession)
     sub = f'<p class="subhead">{esc(subhead)}</p>\n' if subhead and subhead != h1 else ""
     return (
         "<header>\n"
@@ -420,6 +433,8 @@ def _study_facts(
         "publication": None,  # (doi url|None, display text, article name)
         "dataset_doi": None,
         "description": state.metadata.description or "",
+        # Reported whether or not it headlines the page (see `leads_the_page`).
+        "accession": (state.metadata.accession or "").strip(),
     }
     if graph is None:
         m = state.metadata
@@ -569,6 +584,7 @@ def _render_study_card(facts: dict[str, Any]) -> str:
         '<div class="hcard">\n'
         '  <div class="hcard-h">About this study</div>\n'
         '  <div class="hgrid">'
+        + (cell("Identifier", esc(facts["accession"])) if facts.get("accession") else "")
         + cell("Contact person", linked(facts.get("contact")))
         + cell("Affiliation", linked(facts.get("affiliation")))
         + cell("Funder", linked(facts.get("funder")))
@@ -2506,7 +2522,9 @@ def build_maturity_html(
     esc = html.escape
     title = state.metadata.title or "RO-Crate"
     accession = state.metadata.accession or ""
-    page_title = f"{accession or title} — vitro-crate maturity report"
+    # The tab is the same claim in a smaller place, so it follows the same rule.
+    headline = accession if looks_like_identifier(accession) else (title or accession)
+    page_title = f"{headline} — vitro-crate maturity report"
     # MIT is scored against the assembled @graph — the crate_slot vocabulary
     # describes the serialized crate, not CrateState (#311). The export path
     # passes the graph it already built; without one the assessor assembles its

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -289,6 +289,81 @@ class TestHeaderAndCards:
         assert "<h1>Some study</h1>" in page
         assert '<p class="subhead">' not in page
 
+    def test_a_title_slugged_into_the_identifier_does_not_headline(self) -> None:
+        """A crate reached the report headlined
+        `inv_neural_cell_screening_models_for_endocrine_disruption_of_thyroid_
+        hormone_signaling` — a filename slug sitting in the root's `identifier`
+        where a registry accession belongs (#628). The headline is what a reader
+        cites, so it leads with something citable: a slug is not, and the crate's
+        own title is."""
+        state = CrateState()
+        state.metadata.title = "Neural cell in vitro toxicology assays"
+        state.metadata.accession = (
+            "inv_neural_cell_screening_models_for_endocrine_disruption_of_"
+            "thyroid_hormone_signaling"
+        )
+
+        page = build_maturity_html(state)
+
+        assert "<h1>Neural cell in vitro toxicology assays</h1>" in page
+        assert f"<h1>{state.metadata.accession}</h1>" not in page
+
+    def test_the_browser_tab_follows_the_headline(self) -> None:
+        """The tab is the same claim in a smaller place; a slug there is the
+        first thing a reader sees of the crate."""
+        state = CrateState()
+        state.metadata.title = "A readable title"
+        state.metadata.accession = "inv_" + "_".join(["word"] * 20)
+
+        page = build_maturity_html(state)
+
+        assert "<title>A readable title — vitro-crate maturity report</title>" in page
+
+    def test_a_sentence_short_enough_to_fit_still_does_not_headline(self) -> None:
+        """The other half of the rule. A prose phrase written into the
+        identifier field is short enough to pass a length bound, and is still
+        not something anyone can cite — one token is what makes an identifier."""
+        state = CrateState()
+        state.metadata.title = "The real title"
+        state.metadata.accession = "thyroid assay set"
+
+        page = build_maturity_html(state)
+
+        assert "<h1>The real title</h1>" in page
+
+    def test_a_real_accession_still_leads(self) -> None:
+        """The rule refuses a slug, not an identifier. `S-VHPS21` is what people
+        cite this deposit by, and it stays the headline."""
+        page = build_maturity_html(self._state())
+
+        assert "<h1>S-VHPS21</h1>" in page
+
+    def test_a_doi_still_leads(self) -> None:
+        """Long, but a citable identifier — the bound is not merely "short"."""
+        state = CrateState()
+        state.metadata.title = "A study"
+        state.metadata.accession = "https://doi.org/10.1007/s00204-024-03787-2"
+
+        page = build_maturity_html(state)
+
+        assert f"<h1>{state.metadata.accession}</h1>" in page
+
+    def test_an_identifier_that_does_not_headline_is_still_reported(self) -> None:
+        """Demoted, never dropped: it is what the crate claims to be identified
+        by, and a reader who cannot see it cannot question it."""
+        state = CrateState()
+        state.metadata.title = "A study"
+        state.metadata.accession = "inv_" + "_".join(["word"] * 20)
+
+        page = build_maturity_html(state)
+
+        # Located by the card's own heading element, not by the words: the
+        # stylesheet's comments name the card too, and splitting on the text
+        # picked the CSS up instead.
+        card = page.split('<div class="hcard-h">About this study</div>', 1)[1]
+        card = card.split("</div>\n", 1)[0]
+        assert f'<span class="hlabel">Identifier</span>{state.metadata.accession}' in card
+
     def test_the_study_card_states_not_stated_rather_than_guessing(self) -> None:
         page = build_maturity_html(CrateState())
         card = re.search(r'<div class="hcard">.*?About this study.*?</div>\n', page, re.S)

--- a/tests/test_tools_management.py
+++ b/tests/test_tools_management.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import json
 
 import pytest
@@ -392,3 +394,44 @@ class TestConsolidatedMutationTool:
         assert "set_fields" in names
         for redundant in ("update_entity", "bulk_set_fields", "set_entity_field"):
             assert redundant not in names
+
+
+class TestTheAccessionIsJudgedOnShape:
+    """#628: the crate carries the accession as ``schema:identifier``, where
+    every consumer reads it as something to cite."""
+
+    def test_a_slug_is_recorded_but_said_out_loud(self, caplog) -> None:
+        """Recorded, because refusing would drop the only identifier the crate
+        has and this tool cannot tell a weak one from a real one it has never
+        heard of. Said out loud, because a title slugged into that field
+        identifies nothing."""
+        from builder.tools.management import set_crate_metadata
+
+        state = CrateState()
+        slug = "inv_neural_cell_screening_models_for_endocrine_disruption_of_thyroid"
+        with caplog.at_level(logging.WARNING, logger="builder.tools.management"):
+            set_crate_metadata(state, accession=slug)
+
+        assert state.metadata.accession == slug
+        assert any("does not read as an identifier" in r.message for r in caplog.records)
+
+    def test_a_real_accession_passes_without_comment(self, caplog) -> None:
+        from builder.tools.management import set_crate_metadata
+
+        state = CrateState()
+        with caplog.at_level(logging.WARNING, logger="builder.tools.management"):
+            set_crate_metadata(state, accession="S-VHPS21")
+
+        assert state.metadata.accession == "S-VHPS21"
+        assert not caplog.records
+
+    def test_a_doi_passes_without_comment(self, caplog) -> None:
+        """Long, but one token and citable — the rule is not merely "short"."""
+        from builder.tools.management import set_crate_metadata
+
+        state = CrateState()
+        doi = "https://doi.org/10.1007/s00204-024-03787-2"
+        with caplog.at_level(logging.WARNING, logger="builder.tools.management"):
+            set_crate_metadata(state, accession=doi)
+
+        assert not caplog.records


### PR DESCRIPTION
Closes #628. From a review comment on the report artifact, pointing at the `<h1>`: *"this should not contain _"*.

## The defect

A crate reached its report headlined:

    inv_neural_cell_screening_models_for_endocrine_disruption_of_thyroid_hormone_signaling

The headline is the accession **by design** — `S-VHPS21` is what a reader cites, and a title is not (#607 handoff). But here the accession *is* that slug, sitting in the root's `identifier` where a registry accession belongs, while the crate's own `name` is a perfectly good title.

So the underscore was the symptom. Stripping it would have left the false claim in place, just prettier: the value travels inside the crate as `schema:identifier`, where every downstream consumer reads it as something to cite.

## The rule

`state.looks_like_identifier` judges the value on **shape**, because neither caller can know provenance — the report reads a finished crate, and the setter takes whatever the agent extracted. A citable identifier is **one compact token**: no whitespace, no longer than a DOI URL (48 chars).

| value | leads? |
|---|---|
| `S-VHPS21` | ✓ |
| `https://doi.org/10.1007/s00204-024-03787-2` | ✓ |
| `inv_neural_cell_screening_models_for_…` (88 chars) | ✗ |
| `thyroid assay set` (short, but a phrase) | ✗ |

A value that fails leads nowhere: the title takes the headline **and the browser tab** (the tab is the same claim in a smaller place, and was showing the slug too). The study card gains an **Identifier** row, so the value is reported either way — demoted, never dropped, because it is what the crate claims to be identified by and a reader who cannot see it cannot question it.

## The source side

`set_crate_metadata` applies the same test and **warns rather than refusing**. Worth being explicit about why, since the issue proposed refusing: the crate carries the value as `schema:identifier` whatever its shape, this tool cannot tell a weak identifier from a real one it has never heard of, and refusing would drop the only identifier some crates have. If you would rather it refused, that is a one-line change — say so.

Note this was never a deterministic mint: the value arrives through `set_crate_metadata`, i.e. from the agent. The pipeline already forbids drafter leaves from writing `identifier`/`accession` (`_FORBIDDEN_APPLY_FIELDS`), so the remaining route is the metadata setter, which is what now comments on it.

## Testing

Both halves of the shape test are covered, each by a case the other cannot catch — an 88-character slug for the length bound, a short prose phrase for the whitespace one. Mutating either half reddens a test; I added the whitespace case *because* the mutation survived without it.

One test locator fixed along the way: extracting the study card by splitting on the words "About this study" picked up the **stylesheet's comment** instead of the card. It now splits on the card's own heading element.

`uv run ty check` clean, `uvx ruff check` clean, 262 tests pass across the report, management and explorer modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3