### PR TITLE
fix(crate): a placeholder is not an answer the crate may assert

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -35,6 +35,7 @@ from builder.tools.document_discovery import CLASS_PROTOCOL
 from profiles.licenses import describe_license
 from profiles.models.isa import CharacteristicValue, LabProcess, Sample, param_id
 from profiles.models.tox import (
+    _PLACEHOLDER_VALUES,
     CellLineSample,
     LabProcessCellCulture,
     LabProcessDataAnalysis,
@@ -616,6 +617,31 @@ def _preserved_name(field: str) -> str:
     return field.replace("_", " ").strip() or field
 
 
+def _says_nothing(value: Any) -> bool:
+    """Whether *value* is empty, or a placeholder standing in for an answer.
+
+    The emitters' own placeholder set, imported rather than copied so the two
+    cannot drift (the single-source rule eval/scorers.py already follows).
+
+    Without this the rescue undid `_pv`: a value `_pv` refuses for saying nothing
+    was re-attached here under schema:additionalProperty — the predicate
+    `profiles/context.py` also maps `parameter` onto, and the one
+    tox:CellCultureRequirements counts — so a process whose only stated parameter
+    was "not recorded" satisfied a MUST that exists to prompt someone to go and
+    fill it in (D5). #677 closed the route through constructor-consumed fields;
+    `work_package` on a process, and any dropped field on a File, still carried
+    placeholders into the graph.
+
+    This does not, on its own, make that MUST falsifiable: any unowned field
+    holding a REAL value still satisfies it, which matters more once the
+    fabricated culture-medium default is gone. It stops the crate asserting a
+    value nobody supplied, which is the narrower and checkable claim.
+    """
+    if value in (None, "", [], {}):
+        return True
+    return isinstance(value, str) and value.strip().casefold() in _PLACEHOLDER_VALUES
+
+
 def _preserve_unowned_fields(state: CrateState, crate: ROCrate, idx: dict[str, Any]) -> None:
     """Keep a field the build cannot emit, as a ``PropertyValue``, instead of deleting it.
 
@@ -652,7 +678,7 @@ def _preserve_unowned_fields(state: CrateState, crate: ROCrate, idx: dict[str, A
             for key, value in entity.fields.items()
             if field_would_be_dropped(key)
             and key not in consumed
-            and value not in (None, "", [], {})
+            and not _says_nothing(value)
         }
         if not leftovers:
             continue

--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -3448,7 +3448,13 @@ def _build_process(
             identifier=pid,
             name=name,
             cell_line=cell_line,
-            culture_medium=f.get("culture_medium", "Standard medium"),
+            # No default. "Standard medium" was published with propertyID
+            # BAO_0000114 for data nobody supplied - a real ontology term on a
+            # fabricated value, which the tox pass then called conformant. An
+            # unstated medium is passed through as None so `_pv` drops it and
+            # the shape's additionalProperty MUST fires as the prompt to go and
+            # ask (D5 - never fabricate).
+            culture_medium=f.get("culture_medium"),
             result=out,
             labprotocol=protocol,
         )

--- a/builder/tools/repair.py
+++ b/builder/tools/repair.py
@@ -104,11 +104,20 @@ def _resolve_state_entity(state: CrateState, focus_id: str | None) -> Entity | N
 # TOX REQUIRED violation, not a benign gap the build would synthesize.
 _OUTPUT_REQUIRED_TYPES = frozenset({"EndpointReadout", "DataAnalysis"})
 
-# Domain process types whose TOX shape REQUIRES a schema:object (input). Only
-# DataAnalysis declares the missing-input Violation (profiles/shapes/tox/
-# 5_lab_process_data_analysis.ttl: schema:object sh:minCount 1); EndpointReadout
-# requires only a result. A missing object on a DataAnalysis is therefore the
-# symmetric counterpart of the missing-output Violation.
+# Domain process types a REPAIR must wire an input for. NOT the same set as the
+# types whose shape requires one: four shapes declare `schema:object` minCount 1
+# at Violation severity — tox:CellCultureRequirements, tox:ExposureRequirements,
+# tox:EndpointReadoutConsumesExposedMaterial and tox:DataAnalysisRequirements.
+#
+# The other three are excluded because the BUILD already floors them: each
+# supplies a named input when nothing resolves — the CellCulture and Exposure
+# branches of `_build_process`, and `_floor_readout_objects` after the chaining
+# pass — so the violation this rule repairs cannot reach validation for them.
+#
+# DataAnalysis has no such floor, and should not: its object is the data
+# analysed, and synthesizing a stand-in File would assert a measurement that does
+# not exist (D5). It is the one type where a post-validation repair, which links
+# something already in the crate, is the right layer.
 _INPUT_REQUIRED_TYPES = frozenset({"DataAnalysis"})
 
 

--- a/profiles/models/tox.py
+++ b/profiles/models/tox.py
@@ -244,7 +244,7 @@ class LabProcessCellCulture(LabProcess):
         identifier: str,
         name: str,
         cell_line: Sample | list[Sample],
-        culture_medium: str,
+        culture_medium: str | None,
         result: Sample,
         labprotocol: LabProtocol | File | list[LabProtocol | File] | None,
         properties: dict | None = None,
@@ -252,14 +252,14 @@ class LabProcessCellCulture(LabProcess):
     ):
         merged_properties = {
             "additionalType": "CellCulture",
-            "parameter": [
+            "parameter": _pvs(
                 _pv(
                     crate,
                     "Culture Medium",
                     culture_medium,
                     iri("BAO:0000114"),
                 ),
-            ],
+            ),
             "input": cell_line,
             "output": result,
             "name": name,

--- a/tests/test_agents_pipeline.py
+++ b/tests/test_agents_pipeline.py
@@ -757,11 +757,17 @@ class TestMaterializePlan:
             }
         ],
         "process_chain": [
-            # Exposure / EndpointReadout / DataAnalysis each MUST carry at least
-            # one schema:additionalProperty under the tox profile, and `_pv` no
-            # longer publishes "unknown" to satisfy it — so a plan whose crate is
-            # expected to CONFORM has to supply a real parameter per step.
-            {"process_type": "CellCulture", "name": "Seed cells"},
+            # EVERY typed step MUST carry at least one schema:additionalProperty
+            # under the tox profile, and `_pv` no longer publishes "unknown" to
+            # satisfy it — so a plan whose crate is expected to CONFORM has to
+            # supply a real parameter per step. CellCulture used to be the
+            # exception only because the mapper defaulted a missing medium to
+            # "Standard medium"; that fabrication is gone, so it states one.
+            {
+                "process_type": "CellCulture",
+                "name": "Seed cells",
+                "parameters": {"culture_medium": "DMEM + 10% FBS"},
+            },
             {
                 "process_type": "Exposure",
                 "name": "Dose",

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -160,7 +160,16 @@ _PLAN: dict[str, Any] = {
         }
     ],
     "process_chain": [
-        {"process_type": "CellCulture", "name": "FRTL-5 cell culture"},
+        {
+            "process_type": "CellCulture",
+            "name": "FRTL-5 cell culture",
+            "parameters": {
+                "culture_medium": (
+                    "Coon's modified Ham's F-12 with 5% calf serum and 6H hormone "
+                    "supplement"
+                )
+            },
+        },
         {
             "process_type": "Exposure",
             "name": "Methimazole exposure",

--- a/tests/test_pipeline_real_input.py
+++ b/tests/test_pipeline_real_input.py
@@ -491,17 +491,23 @@ class TestRealInputPipeline:
         2,000-char slice that tier receives — so the value never reaches the
         extraction leaf, and `_pv` will not invent one (D5).
 
-        TWO issue classes are outstanding, and both are honest reports rather
+        THREE issue classes are outstanding, and all are honest reports rather
         than regressions:
 
         * that DataAnalysis `additionalProperty`, as above;
+        * the CellCulture `additionalProperty`. Same shape of gap: the SOP names
+          the medium ("DMEM: F12 media") only past offset ~12,800, so it never
+          reaches the extraction leaf either. The shape reports the missing
+          medium rather than the build inventing one — a fabricated default here
+          would publish an ontology-typed BAO_0000114 assertion about data
+          nobody supplied (D5);
         * `schema:result` on the data-producing steps. This deposit DOES ship its
           measurements, but it files both tiers in one
           `raw data+individual processed data/` directory, so nothing can yet say
           which step produced which file (#591). Rather than invent an empty CSV
           to satisfy the shape, the steps keep no result and the Violation says
           so (#592). When #591 lands and the files classify, these clear and the
-          only remaining issue is the DataAnalysis one.
+          only remaining issues are the two parameter ones.
 
         Any OTHER issue here is a real regression.
         """
@@ -516,7 +522,10 @@ class TestRealInputPipeline:
         assert all(
             (
                 str(i.get("property", "")).endswith("additionalProperty")
-                and "DataAnalysis" in str(i.get("message", ""))
+                and (
+                    "DataAnalysis" in str(i.get("message", ""))
+                    or "CellCulture" in str(i.get("message", ""))
+                )
             )
             or str(i.get("property", "")).endswith("result")
             for i in outstanding

--- a/tests/test_tools_process_chain.py
+++ b/tests/test_tools_process_chain.py
@@ -92,11 +92,15 @@ def _scaffold() -> tuple[CrateState, str]:
 
 
 _FULL_CHAIN = [
-    # Exposure / EndpointReadout / DataAnalysis each MUST carry at least one
-    # schema:additionalProperty under the tox profile, and `_pv` no longer
-    # publishes a placeholder like "unknown" as if it were a measurement — so a
-    # chain that is expected to VALIDATE has to state a real parameter per step.
-    {"process_type": "CellCulture", "hints": {"name": "Seed"}},
+    # CellCulture / Exposure / EndpointReadout / DataAnalysis each MUST carry at
+    # least one schema:additionalProperty under the tox profile, and `_pv` no
+    # longer publishes a placeholder like "unknown" (or a fabricated default
+    # medium) as if it were a measurement — so a chain that is expected to
+    # VALIDATE has to state a real parameter per step.
+    {
+        "process_type": "CellCulture",
+        "hints": {"name": "Seed", "culture_medium": "DMEM + 10% FBS"},
+    },
     {"process_type": "Exposure", "hints": {"name": "Dose", "duration": "24 hours"}},
     {
         "process_type": "EndpointReadout",

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -187,3 +187,80 @@ class TestEndpointReadoutInputFloor:
             "the floor displaced the exposed sample; the readout consumes "
             f"{consumed} while the exposure produced {exposed}"
         )
+
+
+class TestInputRequiredTypesIsJustifiedByTheBuildNotTheShapes:
+    """`_INPUT_REQUIRED_TYPES` excludes three types the shapes DO constrain.
+
+    Its comment claimed only DataAnalysis declares a REQUIRED `schema:object`.
+    Four shapes declare it. The exclusion is correct anyway, because the build
+    floors the other three — this pins that reason so the set cannot be narrowed
+    back on the false premise.
+    """
+
+    _SHAPES_DECLARING_REQUIRED_OBJECT = {
+        "CellCulture": ("2_lab_process_cell_culture.ttl", "LabProcessCellCulture"),
+        "Exposure": ("3_lab_process_exposure.ttl", "LabProcessExposure"),
+        "EndpointReadout": (
+            "4_lab_process_endpoint_readout.ttl",
+            "LabProcessEndpointReadout",
+        ),
+        "DataAnalysis": ("5_lab_process_data_analysis.ttl", "LabProcessDataAnalysis"),
+    }
+
+    def test_every_named_shape_declares_a_required_object_at_violation_severity(self):
+        """Read the shapes as RDF, not as text — including this one.
+
+        Asserting that "schema:object", "sh:minCount 1" and "sh:Violation" each
+        appear SOMEWHERE in a file passes on a file where they sit in three
+        unrelated property shapes, which is most of them. The claim being pinned
+        is that ONE property shape on the process's own target class carries all
+        three, so that is what is queried.
+        """
+        from pathlib import Path
+
+        from rdflib import Graph, Namespace
+        from rdflib.namespace import SH
+
+        schema = Namespace("http://schema.org/")
+        tox = Namespace("https://w3id.org/ro/crate/isa-tox/1.0/")
+        shapes_dir = Path("profiles/shapes/tox")
+
+        unconstrained = {}
+        for ptype, (filename, target) in self._SHAPES_DECLARING_REQUIRED_OBJECT.items():
+            graph = Graph().parse(shapes_dir / filename, format="turtle")
+            floors = [
+                prop
+                for shape in graph.subjects(SH.targetClass, tox[target])
+                for prop in graph.objects(shape, SH.property)
+                if (prop, SH.path, schema.object) in graph
+                and (prop, SH.minCount, None) in graph
+                and (prop, SH.severity, SH.Violation) in graph
+            ]
+            if not floors:
+                unconstrained[ptype] = filename
+
+        assert not unconstrained, (
+            "these shapes no longer declare a REQUIRED schema:object at Violation "
+            f"severity on their own target class: {unconstrained}"
+        )
+
+    def test_the_three_excluded_types_are_floored_by_the_build(self):
+        """The actual justification for excluding them from repair.
+
+        Each builds an object with no state to link to, so the REQUIRED
+        violation the repair rule exists to fix cannot occur for them. Collected
+        rather than asserted per type: the loop used to abort at the first
+        failure, so a red run could only ever name one of the three.
+        """
+        from builder.tools.repair import _INPUT_REQUIRED_TYPES
+
+        unfloored = {}
+        for ptype in ("CellCulture", "Exposure", "EndpointReadout"):
+            assert ptype not in _INPUT_REQUIRED_TYPES
+            state = _state_with("proc", {"process_type": ptype, "name": f"{ptype} step"})
+            issues = _tox_issues(state, "http://schema.org/object")
+            if issues:
+                unfloored[ptype] = [i["message"] for i in issues]
+
+        assert not unfloored, f"unfloored by the build: {unfloored}"

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -264,3 +264,89 @@ class TestInputRequiredTypesIsJustifiedByTheBuildNotTheShapes:
                 unfloored[ptype] = [i["message"] for i in issues]
 
         assert not unfloored, f"unfloored by the build: {unfloored}"
+
+
+class TestPlaceholderRescueDoesNotDefeatTheD5Loop:
+    """A value `_pv` refused must not reappear under the same predicate.
+
+    `_pv` drops a placeholder so the shape's "MUST have at least one
+    additionalProperty" fires as the prompt to go and fill it in.
+    `_preserve_unowned_fields` filtered only empties, so a field it rescued
+    re-attached a placeholder under schema:additionalProperty — the predicate the
+    shape counts, since `profiles/context.py` maps `parameter` there too. A
+    CellCulture whose only stated parameter was "not recorded" satisfied the MUST.
+
+    #677 closed this for fields a process constructor consumes, `culture_medium`
+    among them, which is why the medium case below passes unaided and stands as a
+    regression guard rather than a red test. Every other dropped field still
+    reached the graph.
+    """
+
+    @staticmethod
+    def _culture_state(medium: str) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Placeholder probe"
+        state.add_entity(
+            Entity(
+                entity_id="proc_cc",
+                type="LabProcess",
+                fields={
+                    "process_type": "CellCulture",
+                    "name": "Culture step",
+                    "culture_medium": medium,
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        return state
+
+    def test_a_placeholder_medium_leaves_the_shape_free_to_fire(self):
+        """The whole point: an unstated medium must be VISIBLE as unstated."""
+        state = self._culture_state("unknown")
+
+        issues = _tox_issues(state, "http://schema.org/additionalProperty")
+
+        assert issues, (
+            "A CellCulture whose only parameter is 'unknown' passed the "
+            "additionalProperty MUST — the placeholder was re-published"
+        )
+
+    def test_a_real_medium_still_satisfies_the_shape(self):
+        """Guards the over-correction: only placeholders are suppressed."""
+        state = self._culture_state("DMEM + 10% FBS")
+
+        assert _tox_issues(state, "http://schema.org/additionalProperty") == []
+
+    def test_an_unmodelled_field_is_still_rescued_when_it_says_something(self):
+        """The rescue's actual purpose survives: keep a real unmodelled value.
+
+        `work_package` is the field the rescue was written for — a WP number
+        somebody typed deliberately, deleted for being unmodelled.
+        """
+        from builder.tools.builder import assemble_crate
+
+        state = self._culture_state("DMEM + 10% FBS")
+        state.get_entity("proc_cc").fields["work_package"] = "WP4"
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+
+        values = [
+            e.properties().get("value")
+            for e in crate.get_entities()
+            if e.properties().get("@type") == "PropertyValue"
+        ]
+        assert "WP4" in values
+
+    def test_an_unmodelled_field_holding_a_placeholder_is_not_rescued(self):
+        """Same rule, applied to the rescue's own kind of field."""
+        from builder.tools.builder import assemble_crate
+
+        state = self._culture_state("DMEM + 10% FBS")
+        state.get_entity("proc_cc").fields["work_package"] = "not recorded"
+        crate = assemble_crate(state, output_dir=None, materialize_payload=False)
+
+        values = [
+            e.properties().get("value")
+            for e in crate.get_entities()
+            if e.properties().get("@type") == "PropertyValue"
+        ]
+        assert "not recorded" not in values

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -351,3 +351,86 @@ class TestPlaceholderRescueDoesNotDefeatTheD5Loop:
             if e.properties().get("@type") == "PropertyValue"
         ]
         assert "not recorded" not in values
+
+
+class TestCultureMediumIsNotFabricated:
+    """An unstated culture medium is unstated, not "Standard medium".
+
+    `_build_process` defaulted a missing `culture_medium` to a literal, which
+    `_pv` then published with propertyID BAO_0000114 - a real ontology term
+    attached to a value nobody supplied, which the tox pass called conformant.
+    tests/agents/test_leaves.py names this defect: "fabricated experimental
+    conditions with real BAO propertyIDs attached". #379 fixed the plan side, so
+    the extraction leaf has somewhere to put a real value; the mapper still
+    injected the fabrication when the leaf found nothing.
+
+    With the default gone `_pv` receives None and declines, which makes the
+    missing `_pvs` wrap on LabProcessCellCulture load-bearing: it is the one
+    subtype that built its parameter list as a bare list, so the declined
+    parameter survived as a literal null.
+    """
+
+    @staticmethod
+    def _culture_state(fields: dict) -> CrateState:
+        state = CrateState()
+        state.metadata.title = "Fabrication probe"
+        state.add_entity(
+            Entity(
+                entity_id="proc_cc",
+                type="LabProcess",
+                fields={"process_type": "CellCulture", "name": "Culture", **fields},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        return state
+
+    def _build(self, fields: dict):
+        from builder.tools.builder import assemble_crate
+
+        return assemble_crate(
+            self._culture_state(fields), output_dir=None, materialize_payload=False
+        )
+
+    def test_a_missing_medium_is_not_invented(self):
+        """The crate states no medium rather than a plausible-looking one."""
+        values = [
+            e.properties().get("value")
+            for e in self._build({}).get_entities()
+            if e.properties().get("@type") == "PropertyValue"
+        ]
+
+        assert "Standard medium" not in values
+
+    def test_a_missing_medium_leaves_the_shape_free_to_fire(self):
+        """The point of not fabricating: the gap becomes visible to the agent."""
+        issues = _tox_issues(
+            self._culture_state({}), "http://schema.org/additionalProperty"
+        )
+
+        assert issues, "A CellCulture stating no parameter at all passed the MUST"
+
+    def test_a_stated_medium_is_published_with_its_ontology_term(self):
+        """Guards the over-correction: a real value keeps its BAO term."""
+        media = [
+            e.properties()
+            for e in self._build({"culture_medium": "DMEM + 10% FBS"}).get_entities()
+            if e.properties().get("name") == "Culture Medium"
+        ]
+
+        assert media, "a stated medium stopped being published"
+        assert media[0]["value"] == "DMEM + 10% FBS"
+        assert "BAO_0000114" in str(media[0].get("propertyID"))
+
+    def test_the_parameter_list_never_contains_a_null(self):
+        """LabProcessCellCulture is the one subtype that skipped `_pvs`.
+
+        Cosmetic while the fabricated default masked it - JSON-LD drops nulls -
+        and reachable on the ordinary no-medium path once the default is gone.
+        """
+        node = next(
+            e
+            for e in self._build({}).get_entities()
+            if e.properties().get("additionalType") == "CellCulture"
+        )
+
+        assert None not in (node.properties().get("parameter") or [])

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -283,18 +283,21 @@ class TestPlaceholderRescueDoesNotDefeatTheD5Loop:
     """
 
     @staticmethod
-    def _culture_state(medium: str) -> CrateState:
+    def _culture_state(medium: str, work_package: str | None = None) -> CrateState:
         state = CrateState()
         state.metadata.title = "Placeholder probe"
+        fields = {
+            "process_type": "CellCulture",
+            "name": "Culture step",
+            "culture_medium": medium,
+        }
+        if work_package is not None:
+            fields["work_package"] = work_package
         state.add_entity(
             Entity(
                 entity_id="proc_cc",
                 type="LabProcess",
-                fields={
-                    "process_type": "CellCulture",
-                    "name": "Culture step",
-                    "culture_medium": medium,
-                },
+                fields=fields,
                 _provenance=EntityProvenance(created_by="llm"),
             )
         )
@@ -325,8 +328,7 @@ class TestPlaceholderRescueDoesNotDefeatTheD5Loop:
         """
         from builder.tools.builder import assemble_crate
 
-        state = self._culture_state("DMEM + 10% FBS")
-        state.get_entity("proc_cc").fields["work_package"] = "WP4"
+        state = self._culture_state("DMEM + 10% FBS", work_package="WP4")
         crate = assemble_crate(state, output_dir=None, materialize_payload=False)
 
         values = [
@@ -340,8 +342,7 @@ class TestPlaceholderRescueDoesNotDefeatTheD5Loop:
         """Same rule, applied to the rescue's own kind of field."""
         from builder.tools.builder import assemble_crate
 
-        state = self._culture_state("DMEM + 10% FBS")
-        state.get_entity("proc_cc").fields["work_package"] = "not recorded"
+        state = self._culture_state("DMEM + 10% FBS", work_package="not recorded")
         crate = assemble_crate(state, output_dir=None, materialize_payload=False)
 
         values = [

--- a/tests/test_validator_wiring.py
+++ b/tests/test_validator_wiring.py
@@ -72,6 +72,7 @@ def _representative_state() -> CrateState:
             process_type="CellCulture",
             assay_id="assay_1",
             cell_line="cell_1",
+            culture_medium="DMEM + 10% FBS",
         )
     )
     state.add_entity(


### PR DESCRIPTION
Follow-up to #701. Closes the last two routes by which a value **nobody supplied**
satisfied a `Violation`-severity ISA-Tox MUST — one placeholder route, one
fabricated-default route — plus the comment that misstated why the repair set is
the size it is.

Together these finish Tasks 3, 4 and 5 of the 2026-08-25 `tox.py`-vs-shapes audit.

### `fix(crate)` — a placeholder is not an answer (`6a2a479`, `acea59a`)

`_preserve_unowned_fields` rescues a field the build cannot emit by re-attaching
it as a `PropertyValue` under `schema:additionalProperty`. That is the predicate
`profiles/context.py` also maps `parameter` onto, and the one
`tox:CellCultureRequirements` counts. Its emptiness test was
`value not in (None, "", [], {})` — which lets `"not recorded"` through.

So a process whose only stated parameter said nothing **satisfied a MUST that
exists to prompt someone to go and fill it in**. #677 closed the route through
constructor-consumed fields; `work_package` on a process, and any dropped field
on a File, still carried placeholders into the graph.

`_says_nothing` imports the emitters' own `_PLACEHOLDER_VALUES` rather than
copying it, so the two cannot drift — the single-source rule `eval/scorers.py`
already follows.

Scope, stated plainly: this does **not** on its own make that MUST falsifiable.
Any unowned field holding a real value still satisfies it. It stops the crate
asserting a value nobody supplied, which is the narrower and checkable claim.

### `fix(crate)` — an unstated medium is unstated (`e8bc42b`, `ca28b29`)

The second route to the same unfalsifiable check, and the one with a real blast
radius. When `culture_medium` was *absent* rather than placeholder-valued, the
CellCulture branch of `_build_process` substituted the literal string
`"Standard medium"` — so every crate built from an input that never mentioned a
medium still shipped a CellCulture `additionalProperty`, and the shape could not
fail on that account. A fabricated default here publishes an ontology-typed
BAO_0000114 assertion about data nobody supplied (D5).

The default is gone. `LabProcessCellCulture` is the one subtype that does not
wrap its parameter list in `_pvs`, so `_pv(None) -> None` previously survived
into `"parameter": [null]`; that latent defect becomes reachable on the normal
path once the default goes, so `profiles/models/tox.py` drops the `None` in the
same change.

### `docs(repair)` — why three shapes are excluded from `_INPUT_REQUIRED_TYPES` (`034a204`)

The comment justifying that set claimed only DataAnalysis declares the
missing-input Violation, and that EndpointReadout "requires only a result".
Four tox shapes declare `schema:object` minCount 1 at Violation severity:
`tox:CellCultureRequirements`, `tox:ExposureRequirements`,
`tox:EndpointReadoutConsumesExposedMaterial`, `tox:DataAnalysisRequirements`.

The set is right, for a reason the comment did not give: the other three are
floored by the **build** — the CellCulture and Exposure branches of
`_build_process`, and `_floor_readout_objects` after the chaining pass (#701) —
so the violation this rule repairs cannot reach validation for them. Growing the
set would add a second mechanism for a condition the first now prevents, and
`_repair_missing_process_input` mutates state by linking a free-floating entity:
a real behaviour change with no defect to justify it.

No runtime behaviour change in that commit. Its test keeps the justification
honest, and both assertions were mutation-checked rather than assumed —
downgrading the Exposure shape to `sh:Warning` fails the first, and restoring
`_crate_mapping.py` to its pre-floor state fails the second.

### `fix(tests)` — fixtures that expect conformance state their own medium (`b8c02e4`, `8c2e66f`)

Removing the fabricated default turned seven CI shards red on one shape, from one
cause: those CellCulture fixtures had been satisfying the `additionalProperty`
MUST with the invented default rather than with anything the fixture said. That
is the check working. They state a real medium now, so what they assert about
conformance is again a claim about the build.

`tests/test_pipeline_real_input.py` is the deliberate exception and gets no
medium. Its input is the real RIVM deposit, whose SOP names the medium
("DMEM: F12 media") only past offset ~12,800, so it never reaches the extraction
leaf. Its docstring moves from TWO outstanding issue classes to THREE and says
why the third is an honest report rather than a regression — alongside the
existing DataAnalysis `additionalProperty` gap and the `schema:result` gap that
clears when #591 lands.

### Checks

- `tests/test_tox_shape_floors.py` — 11 passed
- the eight tests the medium change turned red — 8 passed locally under
  `VITRO_VALIDATE_SERIAL=1`
- `ruff check builder/ profiles/` — clean (`tests` is excluded by `pyproject.toml`)
- `ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3HYvnv1BibtNEwfbRiup
