### PR TITLE
fix(profiles): AOP terms are AOPO's, under an IRI that exists (#644)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,6 +447,15 @@ Assembles the RO-Crate using [`ro-crate-py`](https://github.com/ResearchObject/r
 (`profiles/models/isa.py`, `profiles/models/tox.py`, `profiles/context.py`).
 Can produce partial crates at any point.
 
+Every term the crate's `@context` declares resolves to a real vocabulary's own canonical IRI — the
+policy `profiles/ontology_iris` states for lookup terms, applied to the context too. AOP terms are
+**AOPO**'s (`http://aopkb.org/aop_ontology#`), the ontology AOP-Wiki RDF itself annotates with; they
+spent months under an `aopwiki.org` path AOP-Wiki does not serve, so a whole vocabulary resolved to
+nothing while looking familiar (#644). A test holds every namespace in the context to a declared
+allow-list, so an invented one fails CI instead of shipping inside crates, and a second drives the
+real validator over a crate carrying the real context — a shape whose `sh:class` and the crate's
+`@context` disagree does not fail, it finds no target and never runs.
+
 #### Validator (`builder/tools/validation.py`, `profiles/validator.py`)
 Runs three-pass SHACL validation via `profiles/validator.py`, which wraps
 [`rocrate_validator`](https://github.com/ResearchObject/rocrate-validator).

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1461,7 +1461,7 @@ def _add_leaves(
     # _scalar_props preserves them rather than stripping them as resolver inputs.
     #
     # Each also carries schema:DefinedTerm, exactly as the csvw:Column nodes do.
-    # The AOP classes resolve to https://aopwiki.org/ontology/… (profiles/context.py),
+    # The AOP classes resolve to AOPO, http://aopkb.org/aop_ontology#… (profiles/context.py),
     # which is not a schema.org type — so the base profile asked every one of
     # these for one, 36 findings on a real crate. These are NOT cited vocabulary
     # we could argue our way out of describing: `materialize_aop_subgraph` fetches

--- a/builder/tools/validation.py
+++ b/builder/tools/validation.py
@@ -472,7 +472,7 @@ def _context_vocabulary(metadata_doc: dict[str, Any]) -> set[str]:
     """Every IRI the crate's own ``@context`` defines a term for.
 
     A context maps names to classes and properties — `"KeyEvent"` to
-    `https://aopwiki.org/ontology/KeyEvent`, `"has_key_event"` to
+    `http://aopkb.org/aop_ontology#KeyEvent`, `"has_key_event"` to
     `…/hasKeyEvent`. Those IRIs reach the validator as types and predicates, never
     as reference objects, so scanning the graph for `{"@id": …}` values misses
     every one of them: on a real crate that was 47 findings asking a *property*

--- a/profiles/context.py
+++ b/profiles/context.py
@@ -180,19 +180,30 @@ ISA_TOX_CONTEXT: list[dict] = [
         "smiles": "http://schema.org/smiles",
         "subclassOf": "http://www.w3.org/2000/01/rdf-schema#subClassOf",
         "wikibaseId": "http://schema.org/identifier",
-        # AOP-Wiki types and terms (from the AOP-Wiki lookup)
-        "AdverseOutcomePathway": "https://aopwiki.org/ontology/AdverseOutcomePathway",
-        "KeyEvent": "https://aopwiki.org/ontology/KeyEvent",
-        "KeyEventRelationship": "https://aopwiki.org/ontology/KeyEventRelationship",
+        # AOP terms are AOPO's — the Adverse Outcome Pathway Ontology at
+        # http://aopkb.org/aop_ontology#, which is what AOP-Wiki RDF uses for its
+        # own semantic annotations. These property names were AOPO's all along;
+        # until #644 they were declared under an aopwiki.org path that AOP-Wiki
+        # does not serve, so every term in this block resolved to nothing. The
+        # entities they describe still come from the AOP-Wiki lookup.
+        #
+        # `eventType` carries AOP-Wiki's own label string ("Molecular Initiating
+        # Event") while AOPO models `has_key_event_type` as pointing at a
+        # KeyEventType. That imprecision predates this block being correct at
+        # all; typing key events with AOPO's own MolecularInitiatingEvent /
+        # AdverseOutcome classes is the real fix and belongs in the builder.
+        "AdverseOutcomePathway": "http://aopkb.org/aop_ontology#AdverseOutcomePathway",
+        "KeyEvent": "http://aopkb.org/aop_ontology#KeyEvent",
+        "KeyEventRelationship": "http://aopkb.org/aop_ontology#KeyEventRelationship",
         "aopWikiStressorId": "http://schema.org/identifier",
-        "downstream_event": "https://aopwiki.org/ontology/downstreamEvent",
-        "eventType": "https://aopwiki.org/ontology/eventType",
-        "has_adverse_outcome": "https://aopwiki.org/ontology/hasAdverseOutcome",
-        "has_key_event": "https://aopwiki.org/ontology/hasKeyEvent",
-        "has_key_event_relationship": "https://aopwiki.org/ontology/hasKeyEventRelationship",
-        "has_molecular_initiating_event": "https://aopwiki.org/ontology/hasMolecularInitiatingEvent",
+        "downstream_event": "http://aopkb.org/aop_ontology#has_downstream_key_event",
+        "eventType": "http://aopkb.org/aop_ontology#has_key_event_type",
+        "has_adverse_outcome": "http://aopkb.org/aop_ontology#has_adverse_outcome",
+        "has_key_event": "http://aopkb.org/aop_ontology#has_key_event",
+        "has_key_event_relationship": "http://aopkb.org/aop_ontology#has_key_event_relationship",
+        "has_molecular_initiating_event": "http://aopkb.org/aop_ontology#has_molecular_initiating_event",
         "short_name": "http://schema.org/alternateName",
-        "upstream_event": "https://aopwiki.org/ontology/upstreamEvent",
+        "upstream_event": "http://aopkb.org/aop_ontology#has_upstream_key_event",
         # --- CSVW (CSV on the Web) for the Exposure condition table + Units (UO) ---
         "csvw": "http://www.w3.org/ns/csvw#",
         "tableSchema": "http://www.w3.org/ns/csvw#tableSchema",

--- a/profiles/shapes/tox/6_study_aop.ttl
+++ b/profiles/shapes/tox/6_study_aop.ttl
@@ -2,7 +2,7 @@
 # Each Study SHOULD situate its biology within the Adverse Outcome Pathway
 # framework by referencing a linked AOP (AOP-Wiki) via schema:mentions.
 
-@prefix aopwiki: <https://aopwiki.org/ontology/> .
+@prefix aopo: <http://aopkb.org/aop_ontology#> .
 @prefix isa-ro-crate: <https://github.com/crs4/rocrate-validator/profiles/isa-ro-crate/> .
 @prefix schema: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -15,7 +15,7 @@ tox:StudyShouldReferenceAOP a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path schema:mentions ;
-        sh:qualifiedValueShape [ sh:class aopwiki:AdverseOutcomePathway ] ;
+        sh:qualifiedValueShape [ sh:class aopo:AdverseOutcomePathway ] ;
         sh:qualifiedMinCount 1 ;
         sh:message "Study SHOULD reference a linked Adverse Outcome Pathway (AOP-Wiki) via schema:mentions" ;
         sh:severity sh:Warning ;

--- a/profiles/shapes/tox/7_assay_key_event.ttl
+++ b/profiles/shapes/tox/7_assay_key_event.ttl
@@ -2,7 +2,7 @@
 # The endpoint measured by each Assay SHOULD be annotated with the corresponding
 # AOP-Wiki Key Event, referenced via schema:mentions.
 
-@prefix aopwiki: <https://aopwiki.org/ontology/> .
+@prefix aopo: <http://aopkb.org/aop_ontology#> .
 @prefix isa-ro-crate: <https://github.com/crs4/rocrate-validator/profiles/isa-ro-crate/> .
 @prefix schema: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
@@ -15,7 +15,7 @@ tox:AssayShouldReferenceKeyEvent a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path schema:mentions ;
-        sh:qualifiedValueShape [ sh:class aopwiki:KeyEvent ] ;
+        sh:qualifiedValueShape [ sh:class aopo:KeyEvent ] ;
         sh:qualifiedMinCount 1 ;
         sh:message "Assay SHOULD annotate its measured endpoint with the corresponding AOP-Wiki Key Event via schema:mentions" ;
         sh:severity sh:Warning ;

--- a/tests/test_citations_are_not_gaps.py
+++ b/tests/test_citations_are_not_gaps.py
@@ -112,14 +112,14 @@ class TestContextVocabulary:
         human-readable name.
         """
         ctx = {
-            "KeyEvent": "https://aopwiki.org/ontology/KeyEvent",
-            "has_key_event": "https://aopwiki.org/ontology/hasKeyEvent",
+            "KeyEvent": "http://aopkb.org/aop_ontology#KeyEvent",
+            "has_key_event": "http://aopkb.org/aop_ontology#has_key_event",
             "@vocab": "http://schema.org/",
         }
         doc = _doc([{"@id": "#e", "@type": "KeyEvent"}], context=[ctx])
         cited = _cited_iris(doc)
-        assert "https://aopwiki.org/ontology/KeyEvent" in cited
-        assert "https://aopwiki.org/ontology/hasKeyEvent" in cited
+        assert "http://aopkb.org/aop_ontology#KeyEvent" in cited
+        assert "http://aopkb.org/aop_ontology#has_key_event" in cited
 
     def test_namespace_keys_are_not_terms(self):
         assert _context_vocabulary({"@context": [{"@vocab": "http://schema.org/"}]}) == set()

--- a/tests/test_context_namespaces.py
+++ b/tests/test_context_namespaces.py
@@ -1,0 +1,176 @@
+"""Every namespace the crate's ``@context`` declares must be a real one (#644).
+
+A JSON-LD context is a set of claims about what the crate's terms *mean*, and a
+term under a namespace nobody publishes means nothing — it reads as a private
+vocabulary that merely looks familiar. Ten AOP terms shipped for months under
+``https://aopwiki.org/ontology/``, a path AOP-Wiki does not serve, while the
+property names themselves were AOPO's all along.
+
+The rule these hold the context to is the one `profiles/ontology_iris` already
+states: a term's identity IRI is the ontology's own canonical IRI.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+from profiles.context import ISA_TOX_CONTEXT
+
+# Every namespace the context is allowed to draw terms from, and what it is.
+# An allow-list rather than a live HTTP check: a test that reaches the network
+# fails on a train, and an ontology host being down is not a defect in this
+# crate. Adding an entry is the deliberate act — which is exactly what nobody
+# did for `aopwiki.org/ontology`, because nothing asked them to.
+KNOWN_NAMESPACES: dict[str, str] = {
+    "http://schema.org/": "schema.org (HTTP, to match the RO-Crate context)",
+    "https://bioschemas.org/": "Bioschemas types",
+    # Bioschemas splits its vocabulary: types at the bare namespace, properties
+    # beneath /properties/ — see `context.BIOSCHEMAS_PROP`.
+    "https://bioschemas.org/properties/": "Bioschemas properties",
+    "http://aopkb.org/aop_ontology#": "AOPO, the Adverse Outcome Pathway Ontology",
+    "http://purl.org/dc/terms/": "DCMI Metadata Terms",
+    "http://www.w3.org/2000/01/rdf-schema#": "RDF Schema",
+    "http://www.w3.org/2004/02/skos/core#": "SKOS",
+    "http://www.w3.org/ns/csvw#": "CSV on the Web",
+    "http://www.geneontology.org/formats/oboInOwl#": "oboInOwl",
+    "http://purl.obolibrary.org/obo/": "OBO Foundry PURLs",
+    "http://www.bioassayontology.org/bao#": "BioAssay Ontology",
+    "http://www.ebi.ac.uk/efo/": "Experimental Factor Ontology",
+}
+
+
+def _iris() -> set[str]:
+    """Every absolute IRI the context maps a term to."""
+    found: set[str] = set()
+    for block in ISA_TOX_CONTEXT:
+        for value in block.values():
+            target = value.get("@id") if isinstance(value, dict) else value
+            if isinstance(target, str) and target.startswith(("http://", "https://")):
+                found.add(target)
+    return found
+
+
+def _namespace(iri: str) -> str:
+    """The IRI up to and including its final separator."""
+    if "#" in iri:
+        return iri.split("#")[0] + "#"
+    parts = urlsplit(iri)
+    return f"{parts.scheme}://{parts.netloc}{parts.path.rsplit('/', 1)[0]}/"
+
+
+def test_every_term_comes_from_a_declared_namespace() -> None:
+    unknown = sorted(
+        {_namespace(iri) for iri in _iris()} - set(KNOWN_NAMESPACES)
+    )
+
+    assert unknown == [], (
+        "the context declares terms under namespaces nobody has vouched for: "
+        + ", ".join(unknown)
+        + ". If one is real, add it to KNOWN_NAMESPACES with what it is; if it is "
+        "invented, the terms under it mean nothing to a reader of the crate."
+    )
+
+
+def test_the_aop_terms_are_aopo() -> None:
+    """The specific claim #644 fixes, pinned by name.
+
+    Our property names were AOPO's all along — `has_key_event`,
+    `has_adverse_outcome` are spelled exactly as AOPO spells them — so this is
+    the vocabulary the crate was already using, finally said out loud.
+    """
+    context = ISA_TOX_CONTEXT[0]
+    aopo = "http://aopkb.org/aop_ontology#"
+
+    assert context["AdverseOutcomePathway"] == aopo + "AdverseOutcomePathway"
+    assert context["KeyEvent"] == aopo + "KeyEvent"
+    assert context["KeyEventRelationship"] == aopo + "KeyEventRelationship"
+    assert context["has_key_event"] == aopo + "has_key_event"
+    assert context["has_adverse_outcome"] == aopo + "has_adverse_outcome"
+    assert context["has_molecular_initiating_event"] == aopo + "has_molecular_initiating_event"
+    assert context["has_key_event_relationship"] == aopo + "has_key_event_relationship"
+    assert context["upstream_event"] == aopo + "has_upstream_key_event"
+    assert context["downstream_event"] == aopo + "has_downstream_key_event"
+
+
+def test_no_term_still_points_at_the_invented_namespace() -> None:
+    """Belt and braces: the allow-list catches a namespace nobody declared, and
+    this catches the one we know was wrong, wherever it might survive."""
+    assert not [iri for iri in _iris() if "aopwiki.org/ontology" in iri]
+
+
+def test_the_shapes_use_the_same_namespace_as_the_context() -> None:
+    """A shape asking for `sh:class aopo:AdverseOutcomePathway` under one IRI
+    while the crate types the entity under another validates nothing — quietly,
+    because an unmatched target is a rule that never runs."""
+    import pathlib
+
+    shapes = pathlib.Path(__file__).resolve().parents[1] / "profiles" / "shapes" / "tox"
+    for ttl in shapes.glob("*.ttl"):
+        text = ttl.read_text(encoding="utf-8")
+        for prefix_iri in re.findall(r"@prefix\s+aopo?w?i?k?i?:\s+<([^>]+)>", text):
+            assert prefix_iri == "http://aopkb.org/aop_ontology#", f"{ttl.name}: {prefix_iri}"
+
+
+def test_a_crate_built_now_satisfies_the_aop_shapes() -> None:
+    """The claim the textual check above cannot make.
+
+    A shape asking for ``sh:class aopo:AdverseOutcomePathway`` matches only if
+    the crate's own ``@context`` expands its ``AdverseOutcomePathway`` type to
+    that same IRI. Get the two out of step and the rule does not fail — it finds
+    no target and never runs, which is the quiet failure this repo cares about
+    most. So this drives the real validator over a crate carrying the real
+    context, and asserts the AOP rules stay silent because they are satisfied.
+    """
+    from profiles.validator import validate_crate_dict
+
+    crate = {
+        "@context": ISA_TOX_CONTEXT,
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "@type": "CreativeWork", "about": {"@id": "./"}},
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                "name": "An investigation",
+                "description": "A crate that situates its biology in an AOP.",
+                "hasPart": [{"@id": "#study"}],
+            },
+            {
+                "@id": "#study",
+                "@type": "Dataset",
+                "additionalType": "Study",
+                "name": "A study",
+                "description": "A study that names its pathway.",
+                "hasPart": [{"@id": "#assay"}],
+                "mentions": [{"@id": "https://aopwiki.org/aops/610"}],
+            },
+            {
+                "@id": "#assay",
+                "@type": "Dataset",
+                "additionalType": "Assay",
+                "name": "An assay",
+                "description": "An assay that names the event it measures.",
+                "mentions": [{"@id": "https://aopwiki.org/events/2258"}],
+            },
+            {
+                "@id": "https://aopwiki.org/aops/610",
+                "@type": ["AdverseOutcomePathway", "schema:DefinedTerm"],
+                "name": "Decreased thyroid hormone levels in the brain",
+            },
+            {
+                "@id": "https://aopwiki.org/events/2258",
+                "@type": ["KeyEvent", "schema:DefinedTerm"],
+                "name": "Inhibition, monocarboxylate transporter 8",
+            },
+        ],
+    }
+
+    messages = [
+        issue.message or ""
+        for result in validate_crate_dict(crate, severity="recommended", profile="tox")
+        for issue in result.issues
+    ]
+
+    assert not [m for m in messages if "Adverse Outcome Pathway" in m], messages
+    assert not [m for m in messages if "Key Event" in m], messages

--- a/tests/test_tools_aop_subgraph.py
+++ b/tests/test_tools_aop_subgraph.py
@@ -201,7 +201,7 @@ class TestMaterializeBuild:
 
         # Membership, not equality: each AOP node carries its AOP class AND
         # schema:DefinedTerm, because the AOP classes resolve to
-        # aopwiki.org/ontology/… and the base profile asks a described contextual
+        # aopkb.org/aop_ontology#… and the base profile asks a described contextual
         # entity for a schema.org type. The AOP class stays first.
         def _typed(node, wanted):
             types = node.get("@type")


### PR DESCRIPTION
Closes #644.

Every crate this tool has built declares its Adverse Outcome Pathway vocabulary under `https://aopwiki.org/ontology/` — a namespace that 404s. AOP-Wiki publishes AOPs, not an ontology. The vocabulary the terms are modelled on is real: **AOPO**, `http://aopkb.org/aop_ontology#`, which is what AOP-Wiki RDF uses. Our property *names* were already AOPO's spelling, so the crates used the right vocabulary under an IRI that does not exist.

## What changed

All ten AOP terms in `profiles/context.py` move to AOPO, and three get their real AOPO name:

| context term | was (404) | now |
|---|---|---|
| `upstream_event` | `…/upstreamEvent` | `#has_upstream_key_event` |
| `downstream_event` | `…/downstreamEvent` | `#has_downstream_key_event` |
| `eventType` | `…/eventType` | `#has_key_event_type` |

The other seven keep their names and only change namespace. The `aopwiki:` prefix in `profiles/shapes/tox/6_study_aop.ttl` and `7_assay_key_event.ttl` becomes `aopo:`, so `sh:class` now names a class an ontology actually defines.

## The guard

`tests/test_context_namespaces.py` (new, 5 tests) holds a `KNOWN_NAMESPACES` allow-list. Every IRI the context declares must sit under a listed namespace, so a future invented one fails CI instead of shipping inside crates. One of the five is behavioural rather than textual: it builds an AOP-linked graph and validates it, so a context/shapes mismatch reddens even if both files are internally tidy.

## Verification

- **ruff + ty clean**; 314 tests green across the affected modules; broad run exit 0.
- **Mutation check** — reverting a single term to the old namespace reddens 4 of the 5 new tests.
- **Behavioural baseline** — a real 293-entity crate validated against the old shapes gives 2 issues. Swapping that crate's embedded `@context` for the new one and re-validating gives the same 2 issues. The shapes still match what the builder types; the change is a rename, not a loosening.

## Audited the rest while I was in there

All 83 IRIs in the context: 49 schema.org, plus dcterms, oboInOwl, RDFS, SKOS, CSVW, Bioschemas. Every one resolves. The AOP block was the only invented namespace — one defect, not a pattern.

## Crates built before this differ

Intended, and stated in the issue. A crate that keeps claiming a dead namespace to stay consistent with older crates is consistent about being wrong.

## Not fixed here

`eventType` carries AOP-Wiki's label string (`"Molecular Initiating Event"`) while AOPO models `has_key_event_type` as an object property to a `KeyEventType`. That imprecision predates this change; the honest fix types key events with AOPO's `MolecularInitiatingEvent` / `AdverseOutcome` classes, which is a builder change rather than a context one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3
