### PR TITLE
feat(crate): an assay's protocols reach the step they describe

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -1985,9 +1985,30 @@ def _add_structural(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> N
 # executing it as the CellCulture's protocol would assert it explains how that
 # line was grown, which nobody checked (#650).
 _CULTURE_PROTOCOL_CUE = re.compile(r"cell\s*culture|culturing|culture\s+protocol")
+# Analysis is cued, never assumed. A document reaches DataAnalysis only by saying
+# so — fitting a curve, running statistics, normalising, quantifying. On the real
+# deposit nothing matches, and that is the right answer: no S-VHPS22 document
+# describes the analysis step, so the honest output is the ISA "SHOULD have a
+# protocol" warning rather than a readout SOP misfiled as an analysis one.
+_ANALYSIS_PROTOCOL_CUE = re.compile(
+    r"data\s*analys|analysis|analyz|statistic|curve\s*fit|fitting|"
+    r"normalis|normaliz|quantif|calculat"
+)
 # What a document found by each cue is FOR. Derived metadata on a real file — with
 # its name, the only thing added beyond the path that identifies it.
-_INTENDED_USE: dict[str, str] = {_CULTURE_PROTOCOL_CUE.pattern: "Cell culture"}
+_INTENDED_USE: dict[str, str] = {
+    _CULTURE_PROTOCOL_CUE.pattern: "Cell culture",
+    _ANALYSIS_PROTOCOL_CUE.pattern: "Data analysis",
+}
+# Measuring is what an assay's SOP describes, so EndpointReadout is where an
+# assay-scoped protocol lands unless a cue sends it elsewhere. Ordered: the first
+# cue that matches wins, and culture is asked first because a culture document
+# naming an assay would otherwise read as that assay's readout procedure.
+_STEP_PROTOCOL_CUES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("CellCulture", _CULTURE_PROTOCOL_CUE),
+    ("DataAnalysis", _ANALYSIS_PROTOCOL_CUE),
+)
+_DEFAULT_PROTOCOL_STEP = "EndpointReadout"
 
 
 def _culture_cell_lines(f: dict[str, Any], idx: dict[str, Any], name: str) -> list[Any]:
@@ -2157,6 +2178,66 @@ def _link_to_study(study: Any, protocol: Any) -> None:
         return
     prop = "hasPart" if _is_file_node(protocol) else "mentions"
     _append_unique(study, prop, protocol)
+
+
+def _step_for_protocol(haystack: str) -> str:
+    """Which step a protocol document describes, from its path and name.
+
+    Default is :data:`_DEFAULT_PROTOCOL_STEP`; a cue moves it. Cue order matters
+    and is fixed in :data:`_STEP_PROTOCOL_CUES`.
+    """
+    text = haystack.replace("%20", " ").casefold()
+    for step, cue in _STEP_PROTOCOL_CUES:
+        if cue.search(text):
+            return step
+    return _DEFAULT_PROTOCOL_STEP
+
+
+def _assay_protocol_documents(
+    state: CrateState, assay_id: Any, idx: dict[str, Any], ptype: str
+) -> list[Any]:
+    """The protocol documents *this assay* ships for *ptype*, in deposit order.
+
+    Scoped by the Assay's own ``hasPart`` — which already lists its documents —
+    rather than by matching folder names, so an assay never borrows a sibling's
+    procedure. Every matching document is returned, not one: each assay in the
+    deposit ships two to four (RNA isolation, then DNase, then cDNA/qPCR are
+    three steps of one readout), and returning one of four would be a silent
+    choice. The single-hit D5 rule still governs :func:`_protocol_document_for`,
+    where a *cell line* has to disambiguate between candidates; here there is no
+    subject to be ambiguous about.
+
+    Nothing is minted: a document is claimed only if it is already a
+    LabProtocol-typed node in the crate, which means the deposit shipped the file
+    (D17).
+    """
+    if not assay_id:
+        return []
+    wanted = str(assay_id)
+    parts: list[Any] = []
+    for assay in state.list_entities("Assay"):
+        if assay.entity_id != wanted:
+            continue
+        for key in ("hasPart", "has_part"):
+            parts.extend(_resolve_many(idx, assay.fields.get(key)))
+        break
+
+    out: list[Any] = []
+    seen: set[Any] = set()
+    for node in parts:
+        nid = getattr(node, "id", None)
+        if nid is None or nid in seen:
+            continue
+        types = getattr(node, "type", None)
+        types = types if isinstance(types, list) else [types]
+        if not any("LabProtocol" in str(t) for t in types if t):
+            continue
+        haystack = f"{nid} {node.get('name') or ''}"
+        if _step_for_protocol(haystack) != ptype:
+            continue
+        seen.add(nid)
+        out.append(node)
+    return out
 
 
 def _protocol_document_for(
@@ -2920,6 +3001,19 @@ def _add_processes(
                 study = _study_of(state, idx, f.get("assay_id"))
                 for one in culture_protocols:
                     _link_to_study(study, one)
+        elif protocol is None:
+            # Everything else is assay-scoped: the deposit files an assay's
+            # procedures beside its data, and the Assay already lists them under
+            # hasPart. A document lands on EndpointReadout unless it says it is
+            # about culturing or analysis, because measuring is what an assay's
+            # SOP describes. DataAnalysis legitimately comes up empty on the real
+            # deposit — no document there covers that step — and an empty result
+            # is the honest one (D17).
+            assay_protocols = _assay_protocol_documents(
+                state, f.get("assay_id"), idx, ptype
+            )
+            if assay_protocols:
+                protocol = assay_protocols
         node = _build_process(
             crate,
             ptype,

--- a/tests/test_builder_domain.py
+++ b/tests/test_builder_domain.py
@@ -178,6 +178,152 @@ class TestISAHierarchy:
 
 
 
+class TestTheAssayProtocolReachesItsStep:
+    """#650 item 3 — an assay's deposited protocols reach the step they describe.
+
+    Only CellCulture ever got a protocol. EndpointReadout and DataAnalysis fell
+    through to nothing, so S-VHPS22's nine assay-scoped documents — the
+    transporter assay, Bradford, deiodinase activity, the UPLC run, RNA
+    isolation, cDNA/qPCR — were carried in the payload and executed by no step.
+
+    Three rules, each pinned below:
+
+    * **The default is EndpointReadout.** Measuring is what an assay's SOP
+      describes; culture and analysis are reached only by an explicit cue.
+    * **A step executes ALL of its documents, not one.** Every assay in the
+      deposit ships two to four (assay_04 has three sequential ones: RNA
+      isolation, DNase, cDNA/qPCR). The single-hit D5 rule still governs the
+      culture lookup, where a *cell line* has to disambiguate; here there is no
+      subject to be ambiguous about, and picking one of four would be a silent
+      choice rather than an honest list.
+    * **Nothing is minted.** A step with no document keeps none (D17).
+    """
+
+    ASSAY_DIR = "assay_02_deiodinase"
+
+    def _state(self, *, docs=("4.1 Deiodinase activity assay.docx",), steps=(
+        ("proc_read", "EndpointReadout"),
+    )):
+        state = CrateState()
+        state.metadata.input_path = "/deposit"
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        doc_ids = []
+        for n, nm in enumerate(docs, start=1):
+            eid = f"doc_{n}"
+            doc_ids.append(eid)
+            state.add_entity(
+                _ent(
+                    eid,
+                    "File",
+                    name=nm,
+                    path=f"{self.ASSAY_DIR}/{nm}",
+                    additional_types=["LabProtocol"],
+                )
+            )
+        state.add_entity(
+            _ent("assay_1", "Assay", name="A1", study_id="study_1", hasPart=doc_ids)
+        )
+        for pid, ptype in steps:
+            state.add_entity(
+                _ent(
+                    pid,
+                    "LabProcess",
+                    name=ptype,
+                    process_type=ptype,
+                    assay_id="assay_1",
+                    endpoint="deiodinase activity",
+                    detection_instrument="gamma counter",
+                )
+            )
+        return state
+
+    def test_the_readout_executes_the_assays_protocol(self, tmp_path):
+        _, by_id = _build(self._state(), tmp_path)
+        executed = _ids(by_id["#LabProcess_proc_read"].get("executesLabProtocol"))
+        assert executed, "the readout executes none of its assay's protocols"
+        assert any("Deiodinase" in e for e in executed), executed
+
+    def test_the_protocol_is_the_document_itself(self, tmp_path):
+        _, by_id = _build(self._state(), tmp_path)
+        executed = _ids(by_id["#LabProcess_proc_read"].get("executesLabProtocol"))
+        assert executed and not executed[0].startswith("#"), (
+            f"a protocol's @id must be its file path, not a minted stub: {executed}"
+        )
+        assert self.ASSAY_DIR in executed[0], executed
+
+    def test_every_protocol_the_assay_ships_is_executed(self, tmp_path):
+        """Two to four per assay is the norm; one-of-four would be a silent pick."""
+        state = self._state(
+            docs=("4.1 Deiodinase activity assay.docx", "3.3 Bradford protocol.xlsx")
+        )
+        _, by_id = _build(state, tmp_path)
+        executed = _ids(by_id["#LabProcess_proc_read"].get("executesLabProtocol"))
+        assert sum("Deiodinase" in e for e in executed) == 1, executed
+        assert sum("Bradford" in e for e in executed) == 1, executed
+
+    def test_an_analysis_document_goes_to_the_analysis_not_the_readout(self, tmp_path):
+        state = self._state(
+            docs=(
+                "4.1 Deiodinase activity assay.docx",
+                "5.4 Data analysis and curve fitting.docx",
+            ),
+            steps=(("proc_read", "EndpointReadout"), ("proc_ana", "DataAnalysis")),
+        )
+        _, by_id = _build(state, tmp_path)
+        # A crate @id percent-encodes its spaces; compare on the decoded path.
+        def _paths(pid):
+            return [
+                e.replace("%20", " ")
+                for e in _ids(by_id[pid].get("executesLabProtocol"))
+            ]
+
+        readout = _paths("#LabProcess_proc_read")
+        analysis = _paths("#LabProcess_proc_ana")
+        assert any("Data analysis" in e for e in analysis), analysis
+        assert not any("Data analysis" in e for e in readout), (
+            f"an analysis protocol must not be claimed by the readout: {readout}"
+        )
+        assert not any("Deiodinase" in e for e in analysis), (
+            f"a readout protocol must not be claimed by the analysis: {analysis}"
+        )
+
+    def test_an_analysis_with_no_document_of_its_own_executes_none(self, tmp_path):
+        """DataAnalysis comes up empty on the real deposit, and that is correct.
+
+        No S-VHPS22 document describes the analysis step, so the honest output is
+        the ISA "SHOULD have a protocol" warning — not a stub that silences it
+        with a procedure nobody wrote (D17).
+        """
+        state = self._state(
+            steps=(("proc_read", "EndpointReadout"), ("proc_ana", "DataAnalysis"))
+        )
+        _, by_id = _build(state, tmp_path)
+        assert _ids(by_id["#LabProcess_proc_ana"].get("executesLabProtocol")) == []
+        assert not any(str(i).startswith("#protocol_") for i in by_id), (
+            f"a stub was minted: {[i for i in by_id if str(i).startswith('#protocol_')]}"
+        )
+
+    def test_another_assays_protocol_is_not_borrowed(self, tmp_path):
+        """Scoping is the assay's own hasPart, not "any protocol in the crate"."""
+        state = self._state()
+        state.add_entity(
+            _ent(
+                "doc_other",
+                "File",
+                name="4.3 Protocol UPLC runnen.docx",
+                path="assay_03_metabolism/4.3 Protocol UPLC runnen.docx",
+                additional_types=["LabProtocol"],
+            )
+        )
+        state.add_entity(_ent("assay_2", "Assay", name="A2", study_id="study_1",
+                              hasPart=["doc_other"]))
+        _, by_id = _build(state, tmp_path)
+        executed = _ids(by_id["#LabProcess_proc_read"].get("executesLabProtocol"))
+        assert not any("UPLC" in e for e in executed), (
+            f"assay_02's readout borrowed assay_03's protocol: {executed}"
+        )
+
+
 class TestLabProcessSubtypes:
     def _state_with_process(self, process_type, **proc_fields):
         state = CrateState()


### PR DESCRIPTION
Item 3 from the #650 follow-up list: readout and analysis had no protocol.

## The gap

Only `CellCulture` ever got one. `EndpointReadout` and `DataAnalysis` fell through to nothing — so S-VHPS22's nine assay-scoped documents (transporter assay, Bradford, deiodinase activity, UPLC run, RNA isolation, cDNA/qPCR, T3 dose-response, metabolism assay) sat in the payload executed by no step, while every readout reported a missing protocol it actually had.

## Three rules

**Measuring is the default.** An assay's SOP describes what it measures, so an assay-scoped document lands on `EndpointReadout`. A cue moves it: `cell culture` / `culturing` / `culture protocol` → `CellCulture`, `analysis` / `curve fit` / `normalise` / `quantif` / … → `DataAnalysis`.

The cue is deliberately narrow. *"Protocol for metabolism assay in neural culture"* stays a readout — the culture cue wants **cell** culture, not any culture.

**A step executes all of its documents, not one.** Every assay in the deposit ships two to four, and assay_04's three are sequential steps of a single readout: RNA isolation → DNase → cDNA/qPCR. `_scanned_protocol_document`'s single-hit D5 rule still governs the culture lookup, where a *cell line* has to disambiguate between candidates. Here there is no subject to be ambiguous about, so returning one of four would be a silent choice rather than an honest list.

Consequence worth naming: assay_01 ships the same protocol twice, one copy flagged *"(need to translate)"*. Both attach. Listing both is more honest than picking one.

**Scoping is the Assay's own `hasPart`**, which already lists its documents — no folder-name matching, and an assay cannot borrow a sibling's procedure.

## Result on the real deposit

| Step | Count |
|---|---|
| EndpointReadout | 9 |
| CellCulture | 3 |
| **DataAnalysis** | **0** |

The zero is the right answer, not a hole in the rule. No S-VHPS22 document describes the analysis step, so the honest output is the ISA *"SHOULD have a protocol"* warning — not a stub that silences it with a procedure nobody wrote (**D17**).

## Tests

`TestTheAssayProtocolReachesItsStep`, six tests. Four pin the new behaviour; two are negative guards that already held and must keep holding — nothing `#protocol_*` is minted, and no assay borrows another's document.

## Verification

- 212 passed across `test_builder_domain`, `test_tools_process_chain`, `test_crate_mapping_references`, `test_csvw_payload`, `test_crate_reads_back`, `test_condition_table`
- `uvx ruff check` clean; `uv run ty check` adds no errors (the 2 reported are pre-existing unresolved `langchain_*` imports, identical on main)
- Step routing checked against all 12 real protocol-classified documents, reproducing the table above

## Not in scope

The protocol's *content* — `intendedUse` is still guessed from the filename, and `labEquipment` / `reagent` / `version` are never set even though the documents carry them. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DxWfFK7SURRZiZSAYdsfQ