### PR TITLE
docs: say what the code does, where the design doc drifted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,18 +285,22 @@ perfectly detailed crate that doesn't build at all.
 
 ### 4.1 Validation Gate Ordering
 
-The three-pass validation in `profiles/validator.py` has a strict dependency:
-- **Base RO-Crate 1.2** must pass before ISA validation is meaningful
-- **ISA Profile** must pass before ISA-Tox validation is meaningful
-- **ISA-Tox Profile** depends on both lower layers
+The three profile passes in `profiles/validator.py` are **independent**: a
+`profile="all"` sweep always runs base, ISA and ISA-Tox, fanned out to a process
+pool unless `VITRO_VALIDATE_SERIAL=1` forces the serial path. The ordering below
+is a **fix priority for the agent**, not a gate in the validator:
+- **Base RO-Crate 1.2** issues are structural — clearing them is what makes the
+  ISA and ISA-Tox findings meaningful
+- **ISA Profile** issues come next
+- **ISA-Tox Profile** rests on both lower layers being sound
 
 If the agent tries to validate and gets `base_passed: false`, there is no point
 fixing ISA-Tox issues until the crate builds. The agent should:
 
 1. Call `build_and_validate` early, even with minimal entities — it assembles
    and validates **in memory** and writes nothing, so it is safe every iteration
-   (`export_crate`/`build_crate` is the only disk-writing step and is called
-   **once**, when the crate is finished)
+   (`export_crate`/`build_crate` is the only disk-writing step; see §5 for how
+   often each arm calls it)
 2. Fix base RO-Crate issues first (structural integrity)
 3. Then iterate on ISA issues
 4. Then iterate on ISA-Tox issues
@@ -1442,7 +1446,10 @@ entity by inverting `_crate_mapping._mint_id`. Each `fixed` item carries
 `{issue, rule, action}`; each `remaining` item `{issue, reason}`.
 
 `export_crate` is the **only** tool that materialises the on-disk RO-Crate
-directory (payload included) — call it once the crate is conformant. It is not
+directory (payload included). The deterministic pipeline calls it **once**, after
+guidance; the ReAct arm calls it **repeatedly** — automatically after every
+base-passing build, and again from the exit backstop — and
+`state.export_fingerprint()` is what keeps the repeat idempotent. It is not
 the only tool that writes at all: `populate_condition_table` writes the condition
 table's CSV, `unzip_file` extracts an archive, and `save_session` persists the
 session.
@@ -2694,13 +2701,15 @@ in-repo A/B; see **D15** for the evidence and the levers.
 INPUT (dir / zip / conversation)
    │
    ▼  DETERMINISTIC PIPELINE (code, not model-driven)
- scan ─ scaffold ISA backbone ─ materialize ─ draft entities ─ build_and_validate ─ fix loop ─ enrich ─ export
-                                                   │  (bounded LLM leaf: extract→entity)     │ (deterministic
-                                                   ▼                                          │  dispatch over
-                                            cheap drafter model                               │  routed issues;
-                                                                                              ▼  LLM only for
-   small TAIL AGENT (strong model) ── only for: no-metadata conversational build,                 content repairs)
+ scan ─ scaffold ISA backbone ─ materialize ─ draft entities ─ retry compounds ─ fix loop ─ data-content pass
+                                     │  (bounded LLM leaf: extract→entity)   │      │ (deterministic
+                                     ▼                                       │      │  dispatch over
+                              cheap drafter model            provider-gated ─┘      ▼  routed issues;
+                                                                                       LLM only for
+   small TAIL AGENT (strong model) ── only for: no-metadata conversational build,       content repairs)
                                        genuine ambiguity, HITL
+   │
+   ▼ export — NOT a spine step: `_run_build_body` calls it after the guidance tail
    │
    ▼ OUTPUT: RO-Crate dir + payload + embedded graph/maturity/preview
 ```

--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -19,8 +19,10 @@ deterministic.
 
 The loop (:func:`run_guidance`) per round:
 
-1. ``report = assess_gaps(engine.state)`` — re-assess from scratch each round so
-   resolved gaps disappear and newly-surfaced ones appear.
+1. ``report = assess_gaps(engine.state)`` — assessed once before the loop, and
+   again after any round that commits something, so resolved gaps disappear and
+   newly-surfaced ones appear. A round that cannot progress reuses the report it
+   already has and only grows the skip-set.
 2. **Terminate** when no MUST gaps remain AND (the user signalled done OR there
    are no actionable SHOULD/MAY gaps left).
 3. Otherwise take the **highest-priority actionable gap** (the report is already
@@ -165,9 +167,10 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["run_guidance"]
 
-# Default upper bound on rounds. Each round runs the SHACL-heavy gap engine once,
-# so this caps the worst-case work and guarantees termination even if a resolved
-# gap never clears (e.g. a user value the validator still rejects).
+# Default upper bound on rounds. A round that commits something runs the
+# SHACL-heavy gap engine again; a round that cannot progress reuses the report it
+# already has. The cap bounds the worst case and guarantees termination even if a
+# resolved gap never clears (e.g. a user value the validator still rejects).
 _DEFAULT_MAX_ROUNDS = 20
 
 # (#257, fix C) Max characters of a pointed-at file's text fed to the extraction

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -551,9 +551,10 @@ _LOOKUP_TOOLS = frozenset(
 # subject — keeping them apart matters: they are stored on the same engine object.
 _LOOKUP_ANSWER_FLAG = "_lookup_seen_answers"
 
-# Repeats of one query against one unchanged state before the turn ends. Two
-# warnings, then hand control back — the same escalation the other guards use,
-# because a corrective the model can bounce off is not a stop.
+# Repeats of one query against one unchanged state before the guard stops
+# answering and only logs. It does NOT end the turn — the idle ladder is what
+# cancels an invocation, and it sees every suppressed call through
+# `_track_progress`.
 _STATE_QUERY_ABORT = 3
 
 # --- consecutive calls that change nothing ----------------------------------
@@ -640,10 +641,10 @@ _IDLE_STREAK_WARN = 3
 _IDLE_NUDGE_LIMIT = 3
 _IDLE_STREAK_ABORT = _IDLE_STREAK_WARN + _IDLE_NUDGE_LIMIT
 
-# Bounces off the suppression guard (same scope, same state) that end the turn.
+# Bounces off the suppression guard (same scope, same state) before it logs.
 # Suppression alone does not stop the loop — the model reads the corrective and
-# calls straight back, so every bounce still costs a full model turn. Two
-# warnings, then hand control to the user.
+# calls straight back, so every bounce still costs a full model turn. Steering,
+# not stopping: ending the turn is the idle ladder's job.
 _VALIDATE_SUPPRESS_ABORT = 3
 
 
@@ -1601,8 +1602,10 @@ def _guard_state_query(
 
     Returns a corrective to hand back instead of running the query, or ``None``
     when the query is new (or the state has moved on) and should run normally.
-    Raises :class:`_InvocationCancelled` once the same question has been asked
-    :data:`_STATE_QUERY_ABORT` times of one unchanged crate.
+    Never ends the turn: past :data:`_STATE_QUERY_ABORT` repeats of one question
+    against one unchanged crate it only logs. Cancelling an invocation is the idle
+    ladder's job, and every corrective returned here is routed through
+    :func:`_track_progress` so the ladder counts it.
 
     Keyed on (query, state fingerprint) rather than on consecutive repeats,
     because the observed loop rotated between three entity types and so never
@@ -2260,10 +2263,7 @@ def _build_langchain_tools(engine: AgentEngine) -> list[Any]:
                         # Suppressing the SHACL pass saves seconds but NOT tokens:
                         # the model reads the corrective and immediately calls
                         # again, so a bounce still costs a full model turn (~12.5k
-                        # input tokens; 17 bounces in 90s were observed). After a
-                        # couple of strikes, end the turn instead of answering —
-                        # handing control back to the user is the only thing that
-                        # reliably stops it.
+                        # input tokens; 17 bounces in 90s were observed).
                         # Steer, don't stop — same reasoning as the state-query
                         # guard: the idle ladder ends turns, and it does so after
                         # three escalating nudges that name what to do instead.


### PR DESCRIPTION
Five verified places where AGENTS.md and two docstrings describe control flow the
implementation does not have. Found while drawing UML activity diagrams of both
build arms and checking every label against the code. **No behaviour changes** —
comments, docstrings and design-doc prose only.

| Site | Claimed | Actually |
|---|---|---|
| §4.1 | the three passes in `profiles/validator.py` have a strict dependency | independent; `profile="all"` always runs all three, fanned out to a process pool unless `VITRO_VALIDATE_SERIAL=1`. The ordering is a fix priority for the agent, not a gate |
| §4.1, §5 | `export_crate` is called **once**, when the crate is finished | true for the pipeline; the ReAct arm exports after every base-passing build and again from the exit backstop, kept idempotent by `state.export_fingerprint()` |
| §14.2 | `… build_and_validate ─ fix loop ─ enrich ─ export` | `… draft entities ─ retry compounds ─ fix loop ─ data-content pass`; export is not a spine step, `_run_build_body` calls it after guidance |
| `guidance.py` ×3 | each round re-assesses gaps from scratch | `assess_gaps` runs once before the loop and again only after a round that commits; a non-progressing round reuses the report |
| `agent_loop.py` ×4 | `_STATE_QUERY_ABORT` / `_VALIDATE_SUPPRESS_ABORT` end the turn | they only log; the idle ladder is the authority that cancels an invocation |

### Checks

- `ruff check builder/` passes
- `tests/test_agent_loop.py tests/test_agents_guidance.py tests/test_lookup_repeat_guard.py` — 217 passed
- `ruff format` reports drift in both touched files, but it is pre-existing (verified by stashing), so it is left alone rather than reformatting ~5k lines inside a docs PR

### Not in scope

§14.6.1 still says an export failure is "re-raised as `CrateExportError` so the CLI signals a non-zero exit". `main.py` has no handler, so it escapes as an uncaught traceback, and the ReAct backstop swallows its own export failure. Left for a separate change since the honest fix may be in the code rather than the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYvdXbtJd7sUh2DJUETc1