### PR TITLE
fix(data): the design table was in the deposit all along — a well key was passing as a condition (#669)

### DIFF
--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -982,9 +982,7 @@ def _merge_plan_chain_names(
         kept = {
             key: value.strip()
             for key, value in raw.items()
-            if key in LABPROCESS_PARAMETER_FIELDS
-            and isinstance(value, str)
-            and value.strip()
+            if key in LABPROCESS_PARAMETER_FIELDS and isinstance(value, str) and value.strip()
         }
         if kept:
             plan_parameters[ptype] = kept
@@ -1201,8 +1199,71 @@ def _scanned_path_for_name(
 _DESIGN_TABLE_SUFFIXES = frozenset({".csv", ".tsv", ".tab", ".xlsx", ".xlsm"})
 
 
+def _assay_table_paths(engine: AgentEngine, exposure_id: str) -> set[str]:
+    """Scanned paths of the files the Exposure's own Assay holds (#669).
+
+    A design table belongs to ONE assay, and the search for it is crate-wide. On
+    S-VHPS22 the only qualifying table is assay 1's tidy export, and nothing
+    stopped its 1048 rows being written into the deiodinase exposure instead — a
+    table that looks populated and attributes the wrong experiment is worse than
+    the empty one it replaces.
+
+    The crate already says which files belong where: an Assay ``hasPart`` its own
+    files and a process carries the ``assay_id`` it serves. That is read here
+    rather than a folder-naming convention, which only this deposit has.
+
+    The bridge is ``dest_path``, not the on-disk source. ``attach_files`` appends
+    a File ENTITY id to ``hasPart``, and that entity records where the file will
+    land in the crate — it does not necessarily carry where it came from, so
+    resolving a source finds nothing for most of them. ``_scanned_dest`` is the
+    same derivation the attachment used, so what an assay holds and what the scan
+    offers cannot disagree about which file they mean.
+
+    Returns the empty set when the exposure names no assay, the assay is missing,
+    or it holds no files. The caller treats that as "no scope", not as "no
+    candidates" — see :func:`_design_table_candidates`.
+    """
+    from pathlib import PurePath
+
+    from builder.tools.provenance import _scanned_dest
+
+    state = engine.state
+    exposure = next(
+        (e for e in state.list_entities("LabProcess") if e.entity_id == exposure_id), None
+    )
+    if exposure is None:
+        return set()
+    assay_id = str(exposure.fields.get("assay_id") or "")
+    if not assay_id:
+        return set()
+    assay = next((e for e in state.list_entities("Assay") if e.entity_id == assay_id), None)
+    if assay is None:
+        return set()
+    members = assay.fields.get("hasPart") or assay.fields.get("has_part") or []
+    if not isinstance(members, list):
+        members = [members]
+    files = {e.entity_id: e for e in state.list_entities("File")}
+    wanted: set[str] = set()
+    for member in members:
+        ref = member.get("@id") if isinstance(member, dict) else member
+        entity = files.get(str(ref))
+        if entity is None:
+            continue
+        dest = str(entity.fields.get("dest_path") or "").strip()
+        if dest:
+            wanted.add(dest)
+    if not wanted:
+        return set()
+    input_path = state.metadata.input_path
+    return {
+        f.path
+        for f in state.scanned_files
+        if _scanned_dest(f.path, f.filename or PurePath(f.path).name, input_path) in wanted
+    }
+
+
 def _design_table_candidates(
-    engine: AgentEngine,
+    engine: AgentEngine, *, allowed: set[str] | None = None
 ) -> tuple[list[tuple[int, int, str]], list[tuple[str, str]]]:
     """Scanned tables that read as a per-condition design table, best first (#594).
 
@@ -1244,6 +1305,10 @@ def _design_table_candidates(
         if _contain(f.path, roots) is None:
             logger.debug("Scanned file %s is outside approved scan roots — refusing.", f.path)
             continue
+        # Scoped to one assay's own files when the caller says so (#669), so a
+        # design table can never be written to an exposure it does not describe.
+        if allowed and f.path not in allowed:
+            continue
         wells, mapped, error = condition_table_fit_of(Path(f.path))
         if wells:
             found.append((wells, mapped, f.path))
@@ -1251,6 +1316,64 @@ def _design_table_candidates(
             unreadable.append((f.path, error))
     found.sort(reverse=True)
     return found, unreadable
+
+
+def _populate_condition_tables(engine: AgentEngine) -> dict[str, Any]:
+    """Populate EVERY Exposure's condition table, each from its own assay (#669).
+
+    This used to run once, for a single exposure taken from ``chain_by_type`` — a
+    dict keyed by process type, so a crate with four exposures collapsed to one
+    and the last won. Three of the four tables could not be populated even in
+    principle, and the one that could had no guarantee of being the assay the
+    design table belonged to.
+
+    Returns the aggregate the build summary already reads — ``populated`` /
+    ``reason`` / ``rows`` / ``proposed`` — with ``per_exposure`` carrying one
+    outcome per exposure for anything that needs the detail. The summary shape is
+    kept so ``builder/agents/build.py``'s condition-table line and #422's posture
+    reporting go on working unchanged.
+    """
+    exposures = [
+        e
+        for e in engine.state.list_entities("LabProcess")
+        if str(e.fields.get("process_type") or "") == "Exposure"
+    ]
+    if not exposures:
+        return {
+            "populated": False,
+            "reason": "no Exposure in the process chain to attach a condition table to",
+            "per_exposure": [],
+        }
+    per: list[dict[str, Any]] = []
+    for exposure in exposures:
+        outcome = _populate_condition_table_from_deposit(engine, exposure.entity_id)
+        per.append({"exposure_id": exposure.entity_id, **outcome})
+
+    if len(per) == 1:
+        # With one exposure the aggregate IS the outcome. Carried through whole
+        # rather than rebuilt, so every key the single-table case has always
+        # reported — `fallback_from`, `proposal_reason`, `path`, `reason` — keeps
+        # reaching the build summary and #422's posture reporting untouched.
+        return {**per[0], "per_exposure": per}
+
+    written = [e for e in per if e.get("populated")]
+    rows = sum(_as_int(e.get("rows")) for e in written)
+    aggregate: dict[str, Any] = {
+        "populated": bool(written),
+        "rows": rows,
+        "per_exposure": per,
+        # `proposed` is a posture, not a count: it is true when every table that
+        # WAS written came from the #438 proposal rather than the deposit, which
+        # is what the build summary tells the depositor to confirm.
+        "proposed": bool(written) and all(e.get("proposed") for e in written),
+    }
+    if len(written) == 1:
+        # One table, one path — what the CSVW validation pass expects.
+        aggregate["path"] = written[0].get("path")
+    if not written:
+        reasons = sorted({str(e.get("reason") or "") for e in per if e.get("reason")})
+        aggregate["reason"] = "; ".join(reasons) or "no reason recorded"
+    return aggregate
 
 
 def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
@@ -1328,9 +1451,7 @@ def _fall_back_to_proposal(
     return primary
 
 
-def _populate_condition_table_from_deposit(
-    engine: AgentEngine, exposure_id: str
-) -> dict[str, Any]:
+def _populate_condition_table_from_deposit(engine: AgentEngine, exposure_id: str) -> dict[str, Any]:
     """Write the deposit's design table into the Exposure's CSV (#408, #594).
 
     Which file is the design table is a question its ROWS answer. It used to be
@@ -1379,7 +1500,13 @@ def _populate_condition_table_from_deposit(
     """
     from pathlib import PurePath
 
-    candidates, unreadable = _design_table_candidates(engine)
+    # Scoped to the exposure's own assay (#669): the search is crate-wide, and
+    # writing one assay's design into another's table is worse than leaving it
+    # empty. Scoping also dissolves most of the ambiguity below, because the
+    # tables that collide are usually siblings from different assays.
+    candidates, unreadable = _design_table_candidates(
+        engine, allowed=_assay_table_paths(engine, exposure_id)
+    )
     if not candidates:
         # No table in the deposit carries per-condition rows. This is the ORDINARY
         # case, not the edge — two of the three real deposits are like this — so
@@ -1479,9 +1606,7 @@ def _populate_condition_table_from_deposit(
             },
         )
 
-    logger.info(
-        "Populated condition table from %s: %s row(s) (#408).", named, outcome.get("rows")
-    )
+    logger.info("Populated condition table from %s: %s row(s) (#408).", named, outcome.get("rows"))
     return {
         "populated": True,
         "reason": "",
@@ -1848,16 +1973,10 @@ def _materialize_plan(
     # than leaving the header-only placeholder beside an untyped payload File.
     # Runs regardless of `compound_ids` — a plate map is worth populating even when
     # no compound resolved. ---
-    exposure_for_table = (chain_by_type.get("Exposure") or {}).get("process_id")
-    if exposure_for_table:
-        result["condition_table"] = _populate_condition_table_from_deposit(
-            engine, str(exposure_for_table)
-        )
-    else:
-        result["condition_table"] = {
-            "populated": False,
-            "reason": "no Exposure in the process chain to attach a condition table to",
-        }
+    # Every exposure, each scoped to its own assay (#669). `chain_by_type` keys a
+    # dict by process type, so four exposures collapsed to one and the last won:
+    # three of the four tables could not be populated even in principle.
+    result["condition_table"] = _populate_condition_tables(engine)
     if cell_line_ids:
         culture_step = chain_by_type.get("CellCulture")
         culture_id = culture_step.get("process_id") if culture_step else None
@@ -2131,10 +2250,29 @@ def _validate_populated_tables(
         return []
     if _as_int(table.get("rows")) <= 0:
         return []
-    path = str(table.get("path") or "").strip()
-    if not path:
+    # Every populated table, not just one: since #669 an exposure gets its own,
+    # each from its own assay, and validating the first would leave the rest
+    # unchecked while the summary read clean.
+    paths = [
+        str(entry.get("path") or "").strip()
+        for entry in (table.get("per_exposure") or [])
+        if entry.get("populated") and _as_int(entry.get("rows")) > 0
+    ]
+    paths = [p for p in paths if p] or [str(table.get("path") or "").strip()]
+    paths = [p for p in paths if p]
+    if not paths:
         return []
+    return [issue for path in paths for issue in _validate_one_table(engine, path)]
 
+
+def _validate_one_table(engine: AgentEngine, path: str) -> list[dict[str, Any]]:
+    """Frictionless issues for one populated condition table, or ``[]``.
+
+    Split out of the pass above so several tables are each checked the same way.
+    Never raises, for the reason that pass records: the payload layer is
+    additive, and a missing optional dependency must not fail a build whose
+    metadata is fine.
+    """
     try:
         from builder.tools._crate_mapping import (
             _CONDITION_TABLE_COLUMNS,

--- a/builder/tools/data_content.py
+++ b/builder/tools/data_content.py
@@ -695,6 +695,20 @@ def condition_table_fit(rows: Sequence[Mapping[str, Any]]) -> tuple[int, int]:
     # not penalised.
     if wells > 1 and len({str(k) for k in keys}) == 1:
         return (0, 0)
+    # A key on its own describes nothing either (#669). `mapped_columns` counts
+    # `well_id` among them, so any table carrying a well-ish header qualified: on
+    # S-VHPS22 a qPCR protocol sheet keyed on `Well Position` and a gamma-counter
+    # export keyed on `Run ID` both did, giving three candidates where there is
+    # one design table — and the spine refuses when several qualify, so the crate
+    # shipped four header-only tables while 1048 rows of real design sat in the
+    # deposit. Knowing WHICH WELLS EXIST says nothing about WHAT WAS DONE to
+    # them, which is the same rule already stated for the other side of the pair.
+    #
+    # The threshold is "more than the key", not "most of the schema": a one-factor
+    # design is still a design, and demanding more would refuse real deposits to
+    # keep this one tidy.
+    if not (set(projection["mapped_columns"]) - {"well_id"}):
+        return (0, 0)
     return (wells, mapped) if wells and mapped else (0, 0)
 
 

--- a/tests/test_condition_table.py
+++ b/tests/test_condition_table.py
@@ -1194,3 +1194,71 @@ class TestAWorkbookThatIsSimplyNotTheDesignTable:
 
         assert error is None
         assert wells == 1 and mapped >= 3
+
+
+class TestAKeyOnItsOwnDescribesNothing:
+    """#669 — a well key and no condition column is a list of wells, not a design.
+
+    ``condition_table_fit`` counted ``well_id`` among the columns it mapped, so
+    any table carrying a well-ish header qualified. On S-VHPS22 that admitted two
+    files that describe no conditions at all — a qPCR protocol sheet whose first
+    column is ``Well Position``, and a gamma-counter export keyed on ``Run ID`` —
+    giving three candidates where there is one design table. The pipeline refuses
+    when several qualify, so **the crate shipped four header-only tables while
+    1048 rows of real design sat in the deposit**.
+
+    The rule already stated for the other side of the pair — "a table with wells
+    but no mapped column describes nothing" — is simply applied to the key too:
+    knowing *which wells exist* says nothing about *what was done to them*.
+    """
+
+    def test_a_key_alone_does_not_qualify(self):
+        rows = [{"well_id": f"A{n}"} for n in range(1, 13)]
+        assert condition_table_fit(rows) == (0, 0), (
+            "twelve well names describe twelve wells and no experiment"
+        )
+
+    def test_the_qpcr_protocol_sheet_does_not_qualify(self):
+        """`5.3 cDNA and qPCR protocol.xlsx`, which became a candidate on the
+        real deposit: 100 distinct well positions, zero conditions."""
+        rows = [
+            {"Well Position": f"{row}{col}", "CT": 22.4}
+            for row in "ABCDEFGHIJ"
+            for col in range(1, 11)
+        ]
+        assert len(rows) == 100
+        assert condition_table_fit(rows) == (0, 0)
+
+    def test_a_measurement_export_keyed_by_position_does_not_qualify(self):
+        """A varying key gets past #656's gate and still describes nothing."""
+        rows = [
+            {"Run ID": n, "I-125 CPM": 100.0 + n, "Measurement date & time": "2023-03-01"}
+            for n in range(1, 26)
+        ]
+        assert condition_table_fit(rows) == (0, 0)
+
+    def test_one_condition_column_beside_the_key_is_enough(self):
+        """The threshold is 'more than the key', not 'most of the schema'. A
+        one-factor design is still a design, and demanding more would refuse
+        real deposits to keep this one tidy."""
+        rows = [{"well_id": f"A{n}", "compound": "Amiodarone"} for n in range(1, 13)]
+        wells, mapped = condition_table_fit(rows)
+        assert wells == 12 and mapped == 2, (wells, mapped)
+
+    def test_the_real_design_table_still_qualifies(self):
+        """The 1048-row tidy export this whole fix exists to let through."""
+        rows = [
+            {
+                "run_id": f"Amiodarone_H4_T3_10.0uM_n{n}",
+                "biosample_type": "H4",
+                "test_substance_id": "Amiodarone",
+                "exposure_concentration_value": 10.0,
+                "exposure_concentration_unit": "uM",
+                "assay_endpoint": "T3",
+                "replicate_id": f"n{n}",
+            }
+            for n in range(1, 20)
+        ]
+        wells, mapped = condition_table_fit(rows)
+        assert wells == 19, wells
+        assert mapped >= 6, mapped

--- a/tests/test_condition_table_per_assay.py
+++ b/tests/test_condition_table_per_assay.py
@@ -1,0 +1,165 @@
+"""A design table belongs to ONE assay, and must not be written to another (#669).
+
+The search for a design table is crate-wide, but the write targets a single
+Exposure taken from ``chain_by_type`` — a dict keyed by process type, so a crate
+with four exposures collapses to one and the last wins. On S-VHPS22 the only
+table that qualifies is assay 1's tidy export; nothing stopped its 1048 rows
+being written into the deiodinase or TR-activation exposure instead. A table
+that looks populated and attributes the wrong experiment is worse than the empty
+one it replaces.
+
+The crate already says which files belong to which assay — an Assay ``hasPart``
+its own files and is ``about`` its own processes — so the scope is read from the
+crate rather than from a folder-naming convention that only this deposit has.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from builder.engine import AgentEngine
+from builder.state import CrateState, Entity, EntityProvenance, FileClassification
+
+pytestmark = pytest.mark.timeout(180)
+
+_DESIGN = "well_id,compound\nA1,Amiodarone\nA2,Cisplatin\nA3,Thyroxine\n"
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+@pytest.fixture
+def two_assays(tmp_path: Path):
+    """Two assays, each with its own exposure and its own design table on disk."""
+    one = tmp_path / "assay_one"
+    two = tmp_path / "assay_two"
+    one.mkdir()
+    two.mkdir()
+    table_one = one / "design_one.csv"
+    table_two = two / "design_two.csv"
+    table_one.write_text(_DESIGN, encoding="utf-8")
+    table_two.write_text(_DESIGN.replace("Amiodarone", "Silychristin"), encoding="utf-8")
+
+    state = CrateState()
+    state.metadata.output_path = str(tmp_path / "crate")
+    state.add_entity(_ent("inv1", "Investigation", name="Inv", description="d"))
+    state.add_entity(_ent("st1", "Study", name="St", description="d", investigation_id="inv1"))
+    # `attach_files` appends the FILE ENTITY id to an Assay's hasPart, and a File
+    # entity carries the on-disk source in `path` — so the scope has to resolve
+    # through the entity, not compare strings. Built that way here on purpose: a
+    # fixture holding raw paths would let an implementation pass that the
+    # pipeline's own shape would defeat.
+    state.add_entity(
+        _ent("file1", "File", name="design_one.csv", dest_path="assay_one/design_one.csv")
+    )
+    state.add_entity(
+        _ent("file2", "File", name="design_two.csv", dest_path="assay_two/design_two.csv")
+    )
+    state.add_entity(
+        _ent("as1", "Assay", name="Assay one", description="d", study_id="st1", hasPart=["file1"])
+    )
+    state.add_entity(
+        _ent("as2", "Assay", name="Assay two", description="d", study_id="st1", hasPart=["file2"])
+    )
+    state.add_entity(
+        _ent("exp1", "LabProcess", process_type="Exposure", name="Exposure one", assay_id="as1")
+    )
+    state.add_entity(
+        _ent("exp2", "LabProcess", process_type="Exposure", name="Exposure two", assay_id="as2")
+    )
+    for path in (table_one, table_two):
+        state.scanned_files.append(
+            FileClassification(
+                path=str(path),
+                filename=path.name,
+                size=path.stat().st_size,
+                mime_type="text/csv",
+            )
+        )
+    state.approved_scan_roots = {str(tmp_path)}
+    # `dest_path` is what an Assay's File entity records, and `_scanned_dest`
+    # mirrors the scan under `input_path` to produce it — so the fixture sets the
+    # input root the same way a build does, or the two would never meet.
+    state.metadata.input_path = str(tmp_path)
+    return AgentEngine(state=state), table_one, table_two
+
+
+class TestAnAssaySeesOnlyItsOwnTables:
+    def test_the_scope_is_the_assay_the_exposure_belongs_to(self, two_assays):
+        from builder.agents.pipeline.pipeline import _assay_table_paths
+
+        engine, table_one, table_two = two_assays
+        assert _assay_table_paths(engine, "exp1") == {str(table_one)}
+        assert _assay_table_paths(engine, "exp2") == {str(table_two)}
+
+    def test_candidates_are_restricted_to_that_scope(self, two_assays):
+        from builder.agents.pipeline.pipeline import (
+            _assay_table_paths,
+            _design_table_candidates,
+        )
+
+        engine, table_one, _ = two_assays
+        found, _unreadable = _design_table_candidates(
+            engine, allowed=_assay_table_paths(engine, "exp1")
+        )
+        assert [p for _w, _m, p in found] == [str(table_one)]
+
+    def test_without_a_scope_both_are_candidates(self, two_assays):
+        """The guard is doing work: unscoped, this is the ambiguity that made the
+        spine refuse and ship a header-only table."""
+        from builder.agents.pipeline.pipeline import _design_table_candidates
+
+        engine, _one, _two = two_assays
+        found, _unreadable = _design_table_candidates(engine)
+        assert len(found) == 2, found
+
+    def test_an_exposure_with_no_assay_scopes_to_nothing(self, two_assays):
+        """Fail closed. An unattributed exposure must not inherit the crate."""
+        from builder.agents.pipeline.pipeline import _assay_table_paths
+
+        engine, _one, _two = two_assays
+        engine.state.add_entity(_ent("exp3", "LabProcess", process_type="Exposure", name="Orphan"))
+        assert _assay_table_paths(engine, "exp3") == set()
+
+
+class TestEachExposureIsPopulatedFromItsOwnAssay:
+    def test_both_exposures_get_their_own_table(self, two_assays):
+        from builder.agents.pipeline.pipeline import _populate_condition_tables
+
+        engine, _one, _two = two_assays
+        outcome = _populate_condition_tables(engine)
+        per = {e["exposure_id"]: e for e in outcome["per_exposure"]}
+        assert set(per) == {"exp1", "exp2"}, sorted(per)
+        assert all(e["populated"] for e in per.values()), per
+
+    def test_the_rows_written_are_the_assay_s_own(self, two_assays):
+        """The failure this exists to stop: assay one's compounds landing in
+        assay two's table."""
+        from builder.tools._crate_mapping import _condition_table_rel, _mint_id
+        from builder.agents.pipeline.pipeline import _populate_condition_tables
+
+        engine, _one, _two = two_assays
+        _populate_condition_tables(engine)
+        out = Path(engine.state.metadata.output_path)
+        by_id = {e.entity_id: e for e in engine.state.list_entities()}
+        first = (out / _condition_table_rel(_mint_id(by_id["exp1"]))).read_text()
+        second = (out / _condition_table_rel(_mint_id(by_id["exp2"]))).read_text()
+        assert "Amiodarone" in first and "Silychristin" not in first
+        assert "Silychristin" in second and "Amiodarone" not in second
+
+    def test_the_summary_stays_a_dict_for_the_build_report(self, two_assays):
+        """`build.py` reads `populated` / `reason` / `rows` off one dict."""
+        from builder.agents.pipeline.pipeline import _populate_condition_tables
+
+        engine, _one, _two = two_assays
+        outcome = _populate_condition_tables(engine)
+        assert outcome["populated"] is True
+        assert outcome["rows"] == 6, outcome


### PR DESCRIPTION
Refs #669. Two defects; the data was never missing.

`assay_01_TH_uptake/EDCs/Combined uptake data EDCs_tidy.csv` carries **1048 rows**
of real per-condition design — compound, cell line, concentration, unit,
endpoint, replicate — and was already copied into the crate, sitting beside a
129-byte header-only table.

## 1. A well key on its own was passing as a condition

`condition_table_fit` counted `well_id` among the columns it mapped, so **any**
table carrying a well-ish header qualified as a design table. On S-VHPS22 that
admitted two files describing no conditions at all:

| wells | mapped | file |
|---|---|---|
| 1048 | **7** | `Combined uptake data EDCs_tidy.csv` — the design table |
| 100 | 1 | `5.3 cDNA and qPCR protocol.xlsx` — `Well Position` + `CT` |
| 25 | 1 | `2023-03-01 0-60 min SKNAS.xlsx` — a gamma-counter export |

The spine refuses when several qualify, so the crate shipped **four header-only
tables, every build**.

The rule the predicate already states for the other side of the pair — *"a table
with wells but no mapped column describes nothing"* — now applies to the key too.
Knowing which wells exist says nothing about what was done to them.

The threshold is **"more than the key"**, not "most of the schema": a one-factor
design is still a design, and demanding more would refuse real deposits to keep
this one tidy. Measured on the deposit: **3 candidates → 1**.

## 2. One exposure, from a crate-wide search

`chain_by_type` keys a dict by process type, so four exposures collapsed to one
and the last won — three of the four tables could not be populated even in
principle. And the search was crate-wide while the write targeted a single
exposure, so assay 1's 1048 rows could have landed in the deiodinase exposure. **A
table that looks populated and attributes the wrong experiment is worse than the
empty one it replaces.**

The crate already says which files belong where — an Assay `hasPart` its own
files, a process carries the `assay_id` it serves — so the scope is read from the
crate rather than from a folder-naming convention only this deposit has.

**The bridge is `dest_path`, not the on-disk source.** `attach_files` appends a
File *entity id*, and that entity records where the file will **land**, not where
it came from — resolving a source finds nothing for most of them, which is what
my first attempt got wrong (seven existing tests caught it). `_scanned_dest` is
the same derivation the attachment used, so what an assay holds and what the scan
offers cannot disagree about which file they mean.

## Deliberately conservative

**An empty scope means "no scope", not "no candidates."** An assay holding no
files leaves the search exactly as it was. So this can only narrow a crate that
has file attribution, and never blocks one that does not — `_attach_scanned_files`
puts everything under the *first* assay, and this must not make that case worse.

The result stays the dict `build.py`'s summary reads. With one exposure the
aggregate **is** the outcome and is carried through whole, so `fallback_from`,
`proposal_reason` and #422's posture reporting are untouched. Several exposures
aggregate, with `per_exposure` carrying the detail; the CSVW validation pass now
checks every populated table rather than the first.

## Honest about what this does not do

This makes the machinery correct. **Only assay 1 has a qualifying table in this
deposit** — the other three still fall back to the #438 proposal, but now *per
assay* rather than not at all. Reading the plate-layout matrix in
`20240327_Xn reeks Sk H4.xlsx` (the `layout` sheet, 80 Rack×Pos rows) so the
other three assays get real designs is the remainder of #669 and is not here.

## Tests

`TestAKeyOnItsOwnDescribesNothing` (5) pins the predicate against the two real
impostor shapes and the real design table. `test_condition_table_per_assay.py`
(7) pins the scope, including that an unscoped search still sees both tables —
so the guard is doing work — and that assay one's compounds never reach assay
two's file.

The unit fixture was rewritten mid-way to use File **entity ids** and `dest_path`,
because my first version put raw paths in `hasPart`, a shape the pipeline never
produces. A fixture that lets an implementation pass where production would
defeat it is worth nothing.

331 passed across the pipeline, condition-table, leaves, real-input and repair
suites. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYLSExAW64e7fe26xHDHUS