### PR TITLE
fix(report): re-land the AOP view and the KeyEventRelationship fix, which never reached main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2055,6 +2055,15 @@ colour they are drawn in. A relationship is in it although nothing `mentions` on
 *reaches* and what an entity *is* are different questions, and a chain whose every link is drawn as
 vocabulary is not a chain.
 
+**Pathways** draws the chain from the other end: every `pathway`-category entity — the adverse
+outcome pathway, its key events and the `KeyEventRelationship`s ordering them — plus the ISA entity
+that `mentions` one, as context. Assays starts at the backbone and follows outward, so it shows only
+what an assay or study points at (5 of 36 on a real deposit); this view starts at the chain, so a
+relationship (which nothing mentions) and an event no assay measures directly are drawn too. The
+chip counts the chain, not the context (#625), and the view is not offered at all when the crate has
+none — `build_explorer_payload` omits any view no entity satisfies, so no per-view guard exists
+(#652).
+
 **LabProcesses** draws the derivation chain plus what each step *is*: the protocol a visible
 process executes and the assay whose `about` points at one. Neither edge lies on the material chain
 the derivation walk follows, and the two point in opposite directions — outward to the protocol,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2055,14 +2055,15 @@ colour they are drawn in. A relationship is in it although nothing `mentions` on
 *reaches* and what an entity *is* are different questions, and a chain whose every link is drawn as
 vocabulary is not a chain.
 
-**Pathways** draws the chain from the other end: every `pathway`-category entity — the adverse
+**Adverse outcome pathway** draws the chain from the other end: every `pathway`-category entity — the adverse
 outcome pathway, its key events and the `KeyEventRelationship`s ordering them — plus the ISA entity
 that `mentions` one, as context. Assays starts at the backbone and follows outward, so it shows only
 what an assay or study points at (5 of 36 on a real deposit); this view starts at the chain, so a
 relationship (which nothing mentions) and an event no assay measures directly are drawn too. The
 chip counts the chain, not the context (#625), and the view is not offered at all when the crate has
-none — `build_explorer_payload` omits any view no entity satisfies, so no per-view guard exists
-(#652).
+none — `build_explorer_payload` omits any view no entity satisfies, so no per-view guard exists.
+It is named for the framework rather than shortened to "Pathways": in this community a *pathway* is a
+WikiPathways molecular pathway, so the short label would promise genes and deliver key events (#652).
 
 **LabProcesses** draws the derivation chain plus what each step *is*: the protocol a visible
 process executes and the assay whose `about` points at one. Neither edge lies on the material chain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2049,8 +2049,11 @@ measure (#627). A domain type also outranks the generic one it refines when a no
 so a key event reads as a key event rather than as the `DefinedTerm` it also is — and it is drawn in
 its own `pathway` category, because what an assay measures takes part in the work rather than
 qualifying it, and the fallback bucket paints csvw columns and the build's own action (#643).
-`PATHWAY_TYPES` is the one list all three rules read: which nodes the view follows to, how they are
-captioned, and what colour they are drawn in.
+`PATHWAY_TYPES` — the pathway, its key events and the `KeyEventRelationship`s that order them — is
+the one list all three rules read: which nodes the view follows to, how they are captioned, and what
+colour they are drawn in. A relationship is in it although nothing `mentions` one: what a view
+*reaches* and what an entity *is* are different questions, and a chain whose every link is drawn as
+vocabulary is not a chain.
 
 **LabProcesses** draws the derivation chain plus what each step *is*: the protocol a visible
 process executes and the assay whose `about` points at one. Neither edge lies on the material chain

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -126,7 +126,7 @@ def _select_files(crate: _Crate) -> set[str]:
     return {n["id"] for n in crate.model["nodes"] if n["category"] in ("data", "container")}
 
 
-def _select_pathways(crate: _Crate) -> set[str]:
+def _select_aop(crate: _Crate) -> set[str]:
     """The adverse outcome pathway itself, and who measures it.
 
     The chain entire — the pathway, its key events and the relationships that
@@ -478,12 +478,18 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         lambda crate: _routed(crate, "cellline", "celllines"),
         _of_inventory("cellline", "celllines"),
     ),
+    # Named for the framework, not for "pathways": in the toxicology community
+    # this crate is written for, a pathway is a WikiPathways molecular pathway —
+    # a different resource entirely — so the short label would promise genes and
+    # deliver key events. The full term is not jargon to the reader who needs
+    # this view; it is the framework they already work in.
     ExplorerView(
-        "pathways",
-        "Pathways",
-        "The adverse outcome pathway, and the assays that measure its events",
+        "aop",
+        "Adverse outcome pathway",
+        "The pathway your assays measure — the events, how they follow one "
+        "another, and which assay measures which",
         False,
-        _select_pathways,
+        _select_aop,
         _of_category("pathway"),
     ),
     ExplorerView(

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -126,6 +126,39 @@ def _select_files(crate: _Crate) -> set[str]:
     return {n["id"] for n in crate.model["nodes"] if n["category"] in ("data", "container")}
 
 
+def _select_pathways(crate: _Crate) -> set[str]:
+    """The adverse outcome pathway itself, and who measures it.
+
+    The chain entire — the pathway, its key events and the relationships that
+    order them — plus the ISA entity that points into it, because *which assay
+    measures which event* is the question the view exists to answer and a bag of
+    events answers nothing.
+
+    Assays draws the same chain from the other end: it starts at the backbone and
+    follows `mentions` outward, so it shows only what an assay or study points
+    at — five of thirty-six on a real deposit. This view starts at the chain, so
+    a relationship (which nothing mentions) and a key event no assay measures
+    directly are drawn too, and the ISA entities arrive as context rather than as
+    the subject (#652).
+
+    Context, not everything that points here: a `CreativeWork` note mentioning a
+    key event is not part of the science, so the source is filtered to the
+    backbone exactly as `_select_assays` filters its destination by type.
+
+    No empty-crate guard: a crate with no pathway selects nothing here, and
+    `build_explorer_payload` already omits a view no entity satisfies rather than
+    offering a chip that draws an empty canvas.
+    """
+    chain = {n["id"] for n in crate.model["nodes"] if n["category"] == "pathway"}
+    backbone = {n["id"] for n in crate.inventory("isa")["nodes"]}
+    measured_by = {
+        edge["src"]
+        for edge in crate.model["edges"]
+        if edge["label"] == "mentions" and edge["src"] in backbone and edge["dst"] in chain
+    }
+    return chain | measured_by
+
+
 def _select_assays(crate: _Crate) -> set[str]:
     """The ISA backbone, and what its assays are for.
 
@@ -444,6 +477,14 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         False,
         lambda crate: _routed(crate, "cellline", "celllines"),
         _of_inventory("cellline", "celllines"),
+    ),
+    ExplorerView(
+        "pathways",
+        "Pathways",
+        "The adverse outcome pathway, and the assays that measure its events",
+        False,
+        _select_pathways,
+        _of_category("pathway"),
     ),
     ExplorerView(
         "people",

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -365,13 +365,19 @@ CATEGORY_STYLES: dict[str, CategoryStyle] = {
     ),
 }
 
-# The two types the ISA-Tox profile defines for an adverse outcome pathway
-# (`profiles/shapes/tox/6_study_aop.ttl`, `7_assay_key_event.ttl`). ONE list,
-# read by three rules that would otherwise drift: which entities the Assays view
-# follows a `mentions` edge to (#627), what the node is captioned, and what
-# colour it is drawn in (#643). A type in one and not the others is drawn as
-# science and captioned as vocabulary, or the reverse.
-PATHWAY_TYPES = frozenset({"AdverseOutcomePathway", "KeyEvent"})
+# The types an adverse outcome pathway is made of — the pathway, its events, and
+# the relationships that order them (`materialize_aop_subgraph` mints all three;
+# `profiles/shapes/tox/6_study_aop.ttl` and `7_assay_key_event.ttl` are where the
+# first two are wired to a Study and an Assay). ONE list, read by three rules
+# that would otherwise drift: which entities the Assays view follows a `mentions`
+# edge to (#627), what the node is captioned, and what colour it is drawn in
+# (#643). A type in one and not the others is drawn as science and captioned as
+# vocabulary, or the reverse.
+#
+# A `KeyEventRelationship` is in the list although nothing `mentions` one: what a
+# view *reaches* and what an entity *is* are different questions, and a chain
+# whose links are drawn as vocabulary is not a chain.
+PATHWAY_TYPES = frozenset({"AdverseOutcomePathway", "KeyEvent", "KeyEventRelationship"})
 
 # Type preference for a node's caption, most specific first: a domain type
 # outranks the generic one it refines.

--- a/tests/fixtures/crate_graphs.py
+++ b/tests/fixtures/crate_graphs.py
@@ -301,6 +301,10 @@ def aop_linked_graph() -> dict[str, Any]:
     the one thing that says what an assay is for was missing from the view named
     after assays.
 
+    The chain also carries a ``KeyEventRelationship`` — what makes a pathway a
+    pathway rather than a bag of events. Nothing ``mentions`` it, so it is the
+    case that separates "part of the pathway" from "followed from an assay".
+
     ``mentions`` is a general relation, so the crate also mentions something that
     is neither — the build's own action, exactly as a real crate does — and it
     must stay out of a view about the science. A second key event is mentioned
@@ -359,6 +363,13 @@ def aop_linked_graph() -> dict[str, Any]:
                 "@id": "https://aopwiki.org/events/9999",
                 "@type": ["KeyEvent", "schema:DefinedTerm"],
                 "name": "A key event no assay measures",
+            },
+            {
+                "@id": "https://aopwiki.org/relationships/4615",
+                "@type": ["KeyEventRelationship", "schema:DefinedTerm"],
+                "name": "Inhibition, MCT8 → A key event no assay measures",
+                "upstream_event": {"@id": "https://aopwiki.org/events/2258"},
+                "downstream_event": {"@id": "https://aopwiki.org/events/9999"},
             },
             {"@id": "#build", "@type": "CreateAction", "name": "vitro-crate build"},
         ]

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -375,6 +375,7 @@ class TestViewMembership:
         assert cats["https://aopwiki.org/events/2258"] == "pathway"
         assert cats["https://aopwiki.org/aops/610"] == "pathway"
         assert cats["#term"] == "annotation", "a plain term still qualifies rather than takes part"
+        assert cats["https://aopwiki.org/relationships/4615"] == "pathway", "and its links"
 
     def test_the_assays_view_and_the_canvas_agree_on_what_a_pathway_is(self) -> None:
         """One list, not two. The view selects what an assay mentions and the

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -377,6 +377,51 @@ class TestViewMembership:
         assert cats["#term"] == "annotation", "a plain term still qualifies rather than takes part"
         assert cats["https://aopwiki.org/relationships/4615"] == "pathway", "and its links"
 
+    def test_pathways_draws_the_whole_chain(self) -> None:
+        """The view the chain never had. Assays reaches only what an ISA entity
+        `mentions` — on a real deposit 5 of 36 — so every relationship and every
+        key event no assay measures directly existed only inside "All entities",
+        among 293 nodes (#652)."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert views["pathways"] >= {
+            "https://aopwiki.org/aops/610",
+            "https://aopwiki.org/events/2258",
+            "https://aopwiki.org/events/9999",
+            "https://aopwiki.org/relationships/4615",
+        }
+
+    def test_pathways_holds_the_assay_that_measures_an_event(self) -> None:
+        """Which assay measures which event is the question the view exists to
+        answer, so the ISA entity pointing into the chain is drawn with it — the
+        same context rule the Chemicals and Biological-models views follow."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert {"#assay", "#study"} <= views["pathways"]
+
+    def test_pathways_leaves_out_what_merely_mentions_an_event(self) -> None:
+        """Context, not everything that points at the chain. The fixture's note
+        mentions a key event and is not part of the science; drawing it would
+        make `mentions` the rule rather than the backbone."""
+        views = _views(build_explorer_payload(aop_linked_graph()))
+
+        assert "#note" not in views["pathways"]
+
+    def test_the_pathways_chip_counts_the_chain_and_not_its_context(self) -> None:
+        """A chip counts what its view is named for (#625). The fixture's chain
+        is four entities and the view draws six; a chip reading 6 would overstate
+        its own label the way LabProcesses did by threefold."""
+        counts = {v["key"]: v["count"] for v in build_explorer_payload(aop_linked_graph())["views"]}
+
+        assert counts["pathways"] == 4
+
+    def test_a_crate_with_no_pathway_is_not_offered_the_view(self) -> None:
+        """The same rule the process flavours follow (#624): a view no entity
+        satisfies is omitted, never offered as a chip that draws nothing."""
+        views = _views(build_explorer_payload(tabbed_views_graph()))
+
+        assert "pathways" not in views
+
     def test_the_assays_view_and_the_canvas_agree_on_what_a_pathway_is(self) -> None:
         """One list, not two. The view selects what an assay mentions and the
         canvas colours what it selected, and each held its own copy of the two

--- a/tests/test_entity_explorer.py
+++ b/tests/test_entity_explorer.py
@@ -377,50 +377,50 @@ class TestViewMembership:
         assert cats["#term"] == "annotation", "a plain term still qualifies rather than takes part"
         assert cats["https://aopwiki.org/relationships/4615"] == "pathway", "and its links"
 
-    def test_pathways_draws_the_whole_chain(self) -> None:
+    def test_the_aop_view_draws_the_whole_chain(self) -> None:
         """The view the chain never had. Assays reaches only what an ISA entity
         `mentions` — on a real deposit 5 of 36 — so every relationship and every
         key event no assay measures directly existed only inside "All entities",
         among 293 nodes (#652)."""
         views = _views(build_explorer_payload(aop_linked_graph()))
 
-        assert views["pathways"] >= {
+        assert views["aop"] >= {
             "https://aopwiki.org/aops/610",
             "https://aopwiki.org/events/2258",
             "https://aopwiki.org/events/9999",
             "https://aopwiki.org/relationships/4615",
         }
 
-    def test_pathways_holds_the_assay_that_measures_an_event(self) -> None:
+    def test_the_aop_view_holds_the_assay_that_measures_an_event(self) -> None:
         """Which assay measures which event is the question the view exists to
         answer, so the ISA entity pointing into the chain is drawn with it — the
         same context rule the Chemicals and Biological-models views follow."""
         views = _views(build_explorer_payload(aop_linked_graph()))
 
-        assert {"#assay", "#study"} <= views["pathways"]
+        assert {"#assay", "#study"} <= views["aop"]
 
-    def test_pathways_leaves_out_what_merely_mentions_an_event(self) -> None:
+    def test_the_aop_view_leaves_out_what_merely_mentions_an_event(self) -> None:
         """Context, not everything that points at the chain. The fixture's note
         mentions a key event and is not part of the science; drawing it would
         make `mentions` the rule rather than the backbone."""
         views = _views(build_explorer_payload(aop_linked_graph()))
 
-        assert "#note" not in views["pathways"]
+        assert "#note" not in views["aop"]
 
-    def test_the_pathways_chip_counts_the_chain_and_not_its_context(self) -> None:
+    def test_the_aop_chip_counts_the_chain_and_not_its_context(self) -> None:
         """A chip counts what its view is named for (#625). The fixture's chain
         is four entities and the view draws six; a chip reading 6 would overstate
         its own label the way LabProcesses did by threefold."""
         counts = {v["key"]: v["count"] for v in build_explorer_payload(aop_linked_graph())["views"]}
 
-        assert counts["pathways"] == 4
+        assert counts["aop"] == 4
 
     def test_a_crate_with_no_pathway_is_not_offered_the_view(self) -> None:
         """The same rule the process flavours follow (#624): a view no entity
         satisfies is omitted, never offered as a chip that draws nothing."""
         views = _views(build_explorer_payload(tabbed_views_graph()))
 
-        assert "pathways" not in views
+        assert "aop" not in views
 
     def test_the_assays_view_and_the_canvas_agree_on_what_a_pathway_is(self) -> None:
         """One list, not two. The view selects what an assay mentions and the

--- a/tests/test_provenance_dag.py
+++ b/tests/test_provenance_dag.py
@@ -1662,6 +1662,18 @@ class TestCategoryRegistry:
         assert _entity_category({"@type": ["AdverseOutcomePathway", "DefinedTerm"]}) == "pathway"
         assert _node_class_for_brief({"tag": "KeyEvent"}) == "pathway"
 
+    def test_the_link_between_two_key_events_is_part_of_the_pathway(self) -> None:
+        """A ``KeyEventRelationship`` is what makes a pathway a pathway rather
+        than a bag of events, and the crate mints one per relation — nineteen of
+        them on a real deposit, against sixteen key events. Nothing ``mentions``
+        one, so a rule that recognised only what an assay points at would leave
+        the chain's every link drawn as vocabulary and captioned ``DefinedTerm``
+        while the events it connects were drawn as science."""
+        relationship = {"@type": ["KeyEventRelationship", "DefinedTerm"]}
+
+        assert _entity_category(relationship) == "pathway"
+        assert _tag(relationship) == "KeyEventRelationship"
+
     def test_an_ordinary_term_is_still_an_annotation(self) -> None:
         """The control. The rule is keyed to the two types the ISA-Tox profile
         defines, not to everything a crate happens to type ``DefinedTerm`` — a


### PR DESCRIPTION
Re-lands the three commits that never reached `main`. Closes #652.

## What happened

Two separate misses, both invisible from GitHub's UI:

**1. #649 merged before its second commit existed.** `fix(report): the links between key events are part of the pathway too` was pushed to `jh-643-pathway-category` after the PR had already been squash-merged. The push succeeded; the code went nowhere. `main` today reads:

```
PATHWAY_TYPES = frozenset({"AdverseOutcomePathway", "KeyEvent"})    ← no KeyEventRelationship
tests/fixtures/crate_graphs.py: "relationships/4615" → 0 occurrences
```

So the 19 `KeyEventRelationship` entities on a real deposit are still drawn as bookkeeping and captioned `DefinedTerm`.

**2. #653 merged into a dead base.** It was opened against `jh-643-pathway-category` because it depended on the `pathway` category. A squash merge does not retarget an open child, so when #653 was merged it landed in a branch nothing points at:

```
$ git merge-base --is-ancestor 82bbc8f origin/main   # the view
NOT an ancestor
$ git merge-base --is-ancestor a1af0d4 origin/main   # the rename
NOT an ancestor
```

GitHub shows both PRs as merged. Both are — one into a corpse, one too early.

I checked the other eleven recently merged PRs: **#653 is the only one with a non-`main` base**, and no other branch has commits ahead of its merged PR. This is the whole of the loss.

## What this restores

Three commits, cherry-picked onto current `main` — clean, no content changes from the reviewed versions:

1. **`the links between key events are part of the pathway too`** — `KeyEventRelationship` joins `PATHWAY_TYPES`. A chain whose every link is drawn as vocabulary is not a chain. On `svhps22_real_input_crate_v19`: pathway 17 → 36, bookkeeping 186 → 150.
2. **`the AOP chain gets a view of its own`** — every `pathway`-category entity plus the ISA entity that `mentions` one as context. 36 counted, 40 drawn, 81 edges. The Assays view reaches only 5 of those 36; the rest existed only inside "All entities", among 293 nodes.
3. **`name the view for the framework, not for "pathways"`** — in this community a *pathway* is a WikiPathways molecular pathway, so the short label promised genes and delivered key events. Key `aop`, deep link `#views=aop`.

## Verification

- **373 passed, 2 skipped** — `test_entity_explorer`, `test_provenance_dag`, `test_maturity_report`, `test_explorer_js_integrity`, `test_entity_explorer_layout`. Run **serially**: the suite auto-parallelises to 41 workers here, which trips #406's load-sensitive timeouts and produced a spurious hang on the first attempt.
- ruff clean.
- Cherry-picking only commits 2 and 3 fails two tests (`aop_view_draws_the_whole_chain`, `aop_chip_counts_the_chain_and_not_its_context`) because the chain is 3 entities without the relationship — which is how the first miss was found.

## The check that would have caught this

A PR's "Merged" badge says a merge happened, not what it merged into, and says nothing about commits pushed after the merge. What distinguishes them:

```
git merge-base --is-ancestor <head-sha> origin/main
```

Worth running after any base branch merges, and after any push to a branch whose PR may already be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Bj5CSJWeQfJ6taHw1fX3
