### PR TITLE
fix(fair): the licence indicators grade the crate, not a field nobody writes

### DIFF
--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -132,30 +132,69 @@ def _check_reuse_attributes(state: CrateState) -> bool:
     return len(state.list_entities()) >= 2
 
 
-def _check_license_present(state: CrateState) -> bool:
-    """Check that metadata includes license information."""
+def _effective_license(state: CrateState, graph: Graph = None) -> str:
+    """The licence the crate actually asserts, or ``""``.
+
+    Read from the assembled Root Data Entity, because that is the licence a reader
+    gets. The three RDA R1.1 indicators and DSM-3-C7 used to read
+    ``entity.fields["license"]`` — a field nothing populates and which never reaches
+    the crate. `_read_declared_licence` (#535) writes the deposit's own declaration to
+    ``state.metadata.license`` and ``_crate_mapping`` assembles it onto the root, so a
+    crate could carry CC-BY in its JSON, render it on the report's study card, and
+    score false on every licence indicator. The crate was right; the instrument was
+    pointed at the wrong object.
+
+    ``LICENCE_NOT_STATED_ID`` is what assembly writes when nobody declared one.
+    Counting it would invert the depositor's own statement in the direction that
+    suppresses reuse — the defect #535 exists to prevent — so it reads as absent.
+
+    Falls back to ``state.metadata.license`` when no graph was supplied, then to an
+    entity field, so a caller holding only state still gets an answer where one
+    honestly exists.
+    """
+    from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+
+    def _usable(value: Any) -> str:
+        text = _ref_id(value) or str(value or "")
+        return "" if text == LICENCE_NOT_STATED_ID else text
+
+    if not _needs_graph(graph):
+        for node in _nodes(graph):
+            if node.get("@id") == "./" or "Dataset" in _node_types(node):
+                if found := _usable(node.get("license")):
+                    return found
+        return ""
+    if found := _usable(state.metadata.license):
+        return found
     for entity in state.list_entities():
-        if "license" in entity.fields and entity.fields["license"]:
-            return True
-    return False
+        if found := _usable(entity.fields.get("license")):
+            return found
+    return ""
 
 
-def _check_license_standard(state: CrateState) -> bool:
-    """Check that metadata refers to a standard reuse license."""
-    for entity in state.list_entities():
-        lic = entity.fields.get("license", "")
-        if lic and ("creativecommons" in str(lic).lower() or "cc-" in str(lic).lower()):
-            return True
-    return False
+def _check_license_present(state: CrateState, graph: Graph = None) -> bool:
+    """RDA-R1.1-01M — metadata includes information about the reuse licence."""
+    return bool(_effective_license(state, graph))
 
 
-def _check_license_machine(state: CrateState) -> bool:
-    """Check that license is machine-understandable (URL)."""
-    for entity in state.list_entities():
-        lic = entity.fields.get("license", "")
-        if lic and str(lic).startswith("http"):
-            return True
-    return False
+def _check_license_standard(state: CrateState, graph: Graph = None) -> bool:
+    """RDA-R1.1-02M — the licence is a *standard* reuse licence, not bespoke terms."""
+    lic = _effective_license(state, graph).lower()
+    return bool(lic) and any(
+        token in lic
+        for token in ("creativecommons", "cc-", "cc0", "spdx.org", "opensource.org",
+                      "apache", "mit", "bsd", "gpl", "opendatacommons", "odbl")
+    )
+
+
+def _check_license_machine(state: CrateState, graph: Graph = None) -> bool:
+    """RDA-R1.1-03M — the licence is machine-understandable, i.e. a resolvable IRI.
+
+    A bare label is a real declaration and #535 returns it verbatim rather than
+    inventing a version (D5) — but "CC-BY" does not say which version, so it is not
+    machine-understandable and this indicator is the one that says so.
+    """
+    return _effective_license(state, graph).startswith(("http://", "https://"))
 
 
 def _check_provenance(state: CrateState) -> bool:
@@ -290,9 +329,13 @@ def _check_resolvable_terms(state: CrateState) -> bool:
     return False
 
 
-def _check_standard_license(state: CrateState) -> bool:
-    """Descriptor references a standard reuse license."""
-    return _check_license_present(state)
+def _check_standard_license(state: CrateState, graph: Graph = None) -> bool:
+    """DSM-3-C7 — the descriptor references a standard reuse licence.
+
+    Answered by the RDA check for the same question, so the two instruments cannot
+    return different verdicts about one crate.
+    """
+    return _check_license_standard(state, graph)
 
 
 def _check_domain_standard(state: CrateState) -> bool:
@@ -583,6 +626,13 @@ def _state_check(fn: Callable[[CrateState], bool]) -> DsmCheck:
     return _wrapped
 
 
+# RDA checks that take the assembled ``@graph`` as a second argument. The rest of the
+# registry is state-only; this set is the migration boundary, not a permanent design —
+# see #665 for why the licence indicators moved first and what a wider move would cost.
+_GRAPH_AWARE_FAIR_CHECKS: frozenset[str] = frozenset(
+    {"license_present", "license_standard", "license_machine"}
+)
+
 # Map check names to functions
 FAIR_CHECKS: dict[str, Any] = {
     "root_global_id": _check_root_global_id,
@@ -622,7 +672,7 @@ DSM_CHECKS: dict[str, DsmCheck] = {
     "data_structured": _state_check(_check_data_structured),
     "domain_model": _state_check(_check_domain_model),
     "resolvable_terms": _state_check(_check_resolvable_terms),
-    "standard_license": _state_check(_check_standard_license),
+    "standard_license": _check_standard_license,
     "domain_standard": _state_check(_check_domain_standard),
     "standard_field_metadata": _state_check(_check_standard_field_metadata),
     "controlled_values": _state_check(_check_controlled_values),
@@ -634,7 +684,7 @@ DSM_CHECKS: dict[str, DsmCheck] = {
     # Readable Format" reuses the RDA R1.1-03M check — same question, both models.
     # It was defined but never registered here, so _compute_dsm_level skipped it
     # and handed out Level 4 for free.
-    "license_machine": _state_check(_check_license_machine),
+    "license_machine": _check_license_machine,
     # --- graph-aware: the DSM's dataset field/value indicators (Levels 2-4) ---
     "tidy_dataset": _check_tidy_dataset,
     "reference_fields": _check_reference_fields,
@@ -704,6 +754,11 @@ def assess_fair_maturity(
                 # never-populated state.mit_assessment (#311).
                 if check_name == "mit_coverage":
                     passed = _mit_has_coverage(mit_report)
+                elif check_name in _GRAPH_AWARE_FAIR_CHECKS:
+                    # The licence lives on the assembled root, not on CrateState —
+                    # see _effective_license. Passing the graph is what makes this
+                    # indicator answerable from the crate a reader receives (#665).
+                    passed = FAIR_CHECKS[check_name](state, graph)
                 else:
                     passed = FAIR_CHECKS[check_name](state)
                 indicator_results.append(

--- a/tests/test_tools_fair_assessment.py
+++ b/tests/test_tools_fair_assessment.py
@@ -7,6 +7,121 @@ from builder.tools.fair_assessment import _check_access_info, assess_fair_maturi
 from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
 
+class TestTheLicenceIndicatorsGradeTheCrate:
+    """They read the licence off the assembled graph, not a field nobody writes.
+
+    `_read_declared_licence` (#535) puts the deposit's own licence on
+    `state.metadata.license`, and assembly puts it on the Root Data Entity. The four
+    licence checks read `entity.fields["license"]` — a field the builder never
+    populates and which never reaches the crate. So a crate carrying CC-BY in its
+    JSON, and rendering it on the report's study card, scored false on all four.
+    """
+
+    @staticmethod
+    def _graph(licence: str | None):
+        root: dict = {"@id": "./", "@type": "Dataset", "name": "A crate"}
+        if licence is not None:
+            root["license"] = {"@id": licence}
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "@type": "CreativeWork",
+                 "about": {"@id": "./"}},
+                root,
+            ]
+        }
+
+    def _verdicts(self, graph):
+        from builder.tools.fair_assessment import assess_fair_maturity
+
+        rep = assess_fair_maturity(CrateState(), graph=graph)
+        return {r["id"]: r["passed"] for r in rep.indicator_results}
+
+    def test_a_licence_on_the_crate_is_found(self):
+        got = self._verdicts(self._graph("https://creativecommons.org/licenses/by/4.0/"))
+        assert got["RDA-R1.1-01M"] is True, "present"
+        assert got["RDA-R1.1-02M"] is True, "a standard reuse licence"
+        assert got["RDA-R1.1-03M"] is True, "machine-understandable"
+
+    def test_no_licence_on_the_crate_fails_all_three(self):
+        got = self._verdicts(self._graph(None))
+        assert [got[i] for i in ("RDA-R1.1-01M", "RDA-R1.1-02M", "RDA-R1.1-03M")] == [
+            False, False, False,
+        ]
+
+    def test_the_not_stated_placeholder_is_not_a_licence(self):
+        """`#licence-not-stated` is what assembly writes when nobody declared one.
+
+        Counting it would invert the depositor's own statement in the one direction
+        that suppresses reuse — which is the defect #535 was opened for.
+        """
+        from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+
+        got = self._verdicts(self._graph(LICENCE_NOT_STATED_ID))
+        assert got["RDA-R1.1-01M"] is False
+
+    def test_a_bare_string_licence_still_counts_as_present(self):
+        """"CC-BY" without a version is a declaration, just not a machine-actionable
+        one — #535 returns it verbatim rather than inventing a 4.0 URI (D5)."""
+        graph = self._graph(None)
+        graph["@graph"][1]["license"] = "CC-BY"
+        got = self._verdicts(graph)
+        assert got["RDA-R1.1-01M"] is True
+        assert got["RDA-R1.1-02M"] is True
+        assert got["RDA-R1.1-03M"] is False, "no IRI, so not machine-understandable"
+
+    def test_the_dsm_licence_check_is_the_rda_one(self):
+        """DSM-3-C7 asks the same question, so it calls the same function.
+
+        Compared at the CHECK level, not through `dsm_verdicts`: the DSM ladder can
+        demote a true statement whose lower rungs fail, which is correct behaviour and
+        would mask whether the two instruments agree about the licence itself.
+        """
+        from builder.tools.fair_assessment import (
+            DSM_CHECKS,
+            FAIR_CHECKS,
+            _check_standard_license,
+        )
+
+        graph = self._graph("https://creativecommons.org/licenses/by/4.0/")
+        assert DSM_CHECKS["standard_license"] is _check_standard_license
+        assert _check_standard_license(CrateState(), graph) is True
+        assert _check_standard_license(CrateState(), graph) is FAIR_CHECKS[
+            "license_standard"
+        ](CrateState(), graph)
+
+    def test_the_ladder_can_still_demote_a_licence_that_is_really_there(self):
+        """A thin crate fails DSM-1-C2, and the ladder demotes DSM-3-C7 above it.
+
+        Pinned because it looks like a licence bug and is not: the statements form a
+        ladder, and a level-3 claim cannot stand on an unmet level-1 one.
+        """
+        from builder.tools.fair_assessment import dsm_verdicts
+
+        graph = self._graph("https://creativecommons.org/licenses/by/4.0/")
+        verdict = dsm_verdicts(CrateState(), None, graph)["DSM-3-C7"]
+        assert verdict.value is False
+        assert "demoted" in verdict.evidence and "DSM-1-C2" in verdict.evidence
+
+    def test_state_and_graph_give_the_same_answer(self):
+        """`#535` writes the licence to `state.metadata.license`; assembly copies it to
+        the root. Both are the same fact, so a caller holding either must not get a
+        different verdict — that divergence is the whole defect."""
+        from builder.tools.fair_assessment import _effective_license
+
+        iri = "https://creativecommons.org/licenses/by/4.0/"
+        from_state = CrateState()
+        from_state.metadata.license = iri
+        assert _effective_license(from_state, None) == iri
+        assert _effective_license(CrateState(), self._graph(iri)) == iri
+
+    def test_nothing_anywhere_declares_a_licence(self):
+        """With no graph and no state licence the answer is "no", not "unknown" —
+        the fact is genuinely absent from both places it could live."""
+        from builder.tools.fair_assessment import _effective_license
+
+        assert _effective_license(CrateState(), None) == ''
+
+
 class TestAssessFairMaturity:
     """Tests for assess_fair_maturity — assesses FAIR maturity from CrateState."""
 


### PR DESCRIPTION
Closes #665.

Four checks scored the crate's licence by reading `entity.fields["license"]`. **Nothing populates that field.**

The licence a deposit declares is read by `_read_declared_licence` (#535) into `state.metadata.license`, and `_crate_mapping.py:1247` assembles it onto the Root Data Entity. So the same crate, in one run:

```
crate JSON root license : {'@id': 'https://creativecommons.org/licenses/by/4.0/'}   OK
report study card       : Creative Commons Attribution 4.0 International            OK
RDA-R1.1-01M/02M/03M    : passed=False                                              WRONG
```

**The crate is right; the instrument was pointed at the wrong object** — the same shape as the DSM `metadata.title` defect. All nine VHP4Safety deposits declare CC-BY and carry it correctly, and all four indicators read false for all nine.

## The fix

`_effective_license(state, graph)` reads the assembled root — the source MIT and AI-readiness already use, so the scorer grades what a reader actually receives. It falls back to `state.metadata.license`, then an entity field, because those are the same fact in the other places it lives; a test pins that state and graph cannot give different answers, since that divergence *is* the defect.

`LICENCE_NOT_STATED_ID` reads as **absent**. Counting the placeholder would invert the depositor's own statement in the direction that suppresses reuse — exactly what #535 exists to prevent.

Two behaviours worth review:

- **R1.1-02M** now recognises a licence family (`creativecommons`, `cc0`, `spdx.org`, `apache`, `mit`, `gpl`, `odbl`, …) instead of the substring `"cc-"`, which matched any identifier containing those two characters.
- **R1.1-03M** is the indicator that distinguishes `"CC-BY"` from a resolvable IRI. #535 returns a bare label verbatim rather than inventing a version (D5) — a real declaration, but not a machine-understandable one, and this is the indicator that says so.

**DSM-3-C7** now calls the RDA function for the question they share, so two instruments cannot disagree about one crate.

## Evidence

On `output/svhps22_real_input_crate_v20`, a real built crate, all three R1.1 indicators go **False → True**.

The golden fixture carries **no licence at all**, so its pinned verdicts do not move — which is precisely why a fixture-only test could never have caught this. The new tests build crates that do declare one.

264 tests pass across the FAIR, DSM, AI-readiness, report and gap-engine suites. `ruff` and `ty` clean.

## Scope

Deliberately the licence checks only. A triage of all 45 assessed RDA + DSM checks (adversarially verified — every proposed predicate executed against the fixture *and* real crates) found:

| verdict | n |
|---|---|
| **tautology** — measures nothing; porting it to the graph makes it a graph tautology | **28** |
| moves the score if migrated | 12 |
| cleanly graph-scorable | **5** |

Two examples of why a wider migration is not a refactor:

- **DSM-1-C1** — `_apply_root_name` derives the root description from Investigation → Study → *the name*, so it can never be empty; an empty `CrateState` assembles to a crate that passes. Today it reads `metadata.title`, `None` on **31 of 32** real sessions. Moving it flips False→True on 97% of the corpus.
- **DSM-1-R0** — true on a 7-node crate assembled from nothing. A property of `ro-crate-py`'s serializer, not of the data.

Together they would lift **12 crates from DSM 0 to DSM 1 for free.** The reproducibility gap is real, but closing it by porting tautologies would inflate the published numbers rather than make them reproducible. That needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)