### PR TITLE
fix(fair): the RDA indicators grade the crate, and can fail (#670)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -598,6 +598,24 @@ output and to the source workbook.
 Note the DSM model text is **CC-BY-4.0**; the FAIRplus repository's MIT `LICENSE.txt`
 covers only its Jekyll theme and does not license the model.
 
+**A check reads the crate, not the session.** An indicator is scored against the
+assembled `@graph` — the bytes a reader receives — so a third party scoring the
+published crate reaches our published number. Given no graph a check answers *not
+assessed* (`None`), which leaves the denominator, rather than guessing from
+`CrateState`; `_GRAPH_AWARE_FAIR_CHECKS` names the checks that hold to this and
+`assessment_graph.needs_graph` states why the alternative is a lie. Two indicators
+asking one question share one function, so the axes cannot disagree about one crate.
+
+**A check must be able to fail, and must ask the published question.** `len(entities)
+> 0` is not an assessment: it scores that the builder ran. The floor is pinned by
+`tests/test_fair_metrics_can_fail.py`, which scores a crate holding two empty entities
+and no payload and requires every indicator whose published text names *the data* to
+read `False`; the packaging indicators it may legitimately meet are enumerated there
+with reasons. Moving a check to the graph without rewriting its predicate inflates the
+score — porting DSM-1-C1 and DSM-1-R0 as-is lifts twelve crates a level for free —
+so **a migration ships with a real crate that fails it, and published scores are
+expected to go down** (#670).
+
 ### External RO-Crate Packages
 
 This project builds on the existing RO-Crate Python ecosystem rather than reinventing crate assembly, validation, or entity models:

--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -74,23 +74,110 @@ def _load_yaml(path: Path) -> dict[str, Any] | None:
         return None
 
 
+def _root_node(graph: Graph) -> dict[str, Any]:
+    """The Root Data Entity — whatever ``ro-crate-metadata.json`` says it is ``about``.
+
+    Followed through the descriptor rather than assumed to be ``./`` so the reading
+    matches the RO-Crate spec's own definition, which is what a third-party reader
+    would follow.
+    """
+    by_id = {str(n.get("@id")): n for n in _nodes(graph)}
+    descriptor = by_id.get("ro-crate-metadata.json", {})
+    return by_id.get(_ref_id(descriptor.get("about")) or "./", by_id.get("./", {}))
+
+
+def _payload_files(graph: Graph) -> tuple[list[dict[str, Any]], set[str]]:
+    """The crate's *data*: File nodes the root claims, transitively through ``hasPart``.
+
+    "The data" cannot mean "every node". The ISA backbone always mints a Study
+    ``Dataset`` into the root's ``hasPart`` — a crate with two empty entities and no
+    payload whatsoever still has one — so any indicator answered by "``hasPart``
+    resolves" is answered by the builder's own scaffolding, not by data. That is the
+    #670 defect in miniature: an indicator about the data, satisfied by the metadata.
+
+    Returns the File nodes and every ``@id`` walked, so a caller can also ask whether
+    the references resolve.
+    """
+    by_id = {str(n.get("@id")): n for n in _nodes(graph)}
+    seen: set[str] = set()
+    found: list[dict[str, Any]] = []
+    queue = [_root_node(graph)]
+    while queue:
+        parts = queue.pop().get("hasPart")
+        for ref in parts if isinstance(parts, list) else [parts] if parts else []:
+            part_id = _ref_id(ref)
+            if part_id in seen:
+                continue
+            seen.add(part_id)
+            child = by_id.get(part_id)
+            if child is None:
+                continue
+            if "File" in _node_types(child):
+                found.append(child)
+            if "Dataset" in _node_types(child):
+                queue.append(child)
+    return found, seen
+
+
+def _root_pid(graph: Graph) -> str:
+    """The persistent identifier the crate claims for itself, or ``""``.
+
+    A DOI, or any absolute IRI. A bare accession like ``S-VHPS22`` does not qualify:
+    it is unique inside BioStudies and ambiguous outside it, and the whole point of
+    the indicator is identification that survives leaving the source repository.
+    """
+    root = _root_node(graph)
+    for value in (root.get("identifier"), root.get("@id")):
+        text = _ref_id(value) or str(value or "")
+        if text.startswith(("http://", "https://", "10.")) or "doi" in text.lower():
+            return text
+    return ""
+
+
 def _check_root_global_id(state: CrateState) -> bool:
     """Check that the crate has a globally unique identifier (accession or session_id)."""
     return bool(state.metadata.accession or state.session_id)
 
 
-def _check_every_entity_has_id(state: CrateState) -> bool:
-    """Check that every entity has an entity_id."""
-    entities = state.list_entities()
-    if not entities:
+def _check_every_entity_has_id(state: CrateState, graph: Graph = None) -> bool | None:
+    """RDA-F1-02D — *the data* is identified by a globally unique identifier.
+
+    Asks it of the data. The old check was ``all(bool(e.entity_id) …)``, which is
+    vacuously true over any entity the builder holds and never asks whether there is
+    data to identify at all: a crate of two empty entities passed it.
+
+    A File is globally identified when its own ``@id`` or ``contentUrl`` is an
+    absolute IRI, or when the root carries a PID the crate-relative paths compose
+    against. On this corpus that is false everywhere, because nothing writes a DOI to
+    the root — the same root cause as RDA-F1-01M, and the two flip together when it is
+    fixed. False for a stated reason is a finding; true for no reason is not.
+    """
+    if _needs_graph(graph):
+        return None
+    files, _ = _payload_files(graph)
+    if not files:
         return False
-    return all(bool(e.entity_id) for e in entities)
+    if _root_pid(graph):
+        return True
+    return all(
+        _is_external_iri(f.get("@id"))
+        or _is_external_iri(f.get("contentUrl"))
+        or _is_external_iri(f.get("identifier"))
+        for f in files
+    )
 
 
-def _check_pid_form(state: CrateState) -> bool:
-    """Check that metadata is identified by a persistent identifier."""
-    accession = state.metadata.accession or ""
-    return bool(accession and (accession.startswith("10.") or "doi" in accession.lower()))
+def _check_pid_form(state: CrateState, graph: Graph = None) -> bool | None:
+    """RDA-F1-01M — metadata is identified by a persistent identifier.
+
+    Reads the assembled root, so the answer is one a reader can reproduce from the
+    crate alone. With no graph it answers "not assessed" rather than falling back to
+    ``state.metadata.accession``: a mix of read-from-crate and guessed-from-session
+    verdicts in one column is exactly the ambiguity #670 exists to remove.
+    """
+    if _needs_graph(graph):
+        return None
+    return bool(_root_pid(graph))
 
 
 def _check_rich_metadata(state: CrateState) -> bool:
@@ -98,19 +185,102 @@ def _check_rich_metadata(state: CrateState) -> bool:
     return bool(state.metadata.title and state.metadata.description)
 
 
-def _check_metadata_refs_data(state: CrateState) -> bool:
-    """Check that metadata references data (entities present)."""
-    return len(state.list_entities()) > 0
+def _check_metadata_refs_data(state: CrateState, graph: Graph = None) -> bool | None:
+    """RDA-F3-01M — metadata includes the identifier for *the data*.
+
+    The descriptor must name the root, the root must claim at least one payload File,
+    and every reference walked must resolve to a node in the graph. The old check was
+    ``len(state.list_entities()) > 0``.
+
+    Note the ISA backbone trap: "the root's ``hasPart`` is non-empty and resolves" is
+    *also* a tautology, because assembly always mints a Study ``Dataset`` there. It is
+    payload that has to be named — see :func:`_payload_files`.
+    """
+    if _needs_graph(graph):
+        return None
+    by_id = {str(n.get("@id")): n for n in _nodes(graph)}
+    descriptor = by_id.get("ro-crate-metadata.json", {})
+    root_id = _ref_id(descriptor.get("about"))
+    if not root_id or root_id not in by_id:
+        return False
+    files, walked = _payload_files(graph)
+    if not files:
+        return False
+    return all(part_id in by_id for part_id in walked)
 
 
-def _check_jsonld_context(state: CrateState) -> bool:
-    """Check that metadata uses JSON-LD context / machine-understandable format."""
-    return len(state.list_entities()) > 0
+_RO_CRATE_PROFILE_PREFIX = "https://w3id.org/ro/crate/"
 
 
-def _check_fair_vocabularies(state: CrateState) -> bool:
-    """Check that metadata uses FAIR-compliant vocabularies (has entity types)."""
-    return len(state.list_entities()) > 0
+def _check_jsonld_context(state: CrateState, graph: Graph = None) -> Verdict | None:
+    """RDA-I1-01M / I1-02M — metadata in a standardised, machine-understandable
+    knowledge representation.
+
+    The crate's own descriptor answers this: ``ro-crate-metadata.json`` declaring
+    ``conformsTo`` an RO-Crate version IRI *is* the statement "this file is JSON-LD
+    following RO-Crate". The old check was ``len(state.list_entities()) > 0``.
+
+    An empty crate still passes, and honestly so — the serialisation really is
+    standardised whether or not anything was put in it. What changes is that the
+    answer now comes from the crate rather than from a session object no reader has,
+    which is the half of #670 that is about reproducibility rather than rigour.
+
+    Kept distinct from :func:`_check_conforms_to_profile`, which asks the *community
+    standard* question (a domain profile beyond bare RO-Crate). Two indicators sharing
+    one check can never disagree, so the two pairs read different edges.
+    """
+    if _needs_graph(graph):
+        return None
+    for node in _nodes(graph):
+        if node.get("@id") != "ro-crate-metadata.json":
+            continue
+        conforms = node.get("conformsTo")
+        for ref in conforms if isinstance(conforms, list) else [conforms]:
+            if _ref_id(ref).startswith(_RO_CRATE_PROFILE_PREFIX):
+                return Verdict(True, f"descriptor conformsTo {_ref_id(ref)}")
+        return Verdict(False, "descriptor declares no RO-Crate profile")
+    return Verdict(False, "no ro-crate-metadata.json descriptor in the crate")
+
+
+def _check_fair_vocabularies(state: CrateState, graph: Graph = None) -> Verdict | None:
+    """RDA-I2-01M — metadata uses FAIR-compliant vocabularies.
+
+    Counts the crate's term-bearing nodes and asks how many are actually bound to a
+    resolvable vocabulary: a ``csvw:Column`` with an absolute-IRI ``propertyUrl``, a
+    ``DefinedTerm`` whose ``@id`` or ``inDefinedTermSet`` is one, or a
+    ``PropertyValue`` with an absolute-IRI ``propertyID``.
+
+    The old check was ``len(state.list_entities()) > 0``, i.e. it credited a crate for
+    having any entity at all. A crate that annotates nothing with a controlled term
+    now scores 0 of 0 and fails, which is the point.
+
+    **The bound ratio is the informative output, not the boolean.** A majority is a
+    stated convention and nothing more; it is deliberately *not* fitted to the crates
+    on hand, whose bound ratios run 0.56-0.87 with a median of 0.70, so any sharper
+    cut would be reading a threshold off a corpus that is essentially one deposit.
+    Read the evidence string, and see #670 for why the number beats the verdict.
+    """
+    if _needs_graph(graph):
+        return None
+    total = bound = 0
+    for node in _nodes(graph):
+        types = _node_types(node)
+        if "Column" in types:
+            total, bound = total + 1, bound + _is_external_iri(node.get("propertyUrl"))
+        elif "DefinedTerm" in types:
+            total += 1
+            bound += _is_external_iri(node.get("@id")) or _is_external_iri(
+                node.get("inDefinedTermSet")
+            )
+        elif "PropertyValue" in types:
+            total, bound = total + 1, bound + _is_external_iri(node.get("propertyID"))
+    if not total:
+        return Verdict(False, "no term-bearing node in the crate to bind")
+    return Verdict(
+        bound / total > 0.5,
+        f"{bound} of {total} term-bearing nodes resolve to an external vocabulary "
+        f"({bound / total:.0%})",
+    )
 
 
 def _check_qualified_refs(state: CrateState) -> bool:
@@ -127,9 +297,88 @@ def _check_qualified_refs(state: CrateState) -> bool:
     return False
 
 
-def _check_reuse_attributes(state: CrateState) -> bool:
-    """Check that a plurality of accurate, relevant attributes exists."""
-    return len(state.list_entities()) >= 2
+# The root attributes a reader needs to reuse a dataset without asking anybody.
+_REUSE_ATTRIBUTES = (
+    "name",
+    "description",
+    "license",
+    "identifier",
+    "datePublished",
+    "author",
+    "creator",
+    "publisher",
+    "conformsTo",
+    "keywords",
+    "citation",
+    "contactPoint",
+)
+# The four RO-Crate 1.2 requires on the Root Data Entity. Anchoring the check here
+# rather than on "any N of the twelve" is what keeps it a reading of the spec instead
+# of a threshold read off whichever crates happened to be on disk.
+_ROOT_REQUIRED = ("name", "description", "datePublished", "license")
+_REUSE_BEYOND_REQUIRED = 2
+# The entities a reuser has to be able to identify: what was dosed, what it was dosed
+# on, and how. A name alone does not let anyone re-run or re-analyse the work.
+_REUSE_SUBJECT_TYPES = frozenset(
+    {"MolecularEntity", "Sample", "CellLineSample", "LabProtocol"}
+)
+
+
+def _check_reuse_attributes(state: CrateState, graph: Graph = None) -> Verdict | None:
+    """RDA-R1-01M — a plurality of accurate and relevant attributes, to allow reuse.
+
+    Two limbs, because "plurality" is about the description, not the count of things
+    described. The root must carry all four attributes RO-Crate requires of it
+    (``_ROOT_REQUIRED``) plus ``_REUSE_BEYOND_REQUIRED`` more from
+    ``_REUSE_ATTRIBUTES`` — "plurality" being more than the bare minimum the spec
+    already mandates. And a majority of the crate's subjects must carry a name *plus*
+    something that identifies them: a description, an identifier, or an
+    ``additionalProperty``. Nobody can reuse a chemical given only a common name.
+
+    The old check was ``len(state.list_entities()) >= 2``. That is the flagship #670
+    absurdity: two entities whose ``fields`` are ``{}`` have zero attributes between
+    them and passed an indicator about the plurality of attributes.
+
+    Placeholders do not count. ``_DEFAULT_ROOT_NAME`` is the constant
+    ``_apply_root_name`` falls back to when nothing supplied a title, and
+    ``LICENCE_NOT_STATED_ID`` is what assembly writes when nobody declared a licence;
+    crediting either would move the same tautology one level down.
+    """
+    if _needs_graph(graph):
+        return None
+    from builder.tools._crate_mapping import LICENCE_NOT_STATED_ID
+    from builder.tools.builder import _DEFAULT_ROOT_NAME
+
+    root = _root_node(graph)
+    present = []
+    for attribute in _REUSE_ATTRIBUTES:
+        value = root.get(attribute)
+        if not value:
+            continue
+        if attribute in ("name", "description") and str(value) == _DEFAULT_ROOT_NAME:
+            continue
+        if attribute == "license" and _ref_id(value) == LICENCE_NOT_STATED_ID:
+            continue
+        present.append(attribute)
+
+    subjects = [n for n in _nodes(graph) if _node_types(n) & _REUSE_SUBJECT_TYPES]
+    described = [
+        n
+        for n in subjects
+        if n.get("name")
+        and (n.get("description") or n.get("identifier") or n.get("additionalProperty"))
+    ]
+    missing = [a for a in _ROOT_REQUIRED if a not in present]
+    beyond = len(present) - (len(_ROOT_REQUIRED) - len(missing))
+    enough_subjects = bool(subjects) and len(described) / len(subjects) > 0.5
+    evidence = (
+        f"root carries {len(present)} of {len(_REUSE_ATTRIBUTES)} reuse attributes"
+        + (f", missing required {missing}" if missing else f", {beyond} beyond the four required")
+        + f"; {len(described)} of {len(subjects)} subjects are described beyond a name"
+    )
+    return Verdict(
+        not missing and beyond >= _REUSE_BEYOND_REQUIRED and enough_subjects, evidence
+    )
 
 
 def _effective_license(state: CrateState, graph: Graph = None) -> str:
@@ -197,16 +446,56 @@ def _check_license_machine(state: CrateState, graph: Graph = None) -> bool:
     return _effective_license(state, graph).startswith(("http://", "https://"))
 
 
-def _check_provenance(state: CrateState) -> bool:
-    """Check that metadata includes provenance per community standards."""
-    return any(e._provenance.created_by != "missing" for e in state.list_entities())
+def _check_provenance(state: CrateState, graph: Graph = None) -> Verdict | None:
+    """RDA-R1.2-01M — provenance information according to community-specific standards.
+
+    RO-Crate's community standard for provenance is a ``CreateAction`` naming the
+    ``instrument`` that produced the crate and pointing its ``result`` at the root.
+    The old check read ``entity._provenance.created_by``, a session-only attribute
+    that never reaches the crate: it recorded who told *us* about an entity, which is
+    not the same claim, and no reader could reproduce it.
+
+    An empty crate still passes. The provenance of the packaging act is genuinely
+    recorded; what is absent is data for it to be about, and that absence is caught by
+    the indicators that ask about data.
+    """
+    if _needs_graph(graph):
+        return None
+    root_id = str(_root_node(graph).get("@id") or "./")
+    for node in _nodes(graph):
+        if "CreateAction" not in _node_types(node):
+            continue
+        if node.get("instrument") and _ref_id(node.get("result")) == root_id:
+            return Verdict(True, f"CreateAction {node.get('@id')} records the build")
+    return Verdict(False, "no CreateAction records how the crate was produced")
 
 
-def _check_conforms_to_profile(state: CrateState) -> bool:
-    """Check that metadata complies with a community standard."""
-    types = {e.type for e in state.list_entities()}
-    has_isa_types = bool(types & {"Investigation", "Study", "Assay", "LabProcess"})
-    return has_isa_types
+def _check_conforms_to_profile(state: CrateState, graph: Graph = None) -> Verdict | None:
+    """RDA-R1.3-01M / R1.3-02M — compliance with a (machine-understandable) community
+    standard.
+
+    The root must declare ``conformsTo`` a *domain* profile — something beyond the
+    bare RO-Crate packaging IRI, which :func:`_check_jsonld_context` already covers.
+    The old check inferred the standard from the presence of ISA-shaped entity types
+    in session state, which is a guess about what the crate probably conforms to
+    rather than a reading of what it declares.
+    """
+    if _needs_graph(graph):
+        return None
+    conforms = _root_node(graph).get("conformsTo")
+    declared = [
+        _ref_id(ref)
+        for ref in (conforms if isinstance(conforms, list) else [conforms])
+        if _is_external_iri(ref)
+    ]
+    domain = [iri for iri in declared if not iri.startswith(_RO_CRATE_PROFILE_PREFIX)]
+    if domain:
+        return Verdict(True, f"root conformsTo {', '.join(domain)}")
+    return Verdict(
+        False,
+        "root declares no domain profile"
+        + (f" (only {', '.join(declared)})" if declared else ""),
+    )
 
 
 def _mit_has_coverage(report: MITReport) -> bool:
@@ -338,9 +627,15 @@ def _check_standard_license(state: CrateState, graph: Graph = None) -> bool:
     return _check_license_standard(state, graph)
 
 
-def _check_domain_standard(state: CrateState) -> bool:
-    """Descriptor uses a community-defined metadata standard."""
-    return _check_conforms_to_profile(state)
+def _check_domain_standard(state: CrateState, graph: Graph = None) -> Verdict | None:
+    """DSM-3-R3 — descriptor uses a community-defined metadata standard.
+
+    Same question as RDA-R1.3-01M, so it stays the same function: two implementations
+    of one question is how two axes come to disagree about one crate. It follows
+    ``_check_conforms_to_profile`` onto the graph for that reason, not because the DSM
+    ladder needed it.
+    """
+    return _check_conforms_to_profile(state, graph)
 
 
 def _check_standard_field_metadata(state: CrateState) -> bool:
@@ -630,7 +925,25 @@ def _state_check(fn: Callable[[CrateState], bool]) -> DsmCheck:
 # registry is state-only; this set is the migration boundary, not a permanent design —
 # see #665 for why the licence indicators moved first and what a wider move would cost.
 _GRAPH_AWARE_FAIR_CHECKS: frozenset[str] = frozenset(
-    {"license_present", "license_standard", "license_machine"}
+    {
+        "license_present",
+        "license_standard",
+        "license_machine",
+        # #670: these four asked their question of CrateState and could not fail. They
+        # now read the crate a reader receives, and answer "not assessed" rather than
+        # guess when no graph was supplied.
+        "pid_form",
+        "every_entity_has_id",
+        "metadata_refs_data",
+        "fair_vocabularies",
+        "reuse_attributes",
+        # These three could already answer honestly on an empty crate, but answered
+        # from session state a reader never receives. Moving them closes the
+        # reproducibility half of #670 without changing any verdict.
+        "jsonld_context",
+        "provenance",
+        "conforms_to_profile",
+    }
 )
 
 # Map check names to functions
@@ -673,7 +986,7 @@ DSM_CHECKS: dict[str, DsmCheck] = {
     "domain_model": _state_check(_check_domain_model),
     "resolvable_terms": _state_check(_check_resolvable_terms),
     "standard_license": _check_standard_license,
-    "domain_standard": _state_check(_check_domain_standard),
+    "domain_standard": _check_domain_standard,
     "standard_field_metadata": _state_check(_check_standard_field_metadata),
     "controlled_values": _state_check(_check_controlled_values),
     "standard_identifiers": _state_check(_check_standard_identifiers),
@@ -757,8 +1070,10 @@ def assess_fair_maturity(
                 elif check_name in _GRAPH_AWARE_FAIR_CHECKS:
                     # The licence lives on the assembled root, not on CrateState —
                     # see _effective_license. Passing the graph is what makes this
-                    # indicator answerable from the crate a reader receives (#665).
-                    passed = FAIR_CHECKS[check_name](state, graph)
+                    # indicator answerable from the crate a reader receives (#665),
+                    # and is what lets the #670 checks ask about data rather than
+                    # about how many entities the session happens to hold.
+                    passed = _as_verdict(FAIR_CHECKS[check_name](state, graph)).value
                 else:
                     passed = FAIR_CHECKS[check_name](state)
                 indicator_results.append(

--- a/tests/test_fair_indicators_source.py
+++ b/tests/test_fair_indicators_source.py
@@ -180,17 +180,39 @@ class TestFairIndicatorsDerivedFromRda:
             assert ind["priority"] == rda[iid]["priority"], iid
             assert ind["text"] == rda[iid]["text"], iid
 
-    def test_fair_scores_unchanged_for_golden_crate(self):
-        """Re-sourcing definitions must not move any score (definitions only, not
-        logic) — regression against the pre-#356 assessment of S-VHPS21."""
+    def test_fair_scores_for_golden_crate(self):
+        """The per-indicator pin for S-VHPS21, scored the way production scores it.
+
+        Was ``test_fair_scores_unchanged_for_golden_crate``, asserting that re-sourcing
+        the definitions moved no verdict. #670 moves verdicts on purpose, so the pin
+        is re-derived rather than defended, and the assessment now runs against the
+        assembled ``@graph`` — which is what both production callers pass, and the only
+        input a reader of the published crate has.
+
+        Two verdicts changed, both downwards, both for a stated reason:
+
+        * ``RDA-F1-02D`` True -> **False**. "Data is identified by a globally unique
+          identifier": the crate's Files carry crate-relative paths and the root mints
+          no DOI for them to compose against. The old check asked whether every
+          ``Entity`` had an ``entity_id``, which nothing in the crate can falsify.
+        * ``RDA-R1-01M`` True -> **False**. "Plurality of accurate and relevant
+          attributes": the root declares no licence — one of the four RO-Crate requires
+          — and 1 of its 4 subjects is described beyond a bare name. The old check was
+          ``len(state.list_entities()) >= 2``.
+
+        13 met / 5 failed -> **11 met / 7 failed**. ``dsm_level`` is unmoved at 2;
+        the ladder must not rise when checks move to the graph (#670).
+        """
         from builder.tools.fair_assessment import assess_fair_maturity
+        from builder.tools.mit_assessment import _assemble_graph
         from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
-        rep = assess_fair_maturity(vhps_fixture_state("S-VHPS21"))
+        state = vhps_fixture_state("S-VHPS21")
+        rep = assess_fair_maturity(state, graph={"@graph": _assemble_graph(state) or []})
         got = {r["id"]: (r.get("passed"), r.get("scope", "")) for r in rep.indicator_results}
         expected = {
             "RDA-F1-02M": (True, ""),
-            "RDA-F1-02D": (True, ""),
+            "RDA-F1-02D": (False, ""),
             "RDA-F1-01M": (False, ""),
             "RDA-F2-01M": (True, ""),
             "RDA-F3-01M": (True, ""),
@@ -202,7 +224,7 @@ class TestFairIndicatorsDerivedFromRda:
             "RDA-I2-01M": (True, ""),
             "RDA-I3-01M": (True, ""),
             "RDA-I3-03M": (True, ""),
-            "RDA-R1-01M": (True, ""),
+            "RDA-R1-01M": (False, ""),
             "RDA-R1.1-01M": (False, ""),
             "RDA-R1.1-02M": (False, ""),
             "RDA-R1.1-03M": (False, ""),
@@ -231,12 +253,35 @@ class TestFairIndicatorsDerivedFromRda:
     def test_widening_the_model_did_not_move_the_score(self):
         """The met count is a property of the crate, not of how many we ask."""
         from builder.tools.fair_assessment import assess_fair_maturity
+        from builder.tools.mit_assessment import _assemble_graph
+        from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+        state = vhps_fixture_state("S-VHPS21")
+        rep = assess_fair_maturity(state, graph={"@graph": _assemble_graph(state) or []})
+        met = sum(1 for r in rep.indicator_results if r.get("passed") is True)
+        failed = sum(1 for r in rep.indicator_results if r.get("passed") is False)
+        # 11/7 is the post-#670 baseline, pinned indicator-by-indicator in the test
+        # above (13/5 before; F1-02D and R1-01M now fail for stated reasons).
+        # R1.3-01D reads False here because no MIT report is passed.
+        assert (met, failed) == (11, 7), "the verdicts moved; only the denominator should"
+        assert len(rep.indicator_results) == 41, "the whole model is reported"
+
+    def test_the_graph_is_what_makes_the_score_answerable(self):
+        """#670: ten indicators read the crate, so state alone cannot answer them.
+
+        Not a redundant restatement of the pin above — it fixes *which* input the
+        number belongs to. A caller passing no graph gets "not assessed" for those
+        ten, and 4 met is a smaller, honest claim rather than the same claim guessed
+        from a session object no reader receives.
+        """
+        from builder.tools.fair_assessment import assess_fair_maturity
         from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
         rep = assess_fair_maturity(vhps_fixture_state("S-VHPS21"))
         met = sum(1 for r in rep.indicator_results if r.get("passed") is True)
-        failed = sum(1 for r in rep.indicator_results if r.get("passed") is False)
-        # 13/5 is the pre-widening baseline, pinned indicator-by-indicator in the
-        # test above. R1.3-01D reads False here because no MIT report is passed.
-        assert (met, failed) == (13, 5), "the verdicts moved; only the denominator should"
-        assert len(rep.indicator_results) == 41, "the whole model is reported"
+        in_scope_unanswered = sum(
+            1
+            for r in rep.indicator_results
+            if r.get("passed") is None and r.get("scope") != "out_of_scope"
+        )
+        assert (met, in_scope_unanswered) == (4, 10)

--- a/tests/test_fair_metrics_can_fail.py
+++ b/tests/test_fair_metrics_can_fail.py
@@ -1,0 +1,358 @@
+"""The FAIR metrics must be able to fail (#670).
+
+A crate holding two empty entities and no payload at all "meets" **9 of the 18**
+assessed RDA indicators today, including *"Plurality of accurate and relevant
+attributes are provided to allow reuse"* over two entities whose ``fields`` are
+``{}``. Those checks score the builder's construction, not the data: eleven of
+them are literally ``len(state.list_entities()) > 0``.
+
+This module pins the floor. It is the definition of done for #670, and it is
+deliberately written before any check changes so that the rewrites have a target
+they cannot drift past.
+
+## The line this module draws
+
+The empty crate assembles to an eight-node skeleton — a root ``Dataset``, the
+``ro-crate-metadata.json`` descriptor, the not-stated licence placeholder, two
+profile IRIs, one ``Study`` Dataset, and the ``SoftwareApplication`` /
+``CreateAction`` pair recording the build. Everything in it is minted by the
+serialiser. Nothing in it came from data, because there is no data.
+
+So an indicator may only pass here if it asks a question **about the packaging**
+that the packaging genuinely answers. An indicator whose published text names
+*the data*, or names attributes, must fail — a crate with no data cannot evidence
+its data, and saying otherwise is what makes the axis unpublishable.
+
+``_ALLOWED`` and ``_MUST_FAIL`` below carry that split per indicator, with the
+published text and the reason, so a future change that moves one across the line
+has to say so in the diff.
+
+## Why the DSM assertions are the anti-inflation pin
+
+The tempting fix for the reproducibility half of #670 — routing the DSM checks
+through the assembled ``@graph`` — inflates rather than corrects. ``DSM-1-C1``
+(``study_summary``) and ``DSM-1-R0`` (``has_descriptor``) read
+``state.metadata.title``, ``None`` on 29 of 32 real sessions; the assembled root
+always carries a name, because ``builder.tools.builder._apply_root_name`` derives
+one and falls back to a constant. Ported as-is they would lift 12 crates from DSM
+0 to DSM 1 for free. ``test_the_ladder_stays_on_the_floor_when_scored_from_the_graph``
+is what makes that regression loud.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.fair_assessment import assess_fair_maturity
+from builder.tools.mit_assessment import _assemble_graph
+
+# Indicators a crate with no data may still honestly meet: each is a property of
+# the RO-Crate packaging, which really is standards-conformant even when empty.
+_ALLOWED: dict[str, str] = {
+    "RDA-I1-01M": (
+        "Metadata uses knowledge representation expressed in standardised format — "
+        "the crate really is JSON-LD carrying a standard @context."
+    ),
+    "RDA-I1-02M": (
+        "Metadata uses machine-understandable knowledge representation — same "
+        "serialisation, and it is machine-understandable whether or not it is empty."
+    ),
+    "RDA-R1.2-01M": (
+        "Metadata includes provenance information according to community-specific "
+        "standards — the minted CreateAction/SoftwareApplication pair is genuine "
+        "RO-Crate provenance of the packaging act. Honest, though it says nothing "
+        "about data provenance, because there is no data to have any."
+    ),
+    "RDA-R1.3-01M": (
+        "Metadata complies with a community standard — the root carries conformsTo "
+        "the RO-Crate and ISA-Tox profile IRIs."
+    ),
+    "RDA-R1.3-02M": (
+        "Metadata is expressed in compliance with a machine-understandable community "
+        "standard — same two profile IRIs, and they resolve."
+    ),
+}
+
+# Indicators that pass today and must not. Each names the false claim it makes.
+_MUST_FAIL: dict[str, str] = {
+    "RDA-F1-02D": (
+        '"Data is identified by a globally unique identifier" — there is no data. '
+        "`all(bool(e.entity_id) for e in entities)` is vacuously true over two "
+        "placeholders and never asks whether any data exists to be identified."
+    ),
+    "RDA-F3-01M": (
+        '"Metadata includes the identifier for the data" — no data, so no identifier '
+        "for it. The check is `len(state.list_entities()) > 0`."
+    ),
+    "RDA-I2-01M": (
+        '"Metadata uses FAIR-compliant vocabularies" — the crate annotates nothing '
+        "with a controlled term. The check is `len(state.list_entities()) > 0`; the "
+        "honest predicate counts entities carrying a resolvable external vocabulary "
+        "term, which `air_assessment._check_descriptive_metadata_rich` already does."
+    ),
+    "RDA-R1-01M": (
+        '"Plurality of accurate and relevant attributes are provided to allow reuse" '
+        "— both entities have `fields == {}`, i.e. zero attributes. The check is "
+        "`len(state.list_entities()) >= 2`, which counts entities, not attributes. "
+        "This is the flagship absurdity of #670."
+    ),
+}
+
+
+def _empty_crate() -> CrateState:
+    """Two typed entities, no fields, no files, no metadata — and nothing else.
+
+    Deliberately not a bare ``CrateState``: the entities exist so that every
+    ``len(state.list_entities()) > 0`` / ``>= 2`` tautology is satisfied. That is
+    the point — the crate is empty of *content* while clearing every entity-count
+    bar the current checks set.
+    """
+    state = CrateState()
+    for entity_id, entity_type in (("e1", "Investigation"), ("e2", "Study")):
+        state.add_entity(
+            Entity(
+                entity_id=entity_id,
+                type=entity_type,
+                fields={},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+    return state
+
+
+@pytest.fixture(scope="module")
+def empty_state() -> CrateState:
+    return _empty_crate()
+
+
+@pytest.fixture(scope="module")
+def empty_graph(empty_state: CrateState) -> dict:
+    return {"@graph": _assemble_graph(empty_state) or []}
+
+
+def _passing(state: CrateState, graph: dict | None = None) -> set[str]:
+    report = assess_fair_maturity(state, graph=graph) if graph else assess_fair_maturity(state)
+    return {r["id"] for r in report.indicator_results if r["passed"] is True}
+
+
+class TestAnEmptyCrateCannotEvidenceItsData:
+    """The RDA floor, scored both ways — a reader gets the graph, we get both."""
+
+    def test_the_crate_really_is_empty(self, empty_state, empty_graph) -> None:
+        """Guard the premise: if the skeleton ever grows content, this file lies."""
+        assert all(e.fields == {} for e in empty_state.list_entities())
+        assert empty_state.metadata.title is None
+        graph_types = [n.get("@type") for n in empty_graph["@graph"]]
+        assert "File" not in graph_types, "no payload may appear in the skeleton"
+
+    @pytest.mark.parametrize(("indicator", "why"), sorted(_MUST_FAIL.items()))
+    def test_indicators_about_data_must_fail(
+        self, empty_state, empty_graph, indicator, why
+    ) -> None:
+        assert indicator not in _passing(empty_state), why
+        assert indicator not in _passing(empty_state, empty_graph), f"{why} (from the graph)"
+
+    @pytest.mark.parametrize(("indicator", "why"), sorted(_ALLOWED.items()))
+    def test_indicators_about_the_packaging_may_pass(
+        self, empty_state, empty_graph, indicator, why
+    ) -> None:
+        """Pinned so that a rewrite which fixes the tautologies by making everything
+        strict gets caught too — "cannot pass" is as broken as "cannot fail".
+
+        Scored from the graph, because that is now the only place they are scored
+        from: all five read the crate a reader receives, and answer "not assessed"
+        without one (see TestTheAnswerIsReproducibleFromTheCrateAlone).
+        """
+        assert indicator in _passing(empty_state, empty_graph), why
+
+    def test_nothing_outside_the_allowlist_passes(self, empty_state, empty_graph) -> None:
+        """The closed half of the pin — a new tautology cannot slip in unnamed."""
+        for label, passing in (
+            ("state", _passing(empty_state)),
+            ("graph", _passing(empty_state, empty_graph)),
+        ):
+            unexpected = passing - set(_ALLOWED)
+            assert not unexpected, (
+                f"scored from {label}, an empty crate meets {sorted(unexpected)}. "
+                "Either the check is a tautology, or it belongs in _ALLOWED with a "
+                "written reason."
+            )
+
+
+class TestTheDsmLadderStaysOnTheFloor:
+    """An empty crate is DSM 0, and must stay 0 however the ladder is scored."""
+
+    def test_the_ladder_is_on_the_floor_today(self, empty_state) -> None:
+        assert assess_fair_maturity(empty_state).dsm_level == 0
+
+    def test_the_ladder_stays_on_the_floor_when_scored_from_the_graph(
+        self, empty_state, empty_graph
+    ) -> None:
+        """The anti-inflation pin (see this module's docstring).
+
+        Porting DSM-1-C1 and DSM-1-R0 to the graph without rewriting their
+        predicates flips this to 1 or more — and would flip 12 real crates off the
+        floor for free. Expect published scores to go DOWN, never up, when a check
+        moves to the graph.
+        """
+        assert assess_fair_maturity(empty_state, graph=empty_graph).dsm_level == 0
+
+
+class TestTheNewPredicatesDiscriminate:
+    """The other half of the rule: each check must be able to *pass*, too.
+
+    Replacing a tautology with a predicate that is false on every crate would swap
+    one useless indicator for its mirror image and still look like progress — the
+    suite would go green either way. These build the passing case explicitly, by
+    supplying the one thing each check asks for, so "false everywhere" cannot be
+    mistaken for "correctly strict".
+
+    They are written as mutations of an assembled crate rather than as pins on a
+    fixture's score, because the crates on hand are essentially one deposit
+    (S-VHPS22) and a threshold tuned to them would not survive the next one.
+    """
+
+    @staticmethod
+    def _crate() -> dict:
+        """A crate with a payload File, a bound column, and a described subject."""
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "@type": "CreativeWork", "about": {"@id": "./"}},
+                {
+                    "@id": "./",
+                    "@type": "Dataset",
+                    "name": "Thyroid uptake assay",
+                    "description": "MCT8-MDCK1 uptake of T3 across eight doses.",
+                    "datePublished": "2026-01-01",
+                    "license": {"@id": "https://creativecommons.org/licenses/by/4.0/"},
+                    "identifier": "10.6019/S-VHPS21",
+                    "author": {"@id": "https://orcid.org/0000-0002-1825-0097"},
+                    "hasPart": [{"@id": "data/uptake.csv"}],
+                },
+                {"@id": "data/uptake.csv", "@type": ["File", "csvw:Table"], "name": "uptake.csv"},
+                {
+                    "@id": "#col_dose",
+                    "@type": "csvw:Column",
+                    "propertyUrl": "http://purl.obolibrary.org/obo/CHEBI_23888",
+                },
+                {
+                    "@id": "#MolecularEntity_t3",
+                    "@type": "MolecularEntity",
+                    "name": "Triiodothyronine",
+                    "identifier": "CHEBI:18258",
+                },
+            ]
+        }
+
+    def _verdict(self, name: str, graph: dict):
+        from builder.tools.assessment_graph import as_verdict
+        from builder.tools.fair_assessment import FAIR_CHECKS
+
+        return as_verdict(FAIR_CHECKS[name](CrateState(), graph)).value
+
+    def test_all_five_pass_on_a_crate_that_earns_them(self) -> None:
+        graph = self._crate()
+        for name in (
+            "pid_form",
+            "every_entity_has_id",
+            "metadata_refs_data",
+            "fair_vocabularies",
+            "reuse_attributes",
+        ):
+            assert self._verdict(name, graph) is True, f"{name} cannot pass at all"
+
+    def test_dropping_the_root_pid_fails_both_identifier_indicators(self) -> None:
+        """F1-01M and F1-02D share one root cause and must move together: nothing
+        writes a DOI to the root, so relative File paths compose against nothing."""
+        graph = self._crate()
+        next(n for n in graph["@graph"] if n["@id"] == "./").pop("identifier")
+        assert self._verdict("pid_form", graph) is False
+        assert self._verdict("every_entity_has_id", graph) is False
+
+    def test_a_file_carrying_its_own_iri_is_identified_without_a_root_pid(self) -> None:
+        """The other way to satisfy F1-02D — how a crate referencing data held in an
+        external repository (GEO, PRIDE) earns it."""
+        graph = self._crate()
+        next(n for n in graph["@graph"] if n["@id"] == "./").pop("identifier")
+        file_node = next(n for n in graph["@graph"] if n["@id"] == "data/uptake.csv")
+        file_node["contentUrl"] = "https://ftp.ebi.ac.uk/biostudies/uptake.csv"
+        assert self._verdict("every_entity_has_id", graph) is True
+
+    def test_a_crate_with_no_payload_names_no_data(self) -> None:
+        """The ISA backbone trap: hasPart is still non-empty, and F3-01M still fails."""
+        graph = self._crate()
+        root = next(n for n in graph["@graph"] if n["@id"] == "./")
+        root["hasPart"] = [{"@id": "#Study_s1"}]
+        graph["@graph"].append({"@id": "#Study_s1", "@type": "Dataset", "additionalType": "Study"})
+        assert root["hasPart"], "the trap only bites while hasPart is non-empty"
+        assert self._verdict("metadata_refs_data", graph) is False
+
+    def test_unbound_columns_fail_the_vocabulary_indicator(self) -> None:
+        graph = self._crate()
+        next(n for n in graph["@graph"] if n["@id"] == "#col_dose").pop("propertyUrl")
+        assert self._verdict("fair_vocabularies", graph) is False
+
+    def test_a_missing_licence_fails_reuse_however_many_other_attributes_there_are(
+        self,
+    ) -> None:
+        """Anchored on the four RO-Crate requires, not on a count — so a crate cannot
+        buy its way past a missing licence with keywords and a contact point."""
+        graph = self._crate()
+        root = next(n for n in graph["@graph"] if n["@id"] == "./")
+        root.pop("license")
+        root |= {
+            "keywords": ["thyroid"],
+            "publisher": {"@id": "#org"},
+            "citation": {"@id": "#paper"},
+            "contactPoint": {"@id": "#person"},
+        }
+        assert self._verdict("reuse_attributes", graph) is False
+
+    def test_a_name_only_subject_fails_reuse(self) -> None:
+        """"Nobody can reuse a chemical identified only by a common name."""
+        graph = self._crate()
+        next(n for n in graph["@graph"] if n["@id"] == "#MolecularEntity_t3").pop("identifier")
+        assert self._verdict("reuse_attributes", graph) is False
+
+
+class TestTheAnswerIsReproducibleFromTheCrateAlone:
+    """#670's second defect: a reader holding only the JSON must get our numbers.
+
+    All five checks now read the graph, so a reader scoring the published crate with
+    an empty CrateState gets exactly what the report says.
+    """
+
+    def test_a_reader_with_no_session_state_gets_the_same_verdicts(self) -> None:
+        graph = TestTheNewPredicatesDiscriminate._crate()
+        ours = assess_fair_maturity(_empty_crate(), graph=graph)
+        theirs = assess_fair_maturity(CrateState(), graph=graph)
+        mine = {r["id"]: r["passed"] for r in ours.indicator_results}
+        yours = {r["id"]: r["passed"] for r in theirs.indicator_results}
+        differing = {k: (mine[k], yours[k]) for k in mine if mine[k] != yours[k]}
+        assert not differing, (
+            f"these indicators still depend on session state a reader never sees: "
+            f"{differing}"
+        )
+
+    def test_without_a_graph_they_say_not_assessed_rather_than_guess(self) -> None:
+        """"Not assessed" leaves the denominator; False counts against the crate."""
+        results = {
+            r["id"]: r["passed"]
+            for r in assess_fair_maturity(_empty_crate()).indicator_results
+        }
+        for indicator in (
+            "RDA-F1-01M",
+            "RDA-F1-02D",
+            "RDA-F3-01M",
+            "RDA-I1-01M",
+            "RDA-I1-02M",
+            "RDA-I2-01M",
+            "RDA-R1-01M",
+            "RDA-R1.2-01M",
+            "RDA-R1.3-01M",
+            "RDA-R1.3-02M",
+        ):
+            assert results[indicator] is None, (
+                f"{indicator} answered {results[indicator]!r} with no crate to read"
+            )


### PR DESCRIPTION
Closes part of #670 — the RDA half. The DSM half (24 remaining tautologies) is not in this PR.

## The defect

A crate holding two empty entities and no payload **met 9 of the 18** assessed RDA indicators, including *"Plurality of accurate and relevant attributes are provided to allow reuse"* over two entities whose `fields` are `{}`.

```bash
uv run python -c "
from builder.state import CrateState, Entity, EntityProvenance
from builder.tools.fair_assessment import assess_fair_maturity
junk = CrateState()
for n in (1, 2):
    junk.add_entity(Entity(entity_id=f'e{n}', type='Investigation' if n==1 else 'Study',
                           fields={}, _provenance=EntityProvenance(created_by='llm')))
print(sum(1 for r in assess_fair_maturity(junk).indicator_results if r['passed'] is True))"
```

Eleven checks were literally `len(state.list_entities()) > 0` — they scored that the builder had run. And they read `CrateState`, never published, so a reader scoring the crate from its JSON could not reach our number.

## What changed

Four checks now ask their published question of the assembled `@graph`:

| Indicator | Now asks |
|---|---|
| `RDA-F1-02D` | of the **payload Files**, not of every entity the session holds |
| `RDA-F3-01M` | that **payload** is named — the ISA backbone always mints a Study Dataset into `hasPart`, so "hasPart resolves" is a tautology too |
| `RDA-I2-01M` | the share of term-bearing nodes bound to a resolvable vocabulary, published as evidence |
| `RDA-R1-01M` | the four attributes RO-Crate requires of a root, plus two more, plus a majority of subjects described beyond a bare name |

Five more move to the graph **without changing any verdict** — they could already answer honestly on an empty crate but answered from session state: `F1-01M`, `I1-01M`/`I1-02M`, `R1.2-01M`, `R1.3-01M`/`R1.3-02M`, and `DSM-3-R3` (the same question as R1.3-01M, so the same function). Given no graph they answer **not assessed** rather than guess.

## Measured, over 38 real sessions

| | before | after |
|---|---|---|
| empty crate | 9 met | **5 met** |
| median session | 15 met | **14 met** |
| distribution | `{9:1, 12:2, 14:1, 15:28, 16:6}` | `{5:1, 10:2, 12:1, 13:9, 14:21, 15:4}` |
| DSM level | `{0:32, 2:6}` | **unchanged** |

Scores go **down**, and the ladder does not move. Porting a tautology to the graph would have raised it — `DSM-1-C1` and `DSM-1-R0` alone lift twelve crates a level for free — which `test_the_ladder_stays_on_the_floor_when_scored_from_the_graph` exists to catch.

## Thresholds are anchored to the specs, not to the corpus

An earlier cut passed `I2-01M` at a 0.7 bound ratio — **precisely the median of the crates on disk**, which are 22 builds of one deposit (S-VHPS22) plus two of another. That is fitting a threshold to one deposit, and it would not survive the next one. The root check now names the four attributes RO-Crate itself requires, and both ratio limbs are a stated majority rather than a fitted cut.

## Two things worth a reviewer's eye

- **`RDA-F1-02D` reads False on every crate here**, because nothing writes a DOI to the root — the same root cause as `RDA-F1-01M`, and the two flip together when it is fixed. `TestTheNewPredicatesDiscriminate` builds the passing cases explicitly so "correctly strict" cannot be confused with "false by construction".
- **Re-derived pins, deliberately.** The golden S-VHPS21 crate goes **13 met / 5 failed → 11 / 7**, now scored with the graph as both production callers do. `F1-02D` fails (crate-relative File paths, no root PID); `R1-01M` fails (no licence on the root; 1 of 4 subjects described beyond a name). `dsm_level` stays 2.

## Tests

`tests/test_fair_metrics_can_fail.py` is the definition of done, written before any check changed. It pins the floor in both directions: every indicator whose published text names *the data* must read False on an empty crate, and the packaging indicators it may legitimately meet are enumerated with reasons — so a new tautology cannot slip in unnamed, and a rewrite that fixes them by making everything strict is caught too.

Full suite green (3381 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)