### PR TITLE
fix(verification): make the verifiable-field set and the dispatch one table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1555,18 +1555,17 @@ id-only allow-list would flag every row of a correct table.
 ### Verification Layer
 Checks that identifiers resolve at their source. Verification failures are REQUIRED — the identifier must be corrected or removed. Leaving a field empty is acceptable (shows up in MIT/FAIR scores but does not block).
 
-> **Status: the single source of truth is not wired to `_select_verifier`.**
-> `_select_verifier` is still a hand-written `if`/`elif` chain carrying its own inline
-> field sets, so a pair added to `_VERIFIABLE_FIELDS` without a matching branch comes
-> back from `verify_all_identifiers` as a blocking `No verifier configured` failure
-> rather than being skipped.
-
-**Derivation (Issue #64):** The set of verifiable fields is no longer a hard-coded flat list.
-`verify_all_identifiers` and `_select_verifier` both derive from `_VERIFIABLE_FIELDS` — a
-frozenset of `(entity_type, field_name)` pairs — so they can never drift apart.
-`_IDENTIFIER_FIELDS` is kept as a legacy re-export derived automatically from the same
-source. Fields like `casrn`/`cas_number`/`inchikey` on `MolecularEntity` are now included,
-while fields like `ror` on `Organization` (which has no verifier) are correctly excluded.
+**Derivation (Issue #64).** `_VERIFIERS` maps each `(entity_type, field_name)` pair to the
+lookup that serves it, and `_VERIFIABLE_FIELDS` is that table's keys — so a pair cannot be
+declared verifiable without wiring the verifier that answers for it.
+`verify_all_identifiers` decides what to queue from those keys and `verify_identifier`
+dispatches through the same table, so the two cannot drift apart. Fields like
+`casrn`/`cas_number`/`inchikey` on `MolecularEntity` are included, while `ror` on
+`Organization` — which has no verifier — is excluded and so is never queued. That exclusion
+is the point: a pair declared verifiable with no verifier behind it comes back
+`No verifier configured`, which §6 treats as a REQUIRED blocking failure on a perfectly
+valid identifier. `tests/test_tools_verification.py` pins the invariant and fails on
+injected drift.
 
 ## 7. Session Persistence & Resume
 

--- a/builder/tools/verification.py
+++ b/builder/tools/verification.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
 from builder.state import CrateState
@@ -22,65 +23,66 @@ from builder.tools.lookups import (
 _VERIFY_WORKERS = 6
 
 
-def _select_verifier(entity_type: str, field: str):
-    """Return an appropriate lookup function for an identifier-like field."""
-    field_name = field.lower()
-    if entity_type == "MolecularEntity" and field_name == "dtxsid":
-        return lookup_dtxsid, "comptox"
-    if entity_type == "MolecularEntity" and field_name in {
-        "identifier",
-        "cas",
-        "casrn",
-        "cas_number",
-        "pubchem_cid",
-        "inchikey",
-    }:
-        return lookup_compound, "pubchem"
-    if entity_type == "CellLineSample" and field_name in {"identifier", "accession"}:
-        return lookup_cell_line, "cellosaurus"
-    if entity_type == "Person" and field_name in {"identifier", "orcid"}:
-        return lookup_orcid, "orcid"
-    if entity_type == "Publication" and field_name in {"identifier", "doi"}:
-        return lookup_doi, "crossref"
-    return None, None
-
-
 # ---------------------------------------------------------------------------
 # Single source of truth for verifiable (entity_type, field) pairs.
-# This is the *authoritative* set — both _select_verifier and
-# verify_all_identifiers derive from it, so they can never drift apart.
+#
+# The dispatch table IS the authoritative set: a pair cannot be declared
+# verifiable without naming the lookup that serves it. ``verify_all_identifiers``
+# decides what to queue from these keys, and ``verify_identifier`` dispatches
+# through the same table — so the two cannot drift apart (#64).
+#
+# The table holds the lookup functions themselves, so the dependency stays
+# visible to the linter and the type checker. ``_select_verifier`` re-resolves
+# each through the module namespace by name before returning it, so patching
+# ``builder.tools.verification.lookup_*`` still takes effect.
 # ---------------------------------------------------------------------------
+_VERIFIERS: dict[tuple[str, str], tuple[Callable[[str], dict], str]] = {
+    # MolecularEntity resolves through PubChem, except dtxsid (EPA CompTox)
+    ("MolecularEntity", "identifier"): (lookup_compound, "pubchem"),
+    ("MolecularEntity", "cas"): (lookup_compound, "pubchem"),
+    ("MolecularEntity", "casrn"): (lookup_compound, "pubchem"),
+    ("MolecularEntity", "cas_number"): (lookup_compound, "pubchem"),
+    ("MolecularEntity", "pubchem_cid"): (lookup_compound, "pubchem"),
+    ("MolecularEntity", "inchikey"): (lookup_compound, "pubchem"),
+    ("MolecularEntity", "dtxsid"): (lookup_dtxsid, "comptox"),
+    # CellLineSample resolves through Cellosaurus
+    ("CellLineSample", "identifier"): (lookup_cell_line, "cellosaurus"),
+    ("CellLineSample", "accession"): (lookup_cell_line, "cellosaurus"),
+    # Person resolves through ORCID
+    ("Person", "identifier"): (lookup_orcid, "orcid"),
+    ("Person", "orcid"): (lookup_orcid, "orcid"),
+    # Publication resolves through Crossref
+    ("Publication", "identifier"): (lookup_doi, "crossref"),
+    ("Publication", "doi"): (lookup_doi, "crossref"),
+}
 
-_VERIFIABLE_FIELDS: frozenset[tuple[str, str]] = frozenset(
-    [
-        # MolecularEntity fields that map to PubChem lookup
-        ("MolecularEntity", "identifier"),
-        ("MolecularEntity", "cas"),
-        ("MolecularEntity", "casrn"),
-        ("MolecularEntity", "cas_number"),
-        ("MolecularEntity", "pubchem_cid"),
-        ("MolecularEntity", "inchikey"),
-        # MolecularEntity dtxsid maps to the EPA CompTox lookup
-        ("MolecularEntity", "dtxsid"),
-        # CellLineSample fields that map to Cellosaurus lookup
-        ("CellLineSample", "identifier"),
-        ("CellLineSample", "accession"),
-        # Person fields that map to ORCID lookup
-        ("Person", "identifier"),
-        ("Person", "orcid"),
-        # Publication fields that map to Crossref lookup
-        ("Publication", "identifier"),
-        ("Publication", "doi"),
-    ]
-)
+_VERIFIABLE_FIELDS: frozenset[tuple[str, str]] = frozenset(_VERIFIERS)
+
+
+def _select_verifier(entity_type: str, field: str):
+    """Return the lookup function and service name for an identifier field.
+
+    Returns ``(None, None)`` when the pair is not verifiable. The pair must be
+    a key of :data:`_VERIFIERS`, which is also what :data:`_VERIFIABLE_FIELDS`
+    is built from — so a pair this returns nothing for is never queued by
+    ``verify_all_identifiers`` in the first place.
+    """
+    entry = _VERIFIERS.get((entity_type, field.lower()))
+    if entry is None:
+        return None, None
+    verifier, lookup_name = entry
+    # Re-resolve through the module namespace so a patched
+    # ``builder.tools.verification.lookup_*`` is honoured.
+    name = getattr(verifier, "__name__", "")
+    return globals().get(name, verifier), lookup_name
 
 
 def _get_verifiable_fields() -> frozenset[tuple[str, str]]:
-    """Return the set of (entity_type, field) pairs that have a verifier.
+    """Return the (entity_type, field) pairs that have a verifier.
 
-    This is the single source of truth for which identifier fields can be
-    auto-verified. Both ``verify_all_identifiers`` and ``_select_verifier``
-    are derived from this set.
+    The single source of truth for which identifier fields can be
+    auto-verified: the keys of :data:`_VERIFIERS`, which ``_select_verifier``
+    dispatches through.
     """
     return _VERIFIABLE_FIELDS
 
@@ -231,10 +233,6 @@ def verify_identifier(state: CrateState, entity_id: str, field: str) -> dict:
     }
 
 
-# Legacy re-export — derived automatically from _get_verifiable_fields so it
-# always stays in sync. Only the flat field names are exposed here; the
-# authoritative pair-based set is _get_verifiable_fields().
-_IDENTIFIER_FIELDS: frozenset[str] = frozenset({f for (_t, f) in _get_verifiable_fields()})
 
 
 def verify_all_identifiers(state: CrateState) -> list[dict]:

--- a/tests/test_tools_verification.py
+++ b/tests/test_tools_verification.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from builder.state import Entity, EntityProvenance, FieldCompletion
+from builder.tools import verification
 from builder.tools.verification import (
-    _IDENTIFIER_FIELDS,
+    _VERIFIERS,
     _get_verifiable_fields,
+    _select_verifier,
     verify_all_identifiers,
     verify_identifier,
 )
@@ -350,23 +352,47 @@ class TestVerifiableFieldSet:
             "Organization ror should produce NO results from verify_all_identifiers"
         )
 
-    def test_sync_test_fails_if_drift_occurs(self):
-        """Ensure _IDENTIFIER_FIELDS (legacy set) and _get_verifiable_fields()
-        stay in sync — this test will fail if they drift apart, alerting
-        developers to update both."""
-        # Get the flat set of field names from _get_verifiable_fields
-        derived_fields = {f for (_t, f) in _get_verifiable_fields()}
+    def test_every_verifiable_pair_dispatches_to_a_verifier(self):
+        """Every pair the authoritative set admits must resolve to a verifier.
 
-        # Every field in _IDENTIFIER_FIELDS that has a verifier should also
-        # appear in the derived set. (Fields like 'ror' that have NO verifier
-        # are excluded from the derived set.)
-        for field in _IDENTIFIER_FIELDS:
-            if field == "ror":
-                continue  # ror has no verifier; allowed to be missing
-            assert field in derived_fields, (
-                f"{field} is in _IDENTIFIER_FIELDS but NOT in derived "
-                f"verifiable fields — they must be kept in sync"
-            )
+        `verify_all_identifiers` decides what to QUEUE from this set, while
+        `verify_identifier` decides what to CALL via `_select_verifier`. A pair
+        in the set with no verifier is queued and then answered "No verifier
+        configured" — and §6 treats a verification failure as REQUIRED, so a
+        valid identifier would block the build.
+        """
+        unwired = sorted(
+            (t, f) for (t, f) in _get_verifiable_fields() if _select_verifier(t, f)[0] is None
+        )
+        assert not unwired, (
+            f"verifiable but not dispatchable: {unwired} — "
+            "adding a pair to the authoritative set must also wire a verifier"
+        )
+
+    def test_that_guard_is_not_vacuous(self, monkeypatch):
+        """The guard above must actually fail when the two sources disagree.
+
+        Its predecessor compared `_IDENTIFIER_FIELDS` against the expression it
+        was *defined as*, so it could never fail. This injects real drift and
+        pins that the check catches it.
+        """
+        monkeypatch.setattr(
+            verification,
+            "_VERIFIABLE_FIELDS",
+            frozenset(verification._VERIFIABLE_FIELDS | {("Organization", "ror")}),
+        )
+        unwired = sorted(
+            (t, f) for (t, f) in _get_verifiable_fields() if _select_verifier(t, f)[0] is None
+        )
+        assert unwired == [("Organization", "ror")]
+
+    def test_the_authoritative_set_is_the_dispatch_table(self):
+        """One source, not two: the verifiable pairs ARE the table's keys.
+
+        Structural, not conventional — a pair cannot be declared verifiable
+        without supplying the verifier that serves it.
+        """
+        assert _get_verifiable_fields() == frozenset(_VERIFIERS)
 
 
 class TestCellLineAccessionIdentityCheck:


### PR DESCRIPTION
`AGENTS.md` and the code both claimed this:

> *"`verify_all_identifiers` and `_select_verifier` both derive from `_VERIFIABLE_FIELDS` — so they can never drift apart."*

**They didn't.** `_select_verifier` was a hand-written if/elif chain carrying its own inline field sets, and never read `_VERIFIABLE_FIELDS`. The two agreed only by hand-maintenance — 13 pairs each, kept in step by luck and care.

## Why that's harmful, not untidy

The two lists are consumed at **different points of the same operation**:

| | uses | to decide |
|---|---|---|
| `verify_all_identifiers` | `_VERIFIABLE_FIELDS` | what to **queue** |
| `verify_identifier` | `_select_verifier` | what to **call** |

Add a pair to `_VERIFIABLE_FIELDS` — which the docstring said was sufficient — and it gets queued, `_select_verifier` returns `(None, None)`, and you get:

```python
{"verified": False, "message": f"No verifier configured for {field} on {entity.type}"}
```

§6 makes verification failures **REQUIRED severity — blocking**: *"the identifier must be corrected or removed."* So a valid identifier blocks the build, with a message blaming the value rather than the missing wiring. The documentation invited exactly the change that breaks it.

## The guard test could not fail

`test_sync_test_fails_if_drift_occurs`, whose docstring promised *"this test will fail if they drift apart"*:

```python
_IDENTIFIER_FIELDS = frozenset({f for (_t, f) in _get_verifiable_fields()})   # verification.py:237
...
derived_fields = {f for (_t, f) in _get_verifiable_fields()}                  # the test
for field in _IDENTIFIER_FIELDS:
    assert field in derived_fields
```

It asserted a set was a subset of **the expression it was defined as**. A tautology. It also discarded `entity_type` — the half that actually varies — and carried a dead `if field == "ror": continue` branch for a value not in the set. It guarded the two things that are definitionally equal instead of the two that can drift, providing false assurance.

## The fix

`_VERIFIERS` maps each `(entity_type, field)` pair to the lookup that serves it, and `_VERIFIABLE_FIELDS` **is** that table's keys. A pair cannot be declared verifiable without wiring the verifier that answers for it — structural, not conventional.

Two implementation details worth review:

- **Late binding preserved.** Eight existing tests patch `builder.tools.verification.lookup_*`. `_select_verifier` re-resolves each function through the module namespace by name before returning it, so those still work.
- **The table holds the function objects, not their names.** A name-keyed table made the `lookup_*` imports read as unused to ruff — and removing them, as the lint suggests, would have broken dispatch at runtime with a `KeyError`. Keeping the objects keeps the dependency visible to both ruff and `ty`.

Also deleted `_IDENTIFIER_FIELDS`, a legacy re-export whose only remaining consumer was the tautological test. Not exported anywhere.

## Verified by mutation

A passing test proves nothing here — that was the original problem. So both directions were mutated:

| Mutation | Result |
|---|---|
| Drop a pair from the table, leave it in the set (drift) | **all 3 new tests fail** |
| Store functions without late re-resolution | **5 existing tests fail** |

101 tests pass on the restored file. `ruff` and `ty` both clean.

## Doc

`AGENTS.md` §6's "Derivation (#64)" paragraph now describes the table, and the status banner saying the invariant was unenforced is removed — it's enforced now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019j5jejw1fBuK75u2icX2rW
