### PR TITLE
fix(crate): two ISA-Tox shape floors — a process names what it consumed

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -3373,7 +3373,9 @@ def _build_process(
 
     if ptype == "Exposure":
         # The Exposure takes the cultured cell Sample(s) as object and emits the
-        # CSVW condition table as its result. ISA forbids a MolecularEntity as a
+        # EXPOSED Sample as its result; the condition table is what the run
+        # FOLLOWS, attached via executesLabProtocol, not what it produces (#650,
+        # 113ea1c). ISA forbids a MolecularEntity as a
         # process object (objects MUST be File/Sample/BioSample — bundled
         # isa-ro-crate shape), so the compound is NOT in `object`; it is connected
         # THROUGH the condition table (table --about--> MolecularEntity) and, at a
@@ -3398,6 +3400,21 @@ def _build_process(
             chems,
             materialize_payload=materialize_payload,
         )
+        # A named placeholder when nothing resolved, so the exposure still says
+        # what it exposed. The tox shape makes schema:object a Violation
+        # (3_lab_process_exposure.ttl:37-43) where the bundled ISA shape rates
+        # the same minCount a Warning, so an exposure whose assay has no culture
+        # and no resolvable sample fails the profile the build asserts. "Cells
+        # were exposed, and we do not know which" is the honest claim; naming a
+        # line, or typing the placeholder as cultured material, would fabricate
+        # an identity nobody stated (D5).
+        #
+        # AFTER the table, never before it: `_synth_condition_table` maps `cells`
+        # onto the CSVW `cell_line` column's valueUrl, so flooring earlier would
+        # assert column-wide that every well held the placeholder — exactly the
+        # unverified mapping `_build_condition_table_schema` warns against. The
+        # table keeps an empty cell_line, which is the honest state.
+        cells = cells or [_synth_sample(crate, pid + "_input", f"Input ({name})")]
         # The Exposure PRODUCES the exposed cells (#650). Before this, its only
         # result was the condition table, no exposed-sample entity existed
         # anywhere in the crate, and every downstream step consumed the cultured

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -3051,6 +3051,61 @@ def _set_refs(node: Any, prop: str, entities: list[Any]) -> None:
     node[prop] = [{"@id": getattr(e, "id", e)} for e in entities]
 
 
+def _floor_readout_objects(crate: ROCrate, built: list[tuple[Any, str, Any]]) -> None:
+    """A readout names what it measured, even with nothing upstream to name.
+
+    ``tox:EndpointReadoutConsumesExposedMaterial``
+    (profiles/shapes/tox/4_lab_process_endpoint_readout.ttl, added 282de2d)
+    makes ``schema:object`` a Violation. :func:`_chain_processes` wires a readout
+    only where its own assay has an Exposure that emitted a Sample, so the
+    characterisation run that shape's own comment calls legitimate reaches the
+    crate with ``"input": null`` and fails the profile the build asserts.
+
+    The culture comes first and a placeholder only where there is none: a
+    characterisation run measures the cultured material, which
+    :func:`_chain_processes` already calls the truth rather than the defect.
+    Minting a stand-in beside real material would state an input nobody has.
+
+    Runs AFTER the chaining pass, never at construction time. A placeholder
+    minted while the process is built makes the readout's consumed set non-empty
+    and not a subset of the cultured samples -- exactly the condition
+    :func:`_chain_processes` reads as "this readout knows better than we do". So
+    an early floor DISPLACES the exposed Sample it exists to stand in for, brings
+    back the star graph #650 removed, and leaves that sample consumed by nothing
+    (#678). The existing suite cannot see it: ``draft_process_chain`` always
+    supplies an object, so the floor never fires there.
+
+    No ``sampleType`` on the placeholder -- it stands for an input nobody stated,
+    and typing it as cultured material would assert a lineage never established
+    (D5).
+    """
+    groups: dict[Any, dict[str, list[Any]]] = {}
+    for assay, ptype, node in built:
+        key = getattr(assay, "id", None)
+        groups.setdefault(key, {}).setdefault(ptype, []).append(node)
+
+    for by_type in groups.values():
+        cultured = [
+            n
+            for proc in by_type.get("CellCulture", [])
+            for n in _linked_nodes(proc, "output", "result")
+            if _is_sample_node(n)
+        ]
+        for readout in by_type.get("EndpointReadout", []):
+            if _linked_nodes(readout, "input", "object"):
+                continue
+            if cultured:
+                _set_refs(readout, "input", cultured)
+                continue
+            fragment = str(getattr(readout, "id", "")).rsplit("#", 1)[-1]
+            label = readout.properties().get("name")
+            _set_refs(
+                readout,
+                "input",
+                [_synth_sample(crate, f"#{fragment}_input", f"Measured ({label})")],
+            )
+
+
 def _add_processes(
     state: CrateState,
     crate: ROCrate,
@@ -3195,6 +3250,7 @@ def _add_processes(
 
     _place_protocols(state, idx, protocol_use)
     _chain_processes(built)
+    _floor_readout_objects(crate, built)
 
 
 def _place_protocols(

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -1,0 +1,72 @@
+"""Every tox process shape that declares `schema:object sh:minCount 1` must be
+satisfiable by the build alone (2026-08-25 tox model/shape audit).
+
+The shapes at profiles/shapes/tox/2_lab_process_cell_culture.ttl:34,
+3_lab_process_exposure.ttl:41 and 4_lab_process_endpoint_readout.ttl:64 all
+declare a REQUIRED schema:object. A build that can emit a process with none of
+them produces a crate that fails the profile the tool asserts end to end.
+
+Each test perturbs a minimal state one way and asserts the tox verdict, so a
+failure names the perturbation rather than the fixture.
+"""
+
+from __future__ import annotations
+
+from builder.state import CrateState, Entity, EntityProvenance
+from builder.tools.validation import build_and_validate
+
+
+def _state_with(entity_id: str, fields: dict) -> CrateState:
+    """A CrateState holding exactly one LabProcess, with nothing else to link to."""
+    state = CrateState()
+    state.metadata.title = "Floor probe"
+    state.add_entity(
+        Entity(
+            entity_id=entity_id,
+            type="LabProcess",
+            fields=fields,
+            _provenance=EntityProvenance(created_by="llm"),
+        )
+    )
+    return state
+
+
+def _tox_issues(state: CrateState, prop: str) -> list[dict]:
+    """REQUIRED tox issues on *prop*, e.g. 'http://schema.org/object'."""
+    result = build_and_validate(state, severity="required", profile="tox")
+    return [i for i in result["issues"] if i.get("property") == prop]
+
+
+class TestExposureInputFloor:
+    """An Exposure with no cell culture still declares what it exposed (#650)."""
+
+    def test_exposure_with_no_resolvable_cells_still_has_an_object(self):
+        state = _state_with(
+            "proc_exp",
+            {"process_type": "Exposure", "name": "Amiodarone exposure"},
+        )
+
+        assert _tox_issues(state, "http://schema.org/object") == []
+
+    def test_the_synthesized_input_is_a_sample_not_an_empty_list(self):
+        """The floor must add a node, not merely silence the count.
+
+        Guards the lazy fix: emitting `"input": [""]` or dropping the key would
+        also clear the minCount in some validators but says nothing about what
+        was exposed.
+        """
+        from builder.tools.builder import assemble_crate
+
+        state = _state_with(
+            "proc_exp",
+            {"process_type": "Exposure", "name": "Amiodarone exposure"},
+        )
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+        node = next(
+            e
+            for e in crate.get_entities()
+            if e.properties().get("additionalType") == "Exposure"
+        )
+        objects = node.properties().get("input")
+        assert objects, "Exposure emitted no schema:object at all"
+        assert not isinstance(objects, str)

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -70,3 +70,120 @@ class TestExposureInputFloor:
         objects = node.properties().get("input")
         assert objects, "Exposure emitted no schema:object at all"
         assert not isinstance(objects, str)
+
+
+class TestEndpointReadoutInputFloor:
+    """A readout says what it measured, even with no exposure in its assay.
+
+    `tox:EndpointReadoutConsumesExposedMaterial` landed 2026-08-24 (282de2d).
+    `_chain_processes` rewires a readout's input only when the same assay has an
+    Exposure that produced a Sample, so the characterisation case the shape's own
+    comment calls legitimate is the one that fails.
+    """
+
+    def test_readout_with_no_exposure_in_its_assay_still_has_an_object(self):
+        state = _state_with(
+            "proc_ro",
+            {
+                "process_type": "EndpointReadout",
+                "name": "Viability readout",
+                "endpoint": "Cell viability",
+                "measured_entity": "ATP",
+            },
+        )
+
+        assert _tox_issues(state, "http://schema.org/object") == []
+
+    def test_the_crate_never_serializes_a_null_input(self):
+        """`"input": null` is JSON the reader has to defend against.
+
+        The null is not what fails the shape — deleting the key fails it
+        identically — but the floor must leave a node behind, not a null.
+        """
+        from builder.tools.builder import assemble_crate
+
+        state = _state_with(
+            "proc_ro",
+            {"process_type": "EndpointReadout", "name": "Viability readout"},
+        )
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+        node = next(
+            e
+            for e in crate.get_entities()
+            if e.properties().get("additionalType") == "EndpointReadout"
+        )
+        assert node.properties().get("input") is not None
+
+    def test_the_floor_never_displaces_the_exposed_sample(self):
+        """The placeholder is a fallback, not a competitor (#650, #678).
+
+        `_chain_processes` skips a readout whose consumed set is not a subset of
+        the cultured samples — one naming its own material knows better than we
+        do. A floor applied while the process is BUILT makes that set the
+        placeholder, so the rescue skips the readout and it measures a
+        synthesized node instead of the sample the exposure produced. The star
+        graph #650 removed comes straight back, and nothing consumes the exposed
+        sample at all.
+
+        Invisible to the rest of the suite: `draft_process_chain` always supplies
+        `object`, so the floor never fires anywhere else and the existing
+        chain assertions stay green either way.
+        """
+        from builder.state import FileClassification
+        from builder.tools.builder import assemble_crate
+        from builder.tools.composites import draft_process_chain, scaffold_isa_backbone
+
+        state = CrateState()
+        state.metadata.title = "Chain floor probe"
+        state.metadata.input_path = "/deposit"
+        state.scanned_files = [
+            FileClassification(
+                path="/deposit/assay/raw data/plate.csv",
+                filename="plate.csv",
+                size=4096,
+                mime_type="text/csv",
+            ),
+        ]
+        ids = scaffold_isa_backbone(
+            state,
+            investigation={"name": "Inv", "description": "d", "identifier": "INV-1"},
+            study={"name": "Study", "description": "d"},
+            assay={"name": "Assay", "description": "d"},
+        )
+        draft_process_chain(
+            state,
+            ids["assay_id"],
+            chain=[
+                {"process_type": "CellCulture", "hints": {"name": "Seed"}},
+                {"process_type": "Exposure", "hints": {"name": "Dose", "duration": "24 h"}},
+                {
+                    "process_type": "EndpointReadout",
+                    "hints": {"name": "Read", "detection_instrument": "Plate reader"},
+                },
+            ],
+        )
+        # The case the floor targets: a readout the drafter left with no input.
+        readout_draft = next(
+            e
+            for e in state.list_entities("LabProcess")
+            if e.fields.get("process_type") == "EndpointReadout"
+        )
+        for key in ("samples", "object", "input"):
+            readout_draft.fields.pop(key, None)
+
+        graph = assemble_crate(
+            state, output_dir=None, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+
+        def _ids(value):
+            items = value if isinstance(value, list) else [value]
+            return {i.get("@id") for i in items if isinstance(i, dict)}
+
+        readout = next(n for n in graph if n.get("additionalType") == "EndpointReadout")
+        exposure = next(n for n in graph if n.get("additionalType") == "Exposure")
+        consumed = _ids(readout.get("input")) | _ids(readout.get("object"))
+        exposed = _ids(exposure.get("output")) | _ids(exposure.get("result"))
+        assert consumed & exposed, (
+            "the floor displaced the exposed sample; the readout consumes "
+            f"{consumed} while the exposure produced {exposed}"
+        )


### PR DESCRIPTION
Two `Violation`-severity ISA-Tox shapes could be failed by a crate the build
itself asserts as conformant, because `_crate_mapping` left `schema:object`
empty on a process whose upstream step does not exist. One floor each, plus the
tests that see them.

### `tox:ExposureRequirements` — an exposure with no culture upstream (5642cfb)

`schema:object` is a Violation there (`3_lab_process_exposure.ttl:37-43`) and
that pass is the only one that says so; the bundled ISA shape rates the same
`minCount` a Warning. The CellCulture branch already had a synthesized-input
floor — the Exposure branch never got one. With no CellCulture in the assay,
`consumed_cells` is `None` and `_resolve_many` returns `[]`, so the exposure
emitted `"input": []`. Nothing downstream rescued it: `_chain_processes` rewires
only EndpointReadout and DataAnalysis, and `repair.py` excludes Exposure. Seen on
a real run (`sessions/20260811_115346/profile.ndjson:304`).

The floor lands **after** the condition table is synthesized. Earlier would push
the placeholder into the CSVW `cell_line` column's `valueUrl` and assert
column-wide that every well held it — the unverified whole-column mapping
`_build_condition_table_schema` warns about. The table keeps an empty
`cell_line`, which is the honest state.

### `tox:EndpointReadoutConsumesExposedMaterial` — a characterisation readout (8029f70)

That shape landed 2026-08-24 (282de2d) and makes `schema:object` a Violation.
`_chain_processes` wires a readout only where its own assay has an Exposure that
emitted a Sample, so a characterisation readout — which the shape's own comment
calls legitimate — reached the crate with `"input": null`. Deleting the key
produces the identical violation; the floor is the fix. `_INPUT_REQUIRED_TYPES`
is DataAnalysis only, so the deterministic repair does not cover it either.

This floor runs **after** the chaining pass, and that placement is the point.
`_chain_processes` skips a readout whose consumed set is non-empty and not a
subset of the cultured samples. A placeholder minted at the constructor IS such a
set, so flooring there makes the rescue skip the readout — it measures the
stand-in while the exposed Sample goes consumed by nothing. That is the star
graph #650 removed, back again.

`test_the_floor_never_displaces_the_exposed_sample` is the test that sees it:
confirmed failing against the constructor-site version, passing against this one.
The existing suite cannot — `draft_process_chain` always supplies an object, so a
constructor-site floor never fires in any current test and
`test_the_readout_consumes_the_exposed_sample` stays green while the graph is wrong.

### Checks

- `tests/test_tox_shape_floors.py` — 5 passed
- crate-mapping and process-chain neighbours run locally; CI is the gate

From the 2026-08-25 audit of `profiles/models/tox.py` against `profiles/shapes/tox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFYvdXbtJd7sUh2DJUETc1