### PR TITLE
fix(report): a layer cannot conform where the layer it extends does not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1995,6 +1995,33 @@ a green zero; REQUIRED/RECOMMENDED issue text is still surfaced as `Must fix` / 
 suggestions. Rendering this from `state.validation` alone (no new validation machinery) keeps the
 pure/cheap contract.
 
+**Conformance is cumulative, because the profile is a stack.** The packaging (RO-Crate) and
+structural (ISA) layers are adopted as published and the domain layer refines them, so
+interoperability is inherited rather than rebuilt and a conforming crate is *simultaneously* a valid
+RO-Crate and an ISA-structured object. The matrix therefore reports each row over `_LAYER_CHAIN` —
+its own checks **and** every layer it extends. Grading each layer in isolation showed the
+contradiction that motivated this: a real crate reported ISA failing REQUIRED on 11 findings while
+ISA-Tox, judged on its own 35 checks and blind to the 140 it inherits, passed clean. Nothing may now
+pass a tier a layer beneath it fails, and a cell whose findings are not its own says so — *"11
+findings at this level, 11 inherited"* — so a reader knows which layer to fix.
+
+The rule lives in `state.conformance_by_layer` / `PROFILE_LAYER_CHAIN`, and **every** surface that
+paints conformance composes through it rather than reading the three per-pass flags raw: the
+matrix, the `prof-card` REQUIRED cards, the TUI status dots (`● base ○ ISA ● Tox` said the crate
+failed ISA and passed ISA-Tox), the TUI summary and conformance lines, `dashboard`'s
+`✓ Base ✗ ISA ✓ Tox`, and `session`'s `validation_status`. Each raw flag reports only what its own
+layer ADDS, which is a fact about the pass and not about the crate; six places restated it and all
+six drew the same impossible picture.
+
+This is also what makes the OPTIONAL column answerable. ISA and our tox profile declare no `sh:Info`
+shape of their own, so in isolation that column was a permanent dash reading as *"this level does
+not apply"* — false for a profile whose conformance includes RO-Crate's twelve MAY checks. It is
+composed from the per-layer verdicts rather than by enabling the validator's own inherited
+reporting: ISA is 1.1-lineage while the base pass runs 1.2, so inherited reporting mixes two
+versions of one spec (measured: 25 findings under `isa` overlapping the base pass's 17 in only 6 —
+neither superset nor partition). Upstream tracks the version bump as crs4/rocrate-validator#194;
+composing needs no re-validation and cannot mix spec versions.
+
 **A verdict states the ground it stands on (#530).** "Is every declared Data Entity part of the
 payload?" is REQUIRED by the base profile and answerable only where the payload exists — the
 in-memory gate validates a document, so that check emits *nothing* there, and its silence must never

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -42,6 +42,11 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+# A pure helper over three booleans, not a coupling to the engine: the renderers
+# stay unit-testable, and the one rule for what "conforms" means lives in one
+# place rather than being restated at every surface that paints it.
+from builder.state import conformance_by_layer
+
 if TYPE_CHECKING:
     from builder.engine import AgentEngine
 
@@ -558,13 +563,18 @@ def render_status_markup(snap: UiSnapshot, *, highlight: dict[str, str] | None =
             )
         )
 
+    # Cumulative, never the raw per-pass flags: a layer cannot pass where the
+    # layer it extends fails, and `● base ○ ISA ● Tox` said exactly that.
+    conforms = conformance_by_layer(
+        base=snap.base_passed, isa=snap.isa_passed, tox=snap.tox_passed
+    )
     return (
         f"{field('session', snap.session_id)}  {_SEP}  "
         f"{field('entities', f'{snap.entity_count} entities')}  {_SEP}  "
         f"{field(*_work_field(snap))}  {_SEP}  "
-        f"{_dot(snap.base_passed)} {field('base', 'base')}  "
-        f"{_dot(snap.isa_passed)} {field('isa', 'ISA')}  "
-        f"{_dot(snap.tox_passed)} {field('tox', 'Tox')}"
+        f"{_dot(conforms['base'])} {field('base', 'base')}  "
+        f"{_dot(conforms['isa'])} {field('isa', 'ISA')}  "
+        f"{_dot(conforms['tox'])} {field('tox', 'Tox')}"
         f"{token_str}"
     )
 
@@ -742,10 +752,13 @@ def render_resume_summary(snap: UiSnapshot, *, resumed: bool) -> RenderableType:
         mit_text, mit_color = format_mit_coverage(snap.mit_score, assessed=True)
         summary.add_row("MIT score:", f"[{mit_color}]{mit_text}[/{mit_color}]")
 
+    conforms = conformance_by_layer(
+        base=snap.base_passed, isa=snap.isa_passed, tox=snap.tox_passed
+    )
     val_status = [
-        "[green]base[/green]" if snap.base_passed else "[red]base[/red]",
-        "[green]ISA[/green]" if snap.isa_passed else "[red]ISA[/red]",
-        "[green]ISA-Tox[/green]" if snap.tox_passed else "[red]ISA-Tox[/red]",
+        f"[{'green' if conforms[layer] else 'red'}]{label}"
+        f"[/{'green' if conforms[layer] else 'red'}]"
+        for layer, label in (("base", "base"), ("isa", "ISA"), ("tox", "ISA-Tox"))
     ]
     summary.add_row("Validation:", "  ".join(val_status))
 
@@ -803,13 +816,13 @@ def render_goodbye(
 
         # Only report a tier that actually ran: "0 recommended issues" would
         # otherwise claim a clean bill of health for checks nobody performed.
+        composed = conformance_by_layer(
+            base=snap.base_passed, isa=snap.isa_passed, tox=snap.tox_passed
+        )
         conformance = "  ".join(
-            f"[{'green' if ok else 'red'}]{label}[/{'green' if ok else 'red'}]"
-            for label, ok in (
-                ("base", snap.base_passed),
-                ("ISA", snap.isa_passed),
-                ("Tox", snap.tox_passed),
-            )
+            f"[{'green' if composed[layer] else 'red'}]{label}"
+            f"[/{'green' if composed[layer] else 'red'}]"
+            for layer, label in (("base", "base"), ("isa", "ISA"), ("tox", "Tox"))
         )
         open_counts: list[str] = [
             f"[red]{snap.required_issue_count} required[/red]"

--- a/builder/state.py
+++ b/builder/state.py
@@ -660,6 +660,36 @@ class CrateMetadata:
         )
 
 
+# Each profile layer, and every layer it is adopted on top of. The profile is a
+# stack: the packaging (RO-Crate) and structural (ISA) layers are adopted as
+# published and the domain layer refines them, so interoperability is inherited
+# rather than rebuilt and a conforming crate is simultaneously a valid RO-Crate
+# and an ISA-structured object. Conformance is therefore CUMULATIVE, and every
+# surface that reports it — the maturity report's matrix and REQUIRED cards, the
+# TUI's status dots — composes through here rather than reading the three
+# per-pass flags raw. Each flag reports only what its own layer ADDS, so reading
+# them raw let a crate show ISA failing while ISA-Tox passed.
+PROFILE_LAYER_CHAIN: dict[str, tuple[str, ...]] = {
+    "base": ("base",),
+    "isa": ("base", "isa"),
+    "tox": ("base", "isa", "tox"),
+}
+
+
+def conformance_by_layer(*, base: bool, isa: bool, tox: bool) -> dict[str, bool]:
+    """Each layer's conformance, INCLUDING every layer it is adopted on top of.
+
+    The arguments are the raw per-pass verdicts — what each layer's own checks
+    said. The result is what "this crate conforms to X" actually means, and it
+    is monotone by construction: nothing passes where a layer beneath it fails.
+    """
+    own = {"base": base, "isa": isa, "tox": tox}
+    return {
+        layer: all(own[beneath] for beneath in chain)
+        for layer, chain in PROFILE_LAYER_CHAIN.items()
+    }
+
+
 @dataclass
 class ValidationReport:
     """Results from the three-pass SHACL validation.

--- a/builder/tools/dashboard.py
+++ b/builder/tools/dashboard.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 import builder.config as _config
+from builder.state import conformance_by_layer
 
 logger = logging.getLogger(__name__)
 
@@ -372,9 +373,15 @@ def _build_cratestate_panel(
 
     # Validation status
     val = state.get("validation", {})
-    base_ok = val.get("base_passed", False)
-    isa_ok = val.get("isa_passed", False)
-    tox_ok = val.get("tox_passed", False)
+    # Cumulative, not the raw per-pass flags: each flag reports only what its
+    # own layer adds, so reading them raw painted "✓ Base ✗ ISA ✓ Tox" — which
+    # cannot happen for a stack where ISA-Tox is adopted on top of ISA.
+    conforms = conformance_by_layer(
+        base=val.get("base_passed", False),
+        isa=val.get("isa_passed", False),
+        tox=val.get("tox_passed", False),
+    )
+    base_ok, isa_ok, tox_ok = conforms["base"], conforms["isa"], conforms["tox"]
     required_count = len(val.get("required_issues", []))
     val_parts = [
         f"{'✓' if base_ok else '✗'} Base",

--- a/builder/tools/session.py
+++ b/builder/tools/session.py
@@ -13,7 +13,7 @@ import os
 import tempfile
 
 import builder.config as _config
-from builder.state import CrateState
+from builder.state import CrateState, conformance_by_layer
 
 logger = logging.getLogger(__name__)
 
@@ -149,11 +149,12 @@ def get_status(state: CrateState) -> dict:
         "entity_counts": entity_counts,
         "total_entities": total_entities,
         "mit_score": state.mit_assessment.overall_score,
-        "validation_status": {
-            "base": state.validation.base_passed,
-            "isa": state.validation.isa_passed,
-            "tox": state.validation.tox_passed,
-        },
+        # Cumulative: a layer cannot conform where the layer it extends does not.
+        "validation_status": conformance_by_layer(
+            base=state.validation.base_passed,
+            isa=state.validation.isa_passed,
+            tox=state.validation.tox_passed,
+        ),
         "iteration_count": state.iteration_count,
         "stuck": state.stuck,
         "last_action": last_action,

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -50,6 +50,7 @@ from pathlib import Path
 from typing import Any
 
 from builder.state import (
+    PROFILE_LAYER_CHAIN,
     AIRReport,
     CrateState,
     FAIRReport,
@@ -704,9 +705,17 @@ def _profile_matrix_tile(
     mark with the finding count on its ``title``. An unassessed tier — and every
     cell of a stale or never-run verdict — is the neutral mark, never a green.
 
-    So is a tier the profile defines no check at (:func:`_tier_capability`): a
-    green there would report the profile's silence as the crate's cleanliness.
-    Only a tier that could have failed is allowed to pass."""
+    So is a tier NOTHING in the stack defines a check at
+    (:func:`_tier_capability`): a green there would report the profiles' silence
+    as the crate's cleanliness. Only a tier that could have failed may pass.
+
+    Each row is cumulative over :data:`~builder.state.PROFILE_LAYER_CHAIN` — its
+    own checks and every layer it extends — because that is what conformance to
+    a layered profile means. It is also what makes the OPTIONAL column answerable at all: ISA and
+    ISA-Tox declare no ``sh:Info`` shape of their own, but they extend a profile
+    that declares twelve, and a crate conforming to ISA-Tox conforms to those
+    too. Reporting each layer in isolation left that column a permanent dash,
+    which reads as "this level does not apply" rather than "inherited"."""
     heads = "".join(f'<span class="pmx-h">{t.capitalize()}</span>' for t in _TIER_KEYS)
     rows = ""
     counts = _profile_tier_counts(val if tiers is not None else None)
@@ -717,30 +726,39 @@ def _profile_matrix_tile(
         "tox": val.tox_passed if val else False,
     }
     for key, label in _PROFILE_LAYERS:
+        chain = PROFILE_LAYER_CHAIN[key]
         cells = ""
         for tier in _TIER_KEYS:
-            n = counts.get(key, {}).get(tier, 0)
+            own = counts.get(key, {}).get(tier, 0)
+            n = sum(counts.get(layer, {}).get(tier, 0) for layer in chain)
+            inherited = n - own
+            tail = f", {inherited} inherited" if inherited else ""
             if tiers is None:
                 state, title = "na", "not yet validated"
             elif stale:
                 state, title = "na", "recorded before the crate&rsquo;s latest changes"
             elif tier not in assessed:
                 state, title = "na", "not assessed at this level"
-            elif tier == "required" and not passed[key]:
+            elif tier == "required" and not all(passed[layer] for layer in chain):
                 state = "no"
                 title = (
-                    f"{n} finding{'s' if n != 1 else ''} at this level"
+                    f"{n} finding{'s' if n != 1 else ''} at this level{tail}"
                     if n
-                    else "profile gate failed"
+                    else (
+                        "profile gate failed"
+                        if not passed[key]
+                        else "a profile it extends did not pass"
+                    )
                 )
             elif n:
-                state, title = "no", f"{n} finding{'s' if n != 1 else ''} at this level"
-            elif tier not in _tier_capability().get(key, frozenset()):
-                # The profile has no rule at this level, so an empty result here
-                # is the profile's silence, not the crate's cleanliness (#620).
-                # Ranked below the count: a finding filed at such a tier — by a
-                # local checker, or by a checkpoint from a profile version that
-                # did have rules here — is still a finding, and still shows.
+                state = "no"
+                title = f"{n} finding{'s' if n != 1 else ''} at this level{tail}"
+            elif not any(tier in _tier_capability().get(layer, frozenset()) for layer in chain):
+                # Nothing in the stack has a rule at this level, so an empty
+                # result is the profiles' silence rather than the crate's
+                # cleanliness (#620). Ranked below the count: a finding filed at
+                # such a tier — by a local checker, or by a checkpoint from a
+                # profile version that did have rules here — is still a finding.
                 state, title = "none", "no checks defined at this level"
             else:
                 state, title = "ok", "no findings at this level"
@@ -1069,6 +1087,7 @@ _PROFILE_LAYERS: tuple[tuple[str, str], ...] = (
     ("tox", "ISA-Tox"),
 )
 
+
 # How many findings of each tier the suggestion list shows before it summarises
 # the rest. REQUIRED is uncapped: those block conformance, so every one is named.
 # With grouped rendering (#510) the advisory caps apply per profile group — the
@@ -1333,10 +1352,15 @@ def _render_profile_section(
             "</section>\n"
         )
 
+    # Cumulative, on the same terms as the matrix (`PROFILE_LAYER_CHAIN`): these
+    # cards are the same conformance claim in a second place, and a card reading
+    # "ISA-Tox met" beside a cell reading "ISA-Tox not met" is the report
+    # contradicting itself.
     passed_by_layer = {"base": val.base_passed, "isa": val.isa_passed, "tox": val.tox_passed}
     cards = "".join(
-        f'<div class="prof-card">{_mk(_kind(passed_by_layer[key]))}<span>{esc(name)}</span>'
-        "<em>REQUIRED</em></div>"
+        f'<div class="prof-card">'
+        f"{_mk(_kind(all(passed_by_layer[layer] for layer in PROFILE_LAYER_CHAIN[key])))}"
+        f"<span>{esc(name)}</span><em>REQUIRED</em></div>"
         for key, name in _PROFILE_LAYERS
     )
     severity_detail = _render_severity_detail(val, tiers)

--- a/profiles/validator.py
+++ b/profiles/validator.py
@@ -505,10 +505,19 @@ def tiers_defined(layer: str) -> frozenset[str]:
 
     Read from the validator's own profile registry — the same objects the pass
     runs — rather than from a hand-kept list, so a profile that gains a MAY rule
-    is honoured the day it does. Inherited requirements count only where the pass
-    reports them: ``isa`` and ``tox`` run with
-    ``disable_inherited_profiles_issue_reporting``, so an inherited MAY rule could
-    not surface under those layers.
+    is honoured the day it does. This reports what a layer's own PASS can emit:
+    ``isa`` and ``tox`` run with ``disable_inherited_profiles_issue_reporting``,
+    so an inherited MAY rule cannot surface under those layers here.
+
+    That suppression stays, and it is not the report's answer to inheritance.
+    The ISA profile is 1.1-lineage while the base pass runs 1.2, so reporting
+    inherited findings under ``isa`` mixes two versions of one spec: measured on
+    a real crate it yields 25 findings under ``isa`` overlapping the base pass's
+    17 in only 6 — neither a superset nor a partition. Upstream tracks the bump
+    (crs4/rocrate-validator#194). Until it lands, the maturity report composes
+    conformance from these per-layer results instead, through
+    ``maturity_report._LAYER_CHAIN``, which needs no re-validation and cannot mix
+    spec versions.
 
     Args:
         layer: A key of :data:`_PROFILE_PASSES` ("base" | "isa" | "tox").

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -641,23 +641,136 @@ class TestProfileConformanceMatrix:
         for profile in ("base", "isa", "tox"):
             assert cells[f"{profile}-optional"][0] == "na"
 
-    def test_a_tier_the_profile_defines_no_checks_at_is_neutral_not_green(self) -> None:
-        """ISA and ISA-Tox declare no MAY (``sh:Info``) shape at all, so their
-        OPTIONAL column can only ever come back empty. Reading that emptiness as
-        "no findings at this level" reports the profile's own silence as the
-        crate's clean bill of health (#620): the cell says "no checks defined"
-        instead, and only the base profile — which does define MAY checks — can
-        earn a green there."""
+    def test_a_tier_nothing_in_the_stack_checks_is_neutral_not_green(
+        self, monkeypatch
+    ) -> None:
+        """#620's guarantee, restated for a cumulative matrix.
+
+        It used to be reachable through ISA's OPTIONAL column, because ISA
+        declares no ``sh:Info`` shape of its own. Now that a row reports what it
+        inherits, that column is answered by the base profile's twelve, and the
+        state is only reached when NOTHING in the stack checks a tier — an
+        unreadable profile registry, or a tier every layer drops. Empty is still
+        never a green: a profile's silence is not the crate's cleanliness.
+        """
+        import builder.writers.maturity_report as report
+
+        monkeypatch.setattr(
+            report, "_tier_capability", lambda: {k: frozenset() for k, _ in report._PROFILE_LAYERS}
+        )
         val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
         val.assessed_tiers = {"required", "recommended", "optional"}
+
         cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
+        for profile in ("base", "isa", "tox"):
+            assert cells[f"{profile}-optional"] == ("na", "no checks defined at this level")
+
+    def test_a_layer_cannot_pass_where_the_layer_it_extends_fails(self) -> None:
+        """Conformance is cumulative, and the matrix has to say so.
+
+        The profile is a three-layer stack in which each layer is adopted on top
+        of the one below — "interoperability is inherited rather than rebuilt",
+        so a conforming crate "is simultaneously a valid RO-Crate and an
+        ISA-structured object". A real report showed ISA failing REQUIRED while
+        ISA-Tox passed it, which under that architecture cannot happen: ISA-Tox
+        was graded on its own 35 checks while ignoring the 140 it inherits.
+        """
+        val = ValidationReport(base_passed=True, isa_passed=False, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        val.issue_records = [
+            {"profile": "isa", "severity": "required", "entity_id": "#a", "message": "m"},
+        ]
+
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
+        assert cells["isa-required"][0] == "no"
+        assert cells["tox-required"][0] == "no", cells["tox-required"]
+
+    def test_an_inherited_finding_shows_in_the_layers_above_it(self) -> None:
+        val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        val.issue_records = [
+            {"profile": "base", "severity": "recommended", "entity_id": "#a", "message": "m"},
+        ]
+
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
+        assert cells["base-recommended"][0] == "no"
+        assert cells["isa-recommended"][0] == "no", cells["isa-recommended"]
+        assert cells["tox-recommended"][0] == "no", cells["tox-recommended"]
+
+    def test_the_optional_level_is_inherited_rather_than_absent(self) -> None:
+        """ISA and ISA-Tox declare no MAY shape of their own, but they extend a
+        profile that does — so their OPTIONAL cell reports what they inherit,
+        not a dash. A dash there reads as "this level does not apply", which is
+        false for a profile whose conformance includes RO-Crate's."""
+        val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
         assert cells["base-optional"] == ("ok", "no findings at this level")
-        assert cells["isa-optional"] == ("na", "no checks defined at this level")
-        assert cells["tox-optional"] == ("na", "no checks defined at this level")
-        # A tier all three DO define checks at is untouched: a clean sweep there
-        # is a real result, and still reads as one.
-        assert cells["isa-recommended"] == ("ok", "no findings at this level")
-        assert cells["tox-required"] == ("ok", "no findings at this level")
+        assert cells["isa-optional"][0] == "ok", cells["isa-optional"]
+        assert cells["tox-optional"][0] == "ok", cells["tox-optional"]
+
+    def test_an_inherited_optional_finding_fails_the_rows_that_inherit_it(self) -> None:
+        val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        val.issue_records = [
+            {"profile": "base", "severity": "optional", "entity_id": "#a", "message": "m"},
+        ]
+
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
+        assert cells["isa-optional"][0] == "no", cells["isa-optional"]
+        assert cells["tox-optional"][0] == "no", cells["tox-optional"]
+
+    def test_the_title_says_when_the_findings_were_inherited(self) -> None:
+        """A reader fixing ISA-Tox needs to know the failure is not ISA-Tox's."""
+        val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        val.issue_records = [
+            {"profile": "isa", "severity": "recommended", "entity_id": "#a", "message": "m"},
+        ]
+
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
+        assert "inherited" in cells["tox-recommended"][1], cells["tox-recommended"]
+        assert "inherited" not in cells["isa-recommended"][1], cells["isa-recommended"]
+
+    def test_the_base_row_still_reports_only_itself(self) -> None:
+        """It is the bottom of the stack: there is nothing beneath it to inherit."""
+        val = ValidationReport(base_passed=True, isa_passed=False, tox_passed=False)
+        val.assessed_tiers = {"required", "recommended", "optional"}
+        val.issue_records = [
+            {"profile": "isa", "severity": "required", "entity_id": "#a", "message": "m"},
+            {"profile": "tox", "severity": "required", "entity_id": "#b", "message": "m"},
+        ]
+
+        cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
+
+        assert cells["base-required"] == ("ok", "no findings at this level")
+
+    def test_the_profile_cards_agree_with_the_matrix(self) -> None:
+        """The REQUIRED cards are the same claim in a second place, so they
+        inherit the same way. A card reading "ISA-Tox met" beside a matrix cell
+        reading "ISA-Tox not met" would be the report contradicting itself."""
+        import re as _re
+
+        val = ValidationReport(base_passed=True, isa_passed=False, tox_passed=True)
+        val.assessed_tiers = {"required"}
+
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val)
+        cards = _re.findall(
+            r'<div class="prof-card"><span class="mk (\w+)"[^>]*>[^<]*</span><span>([^<]+)</span>',
+            page,
+        )
+        by_name = {name: mark for mark, name in cards}
+
+        assert by_name, page[:400]
+        assert by_name["ISA"] == "no"
+        assert by_name["ISA-Tox"] == "no", by_name
 
     def test_a_finding_outranks_the_no_checks_state(self) -> None:
         """A finding filed at a tier the profile defines no checks at — a
@@ -687,7 +800,11 @@ class TestProfileConformanceMatrix:
         val.assessed_tiers = {"required"}
         cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
         assert cells["base-required"] == ("no", "profile gate failed")
-        assert cells["isa-required"][0] == "ok"
+        # And it carries: ISA and ISA-Tox are adopted on top of RO-Crate, so
+        # neither can be conformant at a tier RO-Crate failed. The cell says the
+        # failure is not its own.
+        assert cells["isa-required"] == ("no", "a profile it extends did not pass")
+        assert cells["tox-required"] == ("no", "a profile it extends did not pass")
 
     def test_a_pre_records_verdict_still_counts_by_profile(self) -> None:
         """A checkpoint written before ``issue_records`` existed carries only
@@ -698,9 +815,9 @@ class TestProfileConformanceMatrix:
         val.should_issues = ["[isa] #a: SHOULD have x", "[isa] #b: SHOULD have y",
                              "[base] ./: SHOULD have z"]
         cells = self._cells(build_maturity_html(vhps_fixture_state("S-VHPS21"), validation=val))
-        assert cells["isa-recommended"] == ("no", "2 findings at this level")
         assert cells["base-recommended"] == ("no", "1 finding at this level")
-        assert cells["tox-recommended"] == ("ok", "no findings at this level")
+        assert cells["isa-recommended"] == ("no", "3 findings at this level, 1 inherited")
+        assert cells["tox-recommended"] == ("no", "3 findings at this level, 3 inherited")
 
     def test_findings_with_no_profile_get_their_own_row(self) -> None:
         val = ValidationReport(base_passed=True, isa_passed=True, tox_passed=True)

--- a/tests/test_status_footer.py
+++ b/tests/test_status_footer.py
@@ -199,3 +199,38 @@ class TestFader:
         )
         assert "issues" in before
         assert before["issues"] != after["issues"]
+
+
+class TestTheDotsCannotContradictThemselves:
+    """`● base  ○ ISA  ● Tox` says the crate fails ISA and passes ISA-Tox.
+
+    It cannot. The profile is a stack — ISA-Tox is adopted on top of ISA, which
+    is adopted on top of RO-Crate — so conformance is cumulative and a layer
+    cannot pass where the layer it extends fails. The footer read the three
+    per-pass flags raw, each of which reports only what its own layer adds.
+    """
+
+    def test_a_layer_cannot_pass_where_the_one_it_extends_fails(self) -> None:
+        markup = render_status_markup(_snap(base_passed=True, isa_passed=False, tox_passed=True))
+
+        dots = re.findall(r"\[(green|grey50)\]([●○])\[/\1\]", markup)
+        assert len(dots) == 3, markup
+        assert [d[1] for d in dots] == ["●", "○", "○"], markup
+
+    def test_a_whole_stack_that_passes_is_untouched(self) -> None:
+        markup = render_status_markup(_snap(base_passed=True, isa_passed=True, tox_passed=True))
+
+        assert [d[1] for d in re.findall(r"\[(green|grey50)\]([●○])\[/\1\]", markup)] == [
+            "●",
+            "●",
+            "●",
+        ], markup
+
+    def test_a_failing_base_takes_every_layer_with_it(self) -> None:
+        markup = render_status_markup(_snap(base_passed=False, isa_passed=True, tox_passed=True))
+
+        assert [d[1] for d in re.findall(r"\[(green|grey50)\]([●○])\[/\1\]", markup)] == [
+            "○",
+            "○",
+            "○",
+        ], markup


### PR DESCRIPTION
## The report contradicted itself

`output/svhps22_real_input_crate_v21`:

```
ISA       required  11 findings  ->  ✗ not conformant
ISA-Tox   required   0 findings  ->  ✓ conformant
```

ISA-Tox is adopted on top of ISA, so that cannot be true. It was graded on its
own 35 checks while blind to the **140 it inherits**.

The same picture was drawn by the TUI (`● base ○ ISA ● Tox`) and the dashboard
(`✓ Base ✗ ISA ✓ Tox`).

## Cause

Every surface read the three per-pass flags raw. Each flag reports only what its
own layer **adds** — a fact about the validation pass, not about the crate.

The Methods section states the architecture plainly: the packaging and
structural layers are *"adopted as published"*, *"interoperability is inherited
rather than rebuilt"*, and a conforming crate is *"simultaneously a valid
RO-Crate and an ISA-structured object"*. Conformance is cumulative; nothing said
so.

The ordering contract was even already written down, above `_PROFILE_LAYERS`:
*"base must pass before ISA is meaningful, ISA before ISA-Tox"*. It just was
never enforced.

## Fix

The rule now lives **once**, in `state.conformance_by_layer` /
`PROFILE_LAYER_CHAIN`. Six surfaces compose through it instead of restating it:

| surface | was |
|---|---|
| report — profile matrix | `tox-required` ✓ beside `isa-required` ✗ |
| report — REQUIRED cards | "ISA-Tox met" beside "ISA not met" |
| TUI — status dots | `● base ○ ISA ● Tox` |
| TUI — summary row | red/green per raw flag |
| TUI — conformance line | red/green per raw flag |
| `dashboard` | `✓ Base ✗ ISA ✓ Tox` |
| `session.validation_status` | raw flags in the payload |

The matrix also sums findings across the chain and says when they are not the
row's own, so a reader knows which layer to fix:

```
isa-required       no    11 findings at this level
tox-required       no    11 findings at this level, 11 inherited
isa-optional       no    210 findings at this level, 210 inherited
```

## This is what makes the OPTIONAL column answerable

ISA and our tox profile declare **no `sh:Info` shape of their own**, so in
isolation that column was a permanent dash tooltipped *"no checks defined at
this level"* — which reads as *"this level does not apply"*. False: their
conformance includes RO-Crate's twelve MAY checks.

## Why not just enable the validator's inherited reporting

Measured, and rejected. ISA is 1.1-lineage while the base pass runs 1.2, so
turning on `disable_inherited_profiles_issue_reporting` mixes two versions of
one spec:

```
base                       17 findings
isa (inheritance on)       25 findings, overlapping base in only 6
                           -> neither a superset nor a partition
```

Upstream tracks the bump as crs4/rocrate-validator#194 (open, no activity).
Composing from the per-layer verdicts needs no re-validation and cannot mix spec
versions, so the flag is left exactly as it was — now with the reasoning
recorded next to it.

## #620 is preserved, and had to move

Its guarantee — a tier a profile defines no checks at is never a green — used to
be tested *through* ISA's OPTIONAL column. That column now has an answer, so the
state is only reachable when **nothing in the stack** checks a tier (an
unreadable profile registry). The test exercises it there instead of being
quietly unreachable.

## Verification

Full suite: **3524 passed**.

33 failures in `test_llm.py` / `test_agent_loop.py` / `test_llm_reasoning_model.py`
are **pre-existing and unrelated** — the optional `[langchain]` extra is not
installed. Confirmed by stashing this branch's changes and re-running: the same
33 fail on unmodified `main`.

10 new tests, 3 updated to the new contract. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
