### PR TITLE
fix(data): a human column header maps, and a key that never varies does not

### DIFF
--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -58,6 +58,26 @@ logger = logging.getLogger(__name__)
 # ``biosample_type`` on ``cell_line`` — see the collision rule in
 # :func:`project_condition_rows`. Reporting them is the honest outcome; inventing a
 # canonical home for a measurement column is exactly the fabrication D5 forbids.
+_HEADER_SEPARATORS = re.compile(r"[^0-9a-z]+")
+
+
+def _normalise_header(name: str) -> str:
+    """Fold a source header onto the alias table's ``snake_case`` spelling.
+
+    The aliases are written the way a tidy export names its columns; a working
+    spreadsheet is not. S-VHPS22's gamma counter writes ``Run ID``, and exact
+    matching meant ``run_id`` mapped while ``Run ID`` did not — so every human
+    header landed in ``unmapped_source_columns`` and not one of the deposit's 20
+    spreadsheets could serve as a condition table (#656).
+
+    Case, spaces, hyphens and dots all fold; digits are kept, because ``T3`` and
+    ``T4`` are different columns. This widens the *spelling* of a known name and
+    nothing else — the folded header still has to BE an alias, so a column with
+    no canonical home stays unmapped and stays reported.
+    """
+    return _HEADER_SEPARATORS.sub("_", str(name).strip().casefold()).strip("_")
+
+
 _CONDITION_TABLE_ALIASES: dict[str, str] = {
     "well": "well_id",
     "well_position": "well_id",
@@ -90,6 +110,13 @@ _CONDITION_TABLE_ALIASES: dict[str, str] = {
     "assay_endpoint": "assay",
     "replicate": "technical_replicate",
     "replicate_id": "technical_replicate",
+}
+
+# The alias table keyed by folded name. Built once, and from the table itself so
+# the two can never drift — `"cell line"` folds to `cell_line` here rather than
+# being spelled twice above.
+_NORMALISED_ALIASES: dict[str, str] = {
+    _normalise_header(alias): target for alias, target in _CONDITION_TABLE_ALIASES.items()
 }
 
 # Tidy sources split a duration into value + unit columns where the canonical table
@@ -397,7 +424,7 @@ def project_condition_rows(
     from builder.tools._crate_mapping import _CONDITION_TABLE_HEADER
 
     canonical = _CONDITION_TABLE_HEADER.strip("\n").split(",")
-    canonical_set = set(canonical)
+    canonical_by_norm = {_normalise_header(c): c for c in canonical}
 
     projected: list[dict[str, Any]] = []
     mapped: set[str] = set()
@@ -408,12 +435,13 @@ def project_condition_rows(
         # Canonical headers first, so an alias can never displace them.
         for key, value in row.items():
             name = str(key).strip()
-            if name in canonical_set and _has_value(value):
-                out[name] = value
-                mapped.add(name)
+            canonical_name = canonical_by_norm.get(_normalise_header(name))
+            if canonical_name is not None and _has_value(value):
+                out[canonical_name] = value
+                mapped.add(canonical_name)
         # Value+unit pairs are composed BEFORE the alias pass, so both halves reach
         # the single canonical column they share instead of colliding there.
-        lowered_row = {str(k).strip().lower(): v for k, v in row.items()}
+        lowered_row = {_normalise_header(k): v for k, v in row.items()}
         # Headers the pair rule CLAIMED on this row, i.e. suppressed from
         # `unmapped_source_columns`. A header is claimed only once it has actually
         # been consumed — or had nothing to give. Claiming the pair unconditionally
@@ -452,12 +480,12 @@ def project_condition_rows(
 
         for key, value in row.items():
             name = str(key).strip()
-            if name in canonical_set:
+            normalised = _normalise_header(name)
+            if normalised in canonical_by_norm:
                 continue
-            lowered = name.lower()
-            if lowered in paired_headers:
+            if normalised in paired_headers:
                 continue
-            target = _CONDITION_TABLE_ALIASES.get(lowered)
+            target = _NORMALISED_ALIASES.get(normalised)
             if target is not None:
                 if _has_value(value) and target not in out:
                     out[target] = value
@@ -651,8 +679,22 @@ def condition_table_fit(rows: Sequence[Mapping[str, Any]]) -> tuple[int, int]:
     on how much of the schema it fills.
     """
     projection = project_condition_rows(rows)
-    wells = sum(1 for r in projection["rows"] if _has_value(r.get("well_id")))
+    keys = [r.get("well_id") for r in projection["rows"] if _has_value(r.get("well_id"))]
+    wells = len(keys)
     mapped = len(projection["mapped_columns"])
+    # A well key has to tell the samples apart. `Run ID` names the counter RUN —
+    # the raw file — so it reads 4669 on all 80 rows of S-VHPS22's gamma-counter
+    # sheet, one row per tube. Accepting it there would emit 80 rows that each
+    # claim to be the same sample: worse than the empty table #656 reported,
+    # because it looks populated.
+    #
+    # The `run_id` alias itself is right and stays. A tidy export's run_id
+    # genuinely is its per-row key, and refusing it would drop all 1048 rows of
+    # that case. What distinguishes the two is not the header, it is whether the
+    # column varies — so that is what is asked. A single row cannot vary and is
+    # not penalised.
+    if wells > 1 and len({str(k) for k in keys}) == 1:
+        return (0, 0)
     return (wells, mapped) if wells and mapped else (0, 0)
 
 

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -17,6 +17,7 @@ from builder.state import CrateState, Entity, EntityProvenance
 from builder.tools._crate_mapping import _CONDITION_TABLE_COLUMNS
 from builder.tools.data_content import (
     _UNIT_SUFFIX_RE,
+    condition_table_fit,
     csvw_to_frictionless,
     populate_condition_table,
     project_condition_rows,
@@ -241,6 +242,101 @@ class TestProjectConditionRows:
         assert got["concentration_value"] == "10"
         assert got["concentration_unit"] == "uM"
         assert got["exposure_duration"] == "24h"
+
+
+class TestSourceHeadersAreNormalisedBeforeMapping:
+    """#656 — a human header must map as well as a machine one.
+
+    The alias table is keyed in ``snake_case``; real spreadsheets are not.
+    S-VHPS22's gamma counter writes ``Run ID``, ``Rack``, ``Det``, ``Pos``, and
+    matching was exact — so ``run_id`` mapped and ``Run ID`` did not. Every
+    human-written header fell into ``unmapped_source_columns`` and the sheet
+    described nothing, which is why **zero of the deposit's 20 spreadsheets**
+    could serve as a condition table.
+
+    Normalising is a reader-boundary fix: case, spaces, hyphens and dots all
+    fold to the alias spelling. It is not a licence to guess — the folded name
+    still has to BE an alias, so an unrelated column stays unmapped and stays
+    reported.
+    """
+
+    @pytest.mark.parametrize(
+        "header",
+        ["Run ID", "run id", "Run-ID", "RUN_ID", "Run  Id"],
+        ids=["title", "lower-space", "hyphen", "upper", "double-space"],
+    )
+    def test_a_human_spelling_of_an_alias_maps(self, header):
+        out = project_condition_rows([{header: "4669"}])
+        assert "well_id" in out["mapped_columns"], (
+            f"{header!r} is the same column as run_id; got {out}"
+        )
+
+    def test_a_human_spelling_of_a_canonical_column_maps(self):
+        out = project_condition_rows([{"Cell Line": "SK-N-AS"}])
+        assert "cell_line" in out["mapped_columns"], out
+
+    def test_the_real_gamma_counter_header_maps_its_key(self):
+        """The exact header that shipped zero rows."""
+        row = {
+            "Protocol ID": 65,
+            "Protocol name": "TELLING 5 min",
+            "Run ID": 4669,
+            "Rack": 1,
+            "Det": 1,
+            "Pos": 1,
+            "I-125 CPM": 7026.73,
+        }
+        out = project_condition_rows([row])
+        assert "well_id" in out["mapped_columns"], out
+        assert out["rows"][0]["well_id"] == 4669, out["rows"][0]
+
+    def test_an_unrelated_column_is_still_unmapped_and_still_reported(self):
+        """Normalising must not turn "no canonical home" into a silent guess."""
+        out = project_condition_rows([{"I-125 CPM": 7026.73}])
+        assert out["mapped_columns"] == [], out
+        assert "I-125 CPM" in out["unmapped_source_columns"], out
+
+
+class TestAKeyThatNeverVariesIsNotAKey:
+    """#656 — ``well_id`` identifies the exposed sample, so it has to tell them apart.
+
+    ``Run ID`` names the counter run, i.e. the raw file: it is **4669 on all 80
+    rows** of the gamma-counter sheet, one row per tube. Mapping it to
+    ``well_id`` there would emit 80 rows that all claim to be the same sample —
+    worse than the empty table #656 reported, because it looks populated.
+
+    The alias itself is right and stays: a tidy export's ``run_id`` genuinely is
+    its per-row key, and removing it would drop all 1048 rows of that case on
+    the floor. What was missing is the gate — a well key that never varies
+    across more than one row does not identify anything.
+    """
+
+    def test_a_varying_key_still_qualifies(self):
+        rows = [{"run_id": n, "compound": "Xn"} for n in range(1, 5)]
+        wells, mapped = condition_table_fit(rows)
+        assert wells == 4 and mapped >= 1, (wells, mapped)
+
+    def test_a_constant_key_across_many_rows_does_not(self):
+        rows = [{"run_id": 4669, "compound": "Xn"} for _ in range(80)]
+        assert condition_table_fit(rows) == (0, 0), (
+            "80 rows sharing one key identify one sample, not eighty"
+        )
+
+    def test_a_single_row_is_not_penalised(self):
+        """One row cannot vary, and a one-condition table is still a table."""
+        wells, mapped = condition_table_fit([{"run_id": 4669, "compound": "Xn"}])
+        assert wells == 1 and mapped >= 1, (wells, mapped)
+
+    def test_the_real_gamma_counter_sheet_is_refused(self):
+        rows = [
+            {"Run ID": 4669, "Rack": rack, "Pos": pos, "I-125 CPM": 1.0}
+            for rack in range(1, 9)
+            for pos in range(1, 11)
+        ]
+        assert len(rows) == 80
+        assert condition_table_fit(rows) == (0, 0), (
+            "Run ID is the raw file, not the sample — this sheet has no per-sample key"
+        )
 
 
 class TestPopulateRefusesRatherThanBlanking:


### PR DESCRIPTION
Part of #656. **Does not close it** — see *What this does not fix* below.

## The issue's premise turned out to be wrong

#656 assumed `populate_condition_table` was simply never called. It was not called — but the tool would have produced nothing anyway. **Zero of the deposit's 20 spreadsheets** pass `condition_table_fit`, and I found two independent reasons.

## Defect 1 — headers were matched exactly

The alias table is keyed in `snake_case`. A working spreadsheet is not.

```python
project_condition_rows([{"run_id": 4669}])["mapped_columns"]  # ['well_id']
project_condition_rows([{"Run ID": 4669}])["mapped_columns"]  # []   <-- same column
```

S-VHPS22's gamma counter writes `Run ID`, `Rack`, `Det`, `Pos`. Every one landed in `unmapped_source_columns`, so the sheet described nothing.

Case, spaces, hyphens and dots now fold to the alias spelling. This widens the *spelling* of a known name and nothing else — the folded header still has to BE an alias, so a column with no canonical home stays unmapped and **stays reported**. `_NORMALISED_ALIASES` is derived from the alias table itself, so the two cannot drift.

## Defect 2 — a well key that never varies

`Run ID` names the counter *run*, i.e. the raw file. It reads **4669 on all 80 rows** of `Raw data 27-03` — one row per tube, `Rack` 1–8 × `Pos` 1–10.

With defect 1 fixed alone, it would now map, and the table would ship 80 rows each claiming to be the same sample. That is **worse** than the empty table #656 reported, because it looks populated.

A key that does not vary across more than one row is now refused:

```
mapped_columns now: ['well_id']
rows: 80 | distinct well_id values: 1 -> ['4669']
fit: (0, 0)
```

**The `run_id` alias itself is right and stays.** A tidy export's `run_id` genuinely is its per-row key, and refusing it would drop all 1048 rows of that case — the outcome its own comment warns about. What separates the two is not the header but whether the column varies, so that is what is asked. A single row cannot vary and is not penalised.

## What this does not fix

S-VHPS22 still yields **no** qualifying sheet, and the tables stay empty. Its per-sample key is `Rack`+`Pos`, which nothing models, and the conditions live in a sibling matrix sheet (`layout 27-03`) that `condition_table_fit` will never read. That is **#669**, filed with a verifiable acceptance test: Rack 1/Pos 1 = `7026.73` and Rack 1/Pos 2 = `7233.76` must land on the T3 `1 µM Xn` row.

Also still open from #656: whether to emit a table at all when no sheet qualifies. That touches `_crate_mapping.py`, which #667 already modifies, so it is held back rather than stacked.

## Correction to my own earlier analysis

I initially reported the cause as `read_excel_rows` misreading the header row, and proposed hoisting `_header_index`. That was wrong on both counts. `_header_index` is specific to the RIVM fill-in-the-blanks template — it requires three Dutch authoring-guidance columns — and would return 0 here. And `Raw data 27-03` is read *correctly*: 80 rows, header on row 1, all columns present. The header-row problem is real for other sheets (`Summary` yields `['Name', 'Nathalie']`) but is not what blocked this file.

## Tests

- `TestSourceHeadersAreNormalisedBeforeMapping` — five spellings of `Run ID`, a canonical column spelled by a human, the exact gamma-counter header, and a guard that an unrelated column stays unmapped *and* reported
- `TestAKeyThatNeverVariesIsNotAKey` — varying key still qualifies, constant key across 80 rows does not, a single row is not penalised, and the real sheet is refused

## Verification

146 passed across `test_condition_table`, `test_csvw_payload`, `test_data_content_validation`, `test_tools_process_chain`. `uvx ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DxWfFK7SURRZiZSAYdsfQ