### PR TITLE
feat(report): the inspector names properties the way the crate expands them (#688)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2404,6 +2404,22 @@ prefix would be short and a lie. Labels carry no background box — the text tak
 a surface-coloured `paint-order` halo knocks the line out from behind it, so a label reads as part of
 its edge. Clicking the selected node clears the selection, and the labels with it.
 
+**The inspector's Overview (#688).** The first tab listed an entity's raw JSON keys, which are the
+serializer's shorthand: `input` and `object` are one predicate, `studies` and `assays` and `hasPart`
+are another, and a reader had to know the `@context` to see it. The Overview names each property as
+the crate expands it (`property_terms()`, derived from that context; a key the context does not name
+expands under its `@vocab`, which is the crate's own rule rather than a guess) and shows **one row per
+predicate, not one per spelling** — the crate's own keys are on the row's tooltip. The Links tab names
+relations from the same table the edges do, so a relation is not one word on the canvas and another in
+the panel. `parameter` and `parameterValue` stay two rows: they are two predicates, emitted
+deliberately because the two profiles the crate claims ask for parameters under different ones.
+
+A URL is offered **for copying, never as a link**. The payload carries the crate verbatim,
+`javascript:` URLs and all, so the explorer writes no anchor and no link target — that absence is
+load-bearing and pinned by a test that greps the app for the attribute names. A clipboard write
+navigates nowhere and executes nothing, so the reader gets the URL without the crate getting a way to
+run anything.
+
 A node encodes two orthogonal facts: **the border is its category, the fill is its residence.** A
 tinted fill means the bytes are in the crate directory (#687) — the one thing a reader can act on,
 since it separates a record from a file they can open. Category glyphs are **dropped; colour only.**

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -57,6 +57,15 @@
    * up rather than keeping a second copy of the vocabulary here.
    */
   function term(label) { return (D.relations && D.relations[label]) || label; }
+  /* What an entity KEY expands to. `input` and `object` are one predicate;
+   * `studies`, `assays` and `hasPart` are another. A key the context does not
+   * name expands under the crate's own @vocab, which is the crate's rule rather
+   * than a guess made here. */
+  function prop(key) {
+    if (key.charAt(0) === '@') return key;
+    return (D.properties && D.properties[key]) || (D.vocab_prefix + ':' + key);
+  }
+  function isUrl(v) { return typeof v === 'string' && /^https?:\/\//.test(v); }
   // Everything some view can put on the canvas. Not `D.nodes.length`: that also
   // counts bare references the crate never describes, which no view offers, so
   // a denominator taken from it would be one the numerator can never reach.
@@ -276,6 +285,50 @@
     return html`<span class="ex-json-number">${String(v)}</span>`;
   }
 
+  /* A URL the crate carries, offered as something to take away.
+   *
+   * NOT a link. The payload holds the crate verbatim, `javascript:` URLs and
+   * all, so the explorer writes no anchor and no link target of any kind — that
+   * absence is load-bearing and pinned by a test that greps this file for the
+   * attribute names, which is why they are not written out even here (#169).
+   * Copying navigates nowhere and executes nothing, so the reader gets the URL
+   * without the crate getting a way to run anything.
+   */
+  function Url(props) {
+    var v = props.v;
+    var copied = useState(false), was = copied[0], setWas = copied[1];
+    return html`<button type="button" class=${'ex-url ex-mono' + (was ? ' ex-url-copied' : '')}
+      title=${'Copy ' + v}
+      onClick=${function () {
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(v);
+          setWas(true);
+          setTimeout(function () { setWas(false); }, 1200);
+        }
+      }}>${v}</button>`;
+  }
+
+  /* One row per predicate, not one per spelling. */
+  function overviewRows(entity) {
+    var byTerm = new Map();
+    Object.keys(entity).forEach(function (key) {
+      if (key === '@id') return;
+      var name = prop(key);
+      if (!byTerm.has(name)) byTerm.set(name, { name: name, keys: [], values: [], seen: new Set() });
+      var row = byTerm.get(name);
+      if (row.keys.indexOf(key) < 0) row.keys.push(key);
+      (Array.isArray(entity[key]) ? entity[key] : [entity[key]]).forEach(function (v) {
+        // Two aliases of one predicate carry the same values; showing them
+        // twice is what naming the predicate was meant to stop.
+        var seal = JSON.stringify(v);
+        if (row.seen.has(seal)) return;
+        row.seen.add(seal);
+        row.values.push(v);
+      });
+    });
+    return Array.from(byTerm.values());
+  }
+
   /* ---- side panel ---------------------------------------------------------- */
   function Panel(props) {
     var sel = props.selected, goTo = props.goTo;
@@ -340,7 +393,8 @@
       });
       return Array.from(byRelation.entries()).map(function (pair) {
         return html`<div key=${direction + pair[0]} class="ex-link-group">
-          <div class="ex-relation ex-mono">${(direction === 'out' ? '→ ' : '← ') + pair[0]}
+          <div class="ex-relation ex-mono"
+            title=${pair[0]}>${(direction === 'out' ? '→ ' : '← ') + term(pair[0])}
             <span class="ex-muted">${'(' + pair[1].length + ')'}</span></div>
           ${pair[1].map(function (id) {
             var t = NODE.get(id);
@@ -353,7 +407,7 @@
     }
 
     var tabs = [
-      ['properties', 'Properties'],
+      ['properties', 'Overview'],
       ['links', 'Links (' + (outgoing.length + incoming.length) + ')'],
       ['json', 'JSON-LD']
     ];
@@ -377,11 +431,14 @@
       </div>
       <div class="ex-side-body">
         ${tab === 'properties' ? (entity
-          ? html`<dl class="ex-props">${Object.keys(entity).filter(function (k) { return k !== '@id'; })
-              .map(function (k) {
-                return html`<div key=${k} class="ex-prop">
-                  <dt class="ex-mono">${k}</dt>
-                  <dd><${JsonValue} v=${entity[k]} goTo=${goTo} /></dd></div>`;
+          ? html`<dl class="ex-props">${overviewRows(entity).map(function (row) {
+                return html`<div key=${row.name} class="ex-prop">
+                  <dt class="ex-mono" title=${'in the crate as: ' + row.keys.join(', ')}>${row.name}</dt>
+                  <dd>${row.values.map(function (v, i) {
+                    return html`<div key=${i}>${isUrl(v)
+                      ? html`<${Url} v=${v} />`
+                      : html`<${JsonValue} v=${v} goTo=${goTo} />`}</div>`;
+                  })}</dd></div>`;
               })}</dl>`
           : html`<p class="ex-hint">This entity is described outside the crate; the crate
               carries the reference only.</p>`) : null}

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -54,7 +54,9 @@ from builder.writers.provenance_dag import (
     build_crate_graph,
     build_isa_inventory,
     build_people_inventory,
+    property_terms,
     relation_terms,
+    vocab_prefix,
 )
 
 PAYLOAD_VERSION = 3
@@ -831,6 +833,11 @@ def build_explorer_payload(
         # serialized with. Generated here for the same reason the palette is: the
         # browser must not hold a second copy of it (#688).
         "relations": relation_terms(),
+        # And what each entity KEY expands to. `input` and `object` are one
+        # predicate; a reader had to know the context to see that (#688).
+        "properties": property_terms(),
+        # A key the context does not name expands under the crate's own @vocab.
+        "vocab_prefix": vocab_prefix(),
         "nodes": nodes,
         "edges": [{"src": e["src"], "dst": e["dst"], "label": e["label"]} for e in model["edges"]],
         "views": views,

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -559,6 +559,16 @@ __CATEGORY_STYLES__
 .mat .ex-json-entity{margin:.15rem 0; padding:.2rem .35rem; border:1px solid transparent;
   border-radius:6px;}
 .mat .ex-json-current{background:var(--accent-soft); border-color:var(--accent);}
+/* A URL the crate carries. Deliberately NOT styled as a link, because it is not
+   one: the explorer writes no anchors (#169), so this offers the URL for copying
+   and says so on hover. Underlined on hover only, so it does not promise
+   navigation at rest. */
+.mat .ex-url{font:inherit; font-size:.72rem; text-align:left; padding:0; border:0;
+  background:none; color:var(--accent); cursor:copy; word-break:break-all;}
+.mat .ex-url:hover{text-decoration:underline;}
+.mat .ex-url-copied{color:var(--ok,var(--accent)); text-decoration:none;}
+.mat .ex-url-copied::after{content:" copied"; font-size:.62rem; color:var(--muted);
+  letter-spacing:.04em; text-transform:uppercase;}
 .mat .ex-json-entity-head{display:flex; align-items:center; gap:.3rem; margin-bottom:.1rem;
   font-family:inherit; font-size:.74rem;}
 .mat .ex-side-document .ex-json{padding:.5rem .7rem;}

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -836,6 +836,46 @@ def _qualify(url: str, spaces: dict[str, str]) -> str:
 
 
 @lru_cache(maxsize=1)
+def vocab_prefix() -> str:
+    """The prefix a bare property key expands under, per the crate's ``@vocab``.
+
+    JSON-LD says an unmapped term expands against ``@vocab``, and the crate
+    declares ``http://schema.org/``. So a key the context does not name is a
+    schema.org property by the crate's own rule, not by a guess made here.
+    """
+    from profiles.context import ISA_TOX_CONTEXT
+
+    declared = ISA_TOX_CONTEXT[0]
+    return _qualify(str(declared.get("@vocab", "")), _namespaces()).rstrip(":") or "schema"
+
+
+@lru_cache(maxsize=1)
+def property_terms() -> dict[str, str]:
+    """Entity key → the property it expands to, qualified (#688).
+
+    The inspector listed an entity's raw JSON keys, which are the serializer's
+    shorthand: ``input`` and ``object`` are one predicate, ``studies`` and
+    ``assays`` and ``hasPart`` are another, and a reader had to know the context
+    to see it. This is that context, read rather than restated.
+
+    Only terms mapping to a **property** IRI are returned. A key absent from here
+    expands under :func:`vocab_prefix`.
+    """
+    from profiles.context import ISA_TOX_CONTEXT
+
+    declared = ISA_TOX_CONTEXT[0]
+    spaces = _namespaces()
+    return {
+        term: _qualify(value, spaces)
+        for term, value in declared.items()
+        if not term.startswith("@")
+        and isinstance(value, str)
+        and "://" in value
+        and not (value.endswith("/") or value.endswith("#"))
+    }
+
+
+@lru_cache(maxsize=1)
 def relation_terms() -> dict[str, str]:
     """Edge label → the property it stands for, qualified (#688).
 

--- a/tests/test_overview_tab.py
+++ b/tests/test_overview_tab.py
@@ -1,0 +1,121 @@
+"""The inspector names properties the way the crate does (#688).
+
+The Properties tab listed an entity's raw JSON keys. The crate's own
+``@context`` is what those keys mean — ``input`` and ``object`` are one
+predicate, ``studies`` and ``assays`` and ``hasPart`` are another — so a reader
+saw the serializer's shorthand and had to know the context to read it.
+
+The Overview names each property as the crate expands it, and shows one row per
+predicate rather than one per spelling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from builder.writers.provenance_dag import property_terms
+
+pytestmark = pytest.mark.timeout(180)
+
+
+class TestPropertyNamesComeFromTheContext:
+    def test_a_bioschemas_property_is_named_as_one(self):
+        assert property_terms()["executesLabProtocol"] == "bioschemas:executesLabProtocol"
+
+    def test_the_friendly_aliases_expand_to_what_they_alias(self):
+        """`input` is the builder's readable name for a LabProcess's input; the
+        predicate is schema:object, and that is what the crate carries."""
+        terms = property_terms()
+        assert terms["input"] == "schema:object"
+        assert terms["object"] == "schema:object"
+
+    def test_the_grouped_containment_aliases_all_name_haspart(self):
+        terms = property_terms()
+        assert {terms[k] for k in ("studies", "assays", "protocols", "hasPart")} == {
+            "schema:hasPart"
+        }
+
+    def test_the_two_parameter_predicates_stay_distinct(self):
+        """The builder emits both keys for the same values on purpose: the two
+        profiles it claims ask for parameters under different predicates, and
+        dropping either loses a conformance it advertises. They are two
+        predicates, so the Overview must not merge them into one row.
+        """
+        terms = property_terms()
+        assert terms["parameter"] == "schema:additionalProperty"
+        assert terms["parameterValue"] == "bioschemas:parameterValue"
+
+    def test_every_term_names_something_lookupable(self):
+        for key, term in property_terms().items():
+            assert ":" in term, (key, term)
+
+
+class TestThePayloadCarriesThem:
+    def _payload(self):
+        from builder.writers.entity_explorer import build_explorer_payload
+        from tests.fixtures.crate_graphs import assay_lane_graph
+
+        return build_explorer_payload(assay_lane_graph())
+
+    def test_properties_travel_with_the_crate(self):
+        assert self._payload()["properties"]["input"] == "schema:object"
+
+    def test_a_key_the_context_does_not_map_falls_back_to_the_vocab(self):
+        """The crate declares ``@vocab: http://schema.org/``, so a bare key it
+        does not name expands to schema:<key> — that is the crate's own rule, not
+        a guess made here."""
+        assert self._payload()["vocab_prefix"] == "schema"
+
+    def test_the_app_does_not_restate_the_vocabulary(self):
+        import re
+
+        from builder.writers.entity_explorer import _app_js
+
+        code = re.sub(r"/\*.*?\*/", "", _app_js(), flags=re.S)
+        code = re.sub(r"^\s*//.*$", "", code, flags=re.M)
+        assert "D.properties" in _app_js()
+        for term in ("schema:hasPart", "bioschemas:executesLabProtocol"):
+            assert term not in code, term
+
+
+class TestTheTabIsTheOverview:
+    def _app(self) -> str:
+        from builder.writers.entity_explorer import _app_js
+
+        return _app_js()
+
+    def test_it_is_called_the_overview(self):
+        app = self._app()
+        assert "'Overview'" in app
+        assert "'Properties'" not in app
+
+    def test_the_links_tab_names_relations_the_same_way(self):
+        """A relation shown in the panel and the same relation shown on an edge
+        must not be two different words for one predicate."""
+        app = self._app()
+        assert "term(pair[0])" in app
+
+    def test_the_json_and_links_tabs_are_still_offered(self):
+        app = self._app()
+        assert "'json'" in app and "'links'" in app
+
+
+class TestTheUntrustedTextRuleStillHolds:
+    """#169: the payload carries the crate verbatim, `javascript:` URLs and all.
+
+    The design asked for values to be linked wherever a URL exists. The explorer
+    may not write an anchor, so a URL is offered as something to copy instead —
+    a clipboard write navigates nowhere and executes nothing.
+    """
+
+    def test_the_app_still_writes_no_navigation_sink(self):
+        from builder.writers.entity_explorer import _app_js
+
+        source = _app_js()
+        for sink in ("href", "src=", "window.open", "location.assign", "innerHTML", "<a "):
+            assert sink not in source, sink
+
+    def test_a_url_value_is_offered_for_copying(self):
+        from builder.writers.entity_explorer import _app_js
+
+        assert "clipboard" in _app_js()


### PR DESCRIPTION
Closes #688. The inspector half; the canvas half was #692.

## The defect

The first tab listed an entity's raw JSON keys, which are the serializer's
shorthand. `input` and `object` are one predicate. `studies`, `assays`,
`protocols` and `hasPart` are another. A reader had to know the `@context` to see
that, and the panel never showed it.

## One row per predicate, not one per spelling

`property_terms()` reads the crate's own `@context` rather than restating it, so
the Overview names each property as the crate expands it. Values carried under
two aliases appear once, and the crate's actual keys move to the row's tooltip
("in the crate as: input, object").

A key the context does not name expands under the crate's own `@vocab` — that is
JSON-LD's rule, not a guess made here.

**`parameter` and `parameterValue` stay two rows.** They are two predicates,
emitted deliberately because the two profiles this crate claims ask for
parameters under different ones. Merging them would erase a conformance the crate
advertises.

The Links tab now names relations from the same table the edges do, so a relation
is not one word on the canvas and a different word in the panel.

## Links: what I did not do, and why

**The design asked for values to be linked wherever a URL exists. I did not make
them links, and this is worth your decision rather than my silence.**

The explorer writes no anchor and no link target of any kind. The payload carries
the crate verbatim — `javascript:` URLs and all — so that absence is
load-bearing, and it is pinned by a test that greps the app source for the
attribute names (#169).

So a URL is offered **for copying**: a clipboard write navigates nowhere and
executes nothing, and the reader still gets the URL. It is styled to promise
copying rather than navigation — `cursor: copy`, underlined on hover only.

If you want true links, the safe shape is a scheme allowlist plus a validator,
and that means changing a deliberate XSS invariant. That is your call, and I
would rather change the test knowingly than route around it in a display change.
Say the word and it is a small follow-up.

## Verification

`test_overview_tab.py` (13), including a test that the no-navigation-sink rule
still holds and one that the app spells out no vocabulary of its own.

Checked against the real crate — an Exposure's Overview reads:

```
@type · schema:additionalType · bioschemas:executesLabProtocol · schema:object
schema:name · schema:result · schema:additionalProperty · bioschemas:parameterValue
```

Every one a property a reader can look up.

282 passed locally across the explorer, DAG and report suites. Rebased onto main
after #692 merged — the canvas commit is an ancestor, verified with
`merge-base --is-ancestor`, so this is not a stacked child. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYLSExAW64e7fe26xHDHUS