### PR TITLE
feat(report): draw an assay as a lane, and put the compounds on it (#686)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2343,6 +2343,28 @@ toggle swaps that for the whole `ro-crate-metadata.json`. Every `@id` in either 
 moves the selection — **never a link**: the payload carries the crate verbatim, `javascript:` URLs
 and all, so the absence of anchors is load-bearing and pinned by test.
 
+**An assay is a selectable lane (#686).** One sub-row per assay sits under the Assays chip, minted
+from the crate rather than declared: every other view is a question about the crate, an assay lane is
+named for an entity only this crate has. A lane draws that assay's steps, the materials **one hop**
+out from them, the protocol under each step, and the compounds one hop past those protocols. It
+draws neither the Study, the Investigation, nor the assay itself — drawn, the assay would connect to
+every step and rebuild the star #678 took apart, so it frames the view instead. The material walk is
+a hop and not a closure, or a shared file would lead out of the assay and undo the scoping. Children
+narrow their parent (#624), so choosing an assay replaces the Assays selection and the containers
+drop with it. The key is built from the assay's **name**, because the key is what a shared link
+carries and real ids repeat their own kind; names are not unique, so where two assays share one,
+every lane with that slug takes an id-derived suffix — decided across all assays before any key is
+minted, so keys never depend on the order the graph listed them in. A lane declares `lane` in the
+payload, and the browser picks its layout off that rather than off a naming convention.
+
+**Compounds are one hop past a protocol.** ISA restricts `schema:object` to File/Sample/BioSample at
+Violation severity, so a `MolecularEntity` is never a process input directly; `reagent` is a
+LabProtocol property ranging over it, and `Exposure --executes--> table --reagent--> compound` is the
+correct representation rather than a detour to shorten (#650). The process views follow that second
+hop, anchored on the protocols the drawn steps execute — a compound with no edge to any drawn work is
+what the view is not for. The model draws `reagent` reversed, so the arrow points at the step that
+consumes the material.
+
 **Where the nodes go (`entity_explorer_layout.js`, #619).** Layout is its own module and its own
 `<script>`, holding pure geometry — no DOM, no React, no payload — so a test can run the shipped code
 over a crate's graph rather than a Python restatement of it. A layered pass gives every node in a
@@ -2358,6 +2380,22 @@ or below the cap keeps its column, because a column is a rank and that reads bet
 does. This does not make every view framable — a crate with 80 non-leaf entities over nine ranks is
 some 3,400 px tall whatever is done with its leaves, and "all entities" stays a view to navigate
 rather than to take in at once.
+
+**Where an assay's nodes go (`assay_lane_layout.js`, #686).** Ranking by dependency puts a protocol
+in a rank to the *right* of the step that executes it, so the material chain a reader is following is
+interrupted by what is not material. A lane splits the two directions instead: **horizontal is the
+material chain, vertical is what qualifies a step.** The spine is laid out by the module above rather
+than by geometry of its own — node size, rank gaps and the grid a wide rank packs into are one answer
+given once, so a lane node and a canvas node cannot drift apart — and what is left here is the band:
+a protocol under the step that executes it, a protocol's reagents under the protocol. Both tiers are
+*dealt* into a grid, because a step may execute several protocols and a table may list a dozen
+reagents, and each block is bounded by the spine's own width, so substances cost height and never
+width. `derivesFrom` is excluded from the ranking edges though it is material: a cultured sample
+derives from the line its culture consumed, so the edge points back up the chain. The module returns
+`null` for a graph that is not one chain and the caller falls back to the generic canvas, same
+styling, no seam — declining is the module's job, so the app never has to know which shapes are
+spines. The page loads both modules as plain `<script>` tags, which is the UMD branch `require()`
+never exercises, so a test evaluates the page's own script bodies with no `module` in scope.
 
 **The legend names types, not categories (#623).** A colour key labelled in category prose — "Sample
 / material", "Term / parameter" — explains the canvas in a vocabulary the reader can see nowhere
@@ -2533,6 +2571,7 @@ vitro-crate/
 │   │   ├── entity_explorer.py   Interactive React Flow entity graph (#615)
 │   │   ├── entity_explorer.js   …its browser half (no build step)
 │   │   ├── entity_explorer_layout.js  …where its nodes go (#619)
+│   │   ├── assay_lane_layout.js  …where one assay's nodes go (#686)
 │   │   └── vendor/              Pinned UMD builds inlined into the report
 │   └── agents/                  Orchestration + LLM config
 │       ├── build.py             BuildMode switch + run_build dispatch; pipeline entrypoint (run_interactive_build)

--- a/builder/writers/assay_lane_layout.js
+++ b/builder/writers/assay_lane_layout.js
@@ -1,0 +1,208 @@
+/*
+ * Where one assay's nodes go (#686).
+ *
+ * The generic canvas ranks by dependency, so a protocol lands in a rank to the
+ * RIGHT of the step that executes it and the material chain a reader is
+ * following is interrupted by something that is not material. This module
+ * splits the two directions instead:
+ *
+ *   horizontal is the material chain; vertical is what qualifies a step.
+ *
+ *   spine  CellLine -> Culture -> Cultured -> Exposure -> Exposed -> Readout ...
+ *              |                     |
+ *   band       +-- culture protocol  +-- condition table
+ *                                    +-- compounds (reagent)
+ *
+ * The spine itself is laid out by the SHIPPED generic module rather than by
+ * geometry of its own: node size, rank gaps and the grid a wide rank of files
+ * packs into are all one answer, given once, so a lane and the canvas beside it
+ * cannot drift apart. What is left here is only the two-band split.
+ *
+ * Same contract as `entity_explorer_layout.js` — a position per id — plus one
+ * addition: `null` means "this is not a lane", and the caller draws the graph on
+ * the generic canvas. Declining is this module's job, not its caller's, so the
+ * app never has to know which shapes are spines.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('./entity_explorer_layout.js'));
+  } else {
+    root.AssayLaneLayout = factory(root.ExplorerLayout);
+  }
+}(typeof self !== 'undefined' ? self : this, function (ExplorerLayout) {
+  'use strict';
+
+  var NODE_W = ExplorerLayout.NODE_W, NODE_H = ExplorerLayout.NODE_H;
+  var GAP_X = 12, GAP_Y = 12;
+  // The drop from the spine's floor to the band. Wider than the gap between two
+  // band tiers, so "below the chain" and "below a protocol" read as different
+  // relations rather than as one column of four things.
+  var BAND_DROP = 56;
+
+  // The relations that carry material downstream — the app's own DERIVATION set.
+  // `derivesFrom` is deliberately absent: a cultured sample derives from the
+  // cell line the culture consumed, so the edge points back up the chain, and
+  // ranking on it would put a node before its own ancestor.
+  var MATERIAL = { input: 1, object: 1, result: 1, output: 1 };
+
+  function has(edge, label) {
+    return (edge.labels || []).indexOf(label) >= 0;
+  }
+
+  /* The band, and what each of its members hangs from.
+   *
+   * A protocol hangs from the step that executes it. A compound hangs from the
+   * protocol that lists it as a reagent — the model draws `reagent` REVERSED
+   * (src is the compound, dst the protocol) so the arrow points at the step that
+   * consumes the material, which is also the only route a MolecularEntity has
+   * into the derivation story at all (#650).
+   *
+   * Ties are broken by id rather than by edge order, so two builds of one
+   * deposit produce the same picture.
+   */
+  function bandOf(visible, edges) {
+    var anchor = new Map();
+    edges.forEach(function (e) {
+      if (!visible.has(e.src) || !visible.has(e.dst)) return;
+      if (!has(e, 'executes')) return;
+      var current = anchor.get(e.dst);
+      if (current === undefined || e.src < current) anchor.set(e.dst, e.src);
+    });
+    var compounds = new Map();
+    edges.forEach(function (e) {
+      if (!visible.has(e.src) || !visible.has(e.dst)) return;
+      if (!has(e, 'reagent') || !anchor.has(e.dst)) return;
+      var current = compounds.get(e.src);
+      if (current === undefined || e.dst < current) compounds.set(e.src, e.dst);
+    });
+    return { protocols: anchor, compounds: compounds };
+  }
+
+  /* Whether the spine is one story.
+   *
+   * Uses every edge between spine nodes, not only the material ones: an assay
+   * hanging off its steps is what holds the whole-crate LabProcesses view
+   * together, and that view is several assays at once. Two components mean two
+   * stories, and laying them out as one spine would interleave them.
+   */
+  function connected(ids, edges) {
+    if (ids.length < 2) return true;
+    var present = new Set(ids);
+    var near = new Map();
+    ids.forEach(function (id) { near.set(id, []); });
+    edges.forEach(function (e) {
+      if (!present.has(e.src) || !present.has(e.dst) || e.src === e.dst) return;
+      near.get(e.src).push(e.dst);
+      near.get(e.dst).push(e.src);
+    });
+    var seen = new Set([ids[0]]), queue = [ids[0]];
+    while (queue.length) {
+      near.get(queue.pop()).forEach(function (next) {
+        if (seen.has(next)) return;
+        seen.add(next);
+        queue.push(next);
+      });
+    }
+    return seen.size === ids.length;
+  }
+
+  /* Deal *members* into a grid under *left*, kept inside the spine's own width.
+   *
+   * Twelve compounds in one row would be wider than the chain they qualify, so
+   * the block wraps at whatever the spine can hold and is nudged left when it
+   * would otherwise overhang — the lane's width stays the chain's width, which
+   * is the property the two-band split exists to buy.
+   */
+  function dealt(members, left, top, span) {
+    var cols = Math.max(1, Math.min(
+      members.length,
+      Math.floor((span + GAP_X) / (NODE_W + GAP_X))
+    ));
+    var width = cols * NODE_W + (cols - 1) * GAP_X;
+    var start = Math.max(0, Math.min(left, span - width));
+    var out = new Map();
+    members.forEach(function (id, i) {
+      out.set(id, {
+        x: start + (i % cols) * (NODE_W + GAP_X),
+        y: top + Math.floor(i / cols) * (NODE_H + GAP_Y)
+      });
+    });
+    return out;
+  }
+
+  function group(pairs) {
+    var out = new Map();
+    Array.from(pairs.keys()).sort().forEach(function (id) {
+      var key = pairs.get(id);
+      if (!out.has(key)) out.set(key, []);
+      out.get(key).push(id);
+    });
+    return out;
+  }
+
+  /**
+   * Position one assay's nodes as a lane, or decline the graph.
+   *
+   * @param {Set<string>} visible ids to place.
+   * @param {Array<{src: string, dst: string, labels: Array<string>}>} edges
+   * @param {Map<string, {category: string}>} nodes what each id is.
+   * @returns {Map<string, {x: number, y: number}>|null} top-left corner per id,
+   *   or null when the graph is not a single assay's chain.
+   */
+  function layout(visible, edges, nodes) {
+    if (!visible || !visible.size) return null;
+    edges = edges || [];
+
+    var band = bandOf(visible, edges);
+    var spine = Array.from(visible).filter(function (id) {
+      return !band.protocols.has(id) && !band.compounds.has(id);
+    }).sort();
+
+    // A lane is a chain of work. Without a step there is no chain, and with two
+    // components there are two chains.
+    var steps = spine.filter(function (id) {
+      return ((nodes && nodes.get(id)) || {}).category === 'process';
+    });
+    if (!steps.length) return null;
+    if (!connected(spine, edges)) return null;
+
+    var material = edges.filter(function (e) {
+      if (spine.indexOf(e.src) < 0 || spine.indexOf(e.dst) < 0) return false;
+      return (e.labels || []).some(function (l) { return MATERIAL[l] === 1; });
+    }).map(function (e) { return { src: e.src, dst: e.dst }; });
+
+    var pos = ExplorerLayout.layout(new Set(spine), material);
+    var left = Infinity, right = -Infinity, floor = -Infinity;
+    pos.forEach(function (p) {
+      left = Math.min(left, p.x);
+      right = Math.max(right, p.x + NODE_W);
+      floor = Math.max(floor, p.y + NODE_H);
+    });
+    var span = right - left;
+
+    // Tier one: a protocol directly under the step that executes it, so the
+    // attachment is unambiguous without anything having to say so. Dealt rather
+    // than anchored, because a step may execute several — a readout that
+    // isolates RNA, makes cDNA and runs qPCR executes three — and giving each
+    // its step's x would draw them all at one point.
+    var top = floor + BAND_DROP;
+    var deepest = top;
+    group(band.protocols).forEach(function (members, step) {
+      var at = pos.get(step);
+      dealt(members, (at ? at.x : left) - left, top, span).forEach(function (p, id) {
+        pos.set(id, { x: left + p.x, y: p.y });
+        deepest = Math.max(deepest, p.y + NODE_H);
+      });
+    });
+
+    // Tier two: the substances a protocol lists, under that protocol.
+    group(band.compounds).forEach(function (members, protocol) {
+      var at = pos.get(protocol);
+      var block = dealt(members, (at ? at.x : left) - left, deepest + GAP_Y, span);
+      block.forEach(function (p, id) { pos.set(id, { x: left + p.x, y: p.y }); });
+    });
+    return pos;
+  }
+
+  return { layout: layout, NODE_W: NODE_W, NODE_H: NODE_H, BAND_DROP: BAND_DROP };
+}));

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -43,6 +43,11 @@
     if (!CHILDREN.has(v.parent)) CHILDREN.set(v.parent, []);
     CHILDREN.get(v.parent).push(v.key);
   });
+  // The views that draw one assay's chain, and so want the lane layout (#686).
+  // Read off the payload rather than matched on a key: which views are lanes is
+  // a fact about the selection, not a naming convention the browser re-derives.
+  var LANE = new Set(D.views.filter(function (v) { return v.lane; })
+    .map(function (v) { return v.key; }));
   // Everything some view can put on the canvas. Not `D.nodes.length`: that also
   // counts bare references the crate never describes, which no view offers, so
   // a denominator taken from it would be one the numerator can never reach.
@@ -65,6 +70,7 @@
   // hairball on paper.
   var DERIVATION = new Set(['input', 'object', 'result', 'output']);
   var layout = window.ExplorerLayout.layout;
+  var laneLayout = window.AssayLaneLayout ? window.AssayLaneLayout.layout : null;
   var NODE_W = window.ExplorerLayout.NODE_W, NODE_H = window.ExplorerLayout.NODE_H;
   // How far the opening view is allowed to pull back. A crate's whole graph is
   // thousands of pixels tall — the researcher view of a real deposit lays out
@@ -387,7 +393,26 @@
     }, [views, selected, showDoc, query]);
 
     var graph = useMemo(function () { return visibleGraph(views, pinned); }, [views, pinned]);
-    var positions = useMemo(function () { return layout(graph.visible, graph.edges); }, [graph]);
+    /* Where the nodes go.
+     *
+     * One assay on its own is a chain, and a chain reads as a lane: the material
+     * runs left to right and what qualifies a step hangs below it. Anything else
+     * — several assays at once, the whole crate — is not one chain, so it goes
+     * on the generic canvas.
+     *
+     * The lane may still decline a graph that is nominally an assay but does not
+     * fit a spine (a characterisation run with no exposure, two exposures, an
+     * assay carrying AOP entities). It returns null and the fallback is the same
+     * canvas, same styling, no visible seam.
+     */
+    var positions = useMemo(function () {
+      var lanes = Array.from(views).filter(function (k) { return LANE.has(k); });
+      if (lanes.length === 1 && laneLayout) {
+        var laid = laneLayout(graph.visible, graph.edges, NODE);
+        if (laid) return laid;
+      }
+      return layout(graph.visible, graph.edges);
+    }, [graph, views]);
 
     var needle = query.trim().toLowerCase();
     var hits = useMemo(function () {

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -56,7 +56,7 @@ from builder.writers.provenance_dag import (
     build_people_inventory,
 )
 
-PAYLOAD_VERSION = 1
+PAYLOAD_VERSION = 2
 """Bumped when the payload's shape changes, so a stale cached script is loud."""
 
 _CTX_LABEL = "Referenced outside the crate"
@@ -451,6 +451,14 @@ class ExplorerView(NamedTuple):
     default: bool
     select: Callable[[_Crate], set[str]]
     subject: Callable[[_Crate], set[str]] | None = None
+    lane: bool = False
+    """Whether this view draws one assay's chain, and so wants the lane layout.
+
+    The app reads this to pick a layout rather than matching on a key or on a
+    parent: which views are lanes is a fact about the selection, and the browser
+    should not have to re-derive it from a naming convention.
+    """
+
     parent: str | None = None
     """The view this one refines, if any.
 
@@ -539,6 +547,7 @@ def _assay_lane_views(crate: _Crate) -> list[ExplorerView]:
             "This assay end to end — its materials, steps, protocols and compounds",
             False,
             (lambda i: lambda c: _select_assay_lane(c, i))(assay_id),
+            lane=True,
             parent="assays",
         )
         for assay_id, name, slug in named
@@ -798,6 +807,7 @@ def build_explorer_payload(
                 "hint": view.hint,
                 "default": view.default,
                 "parent": view.parent,
+                "lane": view.lane,
                 "count": len(counted),
                 "members": sorted(members),
             }
@@ -830,6 +840,7 @@ _ASSET_DIR = Path(__file__).resolve().parent
 _VENDOR_DIR = _ASSET_DIR / "vendor"
 _APP_PATH = _ASSET_DIR / "entity_explorer.js"
 _LAYOUT_PATH = _ASSET_DIR / "entity_explorer_layout.js"
+_LANE_PATH = _ASSET_DIR / "assay_lane_layout.js"
 _MANIFEST_PATH = _VENDOR_DIR / "manifest.json"
 
 _APP_ID = "ex-app"
@@ -841,10 +852,10 @@ VENDOR_MANIFEST: tuple[dict[str, Any], ...] = tuple(
 """Every third-party file the page inlines: name, version, licence, origin, digest."""
 
 # react, react-dom, the jsx-runtime shim, React Flow, dagre, htm, the layout
-# module, the data island, the app. Named so a test can state the count without
-# recounting the implementation, and so an accidental extra <script> is a
-# failure, not a habit.
-EXPLORER_SCRIPT_COUNT = 9
+# module, the assay lane's layout, the data island, the app. Named so a test can
+# state the count without recounting the implementation, and so an accidental
+# extra <script> is a failure, not a habit.
+EXPLORER_SCRIPT_COUNT = 10
 
 _JS_BUNDLES = (
     "react.production.min.js",
@@ -915,6 +926,17 @@ def _layout_js() -> str:
 
 
 @lru_cache(maxsize=1)
+def _lane_js() -> str:
+    """The layout an assay lane takes its node positions from.
+
+    Loaded after :func:`_layout_js` and before the app: it reads that module's
+    node size at factory time, so the order is a requirement rather than a
+    convention.
+    """
+    return _LANE_PATH.read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
 def explorer_css() -> str:
     """React Flow's stylesheet, for inlining into the report's one stylesheet.
 
@@ -964,6 +986,7 @@ def render_explorer_section(
             continue
         scripts.append(f"<script>{_banner(filename)}\n{_vendor_text(filename)}</script>")
     scripts.append(f"<script>{_layout_js()}</script>")
+    scripts.append(f"<script>{_lane_js()}</script>")
     scripts.append(
         f'<script id="{_DATA_ID}" type="application/json">'
         f"{_data_island(build_explorer_payload(metadata, default_views=default_views))}"

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import hashlib
 import html
 import json
+import re
 from collections import Counter
 from functools import lru_cache
 from pathlib import Path
@@ -116,8 +117,7 @@ def _select_researcher(crate: _Crate) -> set[str]:
     return {
         n["id"]
         for n in crate.model["nodes"]
-        if n["status"] == "in_crate"
-        and (n["category"] != "annotation" or n["id"] == crate.root)
+        if n["status"] == "in_crate" and (n["category"] != "annotation" or n["id"] == crate.root)
     }
 
 
@@ -249,10 +249,86 @@ def _select_processes(crate: _Crate, flavour: str | None = None) -> set[str]:
         edge["dst"] if outgoing else edge["src"]
         for edge in crate.model["edges"]
         for label, outgoing in _PROCESS_CONTEXT
-        if edge["label"] == label
-        and (edge["src"] if outgoing else edge["dst"]) in processes
+        if edge["label"] == label and (edge["src"] if outgoing else edge["dst"]) in processes
     }
-    return chain | context
+    return chain | context | _reagents_of(crate, processes)
+
+
+def _reagents_of(crate: _Crate, processes: set[str]) -> set[str]:
+    """The substances the drawn steps used, one hop past their protocols (#686).
+
+    An exposure's compounds are the substances under test, and the view about
+    what the steps did drew none of them. They were missing by a hop, not by a
+    modelling gap: ISA restricts ``schema:object`` to File/Sample/BioSample at
+    Violation severity, so a ``MolecularEntity`` can never be a process input
+    directly, and ``reagent`` is a LabProtocol property ranging over it. The
+    crate's route — exposure executes a condition table, the table lists its
+    reagents — is the correct representation, so the selection follows it (#650).
+
+    Anchored on the protocols *these* steps execute, never on every ``reagent``
+    edge in the crate: a compound with no edge to any drawn work is the opposite
+    of what the view is for.
+
+    Note the model draws ``reagent`` REVERSED (``src`` is the compound, ``dst``
+    the protocol) so the arrow points at the step that consumes the material.
+    """
+    protocols = {
+        edge["dst"]
+        for edge in crate.model["edges"]
+        if edge["label"] == "executes" and edge["src"] in processes
+    }
+    return {
+        edge["src"]
+        for edge in crate.model["edges"]
+        if edge["label"] == "reagent" and edge["dst"] in protocols
+    }
+
+
+def _assay_processes(crate: _Crate, assay_id: str) -> list[str]:
+    """The steps an assay is ``about``, or nothing if *assay_id* names no assay."""
+    for node in crate.inventory("isa")["nodes"]:
+        if node["level"] == "Assay" and node["id"] == assay_id:
+            return list(node.get("processes") or [])
+    return []
+
+
+def _select_assay_lane(crate: _Crate, assay_id: str) -> set[str]:
+    """One assay's chain, and nothing that belongs to another (#686).
+
+    An assay is what produces a research object, so it is what the lane draws.
+    Scoped this way the closure is small, and since #678 gave each assay its own
+    culture, no node on the lane belongs to a neighbour.
+
+    What it draws: the assay's steps, the materials those steps consumed and
+    produced, the protocol under each step, and the compounds one hop past the
+    protocols (:func:`_reagents_of`).
+
+    What it does not: the Study, the Investigation, and **the assay itself**.
+    Drawn, the assay would connect to every step and reproduce the star this
+    change exists to remove — so it frames the view rather than appearing in it.
+    That falls out of walking only material and protocol edges, and is pinned by
+    a test so a later switch to :data:`_PROCESS_CONTEXT` cannot quietly undo it.
+
+    The material walk is **one hop** from the steps, not a transitive closure:
+    every material on a spine is adjacent to the step that handled it, so a hop
+    reaches all of them, while a closure would follow a shared file out of the
+    assay and undo the scoping.
+    """
+    processes = set(_assay_processes(crate, assay_id))
+    if not processes:
+        return set()
+    lane = set(processes)
+    for src, dst, _kind in _derivation_edges(crate.nodes):
+        if src in processes:
+            lane.add(dst)
+        if dst in processes:
+            lane.add(src)
+    protocols = {
+        edge["dst"]
+        for edge in crate.model["edges"]
+        if edge["label"] == "executes" and edge["src"] in processes
+    }
+    return lane | protocols | _reagents_of(crate, processes)
 
 
 def _routed(crate: _Crate, inventory: str, members: str) -> set[str]:
@@ -322,9 +398,7 @@ def _of_inventory(
     def subject(crate: _Crate) -> set[str]:
         inv = crate.inventory(name)
         return {
-            member["id"]
-            for member in inv[members]
-            if level is None or member.get("level") == level
+            member["id"] for member in inv[members] if level is None or member.get("level") == level
         }
 
     return subject
@@ -388,6 +462,89 @@ class ExplorerView(NamedTuple):
     """
 
 
+ASSAY_LANE_PREFIX = "assay-"
+"""Namespace for the per-assay sub-row keys, which are minted per crate.
+
+Every other view key is a constant in :data:`EXPLORER_VIEWS`, because every
+other view is a question about the crate rather than about one of its entities.
+An assay lane is named for an assay that only this crate has, so its key is
+derived from that assay's ``@id`` — see :func:`_lane_key`.
+"""
+
+
+def _lane_slug(name: str, assay_id: str) -> str:
+    """The readable half of a lane key: the assay's name, hyphenated.
+
+    Falls back to the ``@id`` only when an assay has no name, which the ISA
+    shapes already treat as a violation.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    if slug:
+        return slug
+    return re.sub(r"[^a-z0-9]+", "-", assay_id.lower()).strip("-") or "lane"
+
+
+def _lane_key(slug: str, assay_id: str, ambiguous: bool) -> str:
+    """A hash-safe view key for one assay's lane.
+
+    View keys are joined with commas into the location hash, so a key carrying
+    one would split into two views that answer to nothing; the slug is
+    ``[a-z0-9-]`` by construction.
+
+    Built from the **name** because the key is what a shared link carries, and
+    real assay ids repeat their own kind — ``#Assay_assay_deiodinase_assay``
+    slugs to ``assay-assay-assay-deiodinase-assay``, which is unique and
+    unreadable. Names are not guaranteed unique, so when two assays share one,
+    the ``@id`` settles it.
+
+    *ambiguous* is decided across all the crate's assays before any key is
+    minted, so **every** lane sharing a slug is suffixed rather than the first
+    one winning the bare key. Otherwise the keys would depend on which assay the
+    graph happened to list first, and two builds of one deposit must produce
+    reports that diff to nothing.
+    """
+    key = ASSAY_LANE_PREFIX + slug
+    if ambiguous:
+        key += "-" + hashlib.sha1(assay_id.encode("utf-8")).hexdigest()[:6]
+    return key
+
+
+def _assay_lane_views(crate: _Crate) -> list[ExplorerView]:
+    """One sub-row per assay, in the crate's own order.
+
+    A child view narrows its parent (#624), so choosing one assay replaces the
+    Assays selection and the containers drop out with it — which is what makes
+    this a lane rather than another top-level chip.
+
+    ``subject`` is left unset: the view is named for an assay and everything it
+    draws belongs to that assay, so the count is the membership (#625).
+    """
+    assays = [n for n in crate.inventory("isa")["nodes"] if n["level"] == "Assay"]
+    named = []
+    for node in assays:
+        assay_id = str(node["id"])
+        raw_name = str(node.get("name") or "")
+        named.append(
+            (
+                assay_id,
+                html.unescape(raw_name or assay_id),
+                _lane_slug(raw_name, assay_id),
+            )
+        )
+    shared = {slug for slug, count in Counter(s for _i, _n, s in named).items() if count > 1}
+    return [
+        ExplorerView(
+            _lane_key(slug, assay_id, slug in shared),
+            name,
+            "This assay end to end — its materials, steps, protocols and compounds",
+            False,
+            (lambda i: lambda c: _select_assay_lane(c, i))(assay_id),
+            parent="assays",
+        )
+        for assay_id, name, slug in named
+    ]
+
+
 # Order matters: "Researcher" opens the section, and the rest follow the tabbed
 # section's reviewed order so a reader who learned it there is not retrained.
 EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
@@ -398,9 +555,7 @@ EXPLORER_VIEWS: tuple[ExplorerView, ...] = (
         True,
         _select_researcher,
     ),
-    ExplorerView(
-        "all", "All entities", "Everything the crate describes", False, _select_all
-    ),
+    ExplorerView("all", "All entities", "Everything the crate describes", False, _select_all),
     ExplorerView(
         "files",
         "Files",
@@ -560,7 +715,10 @@ def _categories(nodes: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     # so this key keeps its wording: it names a provenance status, not a
     # category, and is the one label the census cannot supply.
     out[_CTX_CATEGORY] = {
-        "colour": _CTX_COLOUR, "label": _CTX_LABEL, "glyph": _CTX_GLYPH, "types": [],
+        "colour": _CTX_COLOUR,
+        "label": _CTX_LABEL,
+        "glyph": _CTX_GLYPH,
+        "types": [],
     }
     return out
 
@@ -600,9 +758,7 @@ def build_explorer_payload(
     # because the model yields them from a set and a report must not depend on
     # which way that fell today.
     described = [n for n in model["nodes"] if n["layer"] is not None]
-    stubs = sorted(
-        (n for n in model["nodes"] if n["layer"] is None), key=lambda n: str(n["id"])
-    )
+    stubs = sorted((n for n in model["nodes"] if n["layer"] is None), key=lambda n: str(n["id"]))
     nodes = [
         {
             "id": n["id"],
@@ -625,7 +781,10 @@ def build_explorer_payload(
     ]
 
     views = []
-    for view in EXPLORER_VIEWS:
+    # The lanes are minted from this crate's assays, so they are appended
+    # rather than declared. They carry `parent`, and the app draws children
+    # from that alone, so position among them is the crate's order.
+    for view in (*EXPLORER_VIEWS, *_assay_lane_views(crate)):
         members = view.select(crate) & crate.known
         if not members:
             continue
@@ -654,9 +813,7 @@ def build_explorer_payload(
         "layers": {str(level): name for level, name in _LAYER_NAMES.items()},
         "categories": _categories(nodes),
         "nodes": nodes,
-        "edges": [
-            {"src": e["src"], "dst": e["dst"], "label": e["label"]} for e in model["edges"]
-        ],
+        "edges": [{"src": e["src"], "dst": e["dst"], "label": e["label"]} for e in model["edges"]],
         "views": views,
         "counts": {**model["counts"], "nodes": len(nodes), "edges": len(model["edges"])},
         "document": crate.document,
@@ -765,9 +922,7 @@ def explorer_css() -> str:
     the page; this is only the library's, kept unmodified so it can be re-vendored
     without a merge.
     """
-    return "\n" + _banner("xyflow-react.style.css") + "\n" + _vendor_text(
-        "xyflow-react.style.css"
-    )
+    return "\n" + _banner("xyflow-react.style.css") + "\n" + _vendor_text("xyflow-react.style.css")
 
 
 def _data_island(payload: dict[str, Any]) -> str:
@@ -779,9 +934,7 @@ def _data_island(payload: dict[str, Any]) -> str:
     ``</script>`` can arrive from.
     """
     text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
-    return (
-        text.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
-    )
+    return text.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
 
 
 def render_explorer_section(

--- a/tests/fixtures/assay_lane_probe.js
+++ b/tests/fixtures/assay_lane_probe.js
@@ -1,0 +1,25 @@
+/*
+ * Runs the shipped assay-lane layout over a graph handed in on stdin and prints
+ * what it computed. As with `layout_probe.js`, the tests measure the real module
+ * the report carries rather than a Python restatement of its geometry.
+ *
+ * argv[2]: path to builder/writers/assay_lane_layout.js
+ * stdin:   {"nodes": [{"id":…, "category":…, "type":…}, …],
+ *           "edges": [{"src":…, "dst":…, "labels":[…]}, …]}
+ * stdout:  {"positions": {id: {x, y}} | null, "nodeW": n, "nodeH": n}
+ *
+ * `positions: null` is the module declining the graph — the caller falls back
+ * to the generic canvas, so a null here is a result, not a failure.
+ */
+var L = require(process.argv[2]);
+var input = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+var nodes = new Map(input.nodes.map(function (n) { return [n.id, n]; }));
+var pos = L.layout(new Set(nodes.keys()), input.edges, nodes);
+var positions = null;
+if (pos) {
+  positions = {};
+  pos.forEach(function (p, id) { positions[id] = p; });
+}
+process.stdout.write(JSON.stringify({
+  positions: positions, nodeW: L.NODE_W, nodeH: L.NODE_H
+}));

--- a/tests/fixtures/browser_load_probe.js
+++ b/tests/fixtures/browser_load_probe.js
@@ -1,0 +1,34 @@
+/*
+ * Loads the page's own script bodies the way a browser loads them, and reports
+ * which globals they defined.
+ *
+ * The other probes `require()` the modules, which takes the CommonJS branch of
+ * their UMD wrapper — the branch the report never runs. This one evaluates the
+ * scripts in a context with no `module` and no `require`, so the browser branch
+ * is what is exercised: a module that failed to attach itself to `window`, or
+ * one loaded before the module it reads at factory time, fails here and
+ * nowhere else in the suite.
+ *
+ * stdin:  {"scripts": [source, ...], "expect": [globalName, ...]}
+ * stdout: {"defined": {name: true|false}, "sizes": {name: {NODE_W, NODE_H}}}
+ */
+var vm = require('vm');
+var input = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+
+var sandbox = { console: console };
+sandbox.self = sandbox;
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+input.scripts.forEach(function (source, i) {
+  vm.runInContext(source, sandbox, { filename: 'page-script-' + i + '.js' });
+});
+
+var defined = {}, sizes = {};
+input.expect.forEach(function (name) {
+  var value = sandbox[name];
+  defined[name] = !!value;
+  if (value && value.NODE_W !== undefined) {
+    sizes[name] = { NODE_W: value.NODE_W, NODE_H: value.NODE_H };
+  }
+});
+process.stdout.write(JSON.stringify({ defined: defined, sizes: sizes }));

--- a/tests/fixtures/crate_graphs.py
+++ b/tests/fixtures/crate_graphs.py
@@ -189,8 +189,7 @@ def wide_fanout_graph(files: int = 60) -> dict[str, Any]:
             "@id": "./",
             "@type": "Dataset",
             "name": "A deposit with a long file list",
-            "hasPart": [{"@id": f"data/f{i}.csv"} for i in range(files)]
-            + [{"@id": "#assay"}],
+            "hasPart": [{"@id": f"data/f{i}.csv"} for i in range(files)] + [{"@id": "#assay"}],
             "mentions": [{"@id": "#process"}],
         },
         {
@@ -372,5 +371,217 @@ def aop_linked_graph() -> dict[str, Any]:
                 "downstream_event": {"@id": "https://aopwiki.org/events/9999"},
             },
             {"@id": "#build", "@type": "CreateAction", "name": "vitro-crate build"},
+        ]
+    }
+
+
+def assay_lane_graph() -> dict[str, Any]:
+    """Two assays, each a full material chain, sharing nothing (#686).
+
+    The shape the lane view draws: cell line -> culture -> cultured sample ->
+    exposure -> exposed sample -> readout -> raw files -> analysis -> processed
+    file, with a protocol under each step and the exposure's compounds hanging
+    off its condition table by ``reagent``.
+
+    Two assays rather than one, because a lane must exclude the *other* assay's
+    steps, and a fixture with a single assay cannot tell "scoped to this assay"
+    apart from "everything on a chain". Since #678 each assay cultures its own
+    line, so the two chains are genuinely disjoint.
+
+    Carries the exclusions each rule needs to be tested rather than assumed:
+
+    * ``#spare-protocol`` executes nothing, and its ``#spare-compound`` is a
+      reagent of it alone. A compound hop that swept every ``reagent`` edge in
+      the crate would draw that compound with no edge to any work.
+    * The Study and Investigation are real and populated, so a lane that leaves
+      them out is doing so by rule rather than because the crate has none.
+    """
+    return {
+        "@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "additionalType": "Investigation",
+                "name": "An investigation",
+                "hasPart": [{"@id": "#study"}],
+            },
+            {
+                "@id": "#study",
+                "@type": "Dataset",
+                "additionalType": "Study",
+                "name": "A study",
+                "hasPart": [{"@id": "#assay-a"}, {"@id": "#assay-b"}],
+            },
+            # --- assay A: the lane under test ---------------------------------
+            {
+                "@id": "#assay-a",
+                "@type": "Dataset",
+                "additionalType": "Assay",
+                "name": "Deiodinase assay",
+                "about": [
+                    {"@id": "#culture-a"},
+                    {"@id": "#exposure-a"},
+                    {"@id": "#readout-a"},
+                    {"@id": "#analysis-a"},
+                ],
+            },
+            {
+                "@id": "#cellline-a",
+                "@type": "Sample",
+                "additionalType": "CellLineSample",
+                "name": "SK-N-AS",
+            },
+            {
+                "@id": "#culture-a",
+                "@type": "LabProcess",
+                "additionalType": "CellCulture",
+                "name": "Culture SK-N-AS",
+                "object": {"@id": "#cellline-a"},
+                "result": {"@id": "#cultured-a"},
+                "executesLabProtocol": {"@id": "#culture-protocol-a"},
+            },
+            {
+                "@id": "#culture-protocol-a",
+                "@type": "LabProtocol",
+                "name": "Cell culture protocol SK-N-AS",
+            },
+            {"@id": "#cultured-a", "@type": "Sample", "name": "Cultured (SK-N-AS)"},
+            {
+                "@id": "#exposure-a",
+                "@type": "LabProcess",
+                "additionalType": "Exposure",
+                "name": "Exposure",
+                "object": {"@id": "#cultured-a"},
+                "result": {"@id": "#exposed-a"},
+                "executesLabProtocol": {"@id": "#conditions-a"},
+            },
+            {
+                "@id": "#conditions-a",
+                "@type": "LabProtocol",
+                "name": "Condition table",
+                "reagent": [{"@id": "#compound-a1"}, {"@id": "#compound-a2"}],
+            },
+            {
+                "@id": "#compound-a1",
+                "@type": "MolecularEntity",
+                "name": "Amiodarone",
+                "inChIKey": "IYIKLHRQXLHMJQ-UHFFFAOYSA-N",
+            },
+            {
+                "@id": "#compound-a2",
+                "@type": "MolecularEntity",
+                "name": "Cisplatin",
+                "inChIKey": "LXZZYRPGZAFOLE-UHFFFAOYSA-L",
+            },
+            {"@id": "#exposed-a", "@type": "Sample", "name": "Exposed (SK-N-AS)"},
+            {
+                "@id": "#readout-a",
+                "@type": "LabProcess",
+                "additionalType": "EndpointReadout",
+                "name": "Deiodinase readout",
+                "object": {"@id": "#exposed-a"},
+                "result": [{"@id": "raw/a1.csv"}, {"@id": "raw/a2.csv"}],
+                "executesLabProtocol": {"@id": "#readout-protocol-a"},
+            },
+            {
+                "@id": "#readout-protocol-a",
+                "@type": "LabProtocol",
+                "name": "Deiodinase readout protocol",
+            },
+            {
+                "@id": "raw/a1.csv",
+                "@type": "File",
+                "name": "a1.csv",
+                "encodingFormat": "text/csv",
+            },
+            {
+                "@id": "raw/a2.csv",
+                "@type": "File",
+                "name": "a2.csv",
+                "encodingFormat": "text/csv",
+            },
+            {
+                "@id": "#analysis-a",
+                "@type": "LabProcess",
+                "additionalType": "DataAnalysis",
+                "name": "Deiodinase analysis",
+                "object": [{"@id": "raw/a1.csv"}, {"@id": "raw/a2.csv"}],
+                "result": {"@id": "processed/a.csv"},
+                "executesLabProtocol": {"@id": "#analysis-protocol-a"},
+            },
+            {
+                "@id": "#analysis-protocol-a",
+                "@type": "LabProtocol",
+                "name": "Deiodinase analysis script",
+            },
+            {
+                "@id": "processed/a.csv",
+                "@type": "File",
+                "name": "a.csv",
+                "encodingFormat": "text/csv",
+            },
+            # --- assay B: the lane that must NOT bleed in ---------------------
+            {
+                "@id": "#assay-b",
+                "@type": "Dataset",
+                "additionalType": "Assay",
+                "name": "TH transport assay",
+                "about": [{"@id": "#culture-b"}, {"@id": "#exposure-b"}],
+            },
+            {
+                "@id": "#cellline-b",
+                "@type": "Sample",
+                "additionalType": "CellLineSample",
+                "name": "MO3.13",
+            },
+            {
+                "@id": "#culture-b",
+                "@type": "LabProcess",
+                "additionalType": "CellCulture",
+                "name": "Culture MO3.13",
+                "object": {"@id": "#cellline-b"},
+                "result": {"@id": "#cultured-b"},
+                "executesLabProtocol": {"@id": "#culture-protocol-b"},
+            },
+            {
+                "@id": "#culture-protocol-b",
+                "@type": "LabProtocol",
+                "name": "Cell culture protocol MO3.13",
+            },
+            {"@id": "#cultured-b", "@type": "Sample", "name": "Cultured (MO3.13)"},
+            {
+                "@id": "#exposure-b",
+                "@type": "LabProcess",
+                "additionalType": "Exposure",
+                "name": "Exposure",
+                "object": {"@id": "#cultured-b"},
+                "result": {"@id": "#exposed-b"},
+                "executesLabProtocol": {"@id": "#conditions-b"},
+            },
+            {
+                "@id": "#conditions-b",
+                "@type": "LabProtocol",
+                "name": "Condition table",
+                "reagent": [{"@id": "#compound-b1"}],
+            },
+            {
+                "@id": "#compound-b1",
+                "@type": "MolecularEntity",
+                "name": "Thyroxine",
+            },
+            {"@id": "#exposed-b", "@type": "Sample", "name": "Exposed (MO3.13)"},
+            # --- what no rule may sweep up ------------------------------------
+            {
+                "@id": "#spare-protocol",
+                "@type": "LabProtocol",
+                "name": "A protocol no step executes",
+                "reagent": [{"@id": "#spare-compound"}],
+            },
+            {
+                "@id": "#spare-compound",
+                "@type": "MolecularEntity",
+                "name": "A compound no step uses",
+            },
         ]
     }

--- a/tests/test_assay_lane.py
+++ b/tests/test_assay_lane.py
@@ -251,3 +251,42 @@ class TestTheLaneKeyIsReadableAndUnique:
         reversed_graph["@graph"] = list(reversed(graph["@graph"]))
         backward = {v["label"] + v["key"] for v in self._views(reversed_graph)}
         assert forward == backward, (sorted(forward), sorted(backward))
+
+
+class TestThePageCarriesTheLane:
+    """The lane is a second layout module, so the page has to ship it and the
+    app has to know which views it applies to."""
+
+    def test_a_lane_view_says_it_is_one(self, payload):
+        lanes = [v for v in payload["views"] if v.get("parent") == "assays"]
+        assert lanes and all(v["lane"] for v in lanes)
+
+    def test_no_other_view_claims_to_be_one(self, payload):
+        """The app picks the layout off this flag, so a view that wrongly
+        carried it would be drawn as a chain it is not."""
+        others = [v for v in payload["views"] if v.get("parent") != "assays"]
+        assert others and not any(v["lane"] for v in others)
+
+    def test_the_page_ships_the_lane_module(self):
+        from builder.writers.entity_explorer import render_explorer_section
+
+        section = render_explorer_section(assay_lane_graph())
+        assert "AssayLaneLayout" in section
+
+    def test_the_lane_module_loads_after_the_layout_it_reads(self):
+        """It takes NODE_W/NODE_H from `ExplorerLayout` at factory time, so a
+        page that loaded it first would define the lane against `undefined`."""
+        from builder.writers.entity_explorer import render_explorer_section
+
+        section = render_explorer_section(assay_lane_graph())
+        assert section.index("root.ExplorerLayout = factory") < section.index(
+            "root.AssayLaneLayout = factory"
+        )
+
+    def test_the_lane_module_loads_before_the_app_that_calls_it(self):
+        from builder.writers.entity_explorer import render_explorer_section
+
+        section = render_explorer_section(assay_lane_graph())
+        assert section.index("root.AssayLaneLayout = factory") < section.index(
+            "window.AssayLaneLayout"
+        )

--- a/tests/test_assay_lane.py
+++ b/tests/test_assay_lane.py
@@ -1,0 +1,253 @@
+"""One assay drawn as a lane, and the compounds that were a hop out of reach (#686).
+
+The LabProcesses view draws 74 nodes for 15 steps on a real deposit, and its
+Exposure sub-view draws none of the compounds — a researcher cannot visually
+inspect the flow, which is what the view is for.
+
+Two changes, tested here against the same crate:
+
+* compounds join the process views, which they were missing by one hop rather
+  than by a modelling gap;
+* an assay becomes a selectable unit, drawing its own chain and nothing else.
+
+Layout is a separate module and is tested in ``test_assay_lane_layout.py``
+against the shipped JavaScript.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.writers.entity_explorer import (
+    _Crate,
+    _select_assay_lane,
+    _select_processes,
+    build_explorer_payload,
+)
+from tests.fixtures.crate_graphs import assay_lane_graph
+
+pytestmark = pytest.mark.timeout(180)
+
+
+@pytest.fixture(scope="module")
+def crate() -> _Crate:
+    return _Crate(assay_lane_graph())
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict:
+    return build_explorer_payload(assay_lane_graph())
+
+
+class TestCompoundsReachTheProcessViews:
+    """#650/#686: the exposure's compounds are the substances under test.
+
+    They hang off the condition table the exposure executes, because ISA
+    restricts ``schema:object`` to File/Sample/BioSample at Violation severity,
+    so a MolecularEntity can never be a process input directly. The selection
+    follows that second hop rather than the crate being remodelled around it.
+    """
+
+    def test_a_compound_used_by_a_drawn_exposure_is_selected(self, crate):
+        selected = _select_processes(crate)
+        assert "#compound-a1" in selected, sorted(selected)
+        assert "#compound-a2" in selected, sorted(selected)
+
+    def test_the_compound_arrives_with_the_table_that_links_it(self, crate):
+        """A compound with no edge to any work is the opposite of the point."""
+        selected = _select_processes(crate)
+        assert "#conditions-a" in selected
+
+    def test_a_compound_of_an_undrawn_protocol_stays_out(self, crate):
+        """The rule is 'follow', not 'collect every reagent edge in the crate'."""
+        selected = _select_processes(crate)
+        assert "#spare-compound" not in selected, (
+            "a compound whose protocol no drawn step executes has no place on a "
+            "view about what the steps did"
+        )
+        assert "#spare-protocol" not in selected
+
+    def test_the_exposure_sub_view_carries_them_too(self, crate):
+        """The sub-view is the parent restricted to one discriminator (#624).
+
+        It is the view a reader opens to inspect the exposure, so it is the one
+        that most needs the compounds.
+        """
+        selected = _select_processes(crate, "Exposure")
+        assert {"#compound-a1", "#compound-a2", "#compound-b1"} <= selected, sorted(selected)
+
+    def test_a_readout_sub_view_draws_no_compound(self, crate):
+        """Nothing in a readout executes a protocol carrying reagents."""
+        selected = _select_processes(crate, "EndpointReadout")
+        assert not {"#compound-a1", "#compound-a2", "#compound-b1"} & selected
+
+
+class TestTheLaneDrawsOneAssay:
+    """An assay is what produces a research object, so it is what the view draws.
+
+    Scoped to one assay the closure is small and, since #678 gave each assay its
+    own culture, nothing on the lane belongs to another.
+    """
+
+    def test_it_draws_the_whole_material_chain(self, crate):
+        lane = _select_assay_lane(crate, "#assay-a")
+        spine = {
+            "#cellline-a",
+            "#culture-a",
+            "#cultured-a",
+            "#exposure-a",
+            "#exposed-a",
+            "#readout-a",
+            "raw/a1.csv",
+            "raw/a2.csv",
+            "#analysis-a",
+            "processed/a.csv",
+        }
+        assert spine <= lane, sorted(spine - lane)
+
+    def test_it_draws_the_protocol_under_each_step(self, crate):
+        lane = _select_assay_lane(crate, "#assay-a")
+        band = {
+            "#culture-protocol-a",
+            "#conditions-a",
+            "#readout-protocol-a",
+            "#analysis-protocol-a",
+        }
+        assert band <= lane, sorted(band - lane)
+
+    def test_it_draws_the_compounds(self, crate):
+        lane = _select_assay_lane(crate, "#assay-a")
+        assert {"#compound-a1", "#compound-a2"} <= lane
+
+    def test_no_node_of_another_assay_is_on_the_lane(self, crate):
+        """The property that makes the lane readable at all."""
+        lane = _select_assay_lane(crate, "#assay-a")
+        strays = {i for i in lane if i.endswith("-b") or i.endswith("-b1")}
+        assert not strays, f"assay B bled onto assay A's lane: {sorted(strays)}"
+
+    def test_the_study_and_investigation_are_not_drawn(self, crate):
+        """The lane is the assay. A container reaches every step in it."""
+        lane = _select_assay_lane(crate, "#assay-a")
+        assert "#study" not in lane
+        assert "./" not in lane
+
+    def test_the_assay_itself_is_the_frame_not_a_node(self, crate):
+        """Drawn, it would connect to every step and reproduce the star this
+        whole change removes."""
+        lane = _select_assay_lane(crate, "#assay-a")
+        assert "#assay-a" not in lane, "the lane is named for the assay, not drawn from it"
+
+    def test_the_other_lane_is_the_other_assay(self, crate):
+        """Not a tautology against a fixture with one assay: B is a real chain."""
+        lane = _select_assay_lane(crate, "#assay-b")
+        assert {"#cellline-b", "#culture-b", "#exposure-b", "#compound-b1"} <= lane
+        assert "#cellline-a" not in lane
+
+    def test_an_id_that_is_not_an_assay_draws_nothing(self, crate):
+        assert _select_assay_lane(crate, "#study") == set()
+        assert _select_assay_lane(crate, "#nope") == set()
+
+
+class TestTheLaneIsOfferedAsASubRow:
+    """One sub-row per assay under the Assays chip — the pattern LabProcesses
+    already uses for its four kinds. A child view narrows its parent (#624), so
+    choosing one assay replaces the Assays selection and the containers drop out
+    with it.
+    """
+
+    def _lanes(self, payload):
+        return [v for v in payload["views"] if v.get("parent") == "assays"]
+
+    def test_there_is_one_sub_row_per_assay(self, payload):
+        lanes = self._lanes(payload)
+        assert len(lanes) == 2, [v["key"] for v in lanes]
+
+    def test_each_is_labelled_with_the_assay_name(self, payload):
+        labels = {v["label"] for v in self._lanes(payload)}
+        assert labels == {"Deiodinase assay", "TH transport assay"}
+
+    def test_the_keys_survive_a_url_hash(self, payload):
+        """View keys are joined with commas into the location hash, so a key
+        carrying one would split into two views that do not exist."""
+        for view in self._lanes(payload):
+            assert "," not in view["key"]
+            assert view["key"] == view["key"].strip()
+
+    def test_the_keys_are_distinct(self, payload):
+        keys = [v["key"] for v in self._lanes(payload)]
+        assert len(keys) == len(set(keys)), keys
+
+    def test_the_count_is_what_the_lane_draws(self, payload):
+        """The view's name covers everything it draws, so `subject` is unset and
+        the count is the membership (#625)."""
+        for view in self._lanes(payload):
+            assert view["count"] == len(view["members"])
+
+    def test_a_lane_is_not_on_by_default(self, payload):
+        assert not any(v["default"] for v in self._lanes(payload))
+
+    def test_the_parent_chip_still_counts_only_assays(self, payload):
+        """Adding children must not change what the parent is named for."""
+        assays = next(v for v in payload["views"] if v["key"] == "assays")
+        assert assays["count"] == 2
+
+
+class TestTheLaneKeyIsReadableAndUnique:
+    """The key is what a shared link carries, so it is built from the name.
+
+    Real assay ids repeat their own kind (``#Assay_assay_deiodinase_assay``), so
+    slugging the id yields ``assay-assay-assay-deiodinase-assay`` — unique, and
+    unreadable in a URL. Names read well and are not guaranteed unique, so the
+    name makes the key and the id settles ties.
+    """
+
+    def _views(self, graph):
+        return [v for v in build_explorer_payload(graph)["views"] if v.get("parent") == "assays"]
+
+    def test_the_key_comes_from_the_name(self):
+        graph = assay_lane_graph()
+        keys = {v["label"]: v["key"] for v in self._views(graph)}
+        assert keys["Deiodinase assay"] == "assay-deiodinase-assay"
+        assert keys["TH transport assay"] == "assay-th-transport-assay"
+
+    def test_an_id_that_repeats_its_kind_does_not_repeat_it_in_the_key(self):
+        """The shape every assay in a built crate actually has."""
+        graph = assay_lane_graph()
+        for entity in graph["@graph"]:
+            if entity.get("@id") == "#assay-a":
+                entity["@id"] = "#Assay_assay_deiodinase_assay"
+            for key in ("about", "hasPart"):
+                refs = entity.get(key)
+                if isinstance(refs, list):
+                    for ref in refs:
+                        if ref.get("@id") == "#assay-a":
+                            ref["@id"] = "#Assay_assay_deiodinase_assay"
+        keys = [v["key"] for v in self._views(graph)]
+        assert "assay-deiodinase-assay" in keys, keys
+
+    def test_two_assays_of_one_name_still_get_one_key_each(self):
+        """Names are not unique. A key that collided would make one lane
+        unreachable and the other unlinkable."""
+        graph = assay_lane_graph()
+        for entity in graph["@graph"]:
+            if entity.get("@id") == "#assay-b":
+                entity["name"] = "Deiodinase assay"
+        views = self._views(graph)
+        keys = [v["key"] for v in views]
+        assert len(keys) == len(set(keys)) == 2, keys
+        assert all(k.startswith("assay-deiodinase-assay") for k in keys), keys
+
+    def test_the_tie_break_does_not_depend_on_crate_order(self):
+        """Two builds of one deposit must produce reports that diff to nothing,
+        so a key may not depend on which assay the graph happened to list first.
+        """
+        graph = assay_lane_graph()
+        for entity in graph["@graph"]:
+            if entity.get("@id") == "#assay-b":
+                entity["name"] = "Deiodinase assay"
+        forward = {v["label"] + v["key"] for v in self._views(graph)}
+
+        reversed_graph = dict(graph)
+        reversed_graph["@graph"] = list(reversed(graph["@graph"]))
+        backward = {v["label"] + v["key"] for v in self._views(reversed_graph)}
+        assert forward == backward, (sorted(forward), sorted(backward))

--- a/tests/test_assay_lane_layout.py
+++ b/tests/test_assay_lane_layout.py
@@ -1,0 +1,302 @@
+"""Where the lane puts an assay's nodes (#686).
+
+The layout is JavaScript, and it is the shipped file these tests run: a node
+probe (``tests/fixtures/assay_lane_probe.js``) requires
+``builder/writers/assay_lane_layout.js`` and prints the positions it computed,
+so what is measured here is the code the report carries.
+
+The defect: the LabProcesses view draws 74 nodes for 15 steps, and a layered
+layout gives a protocol its own rank to the *right* of the step that executes
+it, so the material chain a reader is trying to follow is interrupted by things
+that are not material at all. The lane separates the two directions —
+**horizontal is the material chain, vertical is what qualifies a step** — so the
+left-to-right reading is never displaced by a protocol, a compound, or how many
+of either there are.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from builder.writers.entity_explorer import build_explorer_payload
+from tests.fixtures.crate_graphs import assay_lane_graph
+
+pytestmark = pytest.mark.timeout(180)
+
+_REPO = Path(__file__).resolve().parents[1]
+_MODULE = _REPO / "builder" / "writers" / "assay_lane_layout.js"
+_PROBE = _REPO / "tests" / "fixtures" / "assay_lane_probe.js"
+
+
+def _node_exe() -> str:
+    exe = shutil.which("node")
+    if exe is None:  # pragma: no cover — depends on the machine, not the code
+        pytest.skip("node is not installed; the layout module cannot be run")
+    return exe
+
+
+def _run(nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> dict[str, Any]:
+    result = subprocess.run(
+        [_node_exe(), str(_PROBE), str(_MODULE)],
+        input=json.dumps({"nodes": nodes, "edges": edges}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _lane_input(graph: dict[str, Any], key: str) -> tuple[list[dict], list[dict]]:
+    """A lane's members and the edges among them, as the app would hand them over.
+
+    Mirrors ``visibleGraph``: one edge per pair, carrying every relation that
+    connects them.
+    """
+    payload = build_explorer_payload(graph)
+    view = next(v for v in payload["views"] if v["key"] == key)
+    visible = set(view["members"])
+    by_id = {n["id"]: n for n in payload["nodes"]}
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    for edge in payload["edges"]:
+        pair = (edge["src"], edge["dst"])
+        if pair[0] == pair[1] or not visible >= set(pair):
+            continue
+        entry = merged.setdefault(pair, {"src": pair[0], "dst": pair[1], "labels": []})
+        if edge["label"] not in entry["labels"]:
+            entry["labels"].append(edge["label"])
+    nodes = [
+        {"id": i, "category": by_id[i]["category"], "type": by_id[i]["type"]}
+        for i in sorted(visible)
+    ]
+    return nodes, list(merged.values())
+
+
+@pytest.fixture(scope="module")
+def lane() -> dict[str, Any]:
+    nodes, edges = _lane_input(assay_lane_graph(), "assay-deiodinase-assay")
+    out = _run(nodes, edges)
+    assert out["positions"] is not None, "the lane declined a graph that is a lane"
+    return out["positions"]
+
+
+def _x(lane, i):
+    return lane[i]["x"]
+
+
+def _y(lane, i):
+    return lane[i]["y"]
+
+
+SPINE = [
+    "#cellline-a",
+    "#culture-a",
+    "#cultured-a",
+    "#exposure-a",
+    "#exposed-a",
+    "#readout-a",
+    "#analysis-a",
+    "processed/a.csv",
+]
+BAND = [
+    "#culture-protocol-a",
+    "#conditions-a",
+    "#readout-protocol-a",
+    "#analysis-protocol-a",
+]
+COMPOUNDS = ["#compound-a1", "#compound-a2"]
+
+
+class TestTheMaterialChainReadsLeftToRight:
+    def test_every_step_is_right_of_the_one_before_it(self, lane):
+        xs = [(i, _x(lane, i)) for i in SPINE]
+        for (before, bx), (after, ax) in zip(xs, xs[1:]):
+            assert bx < ax, f"{after} is not right of {before}: {bx} vs {ax}"
+
+    def test_the_cell_line_opens_the_spine(self, lane):
+        """Nothing precedes a cell line, so nothing crosses it."""
+        assert _x(lane, "#cellline-a") == min(lane[i]["x"] for i in lane)
+
+    def test_the_raw_files_sit_between_the_readout_and_the_analysis(self, lane):
+        """Raw data is on the material spine; the edge into the analysis has to
+        stay horizontal, which is why a file stack never drops to the band."""
+        for raw in ("raw/a1.csv", "raw/a2.csv"):
+            assert _x(lane, "#readout-a") < _x(lane, raw) < _x(lane, "#analysis-a"), raw
+
+
+class TestWhatQualifiesAStepHangsBelowIt:
+    def test_every_protocol_is_below_every_step_it_could_belong_to(self, lane):
+        """The band is a tier, not an interleaving: a reader scanning the spine
+        never has their eye caught by something that is not material."""
+        floor = max(_y(lane, i) for i in SPINE)
+        for protocol in BAND:
+            assert _y(lane, protocol) > floor, protocol
+
+    def test_a_protocol_sits_under_the_step_that_executes_it(self, lane):
+        """Which is what makes the attachment unambiguous without a label."""
+        for step, protocol in (
+            ("#culture-a", "#culture-protocol-a"),
+            ("#exposure-a", "#conditions-a"),
+            ("#readout-a", "#readout-protocol-a"),
+            ("#analysis-a", "#analysis-protocol-a"),
+        ):
+            assert abs(_x(lane, step) - _x(lane, protocol)) < 1, (
+                f"{protocol} is not under {step}: {_x(lane, protocol)} vs {_x(lane, step)}"
+            )
+
+    def test_several_protocols_under_one_step_do_not_stack(self):
+        """A readout that isolates RNA, makes cDNA and runs qPCR executes three
+        protocols, and the real crate has exactly that. Anchoring each to its
+        step's x put all three at one point, which draws as one node and hides
+        the other two entirely.
+        """
+        graph = assay_lane_graph()
+        extra = [
+            {"@id": f"#readout-extra-{i}", "@type": "LabProtocol", "name": f"Step {i}"}
+            for i in range(2)
+        ]
+        for entity in graph["@graph"]:
+            if entity.get("@id") == "#readout-a":
+                entity["executesLabProtocol"] = [
+                    {"@id": "#readout-protocol-a"},
+                    *({"@id": e["@id"]} for e in extra),
+                ]
+        graph["@graph"].extend(extra)
+        lane = _lane_of(graph)
+
+        placed = [
+            (lane[i]["x"], lane[i]["y"])
+            for i in ("#readout-protocol-a", "#readout-extra-0", "#readout-extra-1")
+        ]
+        assert len(set(placed)) == 3, f"two protocols share a point: {placed}"
+
+    def test_the_compounds_hang_off_the_condition_table(self, lane):
+        """Not off the spine: twelve of them cost one rank of height and no
+        horizontal travel."""
+        for compound in COMPOUNDS:
+            assert _y(lane, compound) > _y(lane, "#conditions-a"), compound
+
+    def test_a_compound_never_displaces_the_spine(self, lane):
+        """The property the whole two-band split exists to buy."""
+        spine_right = max(_x(lane, i) for i in SPINE)
+        assert all(_x(lane, c) <= spine_right for c in COMPOUNDS)
+
+
+def _with_compounds(count: int) -> dict[str, Any]:
+    """The lane fixture, with *count* compounds on the exposure's table.
+
+    A real condition table lists a dozen; the fixture's two are enough to place
+    them and not enough to show what placing them costs.
+    """
+    graph = assay_lane_graph()
+    extra = [
+        {"@id": f"#compound-x{i}", "@type": "MolecularEntity", "name": f"Compound {i}"}
+        for i in range(count)
+    ]
+    for entity in graph["@graph"]:
+        if entity.get("@id") == "#conditions-a":
+            entity["reagent"] = [{"@id": c["@id"]} for c in extra]
+    graph["@graph"].extend(extra)
+    return graph
+
+
+def _lane_of(graph: dict[str, Any]) -> dict[str, Any]:
+    nodes, edges = _lane_input(graph, "assay-deiodinase-assay")
+    out = _run(nodes, edges)
+    assert out["positions"] is not None
+    return out["positions"]
+
+
+def _generic(nodes: list[dict], edges: list[dict]) -> dict[str, Any]:
+    """The same graph through the shipped generic layout, for comparison."""
+    result = subprocess.run(
+        [
+            _node_exe(),
+            str(_REPO / "tests" / "fixtures" / "layout_probe.js"),
+            str(_REPO / "builder" / "writers" / "entity_explorer_layout.js"),
+        ],
+        input=json.dumps({"nodes": [n["id"] for n in nodes], "edges": edges}),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)["positions"]
+
+
+def _width(positions: dict[str, Any]) -> float:
+    xs = [p["x"] for p in positions.values()]
+    return max(xs) - min(xs)
+
+
+def _height(positions: dict[str, Any]) -> float:
+    ys = [p["y"] for p in positions.values()]
+    return max(ys) - min(ys)
+
+
+class TestTheBandNeverWidensTheChain:
+    """The property the two-band split exists to buy, stated as an invariant
+    rather than as one measurement of one crate.
+
+    A dependency-ranked layout gives every compound a rank of its own to the
+    right, so the chain a reader is following gets longer the more substances
+    the exposure used — which is exactly backwards.
+    """
+
+    def test_the_spine_does_not_move_when_compounds_are_added(self):
+        few, many = _lane_of(_with_compounds(2)), _lane_of(_with_compounds(12))
+        for step in SPINE:
+            assert few[step] == many[step], (
+                f"{step} moved when compounds it has nothing to do with were added: "
+                f"{few[step]} -> {many[step]}"
+            )
+
+    def test_twelve_compounds_cost_height_and_not_width(self):
+        few, many = _lane_of(_with_compounds(2)), _lane_of(_with_compounds(12))
+        assert _width(many) <= _width(few), (_width(few), _width(many))
+        assert _height(many) > _height(few), "they have to go somewhere"
+
+    def test_the_lane_is_no_wider_than_the_generic_canvas_and_far_shorter(self):
+        """The comparison that justifies a second layout module existing.
+
+        Width ties here, and that is the honest result rather than a weaker
+        claim: both layouts are as wide as the chain itself, because the lane
+        bounds its band by the spine's width and the generic canvas has the same
+        chain to draw. What the generic canvas spends instead is height — it
+        gives each of the twelve compounds a row, under a protocol that is
+        already a rank of its own.
+        """
+        nodes, edges = _lane_input(_with_compounds(12), "assay-deiodinase-assay")
+        lane = _run(nodes, edges)["positions"]
+        generic = _generic(nodes, edges)
+        assert _width(lane) <= _width(generic), (_width(lane), _width(generic))
+        assert _height(lane) * 2 < _height(generic), (
+            f"lane {_width(lane)}x{_height(lane)} vs generic {_width(generic)}x{_height(generic)}"
+        )
+
+
+class TestWhatTheLaneDeclines:
+    """An assay that does not fit the spine is drawn by the generic canvas, same
+    styling, no visible seam. Declining is the module's job, not the caller's."""
+
+    def test_a_graph_with_no_process_is_declined(self):
+        nodes = [
+            {"id": "a", "category": "data", "type": "File"},
+            {"id": "b", "category": "data", "type": "File"},
+        ]
+        out = _run(nodes, [{"src": "a", "dst": "b", "labels": ["hasPart"]}])
+        assert out["positions"] is None
+
+    def test_two_disjoint_chains_are_declined(self):
+        """The whole-crate LabProcesses view is several assays at once, and a
+        lane is one. Laying that out as a spine would interleave two stories."""
+        nodes, edges = _lane_input(assay_lane_graph(), "processes")
+        out = _run(nodes, edges)
+        assert out["positions"] is None
+
+    def test_an_empty_graph_is_declined(self):
+        assert _run([], [])["positions"] is None

--- a/tests/test_explorer_js_integrity.py
+++ b/tests/test_explorer_js_integrity.py
@@ -85,3 +85,53 @@ def test_the_check_can_fail(tmp_path: Path) -> None:
     wounded.write_text(source[:start] + source[end:], encoding="utf-8")
 
     assert _free_names(wounded) == ["layerName"]
+
+
+class TestThePageLoadsInABrowser:
+    """The UMD branch the report actually runs.
+
+    Every other check in this repo reaches the layout modules through
+    ``require()``, which takes the CommonJS branch of their wrapper. The page
+    takes the other one: plain ``<script>`` tags, attaching to ``window``. A
+    module that failed to attach itself, or one placed before the module it
+    reads at factory time, would pass the whole suite and throw in front of a
+    reader (#686).
+    """
+
+    def _run(self, scripts: list[str], expect: list[str]) -> dict:
+        probe = _REPO / "tests" / "fixtures" / "browser_load_probe.js"
+        result = subprocess.run(
+            [_node(), str(probe)],
+            input=json.dumps({"scripts": scripts, "expect": expect}),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def _geometry_scripts(self) -> list[str]:
+        """dagre and the two layout modules, in the order the page emits them."""
+        import re
+
+        from builder.writers.entity_explorer import render_explorer_section
+        from tests.fixtures.crate_graphs import assay_lane_graph
+
+        section = render_explorer_section(assay_lane_graph())
+        bodies = re.findall(r"<script[^>]*>(.*?)</script>", section, re.S)
+        wanted = ("dagre", "root.ExplorerLayout = factory", "root.AssayLaneLayout = factory")
+        return [
+            body
+            for body in bodies
+            if any(marker in (body if marker != "dagre" else body[:2000]) for marker in wanted)
+        ]
+
+    def test_both_layout_modules_attach_themselves_to_the_window(self):
+        out = self._run(self._geometry_scripts(), ["ExplorerLayout", "AssayLaneLayout"])
+        assert out["defined"] == {"ExplorerLayout": True, "AssayLaneLayout": True}
+
+    def test_the_lane_takes_its_node_size_from_the_layout_beside_it(self):
+        """One component, one set of constants: a lane node and a canvas node
+        are the same node, so the two must not be able to drift apart."""
+        out = self._run(self._geometry_scripts(), ["ExplorerLayout", "AssayLaneLayout"])
+        assert out["sizes"]["AssayLaneLayout"] == out["sizes"]["ExplorerLayout"]
+        assert out["sizes"]["ExplorerLayout"] == {"NODE_W": 200, "NODE_H": 44}

--- a/tests/test_explorer_js_integrity.py
+++ b/tests/test_explorer_js_integrity.py
@@ -30,7 +30,7 @@ _PROBE = _REPO / "tests" / "fixtures" / "js_names_probe.js"
 # adding to it is a deliberate act and not a way to quiet the check.
 _PAGE_GLOBALS = ("React", "ReactDOM", "htm", "dagre", "window", "document", "console")
 
-_SCRIPTS = ("entity_explorer.js", "entity_explorer_layout.js")
+_SCRIPTS = ("entity_explorer.js", "entity_explorer_layout.js", "assay_lane_layout.js")
 
 
 def _node() -> str:


### PR DESCRIPTION
Closes #686. The readability half of the work #678 unblocked.

The LabProcesses view draws **74 nodes for 15 steps** on S-VHPS22, its Exposure
sub-view draws four tables captioned identically as `⚠️ Condition table`, and
none of the compounds under test appear anywhere. This changes the unit the view
draws and the direction the band runs in.

## The unit is the assay

One sub-row per assay under the Assays chip, minted from the crate rather than
declared. A lane draws that assay's steps, the materials **one hop** out from
them, the protocol under each step, and the compounds one hop past those
protocols — not the Study, not the Investigation, and not the assay itself, which
frames the view rather than appearing in it. Drawn, the assay would connect to
every step and rebuild the star #678 took apart.

The material walk is a hop and not a closure, or a shared file would lead out of
the assay and undo the scoping.

## Compounds were one hop out of reach

Not a modelling gap. ISA restricts `schema:object` to File/Sample/BioSample at
Violation severity, so a `MolecularEntity` can never be a process input directly,
and `reagent` is a LabProtocol property ranging over it. The crate's route is
correct; the selection now follows it, anchored on the protocols the drawn steps
execute so a compound with no edge to any drawn work stays out.

The model draws `reagent` **reversed** — the arrow points at the step that
consumes the material — so the hop is inward from the protocol. The spec's prose
described the crate's direction, not the model's.

## Two bands

Horizontal is the material chain; vertical is what qualifies a step.

The spine is laid out by the **shipped** `entity_explorer_layout.js` rather than
by geometry of its own, so node size, rank gaps and wide-rank packing stay one
answer given once and a lane node cannot drift from a canvas node. What is new is
only the band.

Both band tiers are **dealt into a grid**, not anchored to a single x. The KLF9
readout in the real crate executes three protocols — RNA isolation, cDNA, qPCR —
and anchoring put all three at exactly `x=1474, y=292`: one visible node, two
hidden. Each block is bounded by the spine's own width, so twelve compounds cost
height and never width.

`derivesFrom` is excluded from the ranking edges despite being material: a
cultured sample derives from the line its culture consumed, so the edge points
back up the chain and ranking on it would place a node before its own ancestor.

## Declining

The module returns `null` for a graph that is not one chain, and the app falls
back to the generic canvas — same styling, no seam. Declining is the module's
job, so the app never has to know which shapes are spines.

The app *also* gates on the view being a lane, read off a new `lane` flag in the
payload rather than matched on a key. Both are needed: a multi-assay graph can be
connected (S-VHPS22 pre-#678 shares a culture), so topology alone would have laid
the whole crate out as one chain.

## Measured

| assay | n | lane | generic |
|---|---|---|---|
| Deiodinase | 26 | **1160×380** | 1740×767 |
| TH Transport | 37 | 2320×436 | 2320×918 |
| Whole-cell metabolism | 27 | 2320×380 | 1450×750 |
| TR Activation | 20 | 2320×324 | 1450×471 |

**Stated plainly: the lane is wider than the generic canvas on three of four
assays.** It buys an uninterrupted left-to-right reading and roughly half the
height; it does not win on every axis, and these numbers come from a crate built
*before* #678, so its shared culture and star topology still shape them. The
in-repo test asserts the general invariant instead — adding compounds must not
move the spine — rather than any one crate's measurement.

## Tests

`test_assay_lane.py` (29) selection and views; `test_assay_lane_layout.py` (14)
geometry, run against the shipped JS through a node probe;
`test_explorer_js_integrity.py` gains a **browser-mode load test** — every other
check reaches the modules through `require()`, which takes the CommonJS branch
the report never runs, so a module that failed to attach to `window` passed the
whole suite and threw in front of a reader. Verified by mutation: loading the
lane before `ExplorerLayout` fails there and nowhere else.

429 passed locally across the explorer, DAG, report and writer suites. CI is the
gate.

## Left out, deliberately

**File stacks** (#689). The design calls for a step's result files to draw as one
offset stack that unfolds in place. Folding is interaction, not geometry — it
needs a foldable node component and app state — so it belongs with #688's shared
node work. It does not block the lane: within one assay the largest file count on
S-VHPS22 is four, which the existing grid packing handles.

Also split out and filed: #687 (`status` cannot say whose bytes are in the crate,
which blocks the payload tint) and #688 (edge labels, click-to-clear, glyph drop,
Properties→Overview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYLSExAW64e7fe26xHDHUS