### PR TITLE
fix(discovery): the bounded context reaches the agent, and the cap has one home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,18 @@ cannot read. A share too small to carry even the entry's `[kind/class] path` hea
 buys nothing, so that entry is dropped and its share returned rather than emitted as
 a fragment.
 
+**Both arms render through `format_document_context`, and the cap has one home (#675).**
+None of the above reached a model for a while: the engine built the bounded context and
+used the string for its LENGTH in a log line, while each arm re-rolled its own from
+`state.documents` and sliced it to a hardcoded `[:20]`. Measured on S-VHPS22, discovery
+produced 40 candidates balanced 13 metadata / 13 processed / 12 protocol / 2 raw and the
+pipeline sent 26 587 characters — against an 18 000 budget — carrying 4 / 13 / **1** / 2.
+The budget, the header guard and #595's allocation all stopped at the engine. So
+`MAX_DOCUMENT_CANDIDATES` is the only cap, `DocumentationCandidate.from_dict` turns the
+stored dicts back into candidates, and a renderer that wants a different PRESENTATION
+(the ReAct arm's numbered markdown list, which is also the user-facing reply) still takes
+its membership from the same ranking rather than re-deciding what fits.
+
 **The slots are allocated the same way, over the classification (#595).** The cap is
 the agent's whole view of the submission, and it used to be spent on one axis — "how
 document-like is this?" — over a population #591 can classify into four, so whole

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -65,6 +65,10 @@ from typing import TYPE_CHECKING, Any, Callable
 from builder.agents.llm import ModelOverrides, UsageSink, _as_int
 from builder.agents.llm import make_usage_logger as _make_usage_logger
 from builder.config import get_provider
+from builder.tools.document_discovery import (
+    DocumentationCandidate,
+    format_document_context,
+)
 
 # Deterministic given/family split lives in the pure drafter module so the
 # materialize path here and every direct ``draft_person`` call share ONE contract
@@ -558,26 +562,23 @@ def _gather_context(engine: AgentEngine) -> str:
             parts.append("Scanned files:\n" + "\n".join(file_lines))
 
     # Document discovery context (#179): ranked, classified documentation
-    # discovered by the engine after scanning. This is stored as a list of
-    # compact dicts on state and rendered as a concise summary line per doc.
+    # discovered by the engine after scanning, stored on state as compact dicts.
+    # Rendered through the ONE bounded formatter rather than re-rolled here
+    # (#675). Hand-rolling it took `documents[:20]` with `preview[:2000]` each
+    # and no ceiling — 26 587 characters against an 18 000 budget on svhps22,
+    # and half the ranked candidates never named at all. Everything
+    # `format_document_context` decides (the max-min fair character budget of
+    # #587, #591's refusal to emit an entry too small to carry its own filename,
+    # #595's allocation of the slots across the four classes) stopped at the
+    # engine while this ran instead.
     documents = getattr(state, "documents", [])
     if documents:
-        doc_lines: list[str] = []
-        for doc in documents[:20]:
-            role = doc.get("classification", "document")
-            name = doc.get("filename", doc.get("relative_path", "?"))
-            score = doc.get("score", 0.0)
-            reasons = doc.get("reasons", [])
-            reason_str = "; ".join(reasons[:2]) if reasons else ""
-            line = f"[{role}] {name} (score: {score:.2f})"
-            if reason_str:
-                line += f" — {reason_str}"
-            preview = str(doc.get("preview") or "").strip()
-            if preview:
-                line += f"\n{preview[:2000]}"
-            doc_lines.append(line)
-        if doc_lines:
-            parts.append("Discovered documentation:\n" + "\n".join(doc_lines))
+        rendered = format_document_context(
+            [DocumentationCandidate.from_dict(doc) for doc in documents],
+            total_scanned=len(getattr(state, "scanned_files", None) or []),
+        )
+        if rendered:
+            parts.append("Discovered documentation:\n" + rendered)
 
     return "\n\n".join(parts).strip()
 

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -3597,7 +3597,10 @@ def _format_document_context(documents: list[dict[str, Any]] | None) -> str:
     if not documents:
         return ""
     lines: list[str] = []
-    for number, doc in enumerate(documents[:20], 1):  # safety cap — never exceed 20
+    # Every ranked candidate: the cap is `discover_documents`' to set, and a
+    # second one here silently halved it (#675). A file the agent is not told
+    # exists is a file it cannot read.
+    for number, doc in enumerate(documents, 1):
         raw = str(doc.get("classification", "document")).strip() or "document"
         label = _DOCUMENT_CLASS_LABELS.get(raw.lower())
         if label is None:
@@ -4366,7 +4369,7 @@ def run_interactive_agent(
             # context when several documents have different roles.
             documents = getattr(engine.state, "documents", [])
             document_lines = []
-            for doc in documents[:20]:
+            for doc in documents:
                 label = doc.get("classification", "document")
                 name = doc.get("filename", doc.get("relative_path", "?"))
                 score = doc.get("score", 0.0)

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -304,7 +304,6 @@ def _run_document_discovery(engine: AgentEngine) -> None:
     from builder.tools.document_discovery import (
         classify_scanned_files,
         discover_documents,
-        format_document_context,
     )
 
     approved = list(engine.state.approved_scan_roots)
@@ -332,7 +331,6 @@ def _run_document_discovery(engine: AgentEngine) -> None:
     # Pass the scan size so the context can say what it left out: the ranking
     # decides what the agent sees at all, and a silent cap reads as "this is
     # everything" (#587).
-    context = format_document_context(candidates, total_scanned=len(engine.state.scanned_files))
     engine.state.documents = [
         {
             "kind": c.kind,
@@ -345,12 +343,8 @@ def _run_document_discovery(engine: AgentEngine) -> None:
         }
         for c in candidates
     ]
-    if context and engine.state.metadata:
-        logger.info(
-            "Document discovery: %d candidates, ~%d chars of context",
-            len(candidates),
-            len(context),
-        )
+    if candidates and engine.state.metadata:
+        logger.info("Document discovery: %d candidates", len(candidates))
 
 
 # Formats that carry a NAMED licence field, and the filenames whose whole

--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -21,6 +21,12 @@ _DOCUMENT_SUFFIXES = {
     ".txt", ".xml", ".xls", ".xlsx", ".yaml", ".yml",
 }
 _TEXT_MIMES = ("text/", "application/json", "application/xml", "application/pdf")
+# How many ranked candidates the agent is told exist. The cap belongs HERE and
+# nowhere else: both arms used to slice `documents[:20]` on their way to the
+# model, silently halving it and throwing away the allocation #595 had just made
+# across the four classes (#675).
+MAX_DOCUMENT_CANDIDATES = 40
+
 _MAX_PREVIEW_CHARS = 3_000
 _MAX_CONTEXT_CHARS = 18_000
 _JOINER = "\n\n"
@@ -38,6 +44,26 @@ class DocumentationCandidate:
     score: float
     reasons: list[str] = field(default_factory=list)
     preview: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DocumentationCandidate:
+        """Rebuild a candidate from what ``state.documents`` stored (#675).
+
+        The engine keeps the ranking as plain dicts so a session round-trips as
+        JSON; the arms need the objects back to render through the one bounded
+        formatter. Missing keys take the dataclass defaults rather than raising:
+        a checkpoint written before a field existed is still a ranked document.
+        """
+        return cls(
+            path=str(data.get("path") or ""),
+            filename=str(data.get("filename") or ""),
+            relative_path=str(data.get("relative_path") or data.get("filename") or ""),
+            kind=str(data.get("kind") or KIND_OPAQUE),
+            classification=str(data.get("classification") or CLASS_RAW_DATA),
+            score=float(data.get("score") or 0.0),
+            reasons=list(data.get("reasons") or []),
+            preview=str(data.get("preview") or ""),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -695,7 +721,7 @@ def discover_documents(
     *,
     input_root: str,
     approved_roots: set[str],
-    max_candidates: int = 40,
+    max_candidates: int = MAX_DOCUMENT_CANDIDATES,
     max_context_chars: int = _MAX_CONTEXT_CHARS,
     previews: dict[str, str] | None = None,
 ) -> list[DocumentationCandidate]:

--- a/tests/test_discovery_context_reaches_the_agent.py
+++ b/tests/test_discovery_context_reaches_the_agent.py
@@ -1,0 +1,131 @@
+"""What discovery bounds must be what the agent receives (#675).
+
+`engine._run_document_discovery` built the bounded context and threw it away —
+the string was used for its LENGTH in a log line and nothing else. Both arms
+rendered their own from `state.documents` instead, each slicing to a hardcoded
+20, so everything `format_document_context` does stopped at the engine:
+
+* the max-min fair character budget (#587),
+* the header guard that refuses an entry too small to name its own file (#591),
+* the slot allocation across the four classes (#595).
+
+Measured on S-VHPS22 (1468 files) before the fix: discovery produced 40
+candidates balanced 13 metadata / 13 processed / 12 protocol / 2 raw; the
+pipeline sent 26 587 characters — against an 18 000 budget — carrying 4 / 13 /
+**1** / 2. #595's headline result never reached a model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.agents.pipeline.pipeline import _gather_context
+from builder.engine import AgentEngine
+from builder.state import CrateState
+from builder.tools.document_discovery import _MAX_CONTEXT_CHARS
+from builder.tools.hitl import SimulatedHumanInterface
+
+pytestmark = pytest.mark.timeout(300)
+
+FIXTURE = Path("tests/fixtures/svhps22_real_input")
+
+_HEADING = "Discovered documentation:"
+
+
+def _engine() -> AgentEngine:
+    engine = AgentEngine(state=CrateState(), human_interface=SimulatedHumanInterface())
+    engine.initialize(input_path=str(FIXTURE.resolve()))
+    return engine
+
+
+@pytest.fixture(scope="module")
+def discovered() -> tuple[list[dict], str]:
+    """The ranked documents, and the documents block the pipeline actually sends."""
+    if not FIXTURE.exists():  # pragma: no cover - fixture not checked out
+        pytest.skip("S-VHPS22 fixture not available")
+    engine = _engine()
+    context = _gather_context(engine)
+    block = context.split(_HEADING, 1)[-1] if _HEADING in context else ""
+    return list(engine.state.documents), block
+
+
+class TestTheAgentGetsWhatDiscoveryDecided:
+    def test_the_fixture_ranks_more_than_the_old_hardcoded_cap(self, discovered) -> None:
+        """Otherwise every assertion below passes on a list that never exceeded 20."""
+        documents, _ = discovered
+
+        assert len(documents) > 20, len(documents)
+
+    def test_every_ranked_candidate_is_named(self, discovered) -> None:
+        """A file the agent is not told exists is a file it cannot read. The cap
+        belongs to `discover_documents`, not to a literal 20 downstream that
+        silently halves it."""
+        documents, block = discovered
+
+        missing = [
+            d["relative_path"]
+            for d in documents
+            if d.get("filename") not in block and d.get("relative_path") not in block
+        ]
+
+        assert not missing, f"{len(missing)} of {len(documents)} never named: {missing[:5]}"
+
+    def test_the_documents_block_respects_the_budget(self, discovered) -> None:
+        """`preview[:2000]` per document with no ceiling sent 26 587 characters
+        against an 18 000 budget. `_fair_shares` exists to stop exactly that.
+
+        Measured over the entries, excluding the trailing "(N of M scanned files
+        shown)" note — `format_document_context` appends that after the split,
+        and `test_the_ceiling_still_holds` already draws the line there.
+        """
+        _, block = discovered
+
+        entries = block.split("\n\n(", 1)[0]
+
+        assert len(entries) <= _MAX_CONTEXT_CHARS, len(entries)
+
+    def test_the_classes_discovery_balanced_survive(self, discovered) -> None:
+        """#595 allocated the slots across the four classes; taking the top 20 by
+        score threw the balance away — 12 protocols became 1."""
+        documents, block = discovered
+
+        named = {
+            d["classification"]
+            for d in documents
+            if d.get("filename") in block or d.get("relative_path") in block
+        }
+
+        assert named == {c["classification"] for c in documents}, named
+
+
+class TestTheReactArmNamesThemAllToo:
+    """The other arm rendered its own list and sliced it to 20 as well."""
+
+    def test_the_ranked_list_names_every_candidate(self, discovered) -> None:
+        from builder.agents.react.agent_loop import _format_document_context
+
+        documents, _ = discovered
+
+        listing = _format_document_context(documents)
+
+        missing = [d["relative_path"] for d in documents if d["relative_path"] not in listing]
+        assert not missing, f"{len(missing)} of {len(documents)} never named: {missing[:5]}"
+
+    def test_the_cap_has_one_home(self, discovered) -> None:
+        """Two hardcoded 20s downstream could disagree with the ranking's own cap
+        — and did, halving it. Asserted on what each renderer NAMES rather than
+        on the source text: a grep for the old slice matches its own obituary in
+        a comment, and would pass while the behaviour regressed.
+        """
+        from builder.agents.react.agent_loop import _format_document_context
+        from builder.tools.document_discovery import MAX_DOCUMENT_CANDIDATES
+
+        documents, block = discovered
+
+        assert MAX_DOCUMENT_CANDIDATES > 20
+        assert len(documents) <= MAX_DOCUMENT_CANDIDATES
+        # Both renderers track the ranking's length rather than saturating at 20.
+        assert _format_document_context(documents).count("\n") + 1 == len(documents)
+        assert sum(d["relative_path"] in block for d in documents) == len(documents)


### PR DESCRIPTION
Closes #675.

## The context discovery builds was never the one the agent got

`engine._run_document_discovery` built the bounded context and threw it away —
the string was used for its **length** in a log line:

```python
context = format_document_context(candidates, total_scanned=...)
engine.state.documents = [ ... ]                       # only the dicts stored
logger.info("... ~%d chars of context", len(candidates), len(context))
```

Both arms re-rolled their own from `state.documents` and sliced to a hardcoded
`[:20]`. So everything the formatter decides stopped at the engine: the max-min
fair character budget (#587), the header guard that refuses an entry too small
to name its own file (#591), and #595's allocation across the four classes.

## Measured on S-VHPS22 (1468 files)

```
discover_documents      : 40 candidates   metadata 13, processed 13, protocol 12, raw 2
format_document_context : 18120 chars     <- built, then discarded
pipeline ACTUALLY sent  : 26587 chars     metadata 4,  processed 13, protocol 1,  raw 2
budget                  : 18000
```

**#595's result never reached a model.** Its headline was the protocols getting
through; the top-20 slice turned 12 into 1. And the budget did not bind at all —
`preview[:2000]` per document with no ceiling, 47% over.

## Fix

| | before | after |
|---|---|---|
| pipeline context | hand-rolled, unbounded | `format_document_context`, within budget |
| candidates named | 20 of 40 | **all 40** |
| classes reaching the leaf | 4 / 13 / **1** / 2 | 13 / 13 / **12** / 2 |
| the cap | two hardcoded `20`s | `MAX_DOCUMENT_CANDIDATES` |
| `engine.py` | built 18k chars to log a length | builds nothing it discards |

`DocumentationCandidate.from_dict` turns the stored dicts back into candidates,
so both arms share the formatter without the engine holding a rendered string on
state (and a checkpoint missing a field still loads).

The ReAct arm keeps its own **presentation** — a numbered markdown list, which
is also the user-facing reply — but takes its membership from the ranking rather
than re-deciding what fits. That distinction is the point: two renderings of one
decision, not two decisions.

## The risk that didn't bite

`format_document_context` renders a table as its *shape*, not its rows, and
`test_pipeline_real_input` requires 19 named chemicals to survive into the leaf.
All 55 real-input tests pass — those names come from the scanned-files section,
not the documents block. Worth stating because it was the reason to be careful.

## One of my own tests was wrong

I first asserted the fix by grepping the arms' source for `documents[:20]`. It
matched its own obituary in the comment explaining the removal — a source grep
cannot tell code from prose, and it would have passed while the behaviour
regressed. Replaced with an assertion on what each renderer actually names.

## Verification

Full suite: **3576 passed**.

33 failures in `tests/agents/test_llm.py`, `tests/test_agent_loop.py` and
`tests/test_llm_reasoning_model.py` are **pre-existing** — the optional
`[langchain]` extra is not installed. Confirmed by stashing this branch and
re-running on unmodified `main`: the same 33 fail.

6 new tests. `ruff` clean; `ty` clean apart from the same two langchain imports.

## Unblocks

#599 — a deposit census added to the formatter will now reach the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
