### PR TITLE
feat(report): the LabProcesses view opens its four ISA-Tox flavours (#624)

### DIFF
--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -32,6 +32,17 @@
     .filter(function (e) { return e && e['@id']; })
     .map(function (e) { return e['@id']; });
   var VIEW = new Map(D.views.map(function (v) { return [v.key, new Set(v.members)]; }));
+  // A view that refines another (#624): the LabProcesses sub-row. Children
+  // NARROW — a parent with active children draws their union instead of its own
+  // members — so the explorer keeps one rule, "what is on is what is drawn",
+  // rather than gaining a second interaction model for the sub-row.
+  var VIEW_PARENT = new Map(D.views.map(function (v) { return [v.key, v.parent || null]; }));
+  var CHILDREN = new Map();
+  D.views.forEach(function (v) {
+    if (!v.parent) return;
+    if (!CHILDREN.has(v.parent)) CHILDREN.set(v.parent, []);
+    CHILDREN.get(v.parent).push(v.key);
+  });
   // Everything some view can put on the canvas. Not `D.nodes.length`: that also
   // counts bare references the crate never describes, which no view offers, so
   // a denominator taken from it would be one the numerator can never reach.
@@ -113,6 +124,12 @@
       keys = D.views.filter(function (v) { return v.default; }).map(function (v) { return v.key; });
     }
     if (!keys.length) keys = [D.views[0].key];
+    // A link to a flavour opens LabProcesses too: the sub-row lives under its
+    // parent's chip, and a filter the reader cannot see is one they cannot undo.
+    keys.concat().forEach(function (k) {
+      var parent = VIEW_PARENT.get(k);
+      if (parent && keys.indexOf(parent) === -1) keys.push(parent);
+    });
     return {
       views: new Set(keys), selected: p.get('select') || null,
       document: p.get('json') === '1', query: p.get('q') || ''
@@ -131,7 +148,15 @@
   function visibleGraph(views, pinned) {
     var visible = new Set(pinned);
     views.forEach(function (key) {
-      VIEW.get(key).forEach(function (id) { visible.add(id); });
+      var kids = (CHILDREN.get(key) || []).filter(function (k) { return views.has(k); });
+      // A child that is on is drawn by its parent's turn, so a child whose
+      // parent is off draws nothing on its own — the sub-row is a filter on the
+      // parent, not a ninth chip.
+      if (!kids.length && VIEW_PARENT.get(key) && views.has(VIEW_PARENT.get(key))) return;
+      var sources = kids.length ? kids : [key];
+      sources.forEach(function (k) {
+        VIEW.get(k).forEach(function (id) { visible.add(id); });
+      });
     });
     var everything = views.has('all');
 
@@ -450,7 +475,14 @@
     function toggle(key) {
       setViews(function (prev) {
         var next = new Set(prev);
-        if (next.has(key)) next.delete(key); else next.add(key);
+        if (next.has(key)) {
+          next.delete(key);
+          // A sub-row goes with the chip that opens it; a filter still running
+          // behind a hidden control is one the reader cannot undo.
+          (CHILDREN.get(key) || []).forEach(function (k) { next.delete(k); });
+        } else {
+          next.add(key);
+        }
         if (!next.size) next.add(key);  // never leave the canvas blank
         return next;
       });
@@ -478,7 +510,7 @@
     return html`<div class="ex-shell">
       <div class="ex-toolbar">
         <div class="ex-views" role="group" aria-label="Views">
-          ${D.views.map(function (v) {
+          ${D.views.filter(function (v) { return !v.parent; }).map(function (v) {
             return html`<button key=${v.key} type="button" class="ex-chip"
               aria-pressed=${views.has(v.key)} title=${v.hint}
               onClick=${function () { toggle(v.key); }}>${v.label}
@@ -498,6 +530,18 @@
           <span class="ex-count">${summary(graph, hits)}</span>
         </div>
       </div>
+      ${D.views.some(function (v) { return v.parent && views.has(v.parent); })
+        ? html`<div class="ex-flavours" role="group" aria-label="Kinds of step">
+            <span class="ex-sub-h">Only</span>
+            ${D.views.filter(function (v) { return v.parent && views.has(v.parent); })
+              .map(function (v) {
+                return html`<button key=${v.key} type="button" class="ex-chip ex-sub"
+                  aria-pressed=${views.has(v.key)} title=${v.hint}
+                  onClick=${function () { toggle(v.key); }}>${v.label}
+                  <span class="ex-chip-count">${v.count}</span></button>`;
+              })}
+          </div>`
+        : null}
       <div class="ex-legend">
         ${Object.keys(D.categories).filter(function (k) { return present.has(k); })
           .map(function (k) {

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -40,6 +40,7 @@ from builder.writers.provenance_dag import (
     _CTX_COLOUR,
     _CTX_GLYPH,
     _LAYER_NAMES,
+    _PROCESS_DISCRIMINATORS,
     CATEGORY_STYLES,
     _derivation_edges,
     _graph_nodes,
@@ -169,7 +170,20 @@ _PROCESS_CONTEXT: tuple[tuple[str, bool], ...] = (
 )
 
 
-def _select_processes(crate: _Crate) -> set[str]:
+def _process_flavour(node: dict[str, Any]) -> str | None:
+    """The ISA-Tox discriminator a process node carries, if it carries one.
+
+    A process node's type tag *is* its discriminator, so the flavours need no
+    classification of their own (#624). A node captioned with more than one tag
+    (``A \u00b7 B``) is matched on any of them.
+    """
+    for tag in str(node.get("type") or "").split("\u00b7"):
+        if tag.strip() in _PROCESS_DISCRIMINATORS:
+            return tag.strip()
+    return None
+
+
+def _select_processes(crate: _Crate, flavour: str | None = None) -> set[str]:
     """The derivation chain, and what each step is and belongs to.
 
     :func:`_derivation_edges` walks the **material** chain — what a process
@@ -188,6 +202,22 @@ def _select_processes(crate: _Crate) -> set[str]:
     processes = {
         n["id"] for n in crate.model["nodes"] if n["category"] == "process" and n["id"] in chain
     }
+    if flavour is not None:
+        # A flavour is this rule restricted to one discriminator — never a fresh
+        # sweep of the crate by type, or it would draw steps the parent leaves
+        # out. The chain narrows with it, to what those steps touched.
+        processes = {
+            n["id"]
+            for n in crate.model["nodes"]
+            if n["id"] in processes and _process_flavour(n) == flavour
+        }
+        chain = set(processes)
+        for edge in edges:
+            src, dst = edge[0], edge[1]
+            if src in processes:
+                chain.add(dst)
+            if dst in processes:
+                chain.add(src)
     context = {
         edge["dst"] if outgoing else edge["src"]
         for edge in crate.model["edges"]
@@ -273,6 +303,34 @@ def _of_inventory(
     return subject
 
 
+def _of_process_flavour(flavour: str) -> Callable[[_Crate], set[str]]:
+    """The steps of one flavour — what its chip is named for, so the sub-row
+    counts the way every other chip does (#625)."""
+
+    def subject(crate: _Crate) -> set[str]:
+        return {
+            n["id"]
+            for n in crate.model["nodes"]
+            if n["category"] == "process" and _process_flavour(n) == flavour
+        }
+
+    return subject
+
+
+PROCESS_FLAVOURS: dict[str, str] = {
+    "cellculture": "CellCulture",
+    "exposure": "Exposure",
+    "endpointreadout": "EndpointReadout",
+    "dataanalysis": "DataAnalysis",
+}
+"""The LabProcesses sub-row: chip key -> the ISA-Tox discriminator it draws.
+
+The four are the profile's own LabProcess kinds (``_PROCESS_DISCRIMINATORS``),
+each with a shape file of its own; a fifth invented here would be a category no
+crate can carry.
+"""
+
+
 class ExplorerView(NamedTuple):
     """One toggle: a named selection over the crate's entities.
 
@@ -282,6 +340,8 @@ class ExplorerView(NamedTuple):
     and table that link a compound to the work — and counting those made every
     chip overstate its own label, LabProcesses by threefold (#625). A view whose
     name covers everything it draws leaves ``subject`` unset.
+
+    ``parent`` makes the view a refinement of another; see the field.
     """
 
     key: str
@@ -290,6 +350,15 @@ class ExplorerView(NamedTuple):
     default: bool
     select: Callable[[_Crate], set[str]]
     subject: Callable[[_Crate], set[str]] | None = None
+    parent: str | None = None
+    """The view this one refines, if any.
+
+    A child is drawn as a sub-row under its parent's chip and appears only
+    while the parent is on. Children **narrow**: a parent with active children
+    contributes the union of those children instead of its own members, so the
+    explorer keeps one interaction model — views combine — instead of gaining a
+    second one for the sub-row (#624).
+    """
 
 
 # Order matters: "Researcher" opens the section, and the rest follow the tabbed
@@ -328,6 +397,43 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         False,
         _select_processes,
         _of_category("process"),
+    ),
+    *(
+        ExplorerView(
+            key,
+            label,
+            hint,
+            False,
+            (lambda kind: lambda crate: _select_processes(crate, kind))(kind),
+            _of_process_flavour(kind),
+            parent="processes",
+        )
+        for key, kind, label, hint in (
+            (
+                "cellculture",
+                "CellCulture",
+                "Cell culture",
+                "Only the culture steps, with what they used and produced",
+            ),
+            (
+                "exposure",
+                "Exposure",
+                "Exposure",
+                "Only the exposure steps, with what they used and produced",
+            ),
+            (
+                "endpointreadout",
+                "EndpointReadout",
+                "Endpoint readout",
+                "Only the readout steps, with what they measured and produced",
+            ),
+            (
+                "dataanalysis",
+                "DataAnalysis",
+                "Data analysis",
+                "Only the analysis steps, with what they read and produced",
+            ),
+        )
     ),
     ExplorerView(
         "chemicals",
@@ -491,6 +597,7 @@ def build_explorer_payload(
                 "label": view.label,
                 "hint": view.hint,
                 "default": view.default,
+                "parent": view.parent,
                 "count": len(counted),
                 "members": sorted(members),
             }

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -449,6 +449,14 @@ __CATEGORY_STYLES__
 .mat .ex-chip:focus-visible{outline:2px solid var(--accent); outline-offset:1px;}
 .mat .ex-chip[aria-pressed="true"]{background:var(--accent); border-color:var(--accent);
   color:var(--accent-ink);}
+/* The LabProcesses sub-row (#624): a filter on its parent, so it sits under the
+   toolbar rather than in it, and its chips read as subordinate. */
+.mat .ex-flavours{display:flex; flex-wrap:wrap; align-items:center; gap:.3rem;
+  padding:.35rem .6rem; border-bottom:1px solid var(--hairline);
+  background:var(--surface);}
+.mat .ex-sub-h{font-size:.66rem; font-weight:650; letter-spacing:.06em;
+  text-transform:uppercase; color:var(--muted); margin-right:.15rem;}
+.mat .ex-chip.ex-sub{font-size:.74rem; padding:.1rem .45rem;}
 .mat .ex-chip-count{font-size:.72rem; color:var(--muted); background:var(--surface-2);
   border-radius:999px; padding:0 .3rem;}
 .mat .ex-chip[aria-pressed="true"] .ex-chip-count{background:rgba(255,255,255,.22);

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -536,6 +536,147 @@ class TestViewMembership:
         assert {v["key"] for v in payload["views"]} <= {v.key for v in EXPLORER_VIEWS}
 
 
+class TestProcessFlavours:
+    """#624: the LabProcesses view also opens its four ISA-Tox flavours.
+
+    The flavours are a sub-row that appears only while ``LabProcesses`` is on,
+    and they **narrow** what that view contributes rather than adding to the
+    canvas: a parent view with active children draws the union of those
+    children instead of its own members. That keeps one interaction model —
+    views still combine — while answering the review's "just show endpoint
+    readout", and it answers what a dropdown cannot: Exposure *and* endpoint
+    readout together.
+
+    The selection needs no new classification. A process node's type tag is its
+    ISA-Tox discriminator already, so a flavour is the parent's own rule
+    restricted to one tag, context and all.
+    """
+
+    _KEYS = ("cellculture", "exposure", "endpointreadout", "dataanalysis")
+
+    def test_the_four_flavours_are_the_profiles_own_discriminators(self) -> None:
+        """Not a hand-written list: the profile defines exactly these four
+        LabProcess kinds, each with a shape file of its own, and a fifth
+        invented here would be a category the crate can never carry."""
+        from builder.writers.entity_explorer import PROCESS_FLAVOURS
+        from builder.writers.provenance_dag import _PROCESS_DISCRIMINATORS
+
+        assert set(PROCESS_FLAVOURS.values()) == set(_PROCESS_DISCRIMINATORS)
+        assert tuple(PROCESS_FLAVOURS) == self._KEYS
+
+    def test_a_flavour_is_a_child_of_the_labprocesses_view(self) -> None:
+        by_key = {v.key: v for v in EXPLORER_VIEWS}
+
+        assert [by_key[k].parent for k in self._KEYS] == ["processes"] * 4
+        assert by_key["processes"].parent is None
+        assert by_key["researcher"].parent is None
+
+    def test_the_payload_says_which_view_a_flavour_belongs_to(self) -> None:
+        """The browser builds the sub-row from this; without it the flavours
+        would render as four more top-level chips, which is the crowding the
+        sub-row exists to avoid."""
+        payload = build_explorer_payload(tabbed_views_graph())
+        parents = {v["key"]: v["parent"] for v in payload["views"]}
+
+        assert parents["exposure"] == "processes"
+        assert parents["cellculture"] == "processes"
+        assert parents["processes"] is None
+        assert parents["all"] is None
+
+    def test_a_flavour_draws_its_own_steps_and_not_the_others(self) -> None:
+        views = _views(build_explorer_payload(tabbed_views_graph()))
+
+        assert "#exposure" in views["exposure"]
+        assert "#culture" not in views["exposure"]
+        assert "#culture" in views["cellculture"]
+        assert "#exposure" not in views["cellculture"]
+
+    def test_a_flavour_brings_the_context_its_parent_brings(self) -> None:
+        """Narrowing the steps must not strip what makes a step readable — the
+        protocol it executes and the assay it serves (#626), and the material it
+        consumed and produced. A flavour showing bare process boxes would be a
+        worse answer than the unfiltered view."""
+        views = _views(build_explorer_payload(process_context_graph()))
+
+        assert {"#exposure", "#protocol", "#assay", "#cells", "result.csv"} <= views["exposure"]
+
+    def test_a_flavour_never_draws_a_step_its_parent_leaves_out(self) -> None:
+        """The fixture's DataAnalysis step is off the material chain, so the
+        parent view does not draw it — and a flavour is the parent's rule
+        restricted, never a fresh sweep of the crate by type. With no step left,
+        the flavour has nothing to show and is not offered at all."""
+        payload = build_explorer_payload(process_context_graph())
+        views = _views(payload)
+
+        assert "#orphan-step" not in views["processes"]
+        assert "dataanalysis" not in views
+        # No flavour draws it either. (Other views legitimately do — `researcher`
+        # shows the experiment whether or not a step sits on the material chain.)
+        assert not any(k in views and "#orphan-step" in views[k] for k in self._KEYS)
+
+    def test_the_flavours_between_them_cover_every_step_the_parent_draws(self) -> None:
+        """No step falls between the four: a reader who turns all of them on
+        sees what LabProcesses shows. Pinned against the parent's own subject so
+        a new discriminator in the profile fails here rather than silently
+        hiding steps."""
+        payload = build_explorer_payload(tabbed_views_graph())
+        nodes = {n["id"]: n for n in payload["nodes"]}
+        views = _views(payload)
+
+        def steps(key: str) -> set[str]:
+            return {i for i in views[key] if nodes[i]["category"] == "process"}
+
+        covered: set[str] = set()
+        for key in self._KEYS:
+            covered |= steps(key) if key in views else set()
+        assert covered == steps("processes")
+
+    def test_a_flavour_chip_counts_its_own_steps(self) -> None:
+        """The #625 rule holds for the sub-row too: the chip counts the subject
+        it is named for, not the context the selection drags in."""
+        payload = build_explorer_payload(tabbed_views_graph())
+        counts = {v["key"]: v["count"] for v in payload["views"]}
+        members = _views(payload)
+
+        assert counts["exposure"] == 1
+        assert counts["cellculture"] == 1
+        assert len(members["exposure"]) > counts["exposure"]  # context is drawn, not counted
+
+    def test_the_flavours_follow_their_parent_in_the_offered_order(self) -> None:
+        """A sub-row read out by a screen reader follows the chip it refines."""
+        offered = [v["key"] for v in build_explorer_payload(tabbed_views_graph())["views"]]
+        flavours = [k for k in offered if k in self._KEYS]
+
+        assert offered.index("processes") + 1 == offered.index(flavours[0])
+        assert offered[offered.index(flavours[0]) : offered.index(flavours[-1]) + 1] == flavours
+
+    def test_a_flavour_opens_nothing_by_default(self) -> None:
+        """An unfiltered LabProcesses is what the view has always meant; a
+        flavour pressed on load would silently hide steps from a reader who
+        never asked for a filter."""
+        payload = build_explorer_payload(tabbed_views_graph())
+
+        assert not any(v["default"] for v in payload["views"] if v["parent"])
+
+    def test_the_app_narrows_a_parent_to_its_active_children(self) -> None:
+        """A source-level guard, not a behavioural one: the narrowing runs in
+        the browser and this suite has no JS runtime. It pins the two lines that
+        carry the rule, so deleting either fails here rather than in a reader's
+        browser — the behaviour itself was checked by hand in a headless render.
+        """
+        source = _app_js()
+
+        assert "CHILDREN" in source
+        assert "ex-flavours" in source
+        # The sub-row is conditional on its parent being on.
+        assert "v.parent" in source
+
+    def test_the_sub_row_is_styled(self) -> None:
+        from builder.writers.maturity_report import _load_css
+
+        assert ".ex-flavours" in _load_css()
+
+
 class TestAChipCountsWhatItIsNamedFor:
     """A view's members include the supporting entities it drags in so the
     selection has context — the files a step touched, the hops that link a


### PR DESCRIPTION
Closes #624.

The review asked for a way to see the four LabProcess kinds individually, and suggested a dropdown. This ships the middle option the issue named: **a sub-row of four chips that appears only while `LabProcesses` is on**.

## The rule it adds

Views still combine. The rule generalises to one sentence:

> a parent view with active children draws the union of those children instead of its own members.

So the sub-row **narrows** its parent rather than becoming four more top-level chips. That keeps one interaction model, spends no top-level room, and answers what a dropdown cannot ask — `Exposure` **and** `Endpoint readout` together.

## Verified in a browser, not just in pytest

Headless render of the S-VHPS22 crate, by URL fragment:

| fragment | on canvas |
|---|---|
| `#views=processes` | 64 of 255 entities, 114 links |
| `#views=processes,exposure` | 19 of 255, 20 links |
| `#views=processes,exposure,cellculture` | 28 of 255, 32 links |
| `#views=exposure` (deep link) | 19 of 255 — parent auto-opened so the sub-row is visible |

Chip counts on that crate: Cell culture 3, Exposure 4, Endpoint readout 4, Data analysis 4 = the parent's 15.

## Notes

- No new classification: a process node's type tag *is* its ISA-Tox discriminator, so a flavour is `_select_processes` restricted to one tag, context (protocol, assay, materials) and all.
- A flavour never draws a step its parent leaves out, and is not offered at all when it has no steps.
- Turning `LabProcesses` off takes its sub-row with it; a deep link to a flavour opens the parent, so the filter is always visible and undoable.
- 12 new tests (78 → 90 in `test_entity_explorer.py`). The narrowing itself runs in the browser and this suite has no JS runtime, so that one test is an honest source-level guard — the behaviour was checked in the headless render above.

346 pass across `test_entity_explorer` + `test_maturity_report` + `test_provenance_dag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DxWfFK7SURRZiZSAYdsfQ