### PR TITLE
fix(shapes): the CSVW check reads the edge the condition table is on

### DIFF
--- a/profiles/docs/isa_tox.md
+++ b/profiles/docs/isa_tox.md
@@ -251,7 +251,7 @@ well (cell line, compound, concentration, exposure duration).
 |name|MUST|Text|The name of the process, e.g. "Exposure".|
 |object|MUST|[bioschemas.org/Sample](isa.md#sample) or [File](https://schema.org/MediaObject)|The input cell sample(s) being exposed. At least one. (A `MolecularEntity` is **not** allowed here — see note above.)|
 |parameterValue|MUST|[schema.org/PropertyValue](isa.md#propertyvalue) ([Parameter](isa.md#propertyvalue---parameter))|Exposure parameter(s); see expected values below. At least one.|
-|result|MUST|[bioschemas.org/Sample](isa.md#sample) or [File](https://schema.org/MediaObject) (typed also as `csvw:Table`)|The exposed sample(s), and — once populated — the CSVW condition table whose rows name the sample each well produced. At least one.|
+|result|MUST|[bioschemas.org/Sample](isa.md#sample) or [File](https://schema.org/MediaObject)|The exposed sample(s) the step produces. At least one. The condition table is **not** a result — it is the per-well layout the run follows, and it is reached via `executesLabProtocol` below.|
 |executesLabProtocol|SHOULD|[bioschemas.org/LabProtocol](isa.md#labprotocol)|The protocol(s) this step executes: the procedural SOP, and the per-well condition table supplying the plate layout the SOP leaves out.|
 
 **Expected `parameterValue` items.** Each is a Parameter [PropertyValue](isa.md#propertyvalue---parameter)

--- a/profiles/shapes/tox/8_condition_table_csvw.ttl
+++ b/profiles/shapes/tox/8_condition_table_csvw.ttl
@@ -3,22 +3,30 @@
 # carries a datatype and an ontology propertyUrl (machine-actionable, and the
 # basis of the reproducibility-readiness metric).
 
+@prefix bioschemas-prop: <https://bioschemas.org/properties/> .
 @prefix csvw: <http://www.w3.org/ns/csvw#> .
-@prefix schema: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix tox: <https://w3id.org/ro/crate/isa-tox/1.0/> .
 
-# The Exposure result SHOULD include a CSVW-typed condition table.
+# The Exposure SHOULD follow a CSVW-typed condition table.
+#
+# On `executesLabProtocol`, not `schema:result`: the per-well layout is what the
+# run FOLLOWS, not what it emits (#650). An Exposure produces the exposed
+# Sample; the table states which well got which compound at which dose, which is
+# a protocol the run reads. Reading `schema:result` here reported a missing
+# table on every exposure that had one — a check that fires on correct crates
+# is worse than no check, because it sends the repair loop after a defect that
+# is not there.
 tox:ExposureShouldEmitCsvwConditionTable a sh:NodeShape ;
-    sh:name "Exposure SHOULD emit a CSVW condition table" ;
-    sh:description "An exposure's condition-table result SHOULD be CSVW-typed" ;
+    sh:name "Exposure SHOULD follow a CSVW condition table" ;
+    sh:description "An exposure's condition-table protocol SHOULD be CSVW-typed" ;
     sh:targetClass tox:LabProcessExposure ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path schema:result ;
+        sh:path bioschemas-prop:executesLabProtocol ;
         sh:qualifiedValueShape [ sh:class csvw:Table ] ;
         sh:qualifiedMinCount 1 ;
-        sh:message "Exposure SHOULD emit a CSVW-typed condition table (csvw:Table) as a schema:result" ;
+        sh:message "Exposure SHOULD follow a CSVW-typed condition table (csvw:Table) via executesLabProtocol" ;
         sh:severity sh:Warning ;
     ] .
 

--- a/tests/test_csvw_payload.py
+++ b/tests/test_csvw_payload.py
@@ -392,6 +392,102 @@ class TestEmptyConditionTableSaysSo:
         assert "NO rows" not in str(table.get("description", "") or "")
 
 
+class TestTheCsvwShapeLooksWhereTheTableIs:
+    """The tox CSVW shape must read the edge the table is actually on (#650).
+
+    ``tox:ExposureShouldEmitCsvwConditionTable`` was written when the condition
+    table was the Exposure's ``schema:result``. #650 moved it to
+    ``executesLabProtocol`` — the per-well layout is what the run follows, not
+    what it emits — and the shape was not moved with it. The Warning then fired
+    on **every** exposure, including ones that do emit a perfectly good table:
+    a false gap, and worse than a missing check because it reports a defect that
+    is not there.
+
+    Nothing caught it. No test in the suite asserted on this shape, so a
+    recommended-severity finding could invert its meaning without turning CI
+    red. Both directions are pinned here so the next move breaks a test.
+    """
+
+    @staticmethod
+    def _document(state: CrateState) -> dict:
+        crate = ROCrate()
+        crate.metadata.extra_contexts = ISA_TOX_CONTEXT
+        populate_crate(state, crate, None, materialize_payload=False)
+        return crate.metadata.generate()
+
+    @staticmethod
+    def _condition_table_findings(doc: dict) -> list[str]:
+        """Every tox finding about the condition table, at any severity.
+
+        ``severity="optional"`` because the shape is a SHOULD — at the default
+        ``required`` gate it is filtered out before a test could see it, which
+        is the other half of why this regression was invisible.
+        """
+        from profiles.validator import validate_crate_dict
+
+        results = validate_crate_dict(doc, severity="optional", profile="tox")
+        return [
+            str(getattr(issue, "message", ""))
+            for result in (results or [])
+            for issue in (getattr(result, "issues", None) or [])
+            if "condition table" in str(getattr(issue, "message", "")).lower()
+        ]
+
+    def test_an_exposure_that_emits_the_table_is_not_reported(self):
+        doc = self._document(_exposure_state())
+        assert any(
+            str(e.get("@id", "")).endswith("condition_table.csv")
+            for e in doc["@graph"]
+        ), "fixture no longer produces a condition table — this pins nothing"
+
+        findings = self._condition_table_findings(doc)
+        assert findings == [], (
+            "the exposure emits a CSVW condition table, so the shape must not "
+            f"report one missing; got {findings}"
+        )
+
+    def test_an_exposure_that_reaches_no_table_is_still_reported(self):
+        """The check must be able to fail, or it is not a check (D-#620).
+
+        Every built Exposure gets a condition table, so the unmet case is made
+        by cutting the edge on the assembled document rather than by starving
+        the builder — which also keeps this a test of the *shape* rather than
+        of the synthesis path.
+        """
+        doc = self._document(_exposure_state())
+        table_ids = {
+            str(e.get("@id", ""))
+            for e in doc["@graph"]
+            if str(e.get("@id", "")).endswith("condition_table.csv")
+        }
+        assert table_ids, "fixture produced no table to detach"
+
+        detached = 0
+        for entity in doc["@graph"]:
+            if entity.get("additionalType") != "Exposure":
+                continue
+            for key in ("executesLabProtocol", "result"):
+                value = entity.get(key)
+                if value is None:
+                    continue
+                items = value if isinstance(value, list) else [value]
+                kept = [
+                    it
+                    for it in items
+                    if not (
+                        isinstance(it, dict) and str(it.get("@id")) in table_ids
+                    )
+                ]
+                if len(kept) != len(items):
+                    detached += 1
+                entity[key] = kept
+        assert detached, "no exposure edge pointed at the table — nothing was cut"
+
+        assert self._condition_table_findings(doc), (
+            "an exposure that reaches no CSVW condition table must be reported"
+        )
+
+
 def test_property_url_stays_an_id_reference_not_a_bare_string():
     """propertyUrl must be ``{"@id": …}``, not the bare URI string.
 


### PR DESCRIPTION
A regression I shipped in #650, plus the reason nothing caught it.

## The defect

#650 moved the condition table from the Exposure's `schema:result` to its `executesLabProtocol` — the per-well layout is what the run *follows*, not what it emits. `tox:ExposureShouldEmitCsvwConditionTable` was left reading `schema:result`.

Verified live on the S-VHPS21 fixture, before this PR:

```
[recommended] ./#LabProcess_exposure |
  Exposure SHOULD emit a CSVW-typed condition table (csvw:Table) as a schema:result
```

That exposure emits a perfectly good CSVW table. The Warning fired anyway — on every exposure in every crate.

A check that fires on correct crates is worse than no check. It sends the repair loop after a defect that is not there, and it makes a real absence indistinguishable from the false report.

## Why CI stayed green

Two reasons, both worth fixing:

1. **No test asserted on this shape.** Not one, anywhere in the suite.
2. **A recommended-severity finding is filtered out at the default `required` gate**, so even a test calling `build_and_validate` could not have seen it.

Together those meant the shape could invert its meaning without turning anything red.

## The fix

`sh:path schema:result` → `sh:path bioschemas-prop:executesLabProtocol`, matching the IRI the bundled ISA profile uses for the same property (`isa-ro-crate/3_process.ttl:152`). Severity stays `sh:Warning`.

## Tests

`TestTheCsvwShapeLooksWhereTheTableIs` pins **both** directions:

- an exposure that reaches a CSVW table is **not** reported
- an exposure that reaches none **still is** — D-#620, an assertion that cannot fail is not a check

The unmet case is built by cutting the edge on the assembled document rather than by starving the builder, because every built Exposure gets a table. That also keeps it a test of the *shape* rather than of the synthesis path.

Both use `severity="optional"` so a SHOULD is actually visible to the assertion.

## Verification

Re-ran the exact check that found it. The condition-table finding is gone; the six unrelated findings on that fixture (missing compound identifiers, missing AOP links) are unchanged, which is the point — this narrows nothing else.

182 passed across `test_csvw_payload`, `test_condition_table`, `test_tools_process_chain`, `test_builder_domain`, `test_crate_reads_back`. `uvx ruff check` clean.

## Docs

`profiles/docs/isa_tox.md` still described the table as an Exposure `result`; corrected to point at `executesLabProtocol`.

## Not in scope

`profiles/context.py` maps `intendedUse` to `http://schema.org/intendedUse` while the bundled ISA shape reads `bioschemas-prop:intendedUse`, so today's `intendedUse` values are invisible to that shape. Real, separate, and being filed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DxWfFK7SURRZiZSAYdsfQ