### PR TITLE
fix(crate): one CellCulture per cell line, and the co-culture claim made unrepresentable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ ab_comparison/
 mutants/
 .mutmut-cache/
 Maturity report UI mockups.zip
+
+# Deposits and context bundles are NEVER published: they are unpublished
+# experimental data, and this repository is public.
+context/*.zip
+input/raw/*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,3 @@ ab_comparison/
 mutants/
 .mutmut-cache/
 Maturity report UI mockups.zip
-
-# Build context bundle — regenerated, not source (#678 housekeeping)
-context/vitro_crate.zip
-context/*copy*.zip

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -2949,12 +2949,23 @@ def _chain_processes(built: list[tuple[Any, str, Any]]) -> None:
         key = getattr(assay, "id", None)
         groups.setdefault(key, {}).setdefault(ptype, []).append(node)
 
+    # What counts as a cultured sample is a STUDY-level question, not an assay
+    # one: culturing is shared, and S-VHPS22's deiodinase assay exposes and
+    # measures cells the metabolism assay grew. Scoped to the group, that assay's
+    # `cultured_ids` came out empty, the guard below never matched, and its
+    # readout kept consuming the culture with an exposure sitting between them —
+    # the half of #650 that survived it (#678).
+    #
+    # Only this lookup widens. `exposed` stays per-assay: one assay's exposure
+    # must never become another's readout input.
+    cultured_ids = {
+        getattr(n, "id", None)
+        for _assay, ptype, node in built
+        if ptype == "CellCulture"
+        for n in _linked_nodes(node, "output", "result")
+    }
+
     for by_type in groups.values():
-        cultured_ids = {
-            getattr(n, "id", None)
-            for proc in by_type.get("CellCulture", [])
-            for n in _linked_nodes(proc, "output", "result")
-        }
         exposed = [
             n
             for proc in by_type.get("Exposure", [])

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -3021,6 +3021,9 @@ def _add_processes(
     # named only one — so the cultures have to exist first. Ordering the pass is
     # enough; nothing else here depends on the draft's own order.
     cultured_by_assay: dict[Any, list[Any]] = {}
+    # protocol id -> [(assay_id, assay node, protocol node)], one row per process
+    # that executes it. Placement waits for all of them; see `_place_protocols`.
+    protocol_use: dict[Any, list[tuple[Any, Any, Any]]] = {}
     ordered = sorted(
         state.list_entities("LabProcess"),
         key=lambda p: 0
@@ -3060,9 +3063,6 @@ def _add_processes(
             )
             if culture_protocols:
                 protocol = culture_protocols
-                study = _study_of(state, idx, f.get("assay_id"))
-                for one in culture_protocols:
-                    _link_to_study(study, one)
         elif protocol is None:
             # Everything else is assay-scoped: the deposit files an assay's
             # procedures beside its data, and the Assay already lists them under
@@ -3092,10 +3092,6 @@ def _add_processes(
                 per_line = _culture_protocols(
                     state, crate, [line], idx, materialize_payload=materialize_payload
                 )
-                if per_line:
-                    study = _study_of(state, idx, assay_key)
-                    for one in per_line:
-                        _link_to_study(study, one)
                 nodes.append(
                     _build_process(
                         crate,
@@ -3137,10 +3133,50 @@ def _add_processes(
             )
         for node in nodes:
             _wire_process_node(
-                state, crate, idx, proc, node, f, ptype, built, first=(node is nodes[0])
+                state,
+                crate,
+                idx,
+                proc,
+                node,
+                f,
+                ptype,
+                built,
+                protocol_use,
+                first=(node is nodes[0]),
             )
 
+    _place_protocols(state, idx, protocol_use)
     _chain_processes(built)
+
+
+def _place_protocols(
+    state: CrateState,
+    idx: dict[str, Any],
+    protocol_use: dict[Any, list[tuple[Any, Any, Any]]],
+) -> None:
+    """Hang each protocol where its use says it belongs (#678).
+
+    `_link_to_study`'s own contract is that "a protocol that governs several
+    assays is a study-level document and the backbone should say so" — but the
+    build keyed on the protocol's KIND, hoisting every culture protocol to the
+    Study however many assays actually followed it, and nesting every other one
+    under its Assay however many shared it. Reuse decides now:
+
+    * followed by more than one assay -> the Study, once
+    * followed by exactly one -> that Assay
+
+    A protocol entity IS its file (D17), so the #532 reachability rule applies
+    either way: nest it, and keep the root's reference.
+    """
+    for rows in protocol_use.values():
+        assays = {key for key, _assay, _protocol in rows if key is not None}
+        _key, assay, protocol = rows[0]
+        if len(assays) > 1:
+            _link_to_study(study := _study_of(state, idx, _key), protocol)
+            if study is not None:
+                continue
+        if assay is not None:
+            _append_unique(assay, "hasPart", protocol)
 
 
 def _wire_process_node(
@@ -3152,6 +3188,7 @@ def _wire_process_node(
     f: dict[str, Any],
     ptype: str,
     built: list[tuple[Any, str, Any]],
+    protocol_use: dict[Any, list[tuple[Any, Any, Any]]],
     *,
     first: bool,
 ) -> None:
@@ -3185,18 +3222,13 @@ def _wire_process_node(
     # through directory Datasets, and an Assay is a contextual node.
     for file_node in _result_file_nodes(node):
         _append_unique(assay, "hasPart", file_node)
-    # ...and so is the protocol it followed. A protocol entity IS its
-    # file (D17), so the same #532 reachability rule applies: nest it
-    # under the Assay, keep the root's reference. Skipped for a
-    # study-level protocol — one shared across assays is already hung
-    # off the Study, and re-parenting it per assay is the duplication
-    # that made it study-level in the first place.
-    study = _study_of(state, idx, f.get("assay_id"))
-    study_parts = set(_child_ids(study)) if study is not None else set()
+    # ...and so is the protocol it followed, but WHERE it hangs depends on how
+    # many assays follow it, which is not knowable while one process is being
+    # wired. Usage is recorded here and placed once every process exists.
     for protocol_node in _protocol_file_nodes(node):
-        if getattr(protocol_node, "id", None) in study_parts:
-            continue
-        _append_unique(assay, "hasPart", protocol_node)
+        protocol_use.setdefault(getattr(protocol_node, "id", None), []).append(
+            (f.get("assay_id"), assay, protocol_node)
+        )
 
     _chain_processes(built)
 

--- a/builder/tools/gap_analysis.py
+++ b/builder/tools/gap_analysis.py
@@ -28,6 +28,7 @@ repair loop can never drift on what "deterministically fixable" means.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -50,7 +51,7 @@ from builder.tools.mit_assessment import (
 logger = logging.getLogger(__name__)
 
 Tier = Literal["MUST", "SHOULD", "MAY"]
-Source = Literal["shacl", "mit", "fair", "air"]
+Source = Literal["shacl", "mit", "fair", "air", "identity"]
 
 # The MIT checklist path, loader and parameter traversal all live in
 # builder.tools.mit_assessment (#357). This module had its own copy of each, with
@@ -242,6 +243,87 @@ def _instances_of(state: CrateState, entity_type: str | None) -> list[Entity]:
         return list(state.list_entities(entity_type))
     except (KeyError, ValueError):  # pragma: no cover — unknown type is rare
         return []
+
+
+# ---------------------------------------------------------------------------
+# Identity gaps
+# ---------------------------------------------------------------------------
+
+_PUNCT = re.compile(r"[^0-9a-z]+")
+
+
+def _identity_key(name: str) -> str:
+    """A cell-line name with case and punctuation removed, tokens intact.
+
+    "H4", "H-4" and "h 4" collapse together; "CHO-K1" and "CHO-K1 hOATP1C1" do
+    not, because the extra token survives. That distinction is the point: an
+    engineered derivative is a different line, and
+    :func:`~builder.tools.lookups.cell_line_names_match` already refuses to treat
+    it as its parent.
+    """
+    return _PUNCT.sub("", (name or "").casefold())
+
+
+def _identity_gaps(state: CrateState) -> list[Gap]:
+    """Cell lines that may be one line under two spellings — a question, not a merge.
+
+    S-VHPS22 carries "H4" and "H-4" as separate entities, neither resolved. They
+    are probably one line typed twice, and the builder must not act on "probably":
+    Cellosaurus registers H4 (``CVCL_1239``) and H-4 (``CVCL_6C19``) as DISTINCT
+    records that each list the other's name as a synonym, and a third
+    (``CVCL_HA56``) also answers to H4. All three are human, so neither
+    punctuation nor species separates them. There is no general property that
+    tells "one line typed twice" from "two lines sharing a synonym", so merging
+    on a normalised name would fabricate an identity (D5).
+
+    Reported only where NOTHING can settle it — every entity in the group lacks
+    an accession. One accession anywhere in the group answers the question
+    already, and two different accessions mean two lines however alike the names
+    look; :func:`_find_cell_line_by_accession` then merges the ones that really
+    are the same. This is the residue that identifier resolution could not reach.
+
+    One gap per group, not per entity: three spellings of one name is one
+    question.
+    """
+    groups: dict[str, list[Entity]] = {}
+    resolved: set[str] = set()
+    for entity in _instances_of(state, "CellLineSample"):
+        key = _identity_key(str(entity.fields.get("name") or ""))
+        if not key:
+            continue
+        groups.setdefault(key, []).append(entity)
+        if entity.fields.get("accession") or entity.fields.get("identifier"):
+            resolved.add(key)
+
+    gaps: list[Gap] = []
+    for key, members in sorted(groups.items()):
+        if key in resolved or len(members) < 2:
+            continue
+        names = sorted({str(m.fields.get("name") or m.entity_id) for m in members})
+        gaps.append(
+            Gap(
+                tier="SHOULD",
+                source="identity",
+                entity_id=members[0].entity_id,
+                entity_type="CellLineSample",
+                property="name",
+                message=(
+                    f"{len(members)} cell lines differ only in punctuation or case "
+                    f"({', '.join(names)}) and none resolved to a Cellosaurus "
+                    "accession. They may be one line under several spellings, or "
+                    "genuinely different lines that share a synonym — Cellosaurus "
+                    "registers such pairs. The crate cannot tell them apart."
+                ),
+                suggestion=(
+                    "Confirm whether these name one cell line. If they do, give the "
+                    "accession (CVCL_*) so the entities merge on identity; if they "
+                    "do not, name them distinctly."
+                ),
+                fix_hint="ask-user",
+                auto_fixable=False,
+            )
+        )
+    return gaps
 
 
 # ---------------------------------------------------------------------------
@@ -702,8 +784,13 @@ def assess_gaps(state: CrateState) -> GapReport:
     mit_report = assess_mit_coverage(state, graph=metadata_doc)
     fair_gaps, fair_summary = _fair_gaps(state, graph=metadata_doc, mit=mit_report)
     air_gaps, air_summary = _air_gaps(state, graph=metadata_doc)
+    # Reads state, not the assembled document: the question is whether two
+    # entities name one thing, which the crate answers identically either way.
+    identity_gaps = _identity_gaps(state)
 
-    gaps = sorted([*shacl_gaps, *mit_gaps, *fair_gaps, *air_gaps], key=_sort_key)
+    gaps = sorted(
+        [*shacl_gaps, *mit_gaps, *fair_gaps, *air_gaps, *identity_gaps], key=_sort_key
+    )
 
     counts = {
         "must_open": sum(1 for g in gaps if g.tier == "MUST"),

--- a/context/vitro_crate.zip
+++ b/context/vitro_crate.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7787e09aaa09b5327965424458d16ad473822b43dda7c463e33959129be2b49f
+size 356721

--- a/context/vitro_crate.zip
+++ b/context/vitro_crate.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7787e09aaa09b5327965424458d16ad473822b43dda7c463e33959129be2b49f
-size 356721

--- a/input/raw/S-VHPS21.zip
+++ b/input/raw/S-VHPS21.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34739f0c25fa45ddae303eff0af91eeef000a006b3f06c424b772b877bb61b2c
-size 112766786

--- a/input/raw/S-VHPS22.zip
+++ b/input/raw/S-VHPS22.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8e575e0728ab207f6a0096646823f0d37fd2daafff89660de2e416aa60ad531
-size 120187355

--- a/input/raw/S-VHPS26.zip
+++ b/input/raw/S-VHPS26.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77f2d41a88ac3c692ae2e12a60135c91adb675f70f6d1a95418eb20722cd887f
-size 10977849

--- a/profiles/shapes/tox/12_cultured_sample_lineage.ttl
+++ b/profiles/shapes/tox/12_cultured_sample_lineage.ttl
@@ -1,0 +1,90 @@
+# Cultured and co-cultured material — how many cell lines a Sample may come from.
+#
+# A CellCulture of several lines emitting ONE Sample asserts the lines were mixed.
+# The builder splits such a step per line (#678); these make the claim
+# unrepresentable, so a hand-authored or ReAct-built crate cannot make it either.
+#
+# Co-culture is a real design and is accommodated, not forbidden. The material
+# says which it is — never the number of lines listed — and both directions are
+# checked, or the co-culture type becomes a way to escape the first rule.
+#
+#   OBI:0001876  cell culture  ->  exactly one line
+#   NCIT:C93168  co-culture    ->  two or more
+#
+# Path is `schema:isBasedOn`: `derivesFrom` is the compact term the crate writes,
+# and `profiles.context` maps it there. Targeting the alias constrains nothing.
+# OBI:0001876 covers the exposed sample too — an exposure changes a sample's
+# state, not its kind — and one exposed sample derives from one cultured one.
+
+@prefix bioschemas: <https://bioschemas.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix tox: <https://w3id.org/ro/crate/isa-tox/1.0/> .
+@prefix validator: <https://github.com/crs4/rocrate-validator/> .
+
+# Type a Sample by the material it declares itself to be — same idiom and same
+# `sh:order 10` tier as `tox:FindCellLineSamples`.
+tox:FindCulturedSamples a sh:NodeShape, validator:HiddenShape ;
+    sh:name "Identify cultured samples within the RO-Crate" ;
+    sh:description "A Sample whose sampleType is OBI's 'cell culture' holds cultured cells." ;
+    sh:targetClass bioschemas:Sample ;
+    sh:order 10 ;
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object tox:CulturedSample ;
+        sh:condition [
+            a sh:NodeShape ;
+            sh:property [
+                sh:path schema:sampleType ;
+                sh:hasValue <http://purl.obolibrary.org/obo/OBI_0001876> ;
+                sh:minCount 1 ;
+            ] ;
+        ] ;
+    ] .
+
+tox:FindCoCultureSamples a sh:NodeShape, validator:HiddenShape ;
+    sh:name "Identify co-culture samples within the RO-Crate" ;
+    sh:description "A Sample whose sampleType is NCIT's 'Co-Culture' holds cells grown together." ;
+    sh:targetClass bioschemas:Sample ;
+    sh:order 10 ;
+    sh:rule [
+        a sh:TripleRule ;
+        sh:subject sh:this ;
+        sh:predicate rdf:type ;
+        sh:object tox:CoCultureSample ;
+        sh:condition [
+            a sh:NodeShape ;
+            sh:property [
+                sh:path schema:sampleType ;
+                sh:hasValue <http://purl.obolibrary.org/obo/NCIT_C93168> ;
+                sh:minCount 1 ;
+            ] ;
+        ] ;
+    ] .
+
+tox:CulturedSampleDerivesFromOneLine a sh:NodeShape ;
+    sh:name "A cultured Sample derives from ONE cell line" ;
+    sh:description "Culturing several lines separately yields one Sample each; one Sample from several lines is a co-culture and must say so." ;
+    sh:targetClass tox:CulturedSample ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path schema:isBasedOn ;
+        sh:maxCount 1 ;
+        sh:message "A cultured Sample MUST derive from at most one cell line — deriving from several asserts a co-culture. Culture each line separately, or type the material as a co-culture (NCIT:C93168)." ;
+        sh:severity sh:Violation ;
+    ] .
+
+tox:CoCultureDerivesFromSeveralLines a sh:NodeShape ;
+    sh:name "A co-culture Sample derives from SEVERAL cell lines" ;
+    sh:description "The co-culture type describes a mixture; a single line grown alone is a plain culture." ;
+    sh:targetClass tox:CoCultureSample ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path schema:isBasedOn ;
+        sh:minCount 2 ;
+        sh:message "A Sample typed as a co-culture (NCIT:C93168) MUST derive from two or more cell lines. One line grown alone is a cell culture (OBI:0001876)." ;
+        sh:severity sh:Violation ;
+    ] .

--- a/profiles/shapes/tox/12_cultured_sample_lineage.ttl
+++ b/profiles/shapes/tox/12_cultured_sample_lineage.ttl
@@ -73,7 +73,7 @@ tox:CulturedSampleDerivesFromOneLine a sh:NodeShape ;
         a sh:PropertyShape ;
         sh:path schema:isBasedOn ;
         sh:maxCount 1 ;
-        sh:message "A cultured Sample MUST derive from at most one cell line — deriving from several asserts a co-culture. Culture each line separately, or type the material as a co-culture (NCIT:C93168)." ;
+        sh:message "A cultured Sample MUST derive from at most one cell line — culture each line separately, or type the material as a co-culture (NCIT:C93168)" ;
         sh:severity sh:Violation ;
     ] .
 
@@ -85,6 +85,6 @@ tox:CoCultureDerivesFromSeveralLines a sh:NodeShape ;
         a sh:PropertyShape ;
         sh:path schema:isBasedOn ;
         sh:minCount 2 ;
-        sh:message "A Sample typed as a co-culture (NCIT:C93168) MUST derive from two or more cell lines. One line grown alone is a cell culture (OBI:0001876)." ;
+        sh:message "A Sample typed as a co-culture (NCIT:C93168) MUST derive from two or more cell lines — one line grown alone is a cell culture (OBI:0001876)" ;
         sh:severity sh:Violation ;
     ] .

--- a/profiles/shapes/tox/4_lab_process_endpoint_readout.ttl
+++ b/profiles/shapes/tox/4_lab_process_endpoint_readout.ttl
@@ -61,6 +61,6 @@ tox:EndpointReadoutConsumesExposedMaterial a sh:NodeShape ;
             [ sh:class schema:MediaObject ]
             [ sh:class bioschemas:Sample ]
         ) ;
-        sh:message "EndpointReadout process MUST have at least one schema:object naming what it measured — the exposed Sample, or the File it re-analysed. A readout with no input does not say what was measured." ;
+        sh:message "EndpointReadout process MUST have at least one schema:object naming what it measured — the exposed Sample, or the File it re-analysed" ;
         sh:severity sh:Violation ;
     ] .

--- a/profiles/shapes/tox/4_lab_process_endpoint_readout.ttl
+++ b/profiles/shapes/tox/4_lab_process_endpoint_readout.ttl
@@ -42,3 +42,25 @@ tox:EndpointReadoutRequirements a sh:NodeShape ;
         sh:message "EndpointReadout process MUST have at least one schema:additionalProperty (e.g. Detection Instrument, Endpoint, Measured Entity)" ;
         sh:severity sh:Violation ;
     ] .
+
+# What the readout MEASURED. The shape above asks only for a result, so a readout
+# consuming nothing — or the wrong material — validated clean (#650, #678).
+# File OR Sample: a readout measures exposed cells, a re-analysis measures
+# deposited data. That the object should be an EXPOSURE's output is deliberately
+# not asserted here — a characterisation run legitimately measures the culture,
+# and that condition spans two entities, so `_chain_processes` enforces it.
+tox:EndpointReadoutConsumesExposedMaterial a sh:NodeShape ;
+    sh:name "EndpointReadout MUST say what it measured" ;
+    sh:description "An endpoint readout declares the material or data it consumed." ;
+    sh:targetClass tox:LabProcessEndpointReadout ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path schema:object ;
+        sh:minCount 1 ;
+        sh:or (
+            [ sh:class schema:MediaObject ]
+            [ sh:class bioschemas:Sample ]
+        ) ;
+        sh:message "EndpointReadout process MUST have at least one schema:object naming what it measured — the exposed Sample, or the File it re-analysed. A readout with no input does not say what was measured." ;
+        sh:severity sh:Violation ;
+    ] .

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -70,6 +70,7 @@ def _endpoint_readout_missing_result(n_files: int = 1) -> CrateState:
     exactly one un-wired File exists (the deterministic-repair rule's predicate).
     """
     state = _backbone()
+    state.add_entity(_entity("s1", "Sample", name="exposed cells"))
     state.add_entity(
         _entity(
             "er1",
@@ -79,8 +80,11 @@ def _endpoint_readout_missing_result(n_files: int = 1) -> CrateState:
             assay_id="as1",
             # As in tests/test_tools_repair.py: the missing RESULT is the gap
             # under test, so give the readout a real parameter rather than let
-            # the separate additionalProperty MUST fire alongside it.
+            # the separate additionalProperty MUST fire alongside it. Same
+            # reasoning for `samples`, since #678: a readout MUST now say what it
+            # measured, and that MUST would otherwise fire alongside this one.
             detection_instrument="Plate reader",
+            samples="s1",
         )
     )
     for i in range(n_files):

--- a/tests/test_cell_line_collision_gap.py
+++ b/tests/test_cell_line_collision_gap.py
@@ -1,0 +1,122 @@
+"""Two unresolved cell lines whose names differ only in punctuation (#678, inv. 6).
+
+S-VHPS22 carries "H4" and "H-4" as two CellLineSample entities, neither with an
+accession. They are almost certainly one line typed twice — and the builder must
+NOT act on "almost certainly". Cellosaurus registers H4 (CVCL_1239) and H-4
+(CVCL_6C19) as distinct records that each list the other's name as a synonym, and
+a third (CVCL_HA56) also answers to H4; all three are human. No general
+discriminator separates "one line typed twice" from "two lines sharing a
+synonym", so merging on normalised name would fabricate an identity claim.
+
+The collision is reported instead, for the depositor to settle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.gap_analysis import assess_gaps
+
+pytestmark = pytest.mark.timeout(180)
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+def _state(*lines):
+    state = CrateState()
+    state.add_entity(_ent("study_1", "Study", name="S"))
+    for eid, fields in lines:
+        state.add_entity(_ent(eid, "CellLineSample", **fields))
+    return state
+
+
+def _collisions(state):
+    return [g for g in assess_gaps(state).gaps if g.source == "identity"]
+
+
+class TestTheCollisionIsReported:
+    def test_two_unresolved_near_identical_names_collide(self):
+        gaps = _collisions(
+            _state(("cell_h4", {"name": "H4"}), ("cell_h_4", {"name": "H-4"}))
+        )
+        assert len(gaps) == 1, f"expected one collision gap, got {gaps}"
+        message = gaps[0].message
+        assert "H4" in message and "H-4" in message, message
+
+    def test_the_gap_does_not_assert_they_are_the_same(self):
+        """The whole point. It asks; it must not conclude."""
+        gap = _collisions(
+            _state(("cell_h4", {"name": "H4"}), ("cell_h_4", {"name": "H-4"}))
+        )[0]
+        assert gap.tier == "SHOULD", "a question for the depositor is not a blocker"
+        assert gap.fix_hint == "ask-user"
+        assert gap.auto_fixable is False, (
+            "nothing here is resolvable from state alone — that is the finding"
+        )
+
+    def test_it_is_reported_once_per_group_not_once_per_entity(self):
+        gaps = _collisions(
+            _state(
+                ("cell_h4", {"name": "H4"}),
+                ("cell_h_4", {"name": "H-4"}),
+                ("cell_h4b", {"name": "h 4"}),
+            )
+        )
+        assert len(gaps) == 1, f"three spellings of one name is one question: {gaps}"
+
+
+class TestWhatMustNotCollide:
+    def test_resolved_lines_never_collide(self):
+        """Two accessions is two lines, whatever the names look like.
+
+        This is the case that makes punctuation-merging unsafe: Cellosaurus
+        really does register H4 and H-4 separately.
+        """
+        gaps = _collisions(
+            _state(
+                ("cell_h4", {"name": "H4", "accession": "CVCL_1239"}),
+                ("cell_h_4", {"name": "H-4", "accession": "CVCL_6C19"}),
+            )
+        )
+        assert not gaps, f"resolved lines are settled, not colliding: {gaps}"
+
+    def test_one_resolved_one_not_does_not_collide(self):
+        """An accession on either side answers the question already."""
+        gaps = _collisions(
+            _state(
+                ("cell_h4", {"name": "H4", "accession": "CVCL_1239"}),
+                ("cell_h_4", {"name": "H-4"}),
+            )
+        )
+        assert not gaps, gaps
+
+    def test_genuinely_different_names_do_not_collide(self):
+        gaps = _collisions(
+            _state(("cell_a", {"name": "SK-N-AS"}), ("cell_b", {"name": "MO3.13"}))
+        )
+        assert not gaps, gaps
+
+    def test_a_single_unresolved_line_does_not_collide(self):
+        assert not _collisions(_state(("cell_h4", {"name": "H4"})))
+
+    def test_a_derivative_is_not_a_collision(self):
+        """`cell_line_names_match`'s rule, kept: CHO-K1 hOATP1C1 is not CHO-K1.
+
+        Punctuation-insensitivity must not become token-insensitivity, or an
+        engineered derivative reads as a duplicate of its parent.
+        """
+        gaps = _collisions(
+            _state(
+                ("cell_p", {"name": "CHO-K1"}),
+                ("cell_d", {"name": "CHO-K1 hOATP1C1"}),
+            )
+        )
+        assert not gaps, f"a derivative is a different line: {gaps}"

--- a/tests/test_cultured_sample_shapes.py
+++ b/tests/test_cultured_sample_shapes.py
@@ -1,0 +1,235 @@
+"""The co-culture claim is unrepresentable, not merely un-made (#678).
+
+The builder now splits a culture per cell line, so the crates this repo produces
+no longer assert a mixture. That fixes today's output; it does not stop a crate
+built by the ReAct arm, hand-authored, or produced by a future refactor from
+saying it again. These pin the shapes that do.
+
+A co-culture is a real experimental design and is accommodated rather than
+forbidden: the material says which it is, and both directions are checked — a
+mixture posing as a pure culture fails, and a "co-culture" of one line fails too.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import warnings
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.builder import build_crate
+from profiles.validator import validate_crate_dict
+
+pytestmark = pytest.mark.timeout(180)
+
+CELL_CULTURE_TERM = "http://purl.obolibrary.org/obo/OBI_0001876"
+CO_CULTURE_TERM = "http://purl.obolibrary.org/obo/NCIT_C93168"
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+@pytest.fixture(scope="module")
+def valid_doc(tmp_path_factory):
+    """A crate that passes, to be perturbed one property at a time."""
+    state = CrateState()
+    state.add_entity(_ent("assay_1", "Assay", name="Deiodinase Assay"))
+    state.add_entity(
+        _ent("cell_a", "CellLineSample", name="SK-N-AS", accession="CVCL_1700")
+    )
+    state.add_entity(
+        _ent("cell_b", "CellLineSample", name="MO3.13", accession="CVCL_D357")
+    )
+    state.add_entity(
+        _ent(
+            "proc_cult",
+            "LabProcess",
+            name="Culture neural cells",
+            process_type="CellCulture",
+            assay_id="assay_1",
+            cell_line=["cell_a", "cell_b"],
+            culture_medium="CT medium",
+        )
+    )
+    state.add_entity(
+        _ent(
+            "proc_exp",
+            "LabProcess",
+            name="2-hour D3 activity exposure",
+            process_type="Exposure",
+            assay_id="assay_1",
+            duration="2 hours",
+        )
+    )
+    out = tmp_path_factory.mktemp("shapes") / "crate"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert build_crate(state, str(out))["success"] is True
+    with open(out / "ro-crate-metadata.json") as f:
+        return json.load(f)
+
+
+def _tox(doc):
+    """The ISA-Tox pass over an in-memory document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        results = validate_crate_dict(doc, profile="tox")
+    assert results, "no ISA-Tox pass ran"
+    return results[0]
+
+
+def _cultured(doc):
+    """A Sample the crate types as a cell culture."""
+    for node in doc["@graph"]:
+        st = node.get("sampleType")
+        if isinstance(st, dict) and st.get("@id") == CELL_CULTURE_TERM:
+            return node
+    raise AssertionError("no cultured Sample in the fixture")
+
+
+def test_the_fixture_itself_passes(valid_doc):
+    """Guards every other test here: a failure below must be the perturbation."""
+    assert _tox(valid_doc).passed_required, _tox(valid_doc).required_issues
+
+
+class TestACulturedSampleComesFromOneLine:
+    def test_two_lines_on_a_cultured_sample_is_a_violation(self, valid_doc):
+        doc = copy.deepcopy(valid_doc)
+        _cultured(doc)["derivesFrom"] = [
+            {"@id": "https://www.cellosaurus.org/CVCL_1700"},
+            {"@id": "https://www.cellosaurus.org/CVCL_D357"},
+        ]
+        result = _tox(doc)
+        assert not result.passed_required, (
+            "a cultured Sample deriving from two cell lines asserts a co-culture "
+            "and must not validate"
+        )
+
+    def test_the_same_sample_typed_as_a_co_culture_passes(self, valid_doc):
+        """Co-culture is accommodated, not forbidden.
+
+        The only difference from the test above is what the material says it is.
+        """
+        doc = copy.deepcopy(valid_doc)
+        sample = _cultured(doc)
+        sample["derivesFrom"] = [
+            {"@id": "https://www.cellosaurus.org/CVCL_1700"},
+            {"@id": "https://www.cellosaurus.org/CVCL_D357"},
+        ]
+        sample["sampleType"] = {"@id": CO_CULTURE_TERM}
+        doc["@graph"].append(
+            {
+                "@id": CO_CULTURE_TERM,
+                "@type": "DefinedTerm",
+                "name": "Co-Culture",
+                "termCode": "NCIT:C93168",
+            }
+        )
+        result = _tox(doc)
+        assert result.passed_required, (
+            f"a declared co-culture of two lines is legitimate: {result.required_issues}"
+        )
+
+
+class TestACoCultureIsAMixture:
+    def test_a_co_culture_of_one_line_is_a_violation(self, valid_doc):
+        """The other direction: the label must not be free.
+
+        A material typed Co-Culture that derives from a single line is as wrong
+        as a mixture claiming to be pure — it would let the type be used to
+        escape the constraint above rather than to describe an experiment.
+        """
+        doc = copy.deepcopy(valid_doc)
+        sample = _cultured(doc)
+        sample["sampleType"] = {"@id": CO_CULTURE_TERM}
+        sample["derivesFrom"] = [{"@id": "https://www.cellosaurus.org/CVCL_1700"}]
+        doc["@graph"].append(
+            {
+                "@id": CO_CULTURE_TERM,
+                "@type": "DefinedTerm",
+                "name": "Co-Culture",
+                "termCode": "NCIT:C93168",
+            }
+        )
+        assert not _tox(doc).passed_required, (
+            "a co-culture of one cell line is a contradiction"
+        )
+
+
+def _with_readout(doc, *, consumes):
+    """Append a well-formed EndpointReadout that consumes *consumes*.
+
+    Hand-authored rather than built, because the builder will not produce the
+    shapes under test — that is the point of having them.
+    """
+    doc = copy.deepcopy(doc)
+    doc["@graph"].append(
+        {
+            "@id": "data/raw_measurements.csv",
+            "@type": "File",
+            "name": "raw measurements",
+            "encodingFormat": "text/csv",
+        }
+    )
+    doc["@graph"].append(
+        {
+            "@id": "#param_Endpoint_test",
+            "@type": "PropertyValue",
+            "name": "Endpoint",
+            "value": "T3 conversion",
+        }
+    )
+    readout = {
+        "@id": "#LabProcess_proc_read",
+        "@type": ["LabProcess", "schema:Action"],
+        "additionalType": "EndpointReadout",
+        "name": "D3 deiodinase activity readout",
+        "output": [{"@id": "data/raw_measurements.csv"}],
+        "additionalProperty": [{"@id": "#param_Endpoint_test"}],
+        "parameterValue": [{"@id": "#param_Endpoint_test"}],
+    }
+    if consumes is not None:
+        readout["input"] = consumes
+    doc["@graph"].append(readout)
+    for node in doc["@graph"]:
+        if node.get("@id") == "./":
+            node.setdefault("hasPart", [])
+            if isinstance(node["hasPart"], list):
+                node["hasPart"].append({"@id": "data/raw_measurements.csv"})
+    return doc
+
+
+class TestAReadoutSaysWhatItMeasured:
+    """The readout shape had no input rule at all, which is why a readout
+    consuming the wrong material — or nothing — validated clean (#650, #678)."""
+
+    def test_a_readout_consuming_nothing_is_a_violation(self, valid_doc):
+        doc = _with_readout(valid_doc, consumes=None)
+        assert not _tox(doc).passed_required, (
+            "a readout that names no input measured nothing; the crate cannot "
+            "say what was measured"
+        )
+
+    def test_a_readout_consuming_a_sample_passes(self, valid_doc):
+        sample_id = _cultured(valid_doc)["@id"]
+        doc = _with_readout(valid_doc, consumes=[{"@id": sample_id}])
+        result = _tox(doc)
+        assert result.passed_required, (
+            f"a readout measuring a Sample is well-formed: {result.required_issues}"
+        )
+
+    def test_a_readout_consuming_a_file_passes(self, valid_doc):
+        """A File is a legitimate input — a re-analysis measures deposited data."""
+        doc = _with_readout(valid_doc, consumes=[{"@id": "data/raw_measurements.csv"}])
+        result = _tox(doc)
+        assert result.passed_required, (
+            f"a readout measuring a File is well-formed: {result.required_issues}"
+        )

--- a/tests/test_per_cell_line_cultures.py
+++ b/tests/test_per_cell_line_cultures.py
@@ -267,3 +267,81 @@ class TestTheReadoutMeasuresWhatTheExposureProduced:
         assert _ids(readout.get("input")), (
             "a readout in an exposure-free assay keeps consuming the culture"
         )
+
+
+class TestAProtocolSitsWhereItIsUsed:
+    """Invariant 4 — the protocol is the reused entity, so reuse decides placement.
+
+    ``_link_to_study``'s own docstring already says it: "a protocol that governs
+    several assays is a study-level document and the backbone should say so". The
+    implementation keyed on the protocol's KIND instead — every culture protocol
+    went to the Study, however many assays actually followed it.
+    """
+
+    def _two_assays_one_line_each(self):
+        """Each assay grows a different line, so neither document is shared."""
+        state = CrateState()
+        state.metadata.input_path = "/deposit"
+        state.add_entity(_ent("study_1", "Study", name="S"))
+        state.add_entity(_ent("assay_1", "Assay", name="A1", study_id="study_1"))
+        state.add_entity(_ent("assay_2", "Assay", name="A2", study_id="study_1"))
+        state.add_entity(_ent("cell_a", "CellLineSample", name="SK-N-AS"))
+        state.add_entity(_ent("cell_b", "CellLineSample", name="H4"))
+        for eid, nm in (
+            ("proto_sk", "cell culture protocol SK-N-AS.docx"),
+            ("proto_h4", "cell culture protocol H4.docx"),
+        ):
+            state.add_entity(
+                _ent(
+                    eid,
+                    "File",
+                    name=nm,
+                    path=f"cell_line_protocols/{nm}",
+                    additional_types=["LabProtocol"],
+                )
+            )
+        for n, (assay, line) in enumerate(
+            (("assay_1", "cell_a"), ("assay_2", "cell_b")), start=1
+        ):
+            state.add_entity(
+                _ent(
+                    f"proc_{n}",
+                    "LabProcess",
+                    name=f"Culture {n}",
+                    process_type="CellCulture",
+                    assay_id=assay,
+                    cell_line=line,
+                    culture_medium="DMEM",
+                )
+            )
+        return state
+
+    def test_a_protocol_used_by_one_assay_is_not_hoisted_to_the_study(self, tmp_path):
+        _, by_id = _build(self._two_assays_one_line_each(), tmp_path)
+        study_parts = _ids(by_id["#Study_study_1"].get("hasPart"))
+        hoisted = [p for p in study_parts if "cell_line_protocols" in str(p)]
+        assert not hoisted, (
+            "each document is followed by exactly one assay, so none is a "
+            f"study-level protocol: {hoisted}"
+        )
+
+    def test_a_protocol_used_by_one_assay_nests_under_that_assay(self, tmp_path):
+        _, by_id = _build(self._two_assays_one_line_each(), tmp_path)
+        a1 = _ids(by_id["#Assay_assay_1"].get("hasPart"))
+        a2 = _ids(by_id["#Assay_assay_2"].get("hasPart"))
+        assert any("SK-N-AS" in str(p) for p in a1), (
+            f"assay_1 follows the SK-N-AS document: {a1}"
+        )
+        assert any("H4" in str(p) for p in a2), f"assay_2 follows the H4 document: {a2}"
+
+    def test_a_shared_protocol_is_still_study_level(self, tmp_path):
+        """The other half: reuse across assays is what makes it study-level."""
+        state = self._two_assays_one_line_each()
+        state.get_entity("proc_2").set_fields_from_dict(
+            {"cell_line": "cell_a"}, source="llm"
+        )
+        _, by_id = _build(state, tmp_path)
+        study_parts = _ids(by_id["#Study_study_1"].get("hasPart"))
+        assert any("SK-N-AS" in str(p) for p in study_parts), (
+            f"both assays grow SK-N-AS, so its document is study-level: {study_parts}"
+        )

--- a/tests/test_per_cell_line_cultures.py
+++ b/tests/test_per_cell_line_cultures.py
@@ -180,3 +180,90 @@ class TestExposureDoesNotRelocateTheMerge:
                 f"{node.get('name')!r} derives from {len(lineage)} samples; an "
                 "exposed sample comes from exactly one cultured sample"
             )
+
+
+class TestTheReadoutMeasuresWhatTheExposureProduced:
+    """The surviving half of #650, live in S-VHPS22.
+
+    ``_chain_processes`` redirects a readout off the cultured sample onto the
+    exposed one, but grouped by ASSAY — and culturing is study-level, shared
+    between the deiodinase and metabolism assays. The deiodinase group held no
+    CellCulture, so its ``cultured_ids`` was empty, the guard never matched, and
+    its readout kept consuming the culture while an exposure sat between them.
+    """
+
+    def _borrowed_culture(self, *, with_exposure=True):
+        """assay_2 exposes and measures cells that assay_1 grew."""
+        state = CrateState()
+        state.add_entity(_ent("assay_1", "Assay", name="Metabolism"))
+        state.add_entity(_ent("assay_2", "Assay", name="Deiodinase"))
+        state.add_entity(
+            _ent("cell_a", "CellLineSample", name="SK-N-AS", accession="CVCL_1700")
+        )
+        state.add_entity(_ent("sample_cult", "Sample", name="cultured"))
+        state.add_entity(
+            _ent(
+                "proc_cult",
+                "LabProcess",
+                name="Culture SK-N-AS",
+                process_type="CellCulture",
+                assay_id="assay_1",
+                cell_line="cell_a",
+                culture_medium="CT medium",
+                result="sample_cult",
+            )
+        )
+        if with_exposure:
+            state.add_entity(
+                _ent(
+                    "proc_exp",
+                    "LabProcess",
+                    name="2-hour D3 activity exposure",
+                    process_type="Exposure",
+                    assay_id="assay_2",
+                    samples="sample_cult",
+                    duration="2 hours",
+                )
+            )
+        state.add_entity(
+            _ent(
+                "proc_read",
+                "LabProcess",
+                name="D3 deiodinase activity readout",
+                process_type="EndpointReadout",
+                assay_id="assay_2",
+                samples="sample_cult",
+                detection_instrument="UPLC",
+                endpoint="T3 conversion",
+            )
+        )
+        return state
+
+    def test_readout_consumes_the_exposed_sample_not_the_cultured_one(self, tmp_path):
+        graph, by_id = _build(self._borrowed_culture(), tmp_path)
+        exposure = _processes(graph, "Exposure")[0]
+        readout = _processes(graph, "EndpointReadout")[0]
+        exposed = {
+            r
+            for r in _ids(exposure.get("output"))
+            if r in by_id and _typed(by_id[r], "Sample")
+        }
+        consumed = set(_ids(readout.get("input")))
+        assert exposed, "the exposure produced no exposed sample to measure"
+        assert consumed & exposed, (
+            "the readout measured the cultured sample while an exposure sat "
+            f"between them: consumed={sorted(consumed)} exposed={sorted(exposed)}"
+        )
+
+    def test_a_readout_with_no_exposure_still_measures_the_culture(self, tmp_path):
+        """A characterisation run is the truth, not the defect.
+
+        An assay with no Exposure measures the culture, and nothing should
+        redirect it — there is no exposed sample and inventing one would assert
+        an intervention that never happened.
+        """
+        graph, _ = _build(self._borrowed_culture(with_exposure=False), tmp_path)
+        readout = _processes(graph, "EndpointReadout")[0]
+        assert _ids(readout.get("input")), (
+            "a readout in an exposure-free assay keeps consuming the culture"
+        )

--- a/tests/test_tools_repair.py
+++ b/tests/test_tools_repair.py
@@ -57,6 +57,7 @@ def _endpoint_readout_missing_result(n_files: int = 1) -> CrateState:
     fixable iff exactly one un-wired File exists (unambiguous target).
     """
     state = _backbone()
+    state.add_entity(_entity("s1", "Sample", name="exposed cells"))
     state.add_entity(
         _entity(
             "er1",
@@ -68,7 +69,11 @@ def _endpoint_readout_missing_result(n_files: int = 1) -> CrateState:
             # parameter so the separate "MUST have at least one
             # additionalProperty" issue does not also fire and mask the repair
             # under test — `_pv` no longer emits a placeholder to satisfy it.
+            # Same reasoning for `samples`, since #678: a readout MUST now name
+            # what it measured, and that MUST would otherwise fire alongside
+            # the one under test and make the repair look incomplete.
             detection_instrument="Plate reader",
+            samples="s1",
         )
     )
     for i in range(n_files):


### PR DESCRIPTION
Closes #678.

The crate asserted a co-culture that never happened, and the merge repeated one hop later. Both hops are fixed together, and the claim is made unrepresentable rather than merely un-made.

## The six invariants

| | invariant | how |
|---|---|---|
| 1 | a `CellCulture` grows one cell line | a draft naming N lines builds N nodes, each with that line's own protocol |
| 2 | a cultured `Sample` derives from exactly one line | + a SHACL shape |
| 3 | one exposed `Sample` per cultured one consumed | cultures build before exposures so an exposure can see its assay's full set |
| 4 | a protocol hangs where its **use** says, not its kind | placement moves to a pass that runs once every process exists |
| 5 | the readout consumes the exposed samples | the cultured-sample lookup widens study-wide; `exposed` stays per-assay |
| 6 | a cell line appears once | **reported, not merged** — see below |

Only the cultured-sample lookup in `_chain_processes` widens. One assay's exposure must never become another's readout input, so `exposed` stays scoped.

## Three shapes

- `CulturedSampleDerivesFromOneLine` — `maxCount 1` on a `sampleType OBI:0001876` Sample
- `CoCultureDerivesFromSeveralLines` — `minCount 2` on a `sampleType NCIT:C93168` Sample
- `EndpointReadoutConsumesExposedMaterial` — `minCount 1` `schema:object`, File or Sample

**Co-culture is accommodated, not forbidden.** The material declares which it is; the number of lines listed never decides. Both directions are checked, or the co-culture type becomes a way to escape the first rule rather than a way to describe an experiment.

The path is `schema:isBasedOn`, **not** `schema:derivesFrom`. `derivesFrom` is the compact term the crate writes and `profiles.context` maps it there — a shape targeting the alias parses, loads, and constrains nothing. Worth knowing before writing the next one.

That a readout's object should be an *exposure's* output is deliberately not asserted in SHACL: a characterisation run legitimately measures the culture, and the condition spans two entities, so `_chain_processes` enforces it where it can see both.

## Invariant 6 is a report, not a merge

S-VHPS22 carries "H4" and "H-4" as separate entities, neither resolved. Merging them looks obvious and would have been wrong:

| accession | name | `alternateName` | species |
|---|---|---|---|
| `CVCL_1239` | H4 | **H-4** | human |
| `CVCL_6C19` | H-4 | **H4** | human |
| `CVCL_HA56` | Hutt60 | H4, H4.iPSC | human |

Cellosaurus registers them as distinct records that **each list the other's name as a synonym**, and all three are human — so neither punctuation nor species separates them. No general property tells "one line typed twice" from "two lines sharing a synonym", so merging would fabricate an identity (D5) and would be tuned to this deposit's coincidences.

So the collision is reported: SHOULD, `ask-user`, never auto-fixable, one gap per group. It fires only where nothing can settle it — every entity in the group lacks an accession. One accession anywhere answers the question, and two different accessions mean two lines, which `_find_cell_line_by_accession` already handles. This is the residue identifier resolution could not reach.

Punctuation-insensitive, not token-insensitive: `CHO-K1` and `CHO-K1 hOATP1C1` stay distinct.

## Tests changed rather than deleted

Two #650 tests asserted the merged shape — one of them asserted the co-culture claim directly. They are **reversed**, keeping #650's real guarantee that no line is dropped: the lineage is still complete, spread over one sample per line instead of concentrated in a mixture. `test_builder_domain` still collects **53**, checked before and after.

One guidance fixture gains a `samples` value: since a readout MUST now say what it measured, that MUST would otherwise fire alongside the one under test — the same reason the fixture already sets `detection_instrument`.

## Verification

- 295 passed across `builder_domain`, `tools_process_chain`, `process_chain_deposited_outputs`, `provenance_dag`, `provenance_tools`, `isa_reachability`, `crate_graph`
- 283 passed across twelve crate-building modules including `validator_wiring` and `export_smoke` — the ones that would catch the new Violation breaking existing crates
- 180 passed across gap-analysis consumers; 76 across guidance
- `ty` clean

Local runs only, `VITRO_VALIDATE_SERIAL=1`. **CI is the gate.**

## Also in here, and separable

`9d819f2` untracks `input/raw/S-VHPS*.zip` and `context/vitro_crate.zip`, and `871b389` reverts an earlier partial attempt. Unrelated to #678 — happy to split it out. It stops further publication; it does **not** remove what is already in the remote's LFS store, which needs a history rewrite plus a purge GitHub does not expose via API.
