### PR TITLE
fix(crate): a parameter the constructor mints is not also an unowned field (#677)

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -642,10 +642,17 @@ def _preserve_unowned_fields(state: CrateState, crate: ROCrate, idx: dict[str, A
     place.
     """
     for entity in state.list_entities():
+        # A field a process constructor consumes is NOT unowned: the constructor
+        # mints the parameter. Scoped to LabProcess, because the same name on
+        # another entity really is unowned — `detection_instrument` on a File is
+        # consumed by nothing and must still be kept (#677).
+        consumed = _process_constructor_fields() if entity.type == "LabProcess" else frozenset()
         leftovers = {
             key: value
             for key, value in entity.fields.items()
-            if field_would_be_dropped(key) and value not in (None, "", [], {})
+            if field_would_be_dropped(key)
+            and key not in consumed
+            and value not in (None, "", [], {})
         }
         if not leftovers:
             continue
@@ -674,6 +681,51 @@ def _preserve_unowned_fields(state: CrateState, crate: ROCrate, idx: dict[str, A
                 key,
                 entity.entity_id,
             )
+
+
+# Spellings ``_build_process`` reads from state and maps onto a constructor's own
+# parameter name, so they are consumed without appearing in any signature. The
+# tool spec advertises these, and the tox profile's violation message names them.
+_PROCESS_FIELD_ALIASES = frozenset({"data_calculation_and_statistics", "computational_tool"})
+
+
+@lru_cache(maxsize=1)
+def _process_constructor_fields() -> frozenset[str]:
+    """State fields a typed LabProcess constructor consumes into a parameter.
+
+    Derived from the constructors rather than listed, because a list drifts: the
+    dropped-field set names ``units``, ``assay_kit`` and ``substrate`` as "kwargs
+    threaded into the typed subtype constructors" and never gained
+    ``detection_instrument``, ``instrument_manufacturer``, ``measured_entity`` or
+    ``technical_replicate``. Those four went on looking unowned, so
+    :func:`_preserve_unowned_fields` "kept" each one as a second PropertyValue
+    beside the parameter the constructor had already minted from it — 18 of the
+    reference crate's 99 PropertyValue nodes, carrying no information (#677).
+
+    ``properties`` and ``add`` are ``ContextEntity``'s own construction
+    arguments, not crate fields, and are excluded.
+    """
+    import inspect
+
+    from profiles.models import tox
+
+    fields: set[str] = set()
+    for attribute in dir(tox):
+        if not attribute.startswith("LabProcess"):
+            continue
+        model = getattr(tox, attribute)
+        if not isinstance(model, type):
+            continue
+        try:
+            signature = inspect.signature(model.__init__)
+        except (TypeError, ValueError):  # pragma: no cover — a C-level __init__
+            continue
+        fields.update(
+            name
+            for name in signature.parameters
+            if name not in ("self", "crate", "properties", "add")
+        )
+    return frozenset(fields | _PROCESS_FIELD_ALIASES)
 
 
 def field_would_be_dropped(field: str) -> bool:
@@ -1849,8 +1901,7 @@ def _is_sample_node(node: Any) -> bool:
         return False
     types = t if isinstance(t, list) else [t]
     return any(
-        str(x).rsplit("/", 1)[-1].rsplit("#", 1)[-1] in ("Sample", "BioSample")
-        for x in types
+        str(x).rsplit("/", 1)[-1].rsplit("#", 1)[-1] in ("Sample", "BioSample") for x in types
     )
 
 
@@ -2252,8 +2303,7 @@ def _protocol_document_for(
     if not labels:
         return None
     wanted = [
-        re.compile(r"(?<![0-9a-z])" + re.escape(lbl.casefold()) + r"(?![0-9a-z])")
-        for lbl in labels
+        re.compile(r"(?<![0-9a-z])" + re.escape(lbl.casefold()) + r"(?![0-9a-z])") for lbl in labels
     ]
     found: list[Any] = []
     seen: set[Any] = set()
@@ -2984,9 +3034,7 @@ def _chain_processes(built: list[tuple[Any, str, Any]]) -> None:
             _set_refs(readout, "input", exposed)
 
         readout_files = [
-            n
-            for proc in by_type.get("EndpointReadout", [])
-            for n in _result_file_nodes(proc)
+            n for proc in by_type.get("EndpointReadout", []) for n in _result_file_nodes(proc)
         ]
         for analysis in by_type.get("DataAnalysis", []):
             consumed = _linked_nodes(analysis, "input", "object")
@@ -3026,9 +3074,11 @@ def _add_processes(
     protocol_use: dict[Any, list[tuple[Any, Any, Any]]] = {}
     ordered = sorted(
         state.list_entities("LabProcess"),
-        key=lambda p: 0
-        if (p.fields.get("process_type") or p.fields.get("additionalType")) == "CellCulture"
-        else 1,
+        key=lambda p: (
+            0
+            if (p.fields.get("process_type") or p.fields.get("additionalType")) == "CellCulture"
+            else 1
+        ),
     )
     for proc in ordered:
         f = proc.fields
@@ -3071,9 +3121,7 @@ def _add_processes(
             # SOP describes. DataAnalysis legitimately comes up empty on the real
             # deposit — no document there covers that step — and an empty result
             # is the honest one (D17).
-            assay_protocols = _assay_protocol_documents(
-                state, f.get("assay_id"), idx, ptype
-            )
+            assay_protocols = _assay_protocol_documents(state, f.get("assay_id"), idx, ptype)
             if assay_protocols:
                 protocol = assay_protocols
         assay_key = f.get("assay_id")
@@ -3287,9 +3335,9 @@ def _build_process(
         # positive assertion rather than the default: N lines in one draft is the
         # ambiguity the split removes, not evidence that the cells were mixed.
         split = cell_lines is not None
-        cell_lines = (
-            list(cell_lines) if split else _culture_cell_lines(f, idx, name)
-        ) or [_synth_sample(crate, pid + "_input", f"Input ({name})")]
+        cell_lines = (list(cell_lines) if split else _culture_cell_lines(f, idx, name)) or [
+            _synth_sample(crate, pid + "_input", f"Input ({name})")
+        ]
         cell_line = cell_lines if len(cell_lines) > 1 else cell_lines[0]
         if result and keep_drafted_result:
             # The drafter supplied the cultured sample, which is what happens on
@@ -3379,9 +3427,7 @@ def _build_process(
             )
             sid = pid + "_exposed" if index == 0 else f"{pid}_exposed_{index}"
             exposed_samples.append(
-                _synth_sample(
-                    crate, sid, label, cell, sample_type=_cell_culture_term(crate)
-                )
+                _synth_sample(crate, sid, label, cell, sample_type=_cell_culture_term(crate))
             )
         out = rest + exposed_samples + drafted[len(exposed_samples) :]
         # Both protocols: the real SOP (or the drafter's) states the procedure,

--- a/tests/test_parameter_minted_once.py
+++ b/tests/test_parameter_minted_once.py
@@ -1,0 +1,209 @@
+"""A process parameter is one entity, not one per code path that noticed it (#677).
+
+Every parameter the tox model mints from a kwarg was landing in the crate
+**twice**, as two ``PropertyValue`` entities differing only in the casing of
+their ``name`` — ``Detection Instrument`` beside ``detection instrument``, with
+identical values, both on the same process. Because ``parameter`` and
+``additionalProperty`` are both ``schema:additionalProperty`` in
+``profiles/context.py``, the expanded graph merges them into one predicate, so a
+readout with five parameters expanded to nine values.
+
+Measured on the reference crate: **18 of 99 PropertyValue nodes carry no
+information**, across eight names each present in two casings.
+
+The second one comes from :func:`_preserve_unowned_fields`, the pass that keeps a
+field no entity type declares rather than dropping it silently. It asks
+:func:`field_would_be_dropped`, which mirrors ``_scalar_props``' delete rule —
+and ``_scalar_props`` takes a per-caller ``skip`` that the question cannot see.
+So a field consumed as a constructor kwarg looked unowned, and was "preserved"
+alongside the parameter the constructor had already minted from it.
+
+The set of consumed fields was a hand-kept list that had drifted: it names
+``units``, ``assay_kit`` and ``substrate`` but not ``detection_instrument``,
+``measured_entity`` or ``technical_replicate``. It is derived from the
+constructors themselves here, so it cannot drift again.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.builder import build_crate
+
+pytestmark = pytest.mark.timeout(120)
+
+
+def _ent(entity_id, type_, **fields):
+    return Entity(
+        entity_id=entity_id,
+        type=type_,
+        fields=fields,
+        _provenance=EntityProvenance(created_by="llm"),
+    )
+
+
+def _build(state, tmp_path):
+    out = tmp_path / "crate"
+    result = build_crate(state, str(out))
+    assert result["success"] is True, result
+    with open(out / "ro-crate-metadata.json") as f:
+        graph = json.load(f)["@graph"]
+    return graph
+
+
+def _backbone(state):
+    state.add_entity(_ent("inv1", "Investigation", name="Inv", description="d"))
+    state.add_entity(_ent("st1", "Study", name="St", description="d", investigation_id="inv1"))
+    state.add_entity(_ent("as1", "Assay", name="As", description="d", study_id="st1"))
+    state.add_entity(_ent("s1", "Sample", name="exposed cells"))
+    state.add_entity(_ent("f1", "File", name="raw.csv", dest_path="data/raw.csv"))
+
+
+def _pvs(graph):
+    return [e for e in graph if "PropertyValue" in str(e.get("@type", ""))]
+
+
+def _named(graph, name: str):
+    return [e for e in _pvs(graph) if str(e.get("name", "")).strip().casefold() == name]
+
+
+def _readout_state(**extra):
+    state = CrateState()
+    _backbone(state)
+    fields = dict(
+        process_type="EndpointReadout",
+        name="Readout",
+        assay_id="as1",
+        samples="s1",
+        result="f1",
+        detection_instrument="Plate reader",
+    )
+    fields.update(extra)
+    state.add_entity(_ent("er1", "LabProcess", **fields))
+    return state
+
+
+class TestAKwargMintsOneParameter:
+    def test_a_consumed_field_is_not_also_preserved(self, tmp_path):
+        graph = _build(_readout_state(), tmp_path)
+        minted = _named(graph, "detection instrument")
+        assert len(minted) == 1, [e.get("name") for e in minted]
+
+    def test_the_survivor_is_the_profile_typed_one(self, tmp_path):
+        """The constructor's parameter carries ``additionalType:
+        ParameterValue``; the preserved twin carried nothing. Keeping the typed
+        one is what the tox profile reads."""
+        graph = _build(_readout_state(), tmp_path)
+        survivor = _named(graph, "detection instrument")[0]
+        assert survivor.get("additionalType") == "ParameterValue", survivor
+
+    def test_every_readout_kwarg_mints_once(self, tmp_path):
+        """EndpointReadout is worst hit — it has the most named kwargs."""
+        graph = _build(
+            _readout_state(
+                instrument_manufacturer="Acme",
+                measured_entity="T3",
+                technical_replicate="3",
+            ),
+            tmp_path,
+        )
+        for name in (
+            "detection instrument",
+            "instrument manufacturer",
+            "measured entity",
+            "technical replicate",
+        ):
+            assert len(_named(graph, name)) == 1, (
+                name,
+                [e.get("name") for e in _named(graph, name)],
+            )
+
+    def test_the_alias_spellings_mint_once_too(self, tmp_path):
+        """`data_calculation_and_statistics` and `computational_tool` are read by
+        the mapper and mapped onto the constructor's own parameter names, so they
+        are consumed without appearing in any signature."""
+        state = CrateState()
+        _backbone(state)
+        state.add_entity(
+            _ent(
+                "da1",
+                "LabProcess",
+                process_type="DataAnalysis",
+                name="Analysis",
+                assay_id="as1",
+                object="f1",
+                result="f1",
+                data_calculation_and_statistics="mean of replicates",
+                computational_tool="Python",
+            )
+        )
+        graph = _build(state, tmp_path)
+        assert len(_named(graph, "data calculation and statistics")) <= 1
+        assert len(_named(graph, "computational tool")) <= 1
+
+    def test_nothing_is_left_orphaned(self, tmp_path):
+        graph = _build(_readout_state(), tmp_path)
+        referenced: set[str] = set()
+        for entity in graph:
+            for value in entity.values():
+                items = value if isinstance(value, list) else [value]
+                for item in items:
+                    if isinstance(item, dict) and item.get("@id"):
+                        referenced.add(item["@id"])
+        for pv in _pvs(graph):
+            assert pv["@id"] in referenced, f"{pv.get('name')!r} is in the crate unreferenced"
+
+
+class TestThePreservationPassStillWorks:
+    """#677 must not become "stop preserving fields" — that pass exists so a
+    value a caller supplied is never dropped without trace."""
+
+    def test_a_field_no_entity_type_declares_is_still_kept(self, tmp_path):
+        state = CrateState()
+        _backbone(state)
+        state.add_entity(
+            _ent(
+                "er1",
+                "LabProcess",
+                process_type="EndpointReadout",
+                name="Readout",
+                assay_id="as1",
+                samples="s1",
+                result="f1",
+                detection_instrument="Plate reader",
+                humidity_percent="95",
+            )
+        )
+        graph = _build(state, tmp_path)
+        assert _named(graph, "humidity percent"), "an unowned field was dropped silently"
+
+    def test_a_process_kwarg_name_on_another_entity_is_still_kept(self, tmp_path):
+        """The exemption is scoped to processes. `detection_instrument` on a File
+        is not consumed by anything and must survive."""
+        state = CrateState()
+        _backbone(state)
+        state.add_entity(
+            _ent(
+                "f2",
+                "File",
+                name="notes.txt",
+                dest_path="data/notes.txt",
+                detection_instrument="Plate reader",
+            )
+        )
+        state.add_entity(
+            _ent(
+                "er1",
+                "LabProcess",
+                process_type="EndpointReadout",
+                name="Readout",
+                assay_id="as1",
+                samples="s1",
+                result="f1",
+            )
+        )
+        graph = _build(state, tmp_path)
+        assert _named(graph, "detection instrument"), "the exemption leaked past LabProcess"


### PR DESCRIPTION
Closes #677.

## The defect

Every parameter a typed `LabProcess` constructor mints from a kwarg landed in the
crate **twice** — `Detection Instrument` beside `detection instrument`, identical
values, both on the same process. Since `parameter` and `additionalProperty` are
both `schema:additionalProperty`, the expanded graph merges them into one
predicate, so a readout with five parameters expands to nine values.

**18 of the reference crate's 99 PropertyValue nodes carry no information**,
across eight names each present in two casings.

## The issue's diagnosis was wrong, and that matters

#677 says the lower-case set comes from the drafter's inline `additionalProperty`
dicts. **It does not.** A build with no drafted parameter at all reproduces the
pair — both spellings come from the *same scalar field*:

- the constructor kwarg mints `Detection Instrument` (typed `ParameterValue`);
- `_preserve_unowned_fields` mints `detection instrument`.

That second pass exists so a field no entity type declares is never dropped
without trace. It asks `field_would_be_dropped`, which mirrors `_scalar_props`'
delete rule — and `_scalar_props` takes a per-caller **`skip` that the question
cannot see**. So a field consumed as a kwarg looked unowned, and was "preserved"
beside the parameter already minted from it.

## The list had drifted

The dropped-field set names `units`, `assay_kit`, `substrate`,
`acceptance_criteria` and `evaluation_criteria` as *"LabProcess kwargs threaded
into the typed subtype constructors (#143)"* — and never gained
`detection_instrument`, `instrument_manufacturer`, `measured_entity`,
`technical_replicate`, `cell_seeding_density` or `culture_medium`. That is why
`EndpointReadout` is worst hit: it has the most named kwargs.

It is **derived from the constructors** now, so it cannot drift again, plus the
two alias spellings (`data_calculation_and_statistics`, `computational_tool`) the
mapper reads from state and maps onto a constructor's own parameter name — those
are consumed without appearing in any signature.

## Why suppress rather than de-duplicate

Removing a minted node from the process's list afterwards would leave the entity
in the crate with **nothing pointing at it** — trading a duplicate for an orphan,
which the topology strip then reports. The kwarg is left to mint and the twin is
never created.

The survivor is the constructor's, carrying `additionalType: ParameterValue` —
the one the tox profile reads. A test pins that.

## Scoped, so the preservation pass keeps working

The exemption applies to `LabProcess` only. `detection_instrument` on a File is
consumed by nothing and is still preserved, and an undeclared field like
`humidity_percent` on a process is still kept. Both pinned — this must not become
"stop preserving fields".

178 passed across the builder-domain, crate-mapping, condition-table and
export-smoke suites. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYLSExAW64e7fe26xHDHUS