### PR TITLE
fix(discovery): the deposit shape counts every file, including the descriptor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,8 +418,12 @@ broken down the same way.
 The folder listing starts at `_branch_point` rather than the top: a submission is routinely one
 folder deep before anything differs (svhps22 puts all 1468 files under
 `study_01_TH-DNT_Tier1_NeuralCellLines/`), so listing the root reports one folder holding everything.
-Descend while there is exactly one child DIRECTORY, whatever files sit beside it — a deposit keeps
-its descriptor at the root. The tree is bounded to `_MAX_SHAPE_FOLDERS` with the remainder stated,
+Descend while there is exactly one child DIRECTORY, whatever files sit beside it. Everything not
+inside a listed folder — at the trunk and *above* it — is counted under `(top level)`, because the
+descent otherwise walks straight past the root descriptor, the one file that states the study's own
+identity: svhps22 showed 1467 of its 1468 files and said nothing about the one it dropped. The rows
+sum to the total, or the shape is a picture of a different deposit. A deposit that does not branch
+at all — flat, or a single deep chain — gets the tally and no tree. The tree is bounded to `_MAX_SHAPE_FOLDERS` with the remainder stated,
 and is omitted entirely below `_MIN_SHAPE_BRANCHES`: a tree of one limb repeats the tally above it,
 and a census must never be longer than the file list it summarises. It is charged to the same
 character budget, taken off the top, and bounded by construction so it cannot crowd out the

--- a/builder/tools/document_discovery.py
+++ b/builder/tools/document_discovery.py
@@ -908,9 +908,12 @@ def _fair_shares(needs: list[int], budget: int) -> list[int]:
 # (#587).
 _MAX_SHAPE_FOLDERS = 10
 
-# What the files sitting at the branch point itself are called in the listing.
-# A deposit keeps its descriptor and READMEs there, beside the folders.
-_AT_THIS_LEVEL = "(here)"
+# What everything OUTSIDE the listed folders is called. That is the files at the
+# branch point and the files above it — a deposit keeps its descriptor at the
+# root, which is above the trunk the listing descends to, and dropping it lost
+# the one file that states the study's own identity. The rows must sum to the
+# total, or the shape is a picture of a different deposit.
+_OUTSIDE_THE_FOLDERS = "(top level)"
 
 # A tree needs at least this many branches to say anything the class census has
 # not. The trimmed fixtures are a single chain of directories, and #599 is
@@ -976,15 +979,17 @@ def summarise_deposit(
         return ""
     relatives = [_relative(f.path, input_root).replace("\\", "/") for f in files]
     by_relative = dict(zip(relatives, files))
-    header = f"Deposit: {len(files)} files — {_class_tally(files)}."
+    header = f"Deposit: {len(files)} file{'s' if len(files) != 1 else ''} — {_class_tally(files)}."
 
     prefix = _branch_point(relatives)
     groups: dict[str, list[FileClassification]] = {}
     for relative in relatives:
         rest = _below(prefix, relative)
-        if rest is None:
-            continue
-        key = rest.parts[0] + "/" if len(rest.parts) > 1 else _AT_THIS_LEVEL
+        key = (
+            rest.parts[0] + "/"
+            if rest is not None and len(rest.parts) > 1
+            else _OUTSIDE_THE_FOLDERS
+        )
         groups.setdefault(key, []).append(by_relative[relative])
     if len(groups) < _MIN_SHAPE_BRANCHES:
         return header

--- a/tests/test_deposit_shape.py
+++ b/tests/test_deposit_shape.py
@@ -109,6 +109,61 @@ class TestTheCensusEarnsItsSpace:
         assert "more" in census.lower(), census
 
 
+class TestADepositWithoutFoldersIsStillDescribed:
+    """Not every submission is a tree, and the degenerate shapes must not lie."""
+
+    def _census(self, tmp_path: Path, layout: list[str]) -> str:
+        files = []
+        for relative in layout:
+            path = tmp_path / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("well_id,value\nA1,1\n", encoding="utf-8")
+            files.append(
+                FileClassification(
+                    path=str(path), filename=path.name, size=20, mime_type="text/csv"
+                )
+            )
+        classify_scanned_files(
+            files, input_root=str(tmp_path), approved_roots={str(tmp_path.resolve())}
+        )
+        return summarise_deposit(files, input_root=str(tmp_path))
+
+    def test_a_flat_deposit_gets_the_tally_and_no_tree(self, tmp_path) -> None:
+        """Nothing branches, so there is no shape to draw — and a one-row "tree"
+        saying "12 files are in no folder" repeats the line above it."""
+        census = self._census(tmp_path, [f"file_{i}.csv" for i in range(12)])
+
+        assert census.startswith("Deposit: 12 files")
+        assert "Shape" not in census, census
+
+    def test_a_single_deep_chain_gets_no_tree_either(self, tmp_path) -> None:
+        census = self._census(tmp_path, [f"a/b/c/d/file_{i}.csv" for i in range(6)])
+
+        assert "Shape" not in census, census
+
+    def test_one_file_is_not_one_files(self, tmp_path) -> None:
+        assert self._census(tmp_path, ["only.csv"]).startswith("Deposit: 1 file —")
+
+    def test_the_folder_rows_sum_to_the_total(self, deposit) -> None:
+        """The descent walks past folders holding a single child, and files ABOVE
+        the trunk were dropped on the way — including svhps22's own descriptor,
+        the one file that states the study's identity. 1467 of 1468 were shown
+        and nothing said so. A shape whose rows do not add up is a picture of a
+        different deposit.
+        """
+        import re
+
+        files, census = deposit
+
+        stated = re.search(r"Deposit: (\d+)", census)
+        assert stated, census
+        total = int(stated.group(1))
+        rows = [int(n) for n in re.findall(r"^ {2}\S.*?\s(\d+) —", census, re.M)]
+
+        assert total == len(files)
+        assert sum(rows) == total, f"{total - sum(rows)} files missing from:\n{census}"
+
+
 class TestTheContextLeadsWithTheShape:
     def test_the_hidden_tail_is_broken_down_by_class(self, deposit) -> None:
         """"1428 not surfaced" tells the agent nothing about whether the tail is


### PR DESCRIPTION
Follow-up to #679, which merged before these two fixes were committed.

## The folder rows did not add up

```
header total : 1468
folder rows  : 717 + 568 + 145 + 32 + 3 + 2 = 1467
MISSING      : 1
```

The missing file is **`S-VHPS22.json`** — the deposit's own descriptor, the one
file that states the study's accession, title, licence and authors. The header
counted it; the shape never showed it.

`_branch_point` descends past directories holding a single child (svhps22 keeps
all 1468 files under one study folder, so listing the root reports one folder
holding everything). Files sitting **above** where the descent lands were then
dropped: `_below` returned `None` for them and the loop skipped them.

Everything not inside a listed folder — at the trunk and above it — is now
counted under `(top level)`, so the rows sum to the total. A shape whose rows do
not add up is a picture of a different deposit.

```
  assay_02_deiodinase/     717 — 694 raw data, 18 processed data, 3 metadata, 2 protocol
  assay_03_metabolism/     568 — 548 raw data, 16 processed data, 2 protocol, 2 metadata
  assay_01_TH_uptake/      145 — 107 raw data, 24 processed data, 10 metadata, 4 protocol
  assay_04_TRactivation/    32 —  16 processed data, 9 raw data, 4 metadata, 3 protocol
  (top level)                3 —   3 metadata
  cell_line_protocols/       3 —   3 protocol
                          ----
                          1468 ✓
```

## Also: "Deposit: 1 files"

## How they were found

By asking what a deposit with **no folder structure** gets. Those cases were
already right — flat layouts and single deep chains get the class tally and no
tree, because a tree of one limb repeats the line above it — but checking them
meant checking whether the numbers add up, and they did not.

That case is now covered rather than merely working by accident: flat,
single-deep-chain and one-file layouts each have a test, alongside one asserting
the folder rows sum to the stated total.

## Verification

Full suite: **3589 passed**.

33 failures in `tests/agents/test_llm.py`, `tests/test_agent_loop.py` and
`tests/test_llm_reasoning_model.py` are pre-existing — the optional `[langchain]`
extra is not installed.

4 new tests. `ruff` and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
