### PR TITLE
fix(fair): carry all 41 RDA indicators, and cite the right work for each DOI

### DIFF
--- a/fair/indicators.yaml
+++ b/fair/indicators.yaml
@@ -19,10 +19,19 @@
 sources:
   rda:
     name: RDA FAIR Data Maturity Model
-    citation: Bahim et al. 2020, Data Science Journal 19(1):41
-    doi: 10.15497/rda00050
+    specification:
+      name: 'FAIR Data Maturity Model: specification and guidelines'
+      publisher: Research Data Alliance
+      doi: 10.15497/rda00050
+      url: https://doi.org/10.15497/rda00050
+      year: 2020
+    peer_reviewed:
+      citation: 'Bahim C, Casorrán-Amilburu C, Dekkers M, Herczog E, Loozen N, Repanas K, Russell K, Stall
+        S. The FAIR Data Maturity Model: An Approach to Harmonise FAIR Assessments. Data Science Journal
+        19(1):41 (2020)'
+      doi: 10.5334/dsj-2020-041
     distribution: FAIR_evaluation_levels_v0.02.xlsx (sheet 'FAIR Indicators_v0.05'), Zenodo record 3909563
-      — vendored as fair/rda_fdmm.xlsx
+      — vendored as fair/rda_fdmm.xlsx, byte-identical to the published file (md5 b6231346dff874a3675747ab3e295fd9)
     license: CC-BY-4.0
     retrieved: '2026-07-25'
   dsm:

--- a/fair/indicators.yaml
+++ b/fair/indicators.yaml
@@ -10,6 +10,11 @@
 # level and reported out-of-scope, not failed. R1.3-01D delegates to OECD MIT
 # in-vitro coverage. The FAIRplus DSM ladder is generated separately into
 # fair/dsm_indicators.yaml by scripts/gen_dsm_indicators.py.
+#
+# ALL 41 published indicators are carried, including the ones this tool cannot answer.
+# Each of those states WHY, as `scope: out_of_scope` plus a `reason`. Omitting them
+# made a coverage figure overstate itself: "14 of 21 met" reads as coverage of the
+# model when it is really 14 of 41 with 20 never asked.
 
 sources:
   rda:
@@ -30,6 +35,17 @@ sources:
     citation: Ammar, Evelo & Willighagen 2024, Scientific Data 11:503
     doi: 10.1038/s41597-024-03324-x
 indicators:
+- id: RDA-F1-01M
+  dimension: F
+  priority: essential
+  check: pid_form
+  text: Metadata is identified by a persistent identifier
+- id: RDA-F1-01D
+  dimension: F
+  priority: essential
+  scope: out_of_scope
+  reason: the crate's payload files carry no persistent identifier of their own
+  text: Data is identified by a persistent identifier
 - id: RDA-F1-02M
   dimension: F
   priority: essential
@@ -40,11 +56,6 @@ indicators:
   priority: essential
   check: every_entity_has_id
   text: Data is identified by a globally unique identifier
-- id: RDA-F1-01M
-  dimension: F
-  priority: essential
-  check: pid_form
-  text: Metadata is identified by a persistent identifier
 - id: RDA-F2-01M
   dimension: F
   priority: essential
@@ -55,20 +66,83 @@ indicators:
   priority: essential
   check: metadata_refs_data
   text: Metadata includes the identifier for the data
+- id: RDA-F4-01M
+  dimension: F
+  priority: essential
+  scope: out_of_scope
+  reason: harvesting and indexing are properties of the repository serving the crate
+  text: Metadata is offered in such a way that it can be harvested and indexed
+- id: RDA-A1-01M
+  dimension: A
+  priority: important
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Metadata contains information to enable the user to get access to the data
 - id: RDA-A1-02M
   dimension: A
   priority: essential
   scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
   text: Metadata can be accessed manually (i.e. with human intervention)
+- id: RDA-A1-02D
+  dimension: A
+  priority: essential
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Data can be accessed manually (i.e. with human intervention)
+- id: RDA-A1-03M
+  dimension: A
+  priority: essential
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Metadata identifier resolves to a metadata record
+- id: RDA-A1-03D
+  dimension: A
+  priority: essential
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Data identifier resolves to a digital object
+- id: RDA-A1-04M
+  dimension: A
+  priority: essential
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Metadata is accessed through standardised protocol
 - id: RDA-A1-04D
   dimension: A
   priority: essential
   scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
   text: Data is accessible through standardised protocol
+- id: RDA-A1-05D
+  dimension: A
+  priority: important
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Data can be accessed automatically (i.e. by a computer program)
+- id: RDA-A1.1-01M
+  dimension: A
+  priority: essential
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Metadata is accessible through a free access protocol
+- id: RDA-A1.1-01D
+  dimension: A
+  priority: important
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Data is accessible through a free access protocol
+- id: RDA-A1.2-01D
+  dimension: A
+  priority: useful
+  scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
+  text: Data is accessible through an access protocol that supports authentication and authorisation
 - id: RDA-A2-01M
   dimension: A
   priority: essential
   scope: out_of_scope
+  reason: the access protocol is a property of the repository serving the crate, not of the crate itself
   text: Metadata is guaranteed to remain available after data is no longer available
 - id: RDA-I1-01M
   dimension: I
@@ -80,21 +154,66 @@ indicators:
   priority: important
   check: jsonld_context
   text: Metadata uses machine-understandable knowledge representation
+- id: RDA-I1-01D
+  dimension: I
+  priority: important
+  scope: out_of_scope
+  reason: the payload is tabular measurement data, not a knowledge representation; only the metadata layer
+    is expressed in a standardised format
+  text: Data uses knowledge representation expressed in standardised format
+- id: RDA-I1-02D
+  dimension: I
+  priority: important
+  scope: out_of_scope
+  reason: the payload is tabular measurement data, not a knowledge representation; only the metadata layer
+    is expressed in a standardised format
+  text: Data uses machine-understandable knowledge representation
 - id: RDA-I2-01M
   dimension: I
   priority: important
   check: fair_vocabularies
   text: Metadata uses FAIR-compliant vocabularies
+- id: RDA-I2-01D
+  dimension: I
+  priority: useful
+  scope: out_of_scope
+  reason: the payload is tabular measurement data, not a knowledge representation; only the metadata layer
+    is expressed in a standardised format
+  text: Data uses FAIR-compliant vocabularies
 - id: RDA-I3-01M
   dimension: I
   priority: important
   check: qualified_refs
   text: Metadata includes references to other metadata
+- id: RDA-I3-01D
+  dimension: I
+  priority: useful
+  scope: out_of_scope
+  reason: references made from inside the payload files are not inspected
+  text: Data includes references to other data
+- id: RDA-I3-02M
+  dimension: I
+  priority: useful
+  scope: out_of_scope
+  reason: references made from inside the payload files are not inspected
+  text: Metadata includes references to other data
+- id: RDA-I3-02D
+  dimension: I
+  priority: useful
+  scope: out_of_scope
+  reason: references made from inside the payload files are not inspected
+  text: Data includes qualified references to other data
 - id: RDA-I3-03M
   dimension: I
   priority: important
   check: qualified_refs
   text: Metadata includes qualified references to other metadata
+- id: RDA-I3-04M
+  dimension: I
+  priority: useful
+  scope: out_of_scope
+  reason: references made from inside the payload files are not inspected
+  text: Metadata include qualified references to other data
 - id: RDA-R1-01M
   dimension: R
   priority: essential
@@ -120,6 +239,13 @@ indicators:
   priority: important
   check: provenance
   text: Metadata includes provenance information according to community-specific standards
+- id: RDA-R1.2-02M
+  dimension: R
+  priority: useful
+  scope: out_of_scope
+  reason: no cross-community provenance language (PROV-O, PAV) is emitted, so there is nothing to check
+    compliance against
+  text: Metadata includes provenance information according to a cross-community language
 - id: RDA-R1.3-01M
   dimension: R
   priority: essential
@@ -135,3 +261,10 @@ indicators:
   priority: essential
   check: mit_coverage
   text: Data complies with a community standard
+- id: RDA-R1.3-02D
+  dimension: R
+  priority: important
+  scope: out_of_scope
+  reason: the payload's compliance with a machine-understandable community standard is a property of the
+    data files, which this tool does not validate here
+  text: Data is expressed in compliance with a machine-understandable community standard

--- a/scripts/gen_fair_indicators.py
+++ b/scripts/gen_fair_indicators.py
@@ -127,13 +127,33 @@ LOCAL_SCOPE: dict[str, tuple[str | None, str | None]] = {
 }
 
 SOURCES: dict[str, Any] = {
+    # The specification and the journal article are DIFFERENT works and are recorded
+    # separately, as the DSM block does. They were previously one entry — a `citation`
+    # naming Bahim et al. beside a `doi` pointing at the RDA deliverable, which has no
+    # authors — so anyone citing from here produced the right author list against the
+    # wrong DOI.
     "rda": {
         "name": "RDA FAIR Data Maturity Model",
-        "citation": "Bahim et al. 2020, Data Science Journal 19(1):41",
-        "doi": "10.15497/rda00050",
+        "specification": {
+            "name": "FAIR Data Maturity Model: specification and guidelines",
+            "publisher": "Research Data Alliance",
+            "doi": "10.15497/rda00050",
+            "url": "https://doi.org/10.15497/rda00050",
+            "year": 2020,
+        },
+        "peer_reviewed": {
+            "citation": (
+                "Bahim C, Casorrán-Amilburu C, Dekkers M, Herczog E, Loozen N, "
+                "Repanas K, Russell K, Stall S. The FAIR Data Maturity Model: An "
+                "Approach to Harmonise FAIR Assessments. Data Science Journal "
+                "19(1):41 (2020)"
+            ),
+            "doi": "10.5334/dsj-2020-041",
+        },
         "distribution": (
             "FAIR_evaluation_levels_v0.02.xlsx (sheet 'FAIR Indicators_v0.05'), "
-            "Zenodo record 3909563 — vendored as fair/rda_fdmm.xlsx"
+            "Zenodo record 3909563 — vendored as fair/rda_fdmm.xlsx, byte-identical "
+            "to the published file (md5 b6231346dff874a3675747ab3e295fd9)"
         ),
         "license": "CC-BY-4.0",
         "retrieved": "2026-07-25",

--- a/scripts/gen_fair_indicators.py
+++ b/scripts/gen_fair_indicators.py
@@ -15,6 +15,14 @@ pre-publication crate. Only the indicator definitions are externalised.
 The FAIRplus DSM ladder (``fair/dsm_indicators.yaml``) is generated from its own
 vendored assessment workbook by ``scripts/gen_dsm_indicators.py`` — not touched here.
 
+**All 41 published indicators are carried**, including the ones this tool cannot
+answer; each of those states why. Carrying only the assessable subset, as this
+generator used to, let a coverage figure overstate itself — "14 of 21 met" reads as
+coverage of the model when it is really 14 of 41 with 20 never asked. Which parts of
+a published instrument a tool answers is a local decision, and it has to be visible
+rather than implied by absence. :func:`build_data` refuses to emit unless every
+published indicator has either a check or a stated reason.
+
 Regenerate with::
 
     uv run python scripts/gen_fair_indicators.py
@@ -39,39 +47,84 @@ OUT = REPO / "fair" / "indicators.yaml"
 # INDICATORS/text(5), PRIORITY(6).
 _SHEET = "FAIR Indicators_v0.05"
 
-# The crate-intrinsic subset this tool assesses, in report order: indicator id ->
-# check-function name (see builder/tools/fair_assessment.py FAIR_CHECKS), or None to
-# mark it out-of-scope (assessable only with repository/protocol context, e.g. most
-# Accessibility indicators — reported as out-of-scope, not failed).
-LOCAL_SCOPE: list[tuple[str, str | None]] = [
-    # Findable
-    ("RDA-F1-02M", "root_global_id"),
-    ("RDA-F1-02D", "every_entity_has_id"),
-    ("RDA-F1-01M", "pid_form"),
-    ("RDA-F2-01M", "rich_metadata"),
-    ("RDA-F3-01M", "metadata_refs_data"),
-    # Accessible (intrinsically out-of-scope: protocol / repository level)
-    ("RDA-A1-02M", None),
-    ("RDA-A1-04D", None),
-    ("RDA-A2-01M", None),
-    # Interoperable
-    ("RDA-I1-01M", "jsonld_context"),
-    ("RDA-I1-02M", "jsonld_context"),
-    ("RDA-I2-01M", "fair_vocabularies"),
-    ("RDA-I3-01M", "qualified_refs"),
-    ("RDA-I3-03M", "qualified_refs"),
-    # Reusable
-    ("RDA-R1-01M", "reuse_attributes"),
-    ("RDA-R1.1-01M", "license_present"),
-    ("RDA-R1.1-02M", "license_standard"),
-    ("RDA-R1.1-03M", "license_machine"),
-    ("RDA-R1.2-01M", "provenance"),
-    ("RDA-R1.3-01M", "conforms_to_profile"),
-    ("RDA-R1.3-02M", "conforms_to_profile"),
+# Every published indicator is carried, in report order: indicator id ->
+# (check-function name, reason-it-is-not-checked). Exactly one of the pair is set.
+#
+# An indicator with a check is scored; one with a reason is reported `out_of_scope` —
+# never failed, and never silently dropped. Omitting the ones we cannot answer, as
+# this file used to, made "14 of 21 met" read as coverage of the model when it was
+# really 14 of 41 with 20 never asked. Which parts a tool answers is a local decision
+# and has to be visible; the DSM and Bridge2AI generators carry their whole
+# instruments for the same reason.
+_PROTOCOL = (
+    "the access protocol is a property of the repository serving the crate, not of "
+    "the crate itself"
+)
+_HOSTING = "harvesting and indexing are properties of the repository serving the crate"
+_PAYLOAD_PID = "the crate's payload files carry no persistent identifier of their own"
+_PAYLOAD_SEMANTICS = (
+    "the payload is tabular measurement data, not a knowledge representation; only "
+    "the metadata layer is expressed in a standardised format"
+)
+_PAYLOAD_LINKS = "references made from inside the payload files are not inspected"
+
+LOCAL_SCOPE: dict[str, tuple[str | None, str | None]] = {
+    # ---- Findable ----------------------------------------------------------
+    "RDA-F1-01M": ("pid_form", None),
+    "RDA-F1-01D": (None, _PAYLOAD_PID),
+    "RDA-F1-02M": ("root_global_id", None),
+    "RDA-F1-02D": ("every_entity_has_id", None),
+    "RDA-F2-01M": ("rich_metadata", None),
+    "RDA-F3-01M": ("metadata_refs_data", None),
+    "RDA-F4-01M": (None, _HOSTING),
+    # ---- Accessible — every one is protocol / repository level --------------
+    "RDA-A1-01M": (None, _PROTOCOL),
+    "RDA-A1-02M": (None, _PROTOCOL),
+    "RDA-A1-02D": (None, _PROTOCOL),
+    "RDA-A1-03M": (None, _PROTOCOL),
+    "RDA-A1-03D": (None, _PROTOCOL),
+    "RDA-A1-04M": (None, _PROTOCOL),
+    "RDA-A1-04D": (None, _PROTOCOL),
+    "RDA-A1-05D": (None, _PROTOCOL),
+    "RDA-A1.1-01M": (None, _PROTOCOL),
+    "RDA-A1.1-01D": (None, _PROTOCOL),
+    "RDA-A1.2-01D": (None, _PROTOCOL),
+    "RDA-A2-01M": (None, _PROTOCOL),
+    # ---- Interoperable -----------------------------------------------------
+    "RDA-I1-01M": ("jsonld_context", None),
+    "RDA-I1-02M": ("jsonld_context", None),
+    "RDA-I1-01D": (None, _PAYLOAD_SEMANTICS),
+    "RDA-I1-02D": (None, _PAYLOAD_SEMANTICS),
+    "RDA-I2-01M": ("fair_vocabularies", None),
+    "RDA-I2-01D": (None, _PAYLOAD_SEMANTICS),
+    "RDA-I3-01M": ("qualified_refs", None),
+    "RDA-I3-01D": (None, _PAYLOAD_LINKS),
+    "RDA-I3-02M": (None, _PAYLOAD_LINKS),
+    "RDA-I3-02D": (None, _PAYLOAD_LINKS),
+    "RDA-I3-03M": ("qualified_refs", None),
+    "RDA-I3-04M": (None, _PAYLOAD_LINKS),
+    # ---- Reusable ----------------------------------------------------------
+    "RDA-R1-01M": ("reuse_attributes", None),
+    "RDA-R1.1-01M": ("license_present", None),
+    "RDA-R1.1-02M": ("license_standard", None),
+    "RDA-R1.1-03M": ("license_machine", None),
+    "RDA-R1.2-01M": ("provenance", None),
+    "RDA-R1.2-02M": (
+        None,
+        "no cross-community provenance language (PROV-O, PAV) is emitted, so there "
+        "is nothing to check compliance against",
+    ),
+    "RDA-R1.3-01M": ("conforms_to_profile", None),
+    "RDA-R1.3-02M": ("conforms_to_profile", None),
     # R1.3-01D delegates to OECD MIT in-vitro coverage (the community reporting
     # standard); see builder/tools/mit_assessment.py and issue #313.
-    ("RDA-R1.3-01D", "mit_coverage"),
-]
+    "RDA-R1.3-01D": ("mit_coverage", None),
+    "RDA-R1.3-02D": (
+        None,
+        "the payload's compliance with a machine-understandable community standard "
+        "is a property of the data files, which this tool does not validate here",
+    ),
+}
 
 SOURCES: dict[str, Any] = {
     "rda": {
@@ -114,6 +167,11 @@ _HEADER = """\
 # level and reported out-of-scope, not failed. R1.3-01D delegates to OECD MIT
 # in-vitro coverage. The FAIRplus DSM ladder is generated separately into
 # fair/dsm_indicators.yaml by scripts/gen_dsm_indicators.py.
+#
+# ALL 41 published indicators are carried, including the ones this tool cannot answer.
+# Each of those states WHY, as `scope: out_of_scope` plus a `reason`. Omitting them
+# made a coverage figure overstate itself: "14 of 21 met" reads as coverage of the
+# model when it is really 14 of 41 with 20 never asked.
 """
 
 
@@ -134,32 +192,86 @@ def _load_rda() -> dict[str, dict[str, str]]:
 
 
 def build_data() -> dict[str, Any]:
-    """The full ``indicators.yaml`` payload: sources + RDA-sourced indicators."""
+    """The full ``indicators.yaml`` payload: sources + all 41 RDA indicators."""
     rda = _load_rda()
+    unknown = sorted(set(LOCAL_SCOPE) - set(rda))
+    if unknown:
+        raise KeyError(
+            f"{unknown} is not an RDA FAIR Data Maturity Model indicator. "
+            "Fix the mapping rather than the model."
+        )
+    missing = sorted(set(rda) - set(LOCAL_SCOPE))
+    if missing:
+        raise KeyError(
+            f"the published model defines indicators this generator does not place: "
+            f"{missing}. Every one needs either a check or a stated reason — silence "
+            "is how a coverage figure comes to overstate itself."
+        )
+
     indicators: list[dict[str, Any]] = []
-    for iid, check in LOCAL_SCOPE:
-        if iid not in rda:
-            raise KeyError(f"{iid} is not an RDA FAIR Data Maturity Model indicator")
+    for iid, (check, reason) in LOCAL_SCOPE.items():
+        if bool(check) == bool(reason):
+            raise ValueError(
+                f"{iid}: set exactly one of check / reason — an indicator is either "
+                "scored or explained, never both and never neither."
+            )
         d = rda[iid]
         entry: dict[str, Any] = {
             "id": iid,
             "dimension": d["dimension"],
             "priority": d["priority"],
         }
-        if check is None:
-            entry["scope"] = "out_of_scope"
-        else:
+        if check:
             entry["check"] = check
+        else:
+            entry["scope"] = "out_of_scope"
+            entry["reason"] = reason
         entry["text"] = d["text"]
         indicators.append(entry)
     return {"sources": SOURCES, "indicators": indicators}
 
 
+def format_report(data: dict[str, Any]) -> str:
+    """What the model asks, and how much of it this tool answers."""
+    inds = data["indicators"]
+    scored = [i for i in inds if "check" in i]
+    lines = [
+        "RDA FAIR Data Maturity Model — indicator coverage",
+        "=" * 66,
+        f"{'Dim':<5} {'total':>6} {'scored':>7} {'out of scope':>13}",
+        "-" * 66,
+    ]
+    for dim in sorted({i["dimension"] for i in inds}):
+        at = [i for i in inds if i["dimension"] == dim]
+        n = sum(1 for i in at if "check" in i)
+        lines.append(f"{dim:<5} {len(at):>6} {n:>7} {len(at) - n:>13}")
+    lines += [
+        "-" * 66,
+        f"{'ALL':<5} {len(inds):>6} {len(scored):>7} {len(inds) - len(scored):>13}",
+        "",
+        "  by priority:",
+    ]
+    for pri in ("essential", "important", "useful"):
+        at = [i for i in inds if i["priority"] == pri]
+        n = sum(1 for i in at if "check" in i)
+        lines.append(f"    {pri:<10} {n:>2} scored of {len(at):>2}")
+    lines += ["", "  why the rest are out of scope:"]
+    reasons: dict[str, list[str]] = {}
+    for i in inds:
+        if r := i.get("reason"):
+            reasons.setdefault(r, []).append(i["id"])
+    for reason, ids in sorted(reasons.items(), key=lambda kv: -len(kv[1])):
+        lines.append(f"    {len(ids):>2}  {reason}")
+        lines.append(f"        {', '.join(ids)}")
+    return "\n".join(lines)
+
+
 def main() -> None:
-    body = yaml.safe_dump(
-        build_data(), sort_keys=False, allow_unicode=True, width=100
-    )
+    data = build_data()
+    body = yaml.safe_dump(data, sort_keys=False, allow_unicode=True, width=100)
     OUT.write_text(_HEADER + "\n" + body)
+    print(format_report(data))
+    print()
     print(f"Wrote {OUT.relative_to(REPO)} ({len(LOCAL_SCOPE)} indicators from RDA).")
 
 

--- a/tests/test_fair_indicators_source.py
+++ b/tests/test_fair_indicators_source.py
@@ -14,6 +14,7 @@ import importlib.util
 import pathlib
 
 import openpyxl
+import pytest
 import yaml
 
 REPO = pathlib.Path(__file__).resolve().parents[1]
@@ -46,6 +47,70 @@ def _rda_rows() -> dict[str, dict[str, str]]:
                 "text": str(row[5]).strip(),
             }
     return out
+
+
+# The published model, as distributed in the vendored RDA spreadsheet.
+PUBLISHED_TOTAL = 41
+PUBLISHED_PER_PRIORITY = {"essential": 20, "important": 14, "useful": 7}
+
+
+class TestTheWholePublishedModelIsCarried:
+    """All 41 indicators, including the ones this tool cannot answer.
+
+    The DSM and Bridge2AI files carry every published item and mark what they cannot
+    assess. This one used to carry 21 and simply omit the other 20, so "14 of 21 met"
+    read as coverage of the model when it was really 14 of 41 with 20 never asked.
+    An instrument you report against is one you have to reproduce in full; which parts
+    we answer is a local decision that must be visible, not implied by absence.
+    """
+
+    def test_every_published_indicator_is_present(self):
+        committed = yaml.safe_load(INDICATORS_YAML.read_text())["indicators"]
+        assert len(committed) == PUBLISHED_TOTAL
+        assert {i["id"] for i in committed} == set(_rda_rows())
+
+    def test_the_priority_split_is_the_published_one(self):
+        from collections import Counter
+
+        committed = yaml.safe_load(INDICATORS_YAML.read_text())["indicators"]
+        assert dict(Counter(i["priority"] for i in committed)) == PUBLISHED_PER_PRIORITY
+
+    def test_the_useful_tier_is_no_longer_missing_entirely(self):
+        """All 7 `useful` indicators were absent — a whole priority tier unasked."""
+        committed = yaml.safe_load(INDICATORS_YAML.read_text())["indicators"]
+        assert sum(1 for i in committed if i["priority"] == "useful") == 7
+
+    def test_every_unassessed_indicator_says_why(self):
+        """"Not assessed" without a reason is indistinguishable from an oversight."""
+        committed = yaml.safe_load(INDICATORS_YAML.read_text())["indicators"]
+        unscored = [i for i in committed if i.get("scope") == "out_of_scope"]
+        assert unscored
+        for ind in unscored:
+            assert ind.get("reason"), f"{ind['id']} is out of scope with no reason given"
+            assert "check" not in ind, f"{ind['id']} is out of scope but names a check"
+
+    def test_every_scored_indicator_names_a_registered_check(self):
+        from builder.tools.fair_assessment import FAIR_CHECKS
+
+        committed = yaml.safe_load(INDICATORS_YAML.read_text())["indicators"]
+        for ind in committed:
+            if ind.get("scope") != "out_of_scope":
+                assert ind["check"] in FAIR_CHECKS, f"{ind['id']} names an unknown check"
+
+    def test_the_generator_refuses_an_id_the_model_does_not_define(self):
+        gen = _load_generator()
+        gen.LOCAL_SCOPE["RDA-NOPE-01M"] = ("check", None)
+        try:
+            with pytest.raises(KeyError, match="not an RDA"):
+                gen.build_data()
+        finally:
+            gen.LOCAL_SCOPE.pop("RDA-NOPE-01M", None)
+
+    def test_the_report_states_what_is_asked_and_what_is_not(self):
+        gen = _load_generator()
+        report = gen.format_report(gen.build_data())
+        assert "41" in report
+        assert "out of scope" in report.lower()
 
 
 class TestFairIndicatorsDerivedFromRda:
@@ -100,5 +165,32 @@ class TestFairIndicatorsDerivedFromRda:
             "RDA-R1.3-02M": (True, ""),
             "RDA-R1.3-01D": (False, ""),
         }
+        # Carrying the whole model adds 20 indicators this tool does not answer. They
+        # report "not assessed" and must not move a single verdict above.
+        expected.update(
+            {
+                iid: (None, "out_of_scope")
+                for iid in (
+                    "RDA-F1-01D", "RDA-F4-01M", "RDA-A1-01M", "RDA-A1-02D",
+                    "RDA-A1-03M", "RDA-A1-03D", "RDA-A1-04M", "RDA-A1-05D",
+                    "RDA-A1.1-01M", "RDA-A1.1-01D", "RDA-A1.2-01D", "RDA-I1-01D",
+                    "RDA-I1-02D", "RDA-I2-01D", "RDA-I3-01D", "RDA-I3-02M",
+                    "RDA-I3-02D", "RDA-I3-04M", "RDA-R1.2-02M", "RDA-R1.3-02D",
+                )
+            }
+        )
         assert got == expected
         assert rep.dsm_level == 2
+
+    def test_widening_the_model_did_not_move_the_score(self):
+        """The met count is a property of the crate, not of how many we ask."""
+        from builder.tools.fair_assessment import assess_fair_maturity
+        from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+        rep = assess_fair_maturity(vhps_fixture_state("S-VHPS21"))
+        met = sum(1 for r in rep.indicator_results if r.get("passed") is True)
+        failed = sum(1 for r in rep.indicator_results if r.get("passed") is False)
+        # 13/5 is the pre-widening baseline, pinned indicator-by-indicator in the
+        # test above. R1.3-01D reads False here because no MIT report is passed.
+        assert (met, failed) == (13, 5), "the verdicts moved; only the denominator should"
+        assert len(rep.indicator_results) == 41, "the whole model is reported"

--- a/tests/test_fair_indicators_source.py
+++ b/tests/test_fair_indicators_source.py
@@ -54,6 +54,52 @@ PUBLISHED_TOTAL = 41
 PUBLISHED_PER_PRIORITY = {"essential": 20, "important": 14, "useful": 7}
 
 
+class TestTheProvenanceIsCitable:
+    """A reader must be able to get from this file to the actual works, correctly.
+
+    These are offline pins on values verified live against Crossref, DataCite and
+    Zenodo — a citation nobody has resolved is a citation nobody should trust.
+    """
+
+    def test_the_specification_and_the_paper_are_not_conflated(self):
+        """They are two works. One `citation` beside one `doi` made them look like one.
+
+        `10.15497/rda00050` is the RDA deliverable and has no authors; Bahim et al. is
+        a separate peer-reviewed article. Quoting the author list against the
+        deliverable's DOI produces a reference that does not resolve to what it names.
+        """
+        rda = yaml.safe_load(INDICATORS_YAML.read_text())["sources"]["rda"]
+        assert rda["specification"]["doi"] == "10.15497/rda00050"
+        assert rda["peer_reviewed"]["doi"] == "10.5334/dsj-2020-041"
+        assert rda["specification"]["doi"] != rda["peer_reviewed"]["doi"]
+        assert "Bahim" in rda["peer_reviewed"]["citation"]
+        assert "Bahim" not in str(rda["specification"])
+
+    def test_the_specification_is_attributed_to_the_alliance_not_to_authors(self):
+        rda = yaml.safe_load(INDICATORS_YAML.read_text())["sources"]["rda"]
+        assert rda["specification"]["publisher"] == "Research Data Alliance"
+        assert "author" not in rda["specification"]
+
+    def test_the_vendored_workbook_is_the_published_file(self):
+        """Byte-identical to Zenodo record 3909563's FAIR_evaluation_levels_v0.02.xlsx.
+
+        Checked live once; pinned here so a re-vendoring that silently substitutes a
+        different or edited workbook fails rather than quietly changing what the
+        indicator definitions say.
+        """
+        import hashlib
+
+        assert (
+            hashlib.md5(RDA_XLSX.read_bytes()).hexdigest()
+            == "b6231346dff874a3675747ab3e295fd9"
+        )
+        assert RDA_XLSX.stat().st_size == 195824
+
+    def test_the_licence_is_the_one_the_publisher_states(self):
+        rda = yaml.safe_load(INDICATORS_YAML.read_text())["sources"]["rda"]
+        assert rda["license"] == "CC-BY-4.0"
+
+
 class TestTheWholePublishedModelIsCarried:
     """All 41 indicators, including the ones this tool cannot answer.
 


### PR DESCRIPTION
Closes #662. Two defects in how the RDA axis represents its published source. Neither moves a verdict.

## 1. The model was carried at half size

`fair/indicators.yaml` held **21 of 41** published indicators. The other 20 were not marked out of scope — they were absent, because the generator built from a hand-written list of ids rather than from the vendored workbook. So "14 of 21 met" read as coverage of the RDA model when it was really **14 of 41 with 20 never asked**, and an entire priority tier — all 7 `useful` indicators — was missing with nothing saying so.

Its two siblings already do this right: `fair/dsm_indicators.yaml` carries all 83 DSM indicators, `air/criteria.yaml` all 28 Bridge2AI criteria, each marking what it cannot assess. Which parts of a published instrument a tool answers is a local decision and has to be visible, not implied by absence.

`LOCAL_SCOPE` becomes a map over the whole model. Every indicator carries either a check or a reason; `build_data` raises on both, on neither, and on any published indicator the mapping fails to place.

```
Dim    total  scored  out of scope
A         12       0            12
F          7       5             2
I         12       5             7
R         10       8             2
ALL       41      18            23

by priority:  essential 10 of 20 · important 8 of 14 · useful 0 of 7
```

The reasons are grouped rather than a blanket shrug — 12 are access-protocol properties of the repository serving the crate, 4 ask about references made from inside payload files, 3 about the payload being tabular measurement data rather than a knowledge representation.

**No verdict moves.** All 20 newly-carried indicators report *not assessed*; the golden fixture stays at 13 met / 5 failed. Only the denominator becomes honest, and a test pins that alongside the published total and the priority split.

## 2. The citation named the right authors against the wrong DOI

```yaml
citation: Bahim et al. 2020, Data Science Journal 19(1):41
doi: 10.15497/rda00050
```

Both facts are true and they are **two different works**. Resolved live, `10.15497/rda00050` is the Research Data Alliance's deliverable and has no authors. Bahim et al. is a separate peer-reviewed article, `10.5334/dsj-2020-041`. Anyone citing from that block produced a reference whose author list did not belong to its DOI.

Split into `specification` and `peer_reviewed` as the DSM block already does, each with its own DOI, and the article's eight authors written out rather than abbreviated in a machine-readable field.

## Every DOI in the repo was resolved live while fixing this

Crossref for the articles, DataCite for the deliverables, Zenodo for the records. The rest check out: Sci Data **10:291** and **11:503** are the real article numbers; both `CC-BY-4.0` claims match the publishers' own rights statements; the Bridge2AI concept (`…090`) and version (`…091`) DOIs are the right way round.

The strongest is now a test: our vendored `fair/rda_fdmm.xlsx` is **byte-identical** to the file Zenodo record 3909563 publishes — 195,824 bytes, `md5 b6231346dff874a3675747ab3e295fd9` — so a re-vendoring that substitutes an edited workbook fails loudly instead of quietly changing what the indicator definitions say.

## Two things this surfaces for the manuscript

- **`useful` is 0 of 7** — not a bug, just now visible. Worth a Methods sentence rather than a reviewer noticing.
- **Accessibility is 0 of 12**, and structurally so: the whole A dimension is about access protocols and resolution. Same shape as the DSM's hosting indicators and Bridge2AI's Ethics dimension — three independent instruments each having a region a crate on disk cannot evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)