### PR TITLE
feat(readers): an exposure states the conditions its runs shared (#697)

### DIFF
--- a/builder/agents/pipeline/pipeline.py
+++ b/builder/agents/pipeline/pipeline.py
@@ -1376,6 +1376,77 @@ def _populate_condition_tables(engine: AgentEngine) -> dict[str, Any]:
     return aggregate
 
 
+def _apply_layout_conditions(engine: AgentEngine) -> dict[str, Any]:
+    """Put each Exposure's shared run conditions on it as parameters (#697).
+
+    Three of the four assays ship a header-only condition table because no file
+    in them carries per-well rows. But every experiment workbook in this lab's
+    deposits opens its ``layout`` sheet with a block stating what the whole run
+    shared — incubation volume, buffer, substrate, dose, duration — and those are
+    exactly the columns the table is empty in. They describe the run rather than
+    a well, so they belong on the Exposure as parameters, not as table rows.
+
+    Scoped and filtered the same way the condition table is (#669): an Exposure
+    sees only the workbooks its own Assay holds, and only what EVERY run of that
+    assay states identically survives — one metabolism run used ``H4 + SKNAS``
+    and another ``MO3.13``, and neither is a property of the assay. The rest is
+    per-run and belongs with #654.
+
+    Idempotent: the PropertyValue id is derived from name and value, and the
+    reference is appended only when absent, so the spine re-running mints
+    nothing new.
+
+    Never raises: a condition that cannot be written is logged, because a
+    workbook must not break a build whose metadata is fine.
+    """
+    from pathlib import PurePath
+
+    from builder.tools.file_readers import shared_layout_conditions
+
+    exposures = [
+        e
+        for e in engine.state.list_entities("LabProcess")
+        if str(e.fields.get("process_type") or "") == "Exposure"
+    ]
+    applied = 0
+    touched = 0
+    for exposure in exposures:
+        paths = [
+            path
+            for path in _assay_table_paths(engine, exposure.entity_id)
+            if PurePath(path).suffix.lower() in (".xlsx", ".xlsm")
+        ]
+        shared = shared_layout_conditions(paths) if paths else {}
+        if not shared:
+            continue
+        touched += 1
+        existing = exposure.fields.get("additionalProperty") or []
+        if not isinstance(existing, list):
+            existing = [existing]
+        wanted = list(existing)
+        for label, value in shared.items():
+            try:
+                entity = engine.run_tool("draft_property_value", name=label, hints={"value": value})
+            except Exception as exc:  # noqa: BLE001 — one condition must not break a build
+                logger.warning("Could not record layout condition %r: %s", label, exc)
+                continue
+            # `draft_property_value` hands back the Entity itself; older tool
+            # wrappers hand back a dict. Take the id from either, never the
+            # object — a reference field stores ids, and passing anything else
+            # resolves to nothing and is refused.
+            pv_id = (
+                entity.get("entity_id")
+                if isinstance(entity, dict)
+                else getattr(entity, "entity_id", None)
+            )
+            if pv_id and pv_id not in wanted:
+                wanted.append(pv_id)
+                applied += 1
+        if wanted != existing:
+            _set_ref_field(engine, exposure.entity_id, "additionalProperty", wanted)
+    return {"exposures": touched, "conditions": applied}
+
+
 def _pdf_path_for_publication(engine: AgentEngine, title: str) -> str | None:
     """Path of the scanned PDF a plan publication *title* refers to, or ``None``.
 
@@ -1977,6 +2048,10 @@ def _materialize_plan(
     # dict by process type, so four exposures collapsed to one and the last won:
     # three of the four tables could not be populated even in principle.
     result["condition_table"] = _populate_condition_tables(engine)
+    # The conditions a run shared, from the worksheet that states them (#697).
+    # Independent of the table above: an assay with no per-well rows can still
+    # say what its exposure did.
+    result["layout_conditions"] = _apply_layout_conditions(engine)
     if cell_line_ids:
         culture_step = chain_by_type.get("CellCulture")
         culture_id = culture_step.get("process_id") if culture_step else None

--- a/builder/tools/file_readers.py
+++ b/builder/tools/file_readers.py
@@ -1017,7 +1017,7 @@ def _licence_candidates(value: Any) -> list[str]:
         return [found for item in value for found in _licence_candidates(item)]
     if isinstance(value, dict):
         for key in _LICENCE_VALUE_KEYS:
-            if (found := str(value.get(key) or "").strip()):
+            if found := str(value.get(key) or "").strip():
                 return [found]
     return []
 
@@ -1260,6 +1260,124 @@ TOOL_REGISTRY.register(
     read_docx,
     description="Read a Word .docx file and return its text content",
 )
+# A worksheet whose name marks it as the run's plan. Observed as `layout 27-03`,
+# `layout 01-03` and `Layout` across this lab's deposits — the date suffix varies
+# per run, so the match is a prefix-free substring on the case-folded name.
+_LAYOUT_SHEET = "layout"
+
+
+def read_layout_conditions(path: Any) -> dict[str, str]:
+    """Conditions a run's ``layout`` sheet states for the whole run (#697).
+
+    Every experiment workbook in this lab's deposits opens its layout sheet with
+    a block of label/value pairs — incubation volume, buffer, substrate, dose,
+    duration — which are exactly the columns an empty condition table is missing.
+    They describe the run as a whole rather than a well, so they belong on the
+    Exposure as parameters rather than as table rows.
+
+    **Bounded to the leading block.** Below it sits the design matrix, whose
+    cells are adjacent pairs too, so a scan of the whole sheet turns ``D | D``
+    into a condition named "D". The block is the contiguous run of pairs from the
+    top, ending at the first blank row after it starts; a leading blank row is
+    skipped, because every real sheet has one. That bound is the sheet's own
+    structure rather than a list of labels to expect, so a run stating something
+    new is read rather than filtered.
+
+    Only the values are taken. Nothing here parses ``1 nM T3 or T4`` into a
+    quantity or resolves ``Xn`` to a compound: those are the depositor's words,
+    carried verbatim, and inventing structure for them would be a guess.
+
+    Never raises — a deposit holds workbooks no reader can open, and one of them
+    must not stop a build.
+
+    Args:
+        path: The workbook to read.
+
+    Returns:
+        ``{label: value}`` in sheet order, or ``{}`` when the workbook has no
+        layout sheet, no block, or cannot be opened.
+    """
+    from pathlib import Path as _Path
+
+    try:
+        import openpyxl
+    except ImportError:  # pragma: no cover — openpyxl is a hard dependency
+        return {}
+    _silence_openpyxl_extension_warnings()
+    try:
+        workbook = openpyxl.load_workbook(_Path(path), data_only=True, read_only=True)
+    except Exception as exc:  # noqa: BLE001 — an unreadable workbook is not an error
+        logger.debug("No layout conditions from %s: %s", path, exc)
+        return {}
+    try:
+        sheets = [n for n in workbook.sheetnames if _LAYOUT_SHEET in n.casefold()]
+        if not sheets:
+            return {}
+        return _leading_pairs(workbook[sheets[0]])
+    except Exception as exc:  # noqa: BLE001 — same reason
+        logger.debug("No layout conditions from %s: %s", path, exc)
+        return {}
+    finally:
+        workbook.close()
+
+
+def _leading_pairs(worksheet: Any) -> dict[str, str]:
+    """The contiguous label/value block at the top of *worksheet*."""
+    found: dict[str, str] = {}
+    started = False
+    for row in worksheet.iter_rows(values_only=True):
+        pair = None
+        cells = list(row[:4])
+        for left, right in zip(cells, cells[1:]):
+            if not isinstance(left, str) or not left.strip():
+                continue
+            if right is None or not str(right).strip():
+                continue
+            pair = (left.strip(), str(right).strip())
+            break
+        if pair is None:
+            # A blank row before anything has been read is the sheet's own
+            # leading gap; one after the block has started is its end.
+            if started:
+                break
+            continue
+        started = True
+        found.setdefault(pair[0], pair[1])
+    return found
+
+
+def shared_layout_conditions(paths: Any) -> dict[str, str]:
+    """What EVERY run in *paths* states identically (#697).
+
+    An assay holds several experiment workbooks and their blocks disagree: one
+    run of the metabolism assay used ``H4 + SKNAS`` and another ``MO3.13``, one
+    uptake run inhibited with ``Xn`` and another with ``none``. Only what every
+    run agrees on is a property of the assay; the rest is per-run and belongs
+    with the work that gives each run its own exposed samples (#654).
+
+    Agreement is exact on the stated text. ``24hour`` and ``24 hours`` mean the
+    same thing and do not say so — normalising them would be a guess about units
+    and format, so they are dropped rather than reconciled. A label only some
+    runs state is dropped for the same reason: silence is not agreement.
+
+    Args:
+        paths: Workbooks belonging to one assay.
+
+    Returns:
+        ``{label: value}`` every run stated identically, or ``{}``.
+    """
+    blocks = [read_layout_conditions(path) for path in paths]
+    blocks = [b for b in blocks if b]
+    if not blocks:
+        return {}
+    first, rest = blocks[0], blocks[1:]
+    return {
+        label: value
+        for label, value in first.items()
+        if all(other.get(label) == value for other in rest)
+    }
+
+
 TOOL_REGISTRY.register(
     "read_file",
     read_file,

--- a/tests/test_layout_conditions.py
+++ b/tests/test_layout_conditions.py
@@ -1,0 +1,267 @@
+"""The exposure's conditions, read from the worksheet that states them (#697).
+
+Three of the four assays ship a header-only condition table because no file in
+them carries per-well rows. But every experiment workbook in this lab's deposits
+opens its ``layout`` sheet with a block of label/value pairs stating the
+conditions the whole run shared — incubation volume, buffer, substrate, dose,
+duration — and those are exactly the columns the condition table is empty in.
+
+Two things this must not do:
+
+* **Read past the block.** Below it sits the design matrix, whose cells are
+  adjacent pairs too: a naive scan turns ``D | D`` into a condition called "D".
+* **Merge two runs.** An assay holds several experiment workbooks, and their
+  blocks disagree — one run used ``H4 + SKNAS`` and another ``MO3.13``. Only what
+  every run of an assay AGREES on is a property of the assay; the rest is
+  per-run and belongs to #654.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.timeout(180)
+
+
+def _workbook(tmp_path: Path, name: str, sheet: str, rows: list) -> Path:
+    openpyxl = pytest.importorskip("openpyxl")
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = sheet
+    for row in rows:
+        ws.append(row)
+    path = tmp_path / name
+    wb.save(path)
+    return path
+
+
+# The real shape: a leading blank, the pairs, a blank, then the design matrix.
+_UPTAKE = [
+    [None, None],
+    ["Name", "Nathalie"],
+    ["Incubation buffer", "DPBS + 0.1% glucose"],
+    ["Substrate", "1 nM T3 or T4"],
+    ["Incubation volume (ul)", 375],
+    ["cpm per sample", 50000],
+    [None, None],
+    ["Per cellijn", None],
+    ["T3", "DMSO 0.5%", "Sily", "XN  1"],
+    ["T4", "DMSO 0.5%", "Sily", "XN  1"],
+]
+
+_METABOLISM = [
+    [None, None],
+    ["Name", "Nathalie"],
+    ["Cell type", "H4  + SKNAS"],
+    ["Incubation volume", "0.5 ml"],
+    ["cpm per sample", 2000000],
+    [None, None],
+    ["D", "D", "IOP", "IOP"],
+    ["CP", "CP", "NH3", "NH3"],
+]
+
+
+class TestTheBlockIsReadAndBounded:
+    def test_it_reads_the_label_value_pairs(self, tmp_path):
+        from builder.tools.file_readers import read_layout_conditions
+
+        path = _workbook(tmp_path, "run.xlsx", "layout 27-03", _UPTAKE)
+        found = read_layout_conditions(path)
+        assert found["Substrate"] == "1 nM T3 or T4"
+        assert found["Incubation volume (ul)"] == "375"
+        assert found["cpm per sample"] == "50000"
+
+    def test_it_stops_before_the_design_matrix(self, tmp_path):
+        """`D | D` is two cells of a plate grid, not a condition called D."""
+        from builder.tools.file_readers import read_layout_conditions
+
+        path = _workbook(tmp_path, "metab.xlsx", "Layout", _METABOLISM)
+        found = read_layout_conditions(path)
+        assert set(found) == {"Name", "Cell type", "Incubation volume", "cpm per sample"}, found
+
+    def test_a_leading_blank_row_does_not_end_the_block(self, tmp_path):
+        """Every real sheet starts with one."""
+        from builder.tools.file_readers import read_layout_conditions
+
+        path = _workbook(tmp_path, "run.xlsx", "layout 01-03", _UPTAKE)
+        assert read_layout_conditions(path)
+
+    def test_the_sheet_is_matched_case_insensitively(self, tmp_path):
+        """Observed as `layout 27-03`, `layout 01-03` and `Layout`."""
+        from builder.tools.file_readers import read_layout_conditions
+
+        for sheet in ("layout 27-03", "Layout", "LAYOUT"):
+            path = _workbook(tmp_path, f"{sheet}.xlsx", sheet, _UPTAKE)
+            assert read_layout_conditions(path), sheet
+
+    def test_a_workbook_with_no_layout_sheet_yields_nothing(self, tmp_path):
+        from builder.tools.file_readers import read_layout_conditions
+
+        path = _workbook(tmp_path, "raw.xlsx", "Raw data", [["Run ID", 4669]])
+        assert read_layout_conditions(path) == {}
+
+    def test_an_unreadable_file_yields_nothing_rather_than_raising(self, tmp_path):
+        """A deposit holds workbooks no reader can open, and one must not stop a
+        build."""
+        from builder.tools.file_readers import read_layout_conditions
+
+        broken = tmp_path / "broken.xlsx"
+        broken.write_bytes(b"not a workbook")
+        assert read_layout_conditions(broken) == {}
+
+
+class TestOnlyWhatEveryRunAgreesOn:
+    """An assay holds several runs, and their blocks disagree."""
+
+    def test_a_value_two_runs_share_is_kept(self, tmp_path):
+        from builder.tools.file_readers import shared_layout_conditions
+
+        one = _workbook(tmp_path, "one.xlsx", "Layout", _UPTAKE)
+        two = _workbook(
+            tmp_path,
+            "two.xlsx",
+            "Layout",
+            [
+                r if r[0] != "Incubation buffer" else ["Incubation buffer", "something else"]
+                for r in _UPTAKE
+            ],
+        )
+        shared = shared_layout_conditions([one, two])
+        assert shared["Substrate"] == "1 nM T3 or T4"
+        assert shared["Incubation volume (ul)"] == "375"
+
+    def test_a_value_they_disagree_on_is_dropped(self, tmp_path):
+        """`24hour` and `24 hours` mean the same thing and do not say so.
+        Normalising them would be a guess; dropping is honest."""
+        from builder.tools.file_readers import shared_layout_conditions
+
+        one = _workbook(tmp_path, "one.xlsx", "Layout", [["incubation time(s)", "24hour"]])
+        two = _workbook(tmp_path, "two.xlsx", "Layout", [["incubation time(s)", "24 hours"]])
+        assert shared_layout_conditions([one, two]) == {}
+
+    def test_a_label_only_one_run_states_is_dropped(self, tmp_path):
+        """Present in one run and absent in another says nothing about the assay."""
+        from builder.tools.file_readers import shared_layout_conditions
+
+        one = _workbook(tmp_path, "one.xlsx", "Layout", [["Substrate", "T3"], ["Extra", "x"]])
+        two = _workbook(tmp_path, "two.xlsx", "Layout", [["Substrate", "T3"]])
+        assert shared_layout_conditions([one, two]) == {"Substrate": "T3"}
+
+    def test_a_single_run_keeps_everything_it_states(self, tmp_path):
+        """One run cannot disagree with itself."""
+        from builder.tools.file_readers import shared_layout_conditions
+
+        one = _workbook(tmp_path, "one.xlsx", "Layout", _UPTAKE)
+        assert shared_layout_conditions([one])["Substrate"] == "1 nM T3 or T4"
+
+    def test_no_workbooks_yields_nothing(self, tmp_path):
+        from builder.tools.file_readers import shared_layout_conditions
+
+        assert shared_layout_conditions([]) == {}
+
+
+class TestTheyReachTheExposure:
+    """The conditions land on the Exposure whose assay holds the workbook."""
+
+    @pytest.fixture
+    def two_assays(self, tmp_path: Path):
+        from builder.engine import AgentEngine
+        from builder.state import CrateState, Entity, EntityProvenance, FileClassification
+
+        def ent(entity_id, type_, **fields):
+            return Entity(
+                entity_id=entity_id,
+                type=type_,
+                fields=fields,
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+
+        one_dir = tmp_path / "assay_one"
+        two_dir = tmp_path / "assay_two"
+        one_dir.mkdir()
+        two_dir.mkdir()
+        book_one = _workbook(one_dir, "run.xlsx", "Layout", _UPTAKE)
+        book_two = _workbook(two_dir, "run.xlsx", "Layout", _METABOLISM)
+
+        state = CrateState()
+        state.metadata.input_path = str(tmp_path)
+        state.metadata.output_path = str(tmp_path / "crate")
+        state.add_entity(ent("inv1", "Investigation", name="Inv", description="d"))
+        state.add_entity(ent("st1", "Study", name="St", description="d", investigation_id="inv1"))
+        for n, (assay, book) in enumerate(((("as1"), book_one), (("as2"), book_two)), start=1):
+            state.add_entity(
+                ent(
+                    assay,
+                    "Assay",
+                    name=f"Assay {n}",
+                    description="d",
+                    study_id="st1",
+                    hasPart=[f"file{n}"],
+                )
+            )
+            state.add_entity(
+                ent(f"file{n}", "File", name="run.xlsx", dest_path=str(book.relative_to(tmp_path)))
+            )
+            state.add_entity(
+                ent(
+                    f"exp{n}",
+                    "LabProcess",
+                    process_type="Exposure",
+                    name=f"Exposure {n}",
+                    assay_id=assay,
+                )
+            )
+            state.scanned_files.append(
+                FileClassification(
+                    path=str(book),
+                    filename=book.name,
+                    size=book.stat().st_size,
+                    mime_type="application/vnd.ms-excel",
+                )
+            )
+        state.approved_scan_roots = {str(tmp_path)}
+        return AgentEngine(state=state)
+
+    def _params(self, engine, exposure_id):
+        entity = next(
+            e for e in engine.state.list_entities("LabProcess") if e.entity_id == exposure_id
+        )
+        refs = entity.fields.get("additionalProperty") or []
+        refs = refs if isinstance(refs, list) else [refs]
+        by_id = {e.entity_id: e for e in engine.state.list_entities("PropertyValue")}
+        return {
+            by_id[r].fields.get("name"): by_id[r].fields.get("value") for r in refs if r in by_id
+        }
+
+    def test_each_exposure_gets_its_own_assay_s_conditions(self, two_assays):
+        from builder.agents.pipeline.pipeline import _apply_layout_conditions
+
+        outcome = _apply_layout_conditions(two_assays)
+        assert outcome["exposures"] == 2, outcome
+        first = self._params(two_assays, "exp1")
+        second = self._params(two_assays, "exp2")
+        assert first.get("Substrate") == "1 nM T3 or T4"
+        assert "Substrate" not in second, second
+        assert second.get("Cell type") == "H4  + SKNAS"
+
+    def test_nothing_from_another_assay_leaks_in(self, two_assays):
+        from builder.agents.pipeline.pipeline import _apply_layout_conditions
+
+        _apply_layout_conditions(two_assays)
+        assert "Cell type" not in self._params(two_assays, "exp1")
+
+    def test_running_twice_mints_no_duplicates(self, two_assays):
+        """The spine re-runs; a parameter must not double."""
+        from builder.agents.pipeline.pipeline import _apply_layout_conditions
+
+        _apply_layout_conditions(two_assays)
+        before = self._params(two_assays, "exp1")
+        _apply_layout_conditions(two_assays)
+        assert self._params(two_assays, "exp1") == before
+        entity = next(
+            e for e in two_assays.state.list_entities("LabProcess") if e.entity_id == "exp1"
+        )
+        refs = entity.fields.get("additionalProperty") or []
+        assert len(refs) == len(set(refs)), refs


### PR DESCRIPTION
Refs #697 — the safe half. The plate-matrix join stays open.

Three of the four assays ship a header-only condition table because no file in
them carries per-well rows. But every experiment workbook in this lab's deposits
opens its `layout` sheet with a block of label/value pairs stating what the whole
run shared — **incubation volume, buffer, substrate, dose, duration** — which are
exactly the columns the table is empty in.

They describe the run rather than a well, so they land on the Exposure as
parameters, not as rows.

A recurring convention, not a one-off: four experiment workbooks across two
assays, named `layout 27-03`, `layout 01-03` and `Layout`.

## Bounded to the leading block

Below the block sits the design matrix, whose cells are adjacent pairs too — a
scan of the sheet turns `D | D` into a condition named "D". The block is the
contiguous run of pairs from the top, ending at the first blank row after it
starts.

That bound is **the sheet's own structure, not a list of labels to expect**, so a
run stating something new is read rather than filtered out.

## Only what every run agrees on

An assay holds several experiment workbooks and their blocks disagree:

| | run A | run B |
|---|---|---|
| Cell type | `H4 + SKNAS` | `MO3.13` |
| Inhibitors | `Xn` | `none` |
| Incubation time | `10` | `2, 5, 10, 30, 60` |

Neither value is a property of the assay. Only what **every** run states
identically survives; the rest is per-run and belongs with #654.

Agreement is exact on the stated text. `24hour` and `24 hours` mean the same
thing and do not say so — normalising them would be a guess about units and
format. A label only some runs state is dropped for the same reason: silence is
not agreement.

**On the real deposit:** 5 shared conditions for the uptake assay
(`Substrate: 1 nM T3 or T4`, `Incubation volume (ul): 375`, `cpm per sample:
50000`, `Lysis buffer: 0.1 M NaOH`, `Name`) and 4 for metabolism, with 5 per-run
values correctly dropped from each.

## Scoped, and verbatim

Scoped per assay exactly as the condition table is (#669), reusing the same
`hasPart`-through-`dest_path` bridge, so one assay's conditions can never reach
another's exposure. A test pins that.

Values are carried **verbatim**: nothing parses `1 nM T3 or T4` into a quantity
or resolves `Xn` to a compound. Those are the depositor's words.

Idempotent — the PropertyValue id derives from name and value, and a reference is
appended only when absent, so the spine re-running mints nothing new.

## One thing to decide

`Name: Nathalie` agrees across runs, so it comes through as a parameter. It is
the operator, and arguably belongs on `contributor` rather than as an exposure
condition. I did **not** add an exclusion list — a hand-kept set of "labels that
do not count" is exactly the drift #677 just fixed, and the depositor did write
it in the run's condition block. Say the word and I will route it properly.

## Not in scope

The design matrix itself. The measurements are keyed by `Rack`/`Det`/`Pos`, the
matrix by where a cell sits on the page, and `Sample code` — the column that
would join them — is entirely empty. That join is an inferred plate geometry and
must refuse rather than guess; #697 stays open for it.

252 passed across the layout, pipeline and condition-table suites. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYLSExAW64e7fe26xHDHUS