### PR TITLE
feat(report): the Entity coverage blocks fold down (#629)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1853,7 +1853,12 @@ outranks that state: one filed at a tier the profile defines no check at still r
 and filled to the ratio of indicators met, so a gated 0 never reads as "nothing done"), the **FAIR
 principle 1.3** rose (one wedge per MIT module: angle = share of the checklist, radius = fill;
 faint full wedges carry the share), a graph tile (linked / total entities) and reproducibility.
-Findings collapse into **Recommendations** rows — the validator's own message verbatim in a mono
+Each **Entity coverage** block is a fold (#629): the section is an inventory of a whole crate — the
+Files block alone lists 59 on a real deposit — so left open it sits between the reader and
+everything below it, and closed it reads as a contents list. The count rides in the summary
+because that number is the whole value of a block nobody opens, and `@media print` forces every
+fold open so a printed copy keeps the inventory it exists to carry. The Files block's own
+per-Dataset folds nest inside unchanged. Findings collapse into **Recommendations** rows — the validator's own message verbatim in a mono
 chip prefixed by its source layer, the severity badge, then `remediation.describe`'s bold
 instruction with `remediation.why`'s one muted consequence clause — and numbered **References**
 close the page (1: FAIRplus DSM / RDA FDMM; 2: tox-maturity-indicators). There is no FAIR pillar

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -279,6 +279,16 @@ __CATEGORY_STYLES__
    its sections. */
 .mat .cov + .cov { margin-top:1.4rem; padding-top:1.1rem;
   border-top:1px solid var(--hairline); }
+.mat details.cov > summary.cov-h { cursor:pointer; list-style:none; }
+.mat details.cov > summary.cov-h::-webkit-details-marker { display:none; }
+.mat details.cov > summary.cov-h::after { content:"+"; color:var(--muted); margin-left:auto;
+  font-weight:500; }
+.mat details.cov[open] > summary.cov-h::after { content:"\2212"; }
+.mat details.cov > summary.cov-h:hover { color:var(--accent); }
+.mat details.cov > summary.cov-h:focus-visible { outline:2px solid var(--accent);
+  outline-offset:2px; border-radius:4px; }
+.mat details.cov[open] > summary.cov-h { margin-bottom:.6rem; }
+.mat .cov-body { display:block; }
 .mat .cov-h { display:flex; align-items:baseline; gap:.45rem; margin:0 0 .6rem;
   font-size:.95rem; font-weight:660; }
 .mat .cov-n { font-size:.7rem; font-weight:500; color:var(--muted);
@@ -552,6 +562,10 @@ __CATEGORY_STYLES__
   .mat details.sev-fold > .sev-body{display:block !important;}
   .mat details.blockers > .blk{display:grid !important;}
   .mat details.sev-fold > summary::after{display:none;}
+  /* A coverage block is a fold on screen (#629); on paper it is opened, or the
+     printed copy loses the inventory it exists to carry. */
+  .mat details.cov > .cov-body{display:block !important;}
+  .mat details.cov > summary.cov-h::after{display:none;}
   /* The coverage section is longer than a page — every block is shown at
      once (#618) — so it breaks, while a single block stays whole. */
   .mat section.coverage,.mat section.explorer{break-inside:auto;}

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1854,10 +1854,17 @@ def _render_entity_coverage_section(
     if not live:
         return ""
 
+    # One fold per block (#629). The section is an inventory of a whole crate —
+    # on a real deposit the Files block alone lists 59 files — so left open it
+    # sits between the reader and everything below it. Closed, the section reads
+    # as a contents list: a name, a count, and a place to look. The count rides
+    # in the summary because it is the whole value of a block nobody opens, and
+    # `@media print` forces every fold open so a printed copy keeps its
+    # inventory. The Files block's own per-Dataset folds nest unchanged.
     bodies = "".join(
-        f'<div class="cov" id="{bid}"><h3 class="cov-h">{label}'
+        f'<details class="cov" id="{bid}"><summary class="cov-h">{label}'
         + (f'<span class="cov-n">{blocks[bid][1]}</span>' if blocks[bid][1] else "")
-        + f"</h3>{blocks[bid][0]}</div>"
+        + f'</summary><div class="cov-body">{blocks[bid][0]}</div></details>'
         for bid, label in live
     )
     return (

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -628,7 +628,7 @@ class TestTheChipAndTheCoverageBlockAgree:
 
     def _cov_n(self, page: str, block_id: str) -> int:
         match = re.search(
-            rf'id="{block_id}"[^>]*><h3 class="cov-h">.*?<span class="cov-n">(\d+)</span>',
+            rf'id="{block_id}"[^>]*><summary class="cov-h">.*?<span class="cov-n">(\d+)</span>',
             page,
             re.S,
         )
@@ -666,7 +666,7 @@ class TestViewsAgreeWithTheirCoverageBlocks:
     def _listed(self, page: str, block_id: str) -> set[str]:
         """The entity names a coverage block's matrix lists."""
         after = page.split(f'id="{block_id}"', 1)[1]
-        block = re.split(r'<div class="cov" id=|</section>', after, maxsplit=1)[0]
+        block = re.split(r'<details class="cov" id=|</section>', after, maxsplit=1)[0]
         names = set()
         for cell in re.findall(r'<span class="cn">(.*?)</span>', block):
             text = html.unescape(re.sub(r"<[^>]+>", "", cell))

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -55,7 +55,7 @@ def _block(page: str, block_id: str) -> str:
     next block, or the end of the section.
     """
     after = page.split(f'id="{block_id}"', 1)[1]
-    return re.split(r'<div class="cov" id=|</section>', after, maxsplit=1)[0]
+    return re.split(r'<details class="cov" id=|</section>', after, maxsplit=1)[0]
 
 
 def _mit_pct(page: str) -> int:
@@ -1432,7 +1432,7 @@ class TestDatasetsPanel:
     def test_rows_report_the_facts_and_unreachable_sorts_first(self) -> None:
         page = build_maturity_html(CrateState(), graph=self._graph())
         panel = _block(page, "cov-data")
-        assert '<h3 class="cov-h">Files' in page
+        assert '<summary class="cov-h">Files' in page
         rows = re.findall(r"<tr><th scope=\"row\">.*?</tr>", panel, re.S)
         assert len(rows) == 2
         assert "loose.csv" in rows[0] and 'class="mk no"' in rows[0]
@@ -1600,7 +1600,7 @@ class TestChemicalsSection:
 
     def test_section_renders_the_note_and_the_matrix(self) -> None:
         page = self._page()
-        assert '<div class="cov" id="cov-chem">' in page
+        assert '<details class="cov" id="cov-chem">' in page
         assert 'class="chem-tbl"' in page  # the identification matrix
         assert "Aflatoxin B1" in page
         # Matrix columns name the identification fields.
@@ -1766,9 +1766,75 @@ class TestChemicalsSection:
         # The report is offline/no-script; the chemicals diagram must not break
         # that (it is finished SVG, like the derivation chain).
         page = self._page()
-        panel = page.split('<div class="cov" id="cov-chem">', 1)[1].split("</div>", 1)[0]
+        panel = page.split('<details class="cov" id="cov-chem">', 1)[1].split("</div>", 1)[0]
         assert "<script" not in panel.lower()
         assert "src=" not in panel and "@import" not in panel
+
+
+class TestTheCoverageBlocksFoldDown:
+    """#629: the section is an inventory of a whole crate, and it sat between
+    the reader and everything below it."""
+
+    def _page(self) -> str:
+        return build_maturity_html(
+            vhps_fixture_state("S-VHPS21"), graph=tabbed_views_graph()
+        )
+
+    def _blocks(self, page: str) -> list[str]:
+        section = page.split('<section class="coverage">', 1)[1].split("</section>", 1)[0]
+        return re.findall(r"<details class=\"cov\"[^>]*>.*?</details>", section, re.S)
+
+    def test_every_block_is_a_fold(self) -> None:
+        page = self._page()
+        section = page.split('<section class="coverage">', 1)[1].split("</section>", 1)[0]
+
+        assert self._blocks(page), "no block folded"
+        assert '<div class="cov" id=' not in section, "a block stayed open by construction"
+
+    def test_the_summary_carries_the_name_and_the_count(self) -> None:
+        """A closed block shows only its summary, so the count has to be in it —
+        that number is the whole value of a block a reader has not opened."""
+        for block in self._blocks(self._page()):
+            summary = re.search(r"<summary[^>]*>(.*?)</summary>", block, re.S)
+            assert summary, block[:80]
+            if '<span class="cov-n">' in block:
+                assert '<span class="cov-n">' in summary.group(1)
+
+    def test_a_nested_fold_still_works(self) -> None:
+        """The Files block already nests one ``<details>`` per Dataset. Folding
+        the block around them must not swallow those: ``<details>`` nests, and
+        the inner ones keep their own state."""
+        page = self._page()
+        files = next(b for b in self._blocks(page) if 'id="cov-data"' in b)
+
+        assert 'class="ds-fold"' in files
+
+    def test_print_opens_every_block(self) -> None:
+        """The report prints. A printed copy that lost its inventory to a closed
+        fold would be worse than the scrolling this fixes — the same reason the
+        severity folds already force themselves open on paper."""
+        from builder.writers.maturity_report import _load_css
+
+        css = _load_css()
+        printed = css.split("@media print", 1)[1]
+
+        # The rule itself, not merely its words: `details.cov` and
+        # `display:block !important` each appear in the print block for other
+        # reasons, so asserting them separately passed with the rule deleted.
+        assert re.search(
+            r"details\.cov\s*>\s*\.cov-body\s*\{[^}]*display:\s*block\s*!important",
+            printed,
+        ), "print does not force the coverage folds open"
+
+    def test_the_fold_classes_are_styled(self) -> None:
+        """Same guard the report applies to itself: a class with no rule renders
+        at browser defaults, which for a summary means a stray disclosure
+        triangle beside a heading that already has one."""
+        from builder.writers.maturity_report import _load_css
+
+        css = _load_css()
+        for cls in ("cov-body",):
+            assert f".{cls}" in css, cls
 
 
 class TestCellLinesPanel:
@@ -1826,8 +1892,8 @@ class TestCellLinesPanel:
 
     def test_renders_diagram_and_matrix(self) -> None:
         page = self._page()
-        assert '<div class="cov" id="cov-cell">' in page
-        assert '<h3 class="cov-h">Biological models' in page
+        assert '<details class="cov" id="cov-cell">' in page
+        assert '<summary class="cov-h">Biological models' in page
         assert "CHO-K1" in page
         assert "CVCL_0214" in page
         for column in ("RRID", "Type", "Organ", "Tissue", "Passage"):
@@ -1845,7 +1911,7 @@ class TestCellLinesPanel:
         tooltip (the entity is typed as a cell line) and ``CellLine`` itself.
         """
         page = self._page()
-        assert '<h3 class="cov-h">Biological models' in page
+        assert '<summary class="cov-h">Biological models' in page
         assert '<th scope="col">Biological model</th>' in page
         panel = _block(page, "cov-cell")
         rest = panel.replace('title="Typed as a cell line"', "")
@@ -1957,7 +2023,7 @@ class TestPeoplePanel:
 
     def test_renders_diagram_and_matrix(self) -> None:
         page = self._page()
-        assert '<div class="cov" id="cov-people">' in page
+        assert '<details class="cov" id="cov-people">' in page
         assert "Josiah Carberry" in page
         assert "Brown University" in page
         for column in ("PID", "Name", "Affiliation", "Linked"):
@@ -2095,8 +2161,8 @@ class TestCitationsPanel:
 
     def test_renders_diagram_and_matrix(self) -> None:
         page = self._page()
-        assert '<div class="cov" id="cov-cite">' in page
-        assert '<h3 class="cov-h">Citations' in page
+        assert '<details class="cov" id="cov-cite">' in page
+        assert '<summary class="cov-h">Citations' in page
         assert "Two novel in vitro assays for OATP1C1" in page
         assert "10.1007/s00204-024-03787-2" in page
         for column in ("DOI", "Title", "Date", "Authors", "Resolve", "Cited"):


### PR DESCRIPTION
Closes #629. From a review comment on the report artifact: *"make these all fold downs"*.

## Why

The section is an inventory of a whole crate — on `svhps22_real_input_crate_v19` its five blocks run to 71 KB of markup, the Files block alone listing 59 files — and it sat open between the reader and every section below it. It already nested one `<details>` per Dataset *inside* the Files block, so the page had fold-downs inside a block that never folded itself.

## After

Closed, the section is a five-line contents list — a name, a count, and a place to look:

    Files                    59
    Assays                    4
    Chemicals                12
    Biological models         3
    Persons & Organisations   3

The count rides in the `<summary>` because that number is the whole value of a block a reader has not opened.

## Two things kept

- **Print opens every block.** A printed copy that lost its inventory to a closed fold would be worse than the scrolling this fixes. `@media print` forces the bodies open and hides the disclosure marker — exactly what the severity folds already do.
- **The nested folds still work.** `<details>` nests, so the Files block's six per-Dataset folds keep their own state inside the block fold.

## Testing

Five tests, including one that the report's own conventions demanded: every emitted class must have a rule in the stylesheet, or a `<summary>` renders with the browser's default triangle beside the one the CSS draws.

The print test needed sharpening. My first version asserted `"details.cov" in printed` and `"display:block !important" in printed` separately — and **passed with the rule deleted**, because each string appears in the print block for other reasons. It now matches the rule itself.

## Test helpers touched

Helpers in two modules located a block by `<div class="cov" id=…>` and its heading by `<h3 class="cov-h">`. They follow the element to `<details>` / `<summary>`; the contract they assert — a delimited block carrying a count — is unchanged. (One negative assertion in my own new test had to be restored by hand after a blanket replace inverted it.)

`uvx ruff check` clean, 243 tests pass across the report, explorer, XSS and generated-artifact modules.

Independent of #641 — that one touches the header and `state.py`, this one the coverage section and the stylesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3