### PR TITLE
feat(discovery): the context leads with the deposit's shape, not just a sample of it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,24 @@ cannot read. A share too small to carry even the entry's `[kind/class] path` hea
 buys nothing, so that entry is dropped and its share returned rather than emitted as
 a fragment.
 
+**The context leads with the deposit's SHAPE, then the sample (#599).** A ranked sample is only
+meaningful against what it is a sample of: 40 files of 1468 is 2.7% of a submission, and
+"1428 not surfaced" cannot tell a tail of 1352 instrument printouts apart from one hiding sixteen
+unread protocols. Since #591 every scanned file carries a classification, so the census is free and
+complete — it was simply discarded in favour of the count. `summarise_deposit` states the tally per
+class, then the folders that hold the files with their own tallies, and the "not surfaced" line is
+broken down the same way.
+
+The folder listing starts at `_branch_point` rather than the top: a submission is routinely one
+folder deep before anything differs (svhps22 puts all 1468 files under
+`study_01_TH-DNT_Tier1_NeuralCellLines/`), so listing the root reports one folder holding everything.
+Descend while there is exactly one child DIRECTORY, whatever files sit beside it — a deposit keeps
+its descriptor at the root. The tree is bounded to `_MAX_SHAPE_FOLDERS` with the remainder stated,
+and is omitted entirely below `_MIN_SHAPE_BRANCHES`: a tree of one limb repeats the tally above it,
+and a census must never be longer than the file list it summarises. It is charged to the same
+character budget, taken off the top, and bounded by construction so it cannot crowd out the
+documents it exists to introduce.
+
 **Both arms render through `format_document_context`, and the cap has one home (#675).**
 None of the above reached a model for a while: the engine built the bounded context and
 used the string for its LENGTH in a log line, while each arm re-rolled its own from

--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -573,9 +573,12 @@ def _gather_context(engine: AgentEngine) -> str:
     # engine while this ran instead.
     documents = getattr(state, "documents", [])
     if documents:
+        scanned = list(getattr(state, "scanned_files", None) or [])
+        approved = sorted(getattr(state, "approved_scan_roots", None) or [])
         rendered = format_document_context(
             [DocumentationCandidate.from_dict(doc) for doc in documents],
-            total_scanned=len(getattr(state, "scanned_files", None) or []),
+            deposit=scanned,
+            input_root=approved[0] if approved else (state.metadata.input_path or ""),
         )
         if rendered:
             parts.append("Discovered documentation:\n" + rendered)

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -331,18 +331,11 @@ def _run_document_discovery(engine: AgentEngine) -> None:
     # Pass the scan size so the context can say what it left out: the ranking
     # decides what the agent sees at all, and a silent cap reads as "this is
     # everything" (#587).
-    engine.state.documents = [
-        {
-            "kind": c.kind,
-            "classification": c.classification,
-            "filename": c.filename,
-            "relative_path": c.relative_path,
-            "score": c.score,
-            "reasons": list(c.reasons),
-            "preview": c.preview,
-        }
-        for c in candidates
-    ]
+    # `to_dict()`, not a near-copy of it: hand-rolling the same seven fields
+    # dropped `path`, so a candidate rebuilt by `DocumentationCandidate.from_dict`
+    # had no identity to match against the inventory — and the "not surfaced"
+    # breakdown counted the whole deposit instead of the files it hid (#599).
+    engine.state.documents = [c.to_dict() for c in candidates]
     if candidates and engine.state.metadata:
         logger.info("Document discovery: %d candidates", len(candidates))
 

--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import math
 import re
+from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -900,11 +902,110 @@ def _fair_shares(needs: list[int], budget: int) -> list[int]:
     return shares
 
 
+# How many folders the shape lists before it elides the rest. A pathological
+# deposit must not spend the context describing itself, and what is left out is
+# stated rather than trailing off — the same rule the candidate cap follows
+# (#587).
+_MAX_SHAPE_FOLDERS = 10
+
+# What the files sitting at the branch point itself are called in the listing.
+# A deposit keeps its descriptor and READMEs there, beside the folders.
+_AT_THIS_LEVEL = "(here)"
+
+# A tree needs at least this many branches to say anything the class census has
+# not. The trimmed fixtures are a single chain of directories, and #599 is
+# explicit that a census must never be longer than the file list it summarises.
+_MIN_SHAPE_BRANCHES = 2
+
+
+def _class_tally(files: Sequence[FileClassification]) -> str:
+    """``1358 raw data, 74 processed data, 22 metadata, 14 protocol``, biggest first."""
+    counts = Counter(f.classification or CLASS_RAW_DATA for f in files)
+    return ", ".join(
+        f"{n} {name.replace('_data_file', ' data').replace('_', ' ').strip()}"
+        for name, n in counts.most_common()
+    )
+
+
+def _branch_point(relatives: Sequence[str]) -> PurePosixPath:
+    """The directory where the deposit actually branches.
+
+    A submission is routinely one folder deep before anything differs —
+    svhps22 puts all 1468 files under `study_01_TH-DNT_Tier1_NeuralCellLines/`,
+    so listing the top level reports one folder holding everything and tells the
+    agent nothing. Descend while there is exactly one child DIRECTORY, whatever
+    files sit beside it (a deposit keeps its descriptor at the root).
+    """
+    prefix = PurePosixPath()
+    while True:
+        children = {
+            rest.parts[0]
+            for relative in relatives
+            if (rest := _below(prefix, relative)) is not None and len(rest.parts) > 1
+        }
+        if len(children) != 1:
+            return prefix
+        prefix = prefix / next(iter(children))
+
+
+def _below(prefix: PurePosixPath, relative: str) -> PurePosixPath | None:
+    """*relative* re-rooted at *prefix*, or ``None`` when it does not live there."""
+    path = PurePosixPath(str(relative).replace("\\", "/"))
+    try:
+        return path.relative_to(prefix)
+    except ValueError:
+        return None
+
+
+def summarise_deposit(
+    files: Sequence[FileClassification], *, input_root: str, max_folders: int = _MAX_SHAPE_FOLDERS
+) -> str:
+    """The deposit's shape: what it holds, and how its folders are weighted (#599).
+
+    The ranking shows a bounded sample and used to say only "1428 not surfaced" —
+    a bare number, from which a deposit whose tail is 1352 instrument printouts
+    reads exactly like one hiding 16 unread protocols. Every scanned file has
+    carried a classification since #591, so the census is free and complete; it
+    was simply discarded in favour of the count.
+
+    The folder tree is listed from :func:`_branch_point` and bounded to
+    *max_folders*, with the remainder stated. It is omitted entirely when the
+    deposit does not branch — a tree of one limb repeats the tally above it.
+    """
+    if not files:
+        return ""
+    relatives = [_relative(f.path, input_root).replace("\\", "/") for f in files]
+    by_relative = dict(zip(relatives, files))
+    header = f"Deposit: {len(files)} files — {_class_tally(files)}."
+
+    prefix = _branch_point(relatives)
+    groups: dict[str, list[FileClassification]] = {}
+    for relative in relatives:
+        rest = _below(prefix, relative)
+        if rest is None:
+            continue
+        key = rest.parts[0] + "/" if len(rest.parts) > 1 else _AT_THIS_LEVEL
+        groups.setdefault(key, []).append(by_relative[relative])
+    if len(groups) < _MIN_SHAPE_BRANCHES:
+        return header
+
+    ordered = sorted(groups.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    lines = [f"Shape ({prefix}/):" if str(prefix) != "." else "Shape:"]
+    for name, members in ordered[:max_folders]:
+        lines.append(f"  {name:<44.44s} {len(members):5d} — {_class_tally(members)}")
+    if (rest_folders := ordered[max_folders:]) :
+        hidden = sum(len(members) for _, members in rest_folders)
+        lines.append(f"  + {len(rest_folders)} more folders, {hidden} files")
+    return header + "\n" + "\n".join(lines)
+
+
 def format_document_context(
     candidates: list[DocumentationCandidate],
     *,
     max_chars: int = _MAX_CONTEXT_CHARS,
     total_scanned: int | None = None,
+    deposit: Sequence[FileClassification] | None = None,
+    input_root: str = "",
 ) -> str:
     """Format ranked candidates as bounded, kind-labelled agent context.
 
@@ -912,7 +1013,24 @@ def format_document_context(
     scanned, the context says so. A silent cap reads as "this is everything" —
     the same reason the maturity report names the findings it hid rather than
     trailing off (#587).
+
+    Given the whole *deposit* inventory, the context LEADS with its shape
+    (:func:`summarise_deposit`) and breaks the hidden tail down by class rather
+    than reporting a bare count (#599). The sample is only meaningful against
+    what it is a sample OF: 40 files of 1468 is 2.7% of a submission whose
+    remaining 1428 could be all instrument printouts or could hide sixteen
+    unread protocols, and "1428 not surfaced" cannot tell those apart.
+
+    The shape is charged to the same budget as the entries, and taken off the
+    top: it is bounded by construction (:data:`_MAX_SHAPE_FOLDERS`), so it
+    cannot crowd out the documents it exists to introduce — the failure
+    :func:`_fair_shares` prevents one layer down.
     """
+    shape = summarise_deposit(deposit, input_root=input_root) if deposit else ""
+    if shape:
+        max_chars = max(0, max_chars - len(shape) - len(_JOINER))
+    if total_scanned is None and deposit is not None:
+        total_scanned = len(deposit)
     headers = [f"[{c.kind}/{c.classification}] {c.relative_path}\n" for c in candidates]
     bodies = [_context_body(c) for c in candidates]
     blocks = [header + body for header, body in zip(headers, bodies)]
@@ -936,11 +1054,19 @@ def format_document_context(
             kept = body[: room - len(header) - len(_TRUNCATED)].rstrip()
             parts.append(header + kept + _TRUNCATED)
     context = _JOINER.join(parts)
+    if shape:
+        context = shape + _JOINER + context
     if total_scanned is not None and total_scanned > len(candidates):
         hidden = total_scanned - len(candidates)
+        # Broken down by class where the inventory is in hand: a tail that is
+        # all instrument output is not worth opening, and one holding unread
+        # protocols is, and a bare count says neither (#599).
+        named = {c.path for c in candidates}
+        rest = [f for f in deposit if f.path not in named] if deposit else []
+        breakdown = f": {_class_tally(rest)}" if rest else ""
         context += (
             f"\n\n({len(candidates)} of {total_scanned} scanned files shown; "
-            f"{hidden} not surfaced — read any of them directly if this list "
-            "does not cover what you need.)"
+            f"{hidden} not surfaced{breakdown} — read any of them directly if "
+            "this list does not cover what you need.)"
         )
     return context

--- a/tests/test_deposit_shape.py
+++ b/tests/test_deposit_shape.py
@@ -1,0 +1,166 @@
+"""The agent is shown the deposit's shape, not just a sample of it (#599).
+
+The context was a flat list of ranked files and one line: "(40 of 1468 scanned
+files shown; 1428 not surfaced.)" — 2.7% of the deposit, with no shape. From
+that the agent cannot tell how many assays the submission has, how they are
+weighted, or what the 1428 unnamed files are.
+
+The census is free: since #591 every scanned file carries a classification, and
+#598 already groups them. A deposit whose hidden tail is 1352 instrument
+printouts looked identical to one hiding 16 unread protocols.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.state import FileClassification
+from builder.tools.document_discovery import (
+    _MAX_CONTEXT_CHARS,
+    classify_scanned_files,
+    discover_documents,
+    format_document_context,
+    summarise_deposit,
+)
+
+pytestmark = pytest.mark.timeout(300)
+
+FIXTURE = Path("tests/fixtures/svhps22_real_input")
+TINY = Path("tests/fixtures/svhps26_real_input")
+
+
+def _scanned(root: Path) -> list[FileClassification]:
+    from builder.tools.scanner import scan_files
+
+    resolved = str(root.resolve())
+    files = scan_files(resolved, approved_roots={resolved})
+    classify_scanned_files(files, input_root=resolved, approved_roots={resolved})
+    return files
+
+
+@pytest.fixture(scope="module")
+def deposit() -> tuple[list[FileClassification], str]:
+    if not FIXTURE.exists():  # pragma: no cover - fixture not checked out
+        pytest.skip("S-VHPS22 fixture not available")
+    files = _scanned(FIXTURE)
+    return files, summarise_deposit(files, input_root=str(FIXTURE.resolve()))
+
+
+class TestTheCensusNamesWhatIsThere:
+    def test_every_class_the_deposit_holds_is_counted(self, deposit) -> None:
+        files, census = deposit
+
+        present = {f.classification for f in files}
+        for classification in present:
+            assert classification.replace("_data_file", "").replace("_", " ") in census, (
+                f"{classification} missing from:\n{census}"
+            )
+
+    def test_the_total_is_stated(self, deposit) -> None:
+        files, census = deposit
+
+        assert str(len(files)) in census, census
+
+    def test_the_folders_that_hold_the_files_are_named_with_their_weight(self, deposit) -> None:
+        """svhps22 is one study with four assays of very uneven size. None of
+        that reached the agent."""
+        _, census = deposit
+
+        for folder in ("assay_01_TH_uptake", "assay_02_deiodinase", "assay_03_metabolism"):
+            assert folder in census, f"{folder} missing from:\n{census}"
+
+
+class TestTheCensusEarnsItsSpace:
+    def test_a_deposit_that_does_not_branch_gets_no_folder_tree(self) -> None:
+        """The trimmed fixtures are a single chain of directories. A "tree" of one
+        branch says nothing the class census has not already said, and the issue
+        is explicit: a census must not be longer than the file list it summarises.
+        """
+        if not TINY.exists():  # pragma: no cover
+            pytest.skip("fixture not available")
+        files = _scanned(TINY)
+
+        census = summarise_deposit(files, input_root=str(TINY.resolve()))
+
+        assert census.count("\n") <= len(files), census
+
+    def test_the_tree_is_bounded_and_says_what_it_elided(self, tmp_path) -> None:
+        """A pathological deposit must not spend the whole budget describing
+        itself — and the elision is stated, never silent (#587's rule)."""
+        files = []
+        for folder in range(60):
+            path = tmp_path / f"folder_{folder:03d}" / "data.csv"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("well_id,value\nA1,1\n", encoding="utf-8")
+            files.append(
+                FileClassification(
+                    path=str(path), filename="data.csv", size=20, mime_type="text/csv"
+                )
+            )
+        classify_scanned_files(
+            files, input_root=str(tmp_path), approved_roots={str(tmp_path.resolve())}
+        )
+
+        census = summarise_deposit(files, input_root=str(tmp_path))
+
+        assert census.count("\n") < 30, census
+        assert "more" in census.lower(), census
+
+
+class TestTheContextLeadsWithTheShape:
+    def test_the_hidden_tail_is_broken_down_by_class(self, deposit) -> None:
+        """"1428 not surfaced" tells the agent nothing about whether the tail is
+        worth opening."""
+        files, _ = deposit
+        root = str(FIXTURE.resolve())
+        candidates = discover_documents(files, input_root=root, approved_roots={root})
+
+        context = format_document_context(candidates, deposit=files, input_root=root)
+
+        tail = context.rsplit("(", 1)[-1]
+        assert "raw data" in tail, tail
+        assert "metadata" in tail, tail
+
+    def test_the_breakdown_counts_the_hidden_files_and_not_the_deposit(self, deposit) -> None:
+        """It first reported the whole deposit's tally against the hidden count —
+        "14 not surfaced: 15 processed, 14 metadata, 13 protocol, 12 raw", which
+        is 54 files' worth of breakdown for 14 files. The engine hand-rolled the
+        document dicts and omitted `path`, so a rebuilt candidate had no identity
+        to subtract from the inventory. The numbers must add up.
+        """
+        import re
+
+        files, _ = deposit
+        root = str(FIXTURE.resolve())
+        candidates = discover_documents(files, input_root=root, approved_roots={root})
+
+        context = format_document_context(candidates, deposit=files, input_root=root)
+        tail = context.rsplit("(", 1)[-1]
+
+        hidden = len(files) - len(candidates)
+        counted = sum(int(n) for n in re.findall(r"(\d+) [a-z]", tail.split("not surfaced:")[1]))
+        assert counted == hidden, tail
+
+    def test_the_shape_comes_before_the_sample(self, deposit) -> None:
+        files, _ = deposit
+        root = str(FIXTURE.resolve())
+        candidates = discover_documents(files, input_root=root, approved_roots={root})
+
+        context = format_document_context(candidates, deposit=files, input_root=root)
+
+        assert context.index("assay_02_deiodinase") < context.index("["), context[:400]
+
+    def test_the_census_does_not_crowd_out_the_documents(self, deposit) -> None:
+        """A long tree must not delete the documents it is supposed to introduce
+        — the failure `_fair_shares` exists to stop, one layer up."""
+        files, _ = deposit
+        root = str(FIXTURE.resolve())
+        candidates = discover_documents(files, input_root=root, approved_roots={root})
+
+        context = format_document_context(candidates, deposit=files, input_root=root)
+
+        assert len(context.split("\n\n(")[0]) <= _MAX_CONTEXT_CHARS, len(context)
+        named = sum(1 for c in candidates if f"] {c.relative_path}" in context)
+        assert named == len(candidates), f"{len(candidates) - named} candidates lost to the census"


### PR DESCRIPTION
Closes #599.

## The agent saw a sample with nothing to measure it against

```
(40 of 1468 scanned files shown; 1428 not surfaced.)
```

2.7% of the submission, and a bare number for the rest. A tail of 1352
instrument printouts reads exactly like one hiding sixteen unread protocols.

## It now leads with the shape

```
Deposit: 1468 files — 1358 raw data, 74 processed data, 22 metadata, 14 protocol.
Shape (study_01_TH-DNT_Tier1_NeuralCellLines/):
  assay_02_deiodinase/     717 — 694 raw data, 18 processed data, 3 metadata, 2 protocol
  assay_03_metabolism/     568 — 548 raw data, 16 processed data, 2 protocol, 2 metadata
  assay_01_TH_uptake/      145 — 107 raw data, 24 processed data, 10 metadata, 4 protocol
  assay_04_TRactivation/    32 —  16 processed data, 9 raw data, 4 metadata, 3 protocol
  cell_line_protocols/       3 —   3 protocol
  (here)                     2 —   2 metadata
```

**~530 characters** against an 18 000 budget. The census was already computed and
discarded — every scanned file has carried a classification since #591.

The tail is broken down the same way:
`14 not surfaced: 10 raw data, 2 processed data, 1 metadata, 1 protocol`.

## Where the listing starts

At `_branch_point`, not the top. A submission is routinely one folder deep
before anything differs — svhps22 puts all 1468 files under one study folder —
so listing the root reports "one folder, 1467 files" and says nothing. It
descends while there is exactly one child **directory**, whatever files sit
beside it, since a deposit keeps its descriptor at the root.

## Bounded, because deposits vary enormously

- `_MAX_SHAPE_FOLDERS` (10), with the remainder **stated** rather than trailing
  off — #587's rule.
- Charged to the same character budget, taken off the top, and bounded by
  construction so it cannot crowd out the documents it exists to introduce.
- Omitted entirely below `_MIN_SHAPE_BRANCHES`: a tree of one limb repeats the
  tally above it, and #599 is explicit that a census must never be longer than
  the file list it summarises.

Measured across a 300× size range — the trimmed 5-file fixtures get the one-line
tally and no tree; the budget holds at every size and no entry is dropped.

## A bug this found in passing

The first output read `14 not surfaced: 15 processed, 14 metadata, 13 protocol,
12 raw` — **54 files' worth of breakdown for 14 files**. `engine` hand-rolled the
document dicts and omitted `path`, so a candidate rebuilt by
`DocumentationCandidate.from_dict` had no identity to subtract from the
inventory. It now stores `c.to_dict()`, which is what the hand-rolled literal was
duplicating anyway. A test pins that the breakdown sums to the hidden count.

Caught by reading the rendered output rather than trusting green tests.

## Verification

Full suite: **3585 passed**.

33 failures in `tests/agents/test_llm.py`, `tests/test_agent_loop.py` and
`tests/test_llm_reasoning_model.py` are **pre-existing** — the optional
`[langchain]` extra is not installed; confirmed by stashing and re-running on
unmodified `main`.

9 new tests. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
