### PR TITLE
feat(report): an assay lane is ranked by what its steps are, and its edges say which way the crate states them

### DIFF
--- a/builder/writers/assay_lane_view.js
+++ b/builder/writers/assay_lane_view.js
@@ -30,11 +30,13 @@
  * and the canvas beside it cannot drift apart (the rule `assay_lane_layout.js`
  * set and this keeps).
  *
- * Edges carry `reversed` and `subject`. The model draws `input` and `reagent`
- * against the predicate so the arrow points the way material moves — deliberate
- * — but a renderer that labels such an arrow with the bare term asserts the
- * inverse of the triple the crate holds. Saying which end the crate states it
- * from is this module's job, because it is the module that knows.
+ * Edges carry `reversed` and `subject`. The model draws some relations against
+ * the predicate so the arrow points the way material moves — deliberate — but a
+ * renderer that labels such an arrow with the bare term asserts the inverse of
+ * the triple the crate holds. WHICH relations those are is the payload's answer
+ * (`relations_reversed`, derived from the relation tables), passed in rather
+ * than restated here: a second copy in the browser is the drift this codebase
+ * already refuses for the vocabulary itself.
  *
  * Same contract as its predecessor: `null` means "not a lane", and the caller
  * draws the graph on the generic canvas.
@@ -75,10 +77,6 @@
     { key: 'processed', label: 'PROCESSED', kind: 'material', from: 'DataAnalysis' }
   ];
 
-  // Drawn against the predicate: the arrow runs dst -> src in the crate. Kept
-  // here rather than read from the payload because it is a property of how this
-  // module draws, and a renderer must not have to infer it.
-  var REVERSED = { input: 1, reagent: 1 };
 
   function has(edge, label) {
     return (edge.labels || []).indexOf(label) >= 0;
@@ -178,12 +176,15 @@
    * @param {Set<string>} visible ids to place.
    * @param {Array<{src: string, dst: string, labels: Array<string>}>} edges
    * @param {Map<string, {category: string, type: string}>} nodes what each id is.
+   * @param {Array<string>|Set<string>} reversed labels the model draws against
+   *   their own predicate; the payload's `relations_reversed`.
    * @returns {{ranks: Array, positions: Map, edges: Array, width: number,
    *   height: number}|null} the drawing, or null when this is not a chain.
    */
-  function build(visible, edges, nodes) {
+  function build(visible, edges, nodes, reversed) {
     if (!visible || !visible.size) return null;
     edges = edges || [];
+    var against = new Set(reversed || []);
 
     var placed = assign(visible, edges, nodes);
     if (!placed) return null;
@@ -260,7 +261,7 @@
     edges.forEach(function (e) {
       if (!positions.has(e.src) || !positions.has(e.dst)) return;
       (e.labels || []).forEach(function (label) {
-        var back = REVERSED[label] === 1;
+        var back = against.has(label);
         drawn.push({
           src: e.src, dst: e.dst, label: label, reversed: back,
           subject: back ? e.dst : e.src

--- a/builder/writers/assay_lane_view.js
+++ b/builder/writers/assay_lane_view.js
@@ -1,0 +1,293 @@
+/*
+ * One assay, drawn as the chain it is (#686).
+ *
+ * `assay_lane_layout.js` re-ranked the generic canvas: it handed the spine to
+ * the layered pass and then hung a band underneath. That inherited two defects
+ * the layered pass cannot avoid here. Sibling steps land in ONE rank sharing an
+ * x, so their satellites were dealt into the same cell and drew on top of each
+ * other — normal since #678 gave every cell line its own CellCulture. And a
+ * spine that is not one connected component was declined outright, so a
+ * characterisation assay with no Exposure fell back to the canvas the lane
+ * exists to improve on.
+ *
+ * This module ranks by what a node IS in the ISA-Tox chain instead:
+ *
+ *   cellline  culture  cultured  exposure  exposed  readout  raw  analysis  processed
+ *      o    ->   [ ]  ->   o   ->   [ ]  ->   o  ->  [ ]  ->  o  ->  [ ]  ->    o
+ *                 |                  |                |
+ *   band          +- protocol        +- protocol      +- protocol
+ *                                    +- compounds (reagent of that protocol)
+ *
+ * Two consequences the old module had to work for, and this one gets for free:
+ *
+ *   * A rank is a COLUMN. Two CellCultures stack; they cannot coincide, because
+ *     a rank deals its members down its own column and nothing else is in it.
+ *   * A missing step is an EMPTY column, not a broken graph. An assay that ran
+ *     no exposure still draws, and the gap is visible in the place the reader
+ *     is already looking — which is the whole point of a maturity report.
+ *
+ * Node size and the rank gap come from the shipped generic module, so a lane
+ * and the canvas beside it cannot drift apart (the rule `assay_lane_layout.js`
+ * set and this keeps).
+ *
+ * Edges carry `reversed` and `subject`. The model draws `input` and `reagent`
+ * against the predicate so the arrow points the way material moves — deliberate
+ * — but a renderer that labels such an arrow with the bare term asserts the
+ * inverse of the triple the crate holds. Saying which end the crate states it
+ * from is this module's job, because it is the module that knows.
+ *
+ * Same contract as its predecessor: `null` means "not a lane", and the caller
+ * draws the graph on the generic canvas.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('./entity_explorer_layout.js'));
+  } else {
+    root.AssayLaneView = factory(root.ExplorerLayout);
+  }
+}(typeof self !== 'undefined' ? self : this, function (ExplorerLayout) {
+  'use strict';
+
+  var NODE_W = ExplorerLayout.NODE_W, NODE_H = ExplorerLayout.NODE_H;
+  var GAP_X = 58, GAP_Y = 12, MARGIN = 16, TOP = 28;
+  // The drop from the spine's floor to the band. Wider than the gap inside the
+  // band, so "below the chain" and "below a protocol" read as two relations
+  // rather than one column of four things.
+  var BAND_DROP = 48;
+  var PROTO_H = 26, COMP_W = 100, COMP_H = 20;
+
+  /* The chain, in the order ISA-Tox states it.
+   *
+   * `of` is the process additionalType that owns a step rank; a material rank
+   * is named by the step it comes out of, which is why the material ranks carry
+   * `from` rather than a type of their own — a cultured sample is a plain
+   * `Sample` in the crate and only its position in the chain says more.
+   */
+  var RANKS = [
+    { key: 'cellline',  label: 'CELL LINE', kind: 'material', seed: 'CellLineSample' },
+    { key: 'culture',   label: 'CULTURE',   kind: 'process',  of: 'CellCulture' },
+    { key: 'cultured',  label: 'CULTURED',  kind: 'material', from: 'CellCulture' },
+    { key: 'exposure',  label: 'EXPOSURE',  kind: 'process',  of: 'Exposure' },
+    { key: 'exposed',   label: 'EXPOSED',   kind: 'material', from: 'Exposure' },
+    { key: 'readout',   label: 'READOUT',   kind: 'process',  of: 'EndpointReadout' },
+    { key: 'raw',       label: 'RAW',       kind: 'material', from: 'EndpointReadout' },
+    { key: 'analysis',  label: 'ANALYSIS',  kind: 'process',  of: 'DataAnalysis' },
+    { key: 'processed', label: 'PROCESSED', kind: 'material', from: 'DataAnalysis' }
+  ];
+
+  // Drawn against the predicate: the arrow runs dst -> src in the crate. Kept
+  // here rather than read from the payload because it is a property of how this
+  // module draws, and a renderer must not have to infer it.
+  var REVERSED = { input: 1, reagent: 1 };
+
+  function has(edge, label) {
+    return (edge.labels || []).indexOf(label) >= 0;
+  }
+
+  /* A node's additionalType, which the payload appends to its type after a
+   * middle dot ("Sample · CellLineSample"). Absent for a plain entity. */
+  function addType(node) {
+    var parts = String((node && node.type) || '').split('·');
+    return parts.length > 1 ? parts[parts.length - 1].trim() : parts[0].trim();
+  }
+
+  function indexOfRank(key) {
+    for (var i = 0; i < RANKS.length; i++) if (RANKS[i].key === key) return i;
+    return -1;
+  }
+
+  /* Which rank each visible id belongs to.
+   *
+   * Steps go by their additionalType. Materials go by the step they came OUT
+   * of, because that is what distinguishes a cultured sample from an exposed
+   * one when the crate types both as `Sample`. A material no step produced is a
+   * seed — the cell line an assay starts from — and anything left over has no
+   * place on the chain and is not drawn.
+   */
+  function assign(visible, edges, nodes) {
+    var rank = new Map();
+    var stepType = new Map();
+
+    visible.forEach(function (id) {
+      var node = nodes && nodes.get(id);
+      if (!node || node.category !== 'process') return;
+      var at = addType(node);
+      var i = indexOfRank(RANKS.filter(function (r) { return r.of === at; })
+        .map(function (r) { return r.key; })[0]);
+      if (i >= 0) { rank.set(id, i); stepType.set(id, at); }
+    });
+    // Without a single recognised step there is no chain to draw.
+    if (!stepType.size) return null;
+
+    edges.forEach(function (e) {
+      if (!visible.has(e.src) || !visible.has(e.dst)) return;
+      if (!has(e, 'result') || !stepType.has(e.src)) return;
+      var i = indexOfRank(RANKS.filter(function (r) { return r.from === stepType.get(e.src); })
+        .map(function (r) { return r.key; })[0]);
+      if (i >= 0) rank.set(e.dst, i);
+    });
+
+    // A material a recognised step consumes and nothing produced starts the
+    // chain. Its rank is the one before the step that took it in, so a deposit
+    // that hands a File straight to an analysis still reads left to right.
+    edges.forEach(function (e) {
+      if (!visible.has(e.src) || !visible.has(e.dst)) return;
+      if (!has(e, 'input') || rank.has(e.src) || !rank.has(e.dst)) return;
+      rank.set(e.src, Math.max(0, rank.get(e.dst) - 1));
+    });
+
+    return { rank: rank, stepType: stepType };
+  }
+
+  /* The band, and what each member hangs from — unchanged in meaning from
+   * `assay_lane_layout.js`: a protocol hangs from the step that executes it, a
+   * compound from the protocol that lists it as a reagent, and `reagent` is
+   * drawn reversed so the arrow points at the work that consumes the material
+   * (#650). Ties break by id so two builds of one deposit draw alike. */
+  function bandOf(visible, edges, rank) {
+    var protocols = new Map();
+    edges.forEach(function (e) {
+      if (!visible.has(e.src) || !visible.has(e.dst)) return;
+      if (!has(e, 'executes') || !rank.has(e.src)) return;
+      var current = protocols.get(e.dst);
+      if (current === undefined || e.src < current) protocols.set(e.dst, e.src);
+    });
+    var compounds = new Map();
+    edges.forEach(function (e) {
+      if (!visible.has(e.src) || !visible.has(e.dst)) return;
+      if (!has(e, 'reagent') || !protocols.has(e.dst)) return;
+      var current = compounds.get(e.src);
+      if (current === undefined || e.dst < current) compounds.set(e.src, e.dst);
+    });
+    return { protocols: protocols, compounds: compounds };
+  }
+
+  function group(pairs) {
+    var out = new Map();
+    Array.from(pairs.keys()).sort().forEach(function (id) {
+      var key = pairs.get(id);
+      if (!out.has(key)) out.set(key, []);
+      out.get(key).push(id);
+    });
+    return out;
+  }
+
+  /**
+   * Draw one assay as a lane, or decline the graph.
+   *
+   * @param {Set<string>} visible ids to place.
+   * @param {Array<{src: string, dst: string, labels: Array<string>}>} edges
+   * @param {Map<string, {category: string, type: string}>} nodes what each id is.
+   * @returns {{ranks: Array, positions: Map, edges: Array, width: number,
+   *   height: number}|null} the drawing, or null when this is not a chain.
+   */
+  function build(visible, edges, nodes) {
+    if (!visible || !visible.size) return null;
+    edges = edges || [];
+
+    var placed = assign(visible, edges, nodes);
+    if (!placed) return null;
+    var band = bandOf(visible, edges, placed.rank);
+
+    var members = RANKS.map(function () { return []; });
+    Array.from(placed.rank.keys()).sort().forEach(function (id) {
+      if (band.protocols.has(id) || band.compounds.has(id)) return;
+      members[placed.rank.get(id)].push(id);
+    });
+
+    // Every rank is a column at a fixed x; the tallest decides the spine's
+    // height and the shorter ones centre against it, so the chain reads as one
+    // horizontal line rather than as a staircase.
+    var tallest = 0;
+    members.forEach(function (ids) {
+      tallest = Math.max(tallest, ids.length * NODE_H + Math.max(0, ids.length - 1) * GAP_Y);
+    });
+    var middle = TOP + tallest / 2;
+
+    var positions = new Map();
+    var columnX = [];
+    members.forEach(function (ids, i) {
+      var x = MARGIN + i * (NODE_W + GAP_X);
+      columnX.push(x);
+      var height = ids.length * NODE_H + Math.max(0, ids.length - 1) * GAP_Y;
+      var y = middle - height / 2;
+      ids.forEach(function (id) {
+        positions.set(id, { x: x, y: y, w: NODE_W, h: NODE_H });
+        y += NODE_H + GAP_Y;
+      });
+    });
+
+    // Tier one: a protocol under the step that executes it, in that step's own
+    // column. Several protocols under one step stack down the column; several
+    // steps in one rank each keep their own row, because the rows are dealt per
+    // column rather than per anchor.
+    var bandTop = TOP + tallest + BAND_DROP;
+    var floor = bandTop;
+    var rowOf = new Map();
+    group(band.protocols).forEach(function (ids, step) {
+      var at = positions.get(step);
+      if (!at) return;
+      var y = rowOf.has(at.x) ? rowOf.get(at.x) : bandTop;
+      ids.forEach(function (id) {
+        positions.set(id, { x: at.x, y: y, w: NODE_W, h: PROTO_H });
+        y += PROTO_H + GAP_Y;
+      });
+      rowOf.set(at.x, y);
+      floor = Math.max(floor, y);
+    });
+
+    // Tier two: the substances a protocol lists, under that protocol, dealt
+    // into the width of one column so the lane stays as wide as its chain.
+    var cols = Math.max(1, Math.floor((NODE_W + GAP_X) / (COMP_W + GAP_Y)));
+    group(band.compounds).forEach(function (ids, protocol) {
+      var at = positions.get(protocol);
+      if (!at) return;
+      var base = Math.max(floor, at.y + at.h) + GAP_Y;
+      ids.forEach(function (id, i) {
+        positions.set(id, {
+          x: at.x + (i % cols) * (COMP_W + GAP_Y),
+          y: base + Math.floor(i / cols) * (COMP_H + GAP_Y),
+          w: COMP_W, h: COMP_H
+        });
+      });
+      floor = Math.max(floor, base + Math.ceil(ids.length / cols) * (COMP_H + GAP_Y));
+    });
+
+    // Only edges between two drawn nodes, each said in the direction the crate
+    // states it. `subject` is the end the triple is asserted FROM, so a label
+    // can be oriented without the renderer re-deriving which relations reverse.
+    var drawn = [];
+    edges.forEach(function (e) {
+      if (!positions.has(e.src) || !positions.has(e.dst)) return;
+      (e.labels || []).forEach(function (label) {
+        var back = REVERSED[label] === 1;
+        drawn.push({
+          src: e.src, dst: e.dst, label: label, reversed: back,
+          subject: back ? e.dst : e.src
+        });
+      });
+    });
+
+    var width = 0, height = 0;
+    positions.forEach(function (p) {
+      width = Math.max(width, p.x + p.w);
+      height = Math.max(height, p.y + p.h);
+    });
+
+    return {
+      ranks: RANKS.map(function (r, i) {
+        return { key: r.key, label: r.label, x: columnX[i], members: members[i] };
+      }),
+      positions: positions,
+      edges: drawn,
+      // Where the chain ends and the band begins. The chain is what the generic
+      // canvas draws too, so it is the half the two layouts can be compared on;
+      // the band is information the canvas scatters into ranks instead.
+      bandTop: bandTop,
+      width: width + MARGIN,
+      height: height + MARGIN
+    };
+  }
+
+  return { build: build, NODE_W: NODE_W, NODE_H: NODE_H, RANKS: RANKS };
+}));

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -62,6 +62,16 @@
    * up rather than keeping a second copy of the vocabulary here.
    */
   function term(label) { return (D.relations && D.relations[label]) || label; }
+  /* The same, said in the direction the ARROW runs.
+   *
+   * `input` and `reagent` are drawn against their own predicate so the arrow
+   * points the way material moves (#650). Printing the bare term on such an
+   * arrow claims the inverse of what the crate holds — a third of a lane's
+   * edges did. `←` marks the ones whose predicate runs back the other way. */
+  function edgeTerm(label) {
+    var back = (D.relations_reversed || []).indexOf(label) >= 0;
+    return (back ? '\u2190 ' : '') + term(label);
+  }
   /* What an entity KEY expands to. `input` and `object` are one predicate;
    * `studies`, `assays` and `hasPart` are another. A key the context does not
    * name expands under the crate's own @vocab, which is the crate's rule rather
@@ -93,7 +103,7 @@
   // hairball on paper.
   var DERIVATION = new Set(['input', 'object', 'result', 'output']);
   var layout = window.ExplorerLayout.layout;
-  var laneLayout = window.AssayLaneLayout ? window.AssayLaneLayout.layout : null;
+  var laneView = window.AssayLaneView ? window.AssayLaneView.build : null;
   var NODE_W = window.ExplorerLayout.NODE_W, NODE_H = window.ExplorerLayout.NODE_H;
   // How far the opening view is allowed to pull back. A crate's whole graph is
   // thousands of pixels tall — the researcher view of a real deposit lays out
@@ -251,7 +261,29 @@
       <${Handle} type="source" position=${Position.Right} />
     </div>`;
   }
-  var nodeTypes = { entity: EntityNode };
+  /* The column headings a lane reads under, and the rule that separates the
+   * chain from the band.
+   *
+   * Not entities: they carry no id and cannot be selected. They exist because a
+   * fixed-rank lane means a column ALWAYS stands for the same step, so naming
+   * the columns once turns nine positions into nine words — and an empty column
+   * then says, in the place the reader is already looking, that the deposit
+   * recorded no such step. That is the finding a maturity report is for, and
+   * the old layout hid it by declining the whole graph.
+   */
+  function RankLabel(props) {
+    var cls = 'ex-rank' + (props.data.empty ? ' ex-rank-empty' : '');
+    return html`<div class=${cls}>
+      <div class="ex-rank-name">${props.data.label}</div>
+      ${props.data.empty
+        ? html`<div class="ex-rank-none">not recorded</div>`
+        : null}
+    </div>`;
+  }
+  function BandRule(props) {
+    return html`<div class="ex-band-rule"><span>${props.data.label}</span></div>`;
+  }
+  var nodeTypes = { entity: EntityNode, rank: RankLabel, band: BandRule };
 
   /* ---- JSON-LD, with every reference walkable ------------------------------ */
   function Ref(props) {
@@ -487,14 +519,17 @@
      * assay carrying AOP entities). It returns null and the fallback is the same
      * canvas, same styling, no visible seam.
      */
-    var positions = useMemo(function () {
+    var drawing = useMemo(function () {
       var lanes = Array.from(views).filter(function (k) { return LANE.has(k); });
-      if (lanes.length === 1 && laneLayout) {
-        var laid = laneLayout(graph.visible, graph.edges, NODE);
+      if (lanes.length === 1 && laneView) {
+        var laid = laneView(graph.visible, graph.edges, NODE, D.relations_reversed);
         if (laid) return laid;
       }
-      return layout(graph.visible, graph.edges);
+      return null;
     }, [graph, views]);
+    var positions = useMemo(function () {
+      return drawing ? drawing.positions : layout(graph.visible, graph.edges);
+    }, [drawing, graph]);
 
     var needle = query.trim().toLowerCase();
     var hits = useMemo(function () {
@@ -522,7 +557,12 @@
       return Array.from(graph.visible).map(function (id) {
         return {
           id: id, type: 'entity', position: positions.get(id),
-          width: NODE_W, height: NODE_H, selected: id === selected,
+          // A lane sizes its own boxes: a protocol is shorter than a step and a
+          // compound is smaller again, so the band reads as annotation rather
+          // than as more chain. The generic canvas has one size for everything.
+          width: (positions.get(id) || {}).w || NODE_W,
+          height: (positions.get(id) || {}).h || NODE_H,
+          selected: id === selected,
           data: {
             n: NODE.get(id),
             hit: hits ? hits.has(id) : false,
@@ -531,6 +571,34 @@
         };
       });
     }, [graph, positions, selected, hits]);
+
+    /* Headings and the band rule, added only when a lane is what is drawn.
+     *
+     * Ids are namespaced so they cannot collide with a crate `@id`, and these
+     * nodes never enter `graph.visible` — search, selection and the coverage
+     * counts are about entities, and a heading is not one.
+     */
+    var furniture = useMemo(function () {
+      if (!drawing) return [];
+      var out = drawing.ranks.map(function (r) {
+        return {
+          id: '\u0000rank:' + r.key, type: 'rank',
+          position: { x: r.x, y: 0 },
+          width: NODE_W, height: 22, draggable: false, selectable: false,
+          data: { label: r.label, empty: !r.members.length }
+        };
+      });
+      if (drawing.bandTop) {
+        out.push({
+          id: '\u0000band', type: 'band',
+          position: { x: drawing.ranks[0].x, y: drawing.bandTop - 22 },
+          width: drawing.width - drawing.ranks[0].x, height: 20,
+          draggable: false, selectable: false,
+          data: { label: 'LABPROTOCOL' }
+        });
+      }
+      return out;
+    }, [drawing]);
 
     var edges = useMemo(function () {
       return graph.edges.map(function (e) {
@@ -543,7 +611,11 @@
           // knocks the line out from behind the text (see `.ex-canvas
           // .react-flow__edge-text` in the stylesheet), so it reads as part of
           // the edge rather than as a card sitting on top of one.
-          label: lit ? e.labels.map(term).join(', ') : undefined,
+          // A relation the model draws reversed keeps the crate's predicate but
+          // runs the other way along this arrow, so the term alone would assert
+          // the inverse triple. The glyph is the one the side panel already
+          // uses for an incoming property, so the two read alike.
+          label: lit ? e.labels.map(edgeTerm).join(', ') : undefined,
           labelShowBg: false,
           labelStyle: { fontSize: 10, fill: colour },
           style: { stroke: colour, strokeWidth: lit ? 2 : 1, opacity: hits && !lit ? 0.25 : 1 },
@@ -666,7 +738,7 @@
       </div>
       <div class="ex-main">
         <div class="ex-canvas">
-          <${ReactFlowCanvas} nodes=${nodes} edges=${edges} nodeTypes=${nodeTypes}
+          <${ReactFlowCanvas} nodes=${nodes.concat(furniture)} edges=${edges} nodeTypes=${nodeTypes}
             onNodeClick=${function (_e, n) {
               // Click again to clear, taking the edge labels with it. Selection
               // used to change only by choosing something else, so a reader who

--- a/builder/writers/entity_explorer.py
+++ b/builder/writers/entity_explorer.py
@@ -55,6 +55,7 @@ from builder.writers.provenance_dag import (
     build_people_inventory,
     property_terms,
     relation_terms,
+    reversed_relations,
     vocab_prefix,
 )
 
@@ -830,6 +831,11 @@ def build_explorer_payload(
         # serialized with. Generated here for the same reason the palette is: the
         # browser must not hold a second copy of it (#688).
         "relations": relation_terms(),
+        # And which of them the model draws against their own predicate, so a
+        # renderer can say `schema:object` on an arrow that runs the other way
+        # without asserting the inverse triple. The flag lives in the relation
+        # tables; the browser reads it rather than keeping a second copy.
+        "relations_reversed": sorted(reversed_relations()),
         # And what each entity KEY expands to. `input` and `object` are one
         # predicate; a reader had to know the context to see that (#688).
         "properties": property_terms(),
@@ -853,7 +859,7 @@ _ASSET_DIR = Path(__file__).resolve().parent
 _VENDOR_DIR = _ASSET_DIR / "vendor"
 _APP_PATH = _ASSET_DIR / "entity_explorer.js"
 _LAYOUT_PATH = _ASSET_DIR / "entity_explorer_layout.js"
-_LANE_PATH = _ASSET_DIR / "assay_lane_layout.js"
+_LANE_PATH = _ASSET_DIR / "assay_lane_view.js"
 _CODEC_PATH = _ASSET_DIR / "payload_codec.js"
 _MANIFEST_PATH = _VENDOR_DIR / "manifest.json"
 
@@ -941,7 +947,7 @@ def _layout_js() -> str:
 
 @lru_cache(maxsize=1)
 def _lane_js() -> str:
-    """The layout an assay lane takes its node positions from.
+    """The drawing an assay lane takes its ranks, boxes and edges from.
 
     Loaded after :func:`_layout_js` and before the app: it reads that module's
     node size at factory time, so the order is a requirement rather than a

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -496,6 +496,22 @@ __CATEGORY_STYLES__
 .mat .ex-node-name{font-weight:640; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
 .mat .ex-node-tag{font-size:.58rem; letter-spacing:.04em; text-transform:uppercase;
   color:var(--muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
+/* A lane's column headings and the rule under its chain (#686).
+   Furniture, not entities: no border, no hit area, and muted enough that the
+   chain stays the figure. An empty column keeps its heading and says so — the
+   deposit recorded no such step, and that gap is the finding. */
+.mat .ex-rank{font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.55rem; letter-spacing:.09em;
+  color:var(--muted); text-transform:uppercase; pointer-events:none;
+  white-space:nowrap;}
+.mat .ex-rank-name{overflow:hidden; text-overflow:ellipsis;}
+.mat .ex-rank-empty{opacity:.72;}
+.mat .ex-rank-none{font-size:.52rem; letter-spacing:.02em; text-transform:none;
+  color:var(--warn); font-style:italic;}
+.mat .ex-band-rule{display:flex; align-items:center; gap:.5rem; pointer-events:none;
+  font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.55rem; letter-spacing:.09em;
+  color:var(--muted); text-transform:uppercase; white-space:nowrap;}
+.mat .ex-band-rule::after{content:""; flex:1; border-top:1px dashed var(--border);}
+
 /* An edge label integrates into its edge instead of sitting in a box on it: the
    text takes the edge's own colour (set inline, from the payload's palette) and
    `paint-order` lays a surface-coloured halo down first, knocking the line out

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -912,6 +912,27 @@ def relation_terms() -> dict[str, str]:
     return terms
 
 
+def reversed_relations() -> set[str]:
+    """The labels whose edge is drawn against the predicate that names it.
+
+    ``_extract_edges`` flips ``src`` and ``dst`` for a ``reverse=True`` relation
+    so the arrow points the way material moves — the cell line INTO the step
+    that consumed it, the compound INTO the protocol that lists it — which is
+    what lets a chain be read left to right. The label it keeps is still the
+    crate's predicate, and that predicate runs the other way.
+
+    A renderer therefore cannot print the bare term on such an arrow without
+    asserting the inverse triple, and it needs this set to know which. Derived
+    from the relation tables rather than restated, for the reason
+    :func:`relation_terms` is: the tables are where the flag already lives.
+    """
+    return {
+        label
+        for _keys, label, is_reversed in _PRIMARY_RELATIONS + _SECONDARY_RELATIONS
+        if is_reversed
+    }
+
+
 def _entity_layer(node: dict[str, Any]) -> int:
     """Classify a node into a paper layer (1 packaging / 2 ISA / 3 ISA-Tox).
 

--- a/tests/fixtures/assay_lane_view_probe.js
+++ b/tests/fixtures/assay_lane_view_probe.js
@@ -9,7 +9,8 @@
  *
  * argv[2]: path to builder/writers/assay_lane_view.js
  * stdin:   {"nodes": [{"id":…, "category":…, "type":…}, …],
- *           "edges": [{"src":…, "dst":…, "labels":[…]}, …]}
+ *           "edges": [{"src":…, "dst":…, "labels":[…]}, …],
+ *           "reversed": [label, …]}   the payload's relations_reversed
  * stdout:  {"ranks": [{key, label, members}],
  *           "positions": {id: {x, y, w, h}},
  *           "edges": [{src, dst, label, reversed, subject}],
@@ -22,7 +23,7 @@ var G = require(require('path').join(require('path').dirname(process.argv[2]),
 var input = JSON.parse(require('fs').readFileSync(0, 'utf8'));
 var nodes = new Map(input.nodes.map(function (n) { return [n.id, n]; }));
 
-var drawing = V.build(new Set(nodes.keys()), input.edges, nodes);
+var drawing = V.build(new Set(nodes.keys()), input.edges, nodes, input.reversed);
 
 /* Segments that cross, counted the same way for both layouts so the comparison
  * is about the drawing and not about how each one is measured. */

--- a/tests/fixtures/assay_lane_view_probe.js
+++ b/tests/fixtures/assay_lane_view_probe.js
@@ -1,0 +1,99 @@
+/*
+ * Runs the shipped assay-lane VIEW over a graph handed in on stdin and prints
+ * the whole drawing — ranks, boxes, edges — plus the generic canvas's numbers
+ * for the same graph, so a test can compare the two without a second opinion
+ * about geometry.
+ *
+ * As with `assay_lane_probe.js`, the point is that the tests measure the real
+ * module the report carries rather than a Python restatement of it.
+ *
+ * argv[2]: path to builder/writers/assay_lane_view.js
+ * stdin:   {"nodes": [{"id":…, "category":…, "type":…}, …],
+ *           "edges": [{"src":…, "dst":…, "labels":[…]}, …]}
+ * stdout:  {"ranks": [{key, label, members}],
+ *           "positions": {id: {x, y, w, h}},
+ *           "edges": [{src, dst, label, reversed, subject}],
+ *           "bandTop", "width", "height", "crossings",
+ *           "generic": {"width", "height", "crossings"}}
+ */
+var V = require(process.argv[2]);
+var G = require(require('path').join(require('path').dirname(process.argv[2]),
+  'entity_explorer_layout.js'));
+var input = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+var nodes = new Map(input.nodes.map(function (n) { return [n.id, n]; }));
+
+var drawing = V.build(new Set(nodes.keys()), input.edges, nodes);
+
+/* Segments that cross, counted the same way for both layouts so the comparison
+ * is about the drawing and not about how each one is measured. */
+function crossings(boxes, edges) {
+  var seg = edges.map(function (e) {
+    var a = boxes[e.src], b = boxes[e.dst];
+    if (!a || !b) return null;
+    return [a.x + a.w / 2, a.y + a.h / 2, b.x + b.w / 2, b.y + b.h / 2];
+  }).filter(Boolean);
+  function turn(ax, ay, bx, by, cx, cy) {
+    var v = (by - ay) * (cx - bx) - (bx - ax) * (cy - by);
+    return v > 0 ? 1 : (v < 0 ? -1 : 0);
+  }
+  var n = 0;
+  for (var i = 0; i < seg.length; i++) {
+    for (var j = i + 1; j < seg.length; j++) {
+      var p = seg[i], q = seg[j];
+      if (p[0] === q[0] && p[1] === q[1]) continue;
+      if (p[2] === q[2] && p[3] === q[3]) continue;
+      var d1 = turn(p[0], p[1], p[2], p[3], q[0], q[1]);
+      var d2 = turn(p[0], p[1], p[2], p[3], q[2], q[3]);
+      var d3 = turn(q[0], q[1], q[2], q[3], p[0], p[1]);
+      var d4 = turn(q[0], q[1], q[2], q[3], p[2], p[3]);
+      if (d1 !== d2 && d3 !== d4) n++;
+    }
+  }
+  return n;
+}
+
+var positions = {};
+if (drawing) {
+  drawing.positions.forEach(function (p, id) { positions[id] = p; });
+}
+
+/* The generic canvas over the same graph, for the size and crossing comparison.
+ * Material edges only, which is what it ranks on. */
+var gpos = G.layout(new Set(nodes.keys()), input.edges.map(function (e) {
+  return { src: e.src, dst: e.dst };
+}));
+var gboxes = {}, gw = 0, gh = 0;
+gpos.forEach(function (p, id) {
+  gboxes[id] = { x: p.x, y: p.y, w: G.NODE_W, h: G.NODE_H };
+  gw = Math.max(gw, p.x + G.NODE_W);
+  gh = Math.max(gh, p.y + G.NODE_H);
+});
+
+process.stdout.write(JSON.stringify({
+  ranks: drawing ? drawing.ranks : null,
+  positions: positions,
+  edges: drawing ? drawing.edges : null,
+  bandTop: drawing ? drawing.bandTop : null,
+  width: drawing ? drawing.width : null,
+  height: drawing ? drawing.height : null,
+  crossings: drawing ? crossings(positions, drawing.edges) : null,
+  // Split, because the two halves are drawn differently: the chain is solid
+  // arrows a reader follows, the band is dashed connectors that qualify a step.
+  chainCrossings: drawing ? crossings(positions, drawing.edges.filter(function (e) {
+    return e.label !== 'executes' && e.label !== 'reagent';
+  })) : null,
+
+  generic: {
+    width: gw,
+    height: gh,
+    crossings: crossings(gboxes, input.edges),
+    // The same edge set the lane's chain figure counts, so the two numbers
+    // compare like for like: the canvas has no band, it ranks protocols and
+    // compounds into the chain, which is the difference being measured.
+    chainCrossings: crossings(gboxes, input.edges.filter(function (e) {
+      return (e.labels || []).some(function (l) {
+        return l !== 'executes' && l !== 'reagent';
+      });
+    }))
+  }
+}));

--- a/tests/fixtures/crate_graphs.py
+++ b/tests/fixtures/crate_graphs.py
@@ -585,3 +585,156 @@ def assay_lane_graph() -> dict[str, Any]:
             },
         ]
     }
+
+
+def assay_lane_real_shapes_graph() -> dict[str, Any]:
+    """The two shapes a real deposit has and ``assay_lane_graph`` does not.
+
+    ``assay_lane_graph`` predates #678 and gives every assay exactly one cell
+    line, so two things the RIVM deposit does on every build are untested:
+
+    * **Assay C — several lines, one exposure.** Since #678 an assay cultures
+      each line separately, so three CellCulture steps share a rank and each
+      executes its own protocol. A layout that gives a step's satellites the
+      step's own x draws all three protocols at one point, and two of the three
+      are invisible. One line cannot show that; three can.
+    * **Assay D — no exposure at all.** A characterisation run measures the
+      cultured material directly. Nothing fans the cultured samples together,
+      so a spine that requires one component sees two stories and declines the
+      whole lane. The gap is real and belongs on the diagram; declining hides
+      both the work and the gap.
+
+    Deliberately NOT a copy of the deposit: the shapes are what matters, and a
+    fixture that reproduced one crate's coincidences would only prove that crate
+    (see the repo's rule against overfitting the example crate).
+    """
+    lines_c = [("h4", "H4"), ("mo313", "MO3.13"), ("skn", "SK-N-AS")]
+    lines_d = [("hepg2", "HepG2"), ("caco2", "Caco-2")]
+    graph: list[dict[str, Any]] = [
+        {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "additionalType": "Investigation",
+            "name": "An investigation",
+            "hasPart": [{"@id": "#study"}],
+        },
+        {
+            "@id": "#study",
+            "@type": "Dataset",
+            "additionalType": "Study",
+            "name": "A study",
+            "hasPart": [{"@id": "#assay-c"}, {"@id": "#assay-d"}],
+        },
+        # --- assay C: three lines into one exposure -------------------------
+        {
+            "@id": "#assay-c",
+            "@type": "Dataset",
+            "additionalType": "Assay",
+            "name": "Transport assay",
+            "about": [{"@id": f"#culture-c-{k}"} for k, _ in lines_c]
+            + [
+                {"@id": "#exposure-c"},
+                {"@id": "#readout-c"},
+                {"@id": "#analysis-c"},
+            ],
+        },
+        {
+            "@id": "#exposure-c",
+            "@type": "LabProcess",
+            "additionalType": "Exposure",
+            "name": "Transport exposure",
+            "object": [{"@id": f"#cultured-c-{k}"} for k, _ in lines_c],
+            "result": [{"@id": f"#exposed-c-{k}"} for k, _ in lines_c],
+            "executesLabProtocol": {"@id": "#conditions-c"},
+        },
+        {
+            "@id": "#conditions-c",
+            "@type": "LabProtocol",
+            "name": "Condition table",
+            "reagent": [{"@id": "#compound-c1"}, {"@id": "#compound-c2"}],
+        },
+        {"@id": "#compound-c1", "@type": "MolecularEntity", "name": "Amiodarone"},
+        {"@id": "#compound-c2", "@type": "MolecularEntity", "name": "TBBPA"},
+        {
+            "@id": "#readout-c",
+            "@type": "LabProcess",
+            "additionalType": "EndpointReadout",
+            "name": "Uptake readout",
+            "object": [{"@id": f"#exposed-c-{k}"} for k, _ in lines_c],
+            "result": [{"@id": "raw/c1.csv"}],
+            "executesLabProtocol": {"@id": "#readout-protocol-c"},
+        },
+        {"@id": "#readout-protocol-c", "@type": "LabProtocol", "name": "Uptake protocol"},
+        {"@id": "raw/c1.csv", "@type": "File", "name": "c1.csv", "encodingFormat": "text/csv"},
+        {
+            "@id": "#analysis-c",
+            "@type": "LabProcess",
+            "additionalType": "DataAnalysis",
+            "name": "Uptake analysis",
+            "object": [{"@id": "raw/c1.csv"}],
+            "result": [{"@id": "processed/c.csv"}],
+            "executesLabProtocol": {"@id": "#analysis-protocol-c"},
+        },
+        {"@id": "#analysis-protocol-c", "@type": "LabProtocol", "name": "Uptake analysis script"},
+        {"@id": "processed/c.csv", "@type": "File", "name": "c.csv", "encodingFormat": "text/csv"},
+        # --- assay D: no exposure -------------------------------------------
+        {
+            "@id": "#assay-d",
+            "@type": "Dataset",
+            "additionalType": "Assay",
+            "name": "Characterisation assay",
+            "about": [{"@id": f"#culture-d-{k}"} for k, _ in lines_d]
+            + [{"@id": "#readout-d"}],
+        },
+        {
+            "@id": "#readout-d",
+            "@type": "LabProcess",
+            "additionalType": "EndpointReadout",
+            "name": "Characterisation readout",
+            "object": [{"@id": f"#cultured-d-{k}"} for k, _ in lines_d],
+            "result": [{"@id": "raw/d1.csv"}],
+            "executesLabProtocol": {"@id": "#readout-protocol-d"},
+        },
+        {"@id": "#readout-protocol-d", "@type": "LabProtocol", "name": "Characterisation protocol"},
+        {"@id": "raw/d1.csv", "@type": "File", "name": "d1.csv", "encodingFormat": "text/csv"},
+    ]
+    for assay, lines in (("c", lines_c), ("d", lines_d)):
+        for key, name in lines:
+            graph += [
+                {
+                    "@id": f"#cellline-{assay}-{key}",
+                    "@type": "Sample",
+                    "additionalType": "CellLineSample",
+                    "name": name,
+                },
+                {
+                    "@id": f"#culture-{assay}-{key}",
+                    "@type": "LabProcess",
+                    "additionalType": "CellCulture",
+                    "name": f"Culture {name}",
+                    "object": {"@id": f"#cellline-{assay}-{key}"},
+                    "result": {"@id": f"#cultured-{assay}-{key}"},
+                    "executesLabProtocol": {"@id": f"#culture-protocol-{assay}-{key}"},
+                },
+                {
+                    "@id": f"#culture-protocol-{assay}-{key}",
+                    "@type": "LabProtocol",
+                    "name": f"Cell culture protocol {name}",
+                },
+                {
+                    "@id": f"#cultured-{assay}-{key}",
+                    "@type": "Sample",
+                    "name": f"Cultured ({name})",
+                },
+            ]
+        if assay == "c":
+            for key, name in lines:
+                graph.append(
+                    {
+                        "@id": f"#exposed-{assay}-{key}",
+                        "@type": "Sample",
+                        "name": f"Exposed ({name})",
+                    }
+                )
+    return {"@graph": graph}

--- a/tests/test_assay_lane.py
+++ b/tests/test_assay_lane.py
@@ -271,7 +271,7 @@ class TestThePageCarriesTheLane:
         from builder.writers.entity_explorer import render_explorer_section
 
         section = render_explorer_section(assay_lane_graph())
-        assert "AssayLaneLayout" in section
+        assert "AssayLaneView" in section
 
     def test_the_lane_module_loads_after_the_layout_it_reads(self):
         """It takes NODE_W/NODE_H from `ExplorerLayout` at factory time, so a
@@ -280,13 +280,13 @@ class TestThePageCarriesTheLane:
 
         section = render_explorer_section(assay_lane_graph())
         assert section.index("root.ExplorerLayout = factory") < section.index(
-            "root.AssayLaneLayout = factory"
+            "root.AssayLaneView = factory"
         )
 
     def test_the_lane_module_loads_before_the_app_that_calls_it(self):
         from builder.writers.entity_explorer import render_explorer_section
 
         section = render_explorer_section(assay_lane_graph())
-        assert section.index("root.AssayLaneLayout = factory") < section.index(
-            "window.AssayLaneLayout"
+        assert section.index("root.AssayLaneView = factory") < section.index(
+            "window.AssayLaneView"
         )

--- a/tests/test_assay_lane_view.py
+++ b/tests/test_assay_lane_view.py
@@ -1,0 +1,263 @@
+"""What the assay lane draws, measured on the shapes a real deposit has (#686).
+
+The lane view shipped with 43 tests and four defects, because every one of them
+drove ``assay_lane_graph`` — a fixture that predates #678 and gives each assay a
+single cell line. A real deposit cultures each line separately, so a rank holds
+several steps, and it runs characterisation assays with no exposure at all.
+Neither shape was ever laid out in CI.
+
+These tests drive ``assay_lane_real_shapes_graph`` instead, and they run the
+SHIPPED JavaScript over it rather than a Python restatement of the geometry —
+the same rule ``test_assay_lane_layout`` follows, for the same reason: the
+report carries the module, so the module is what has to be measured.
+
+The lane is its own view rather than a re-ranking of the generic canvas
+(``assay_lane_view.js``). A step's place comes from what it IS in the ISA-Tox
+chain, not from where a layered pass happens to put it, which is why two steps
+of one kind cannot collide and why an assay missing a kind still draws.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from builder.writers.entity_explorer import build_explorer_payload
+from tests.fixtures.crate_graphs import assay_lane_real_shapes_graph
+
+pytestmark = pytest.mark.timeout(180)
+
+_REPO = Path(__file__).resolve().parents[1]
+_MODULE = _REPO / "builder" / "writers" / "assay_lane_view.js"
+_PROBE = _REPO / "tests" / "fixtures" / "assay_lane_view_probe.js"
+
+
+def _node_exe() -> str:
+    exe = shutil.which("node")
+    if exe is None:  # pragma: no cover — depends on the machine, not the code
+        pytest.skip("node is not installed; the lane module cannot be run")
+    return exe
+
+
+def _lanes() -> dict[str, dict[str, Any]]:
+    """Every lane the fixture mints, drawn by the shipped module.
+
+    One payload build and one node process per lane, keyed by view — the tests
+    below each ask a different question of the same drawing.
+    """
+    payload = build_explorer_payload(assay_lane_real_shapes_graph())
+    by_id = {n["id"]: n for n in payload["nodes"]}
+    out: dict[str, dict[str, Any]] = {}
+    for view in payload["views"]:
+        if not view.get("lane"):
+            continue
+        members = set(view["members"])
+        merged: dict[tuple[str, str], dict[str, Any]] = {}
+        for edge in payload["edges"]:
+            if edge["src"] in members and edge["dst"] in members:
+                key = (edge["src"], edge["dst"])
+                merged.setdefault(key, {"src": key[0], "dst": key[1], "labels": []})
+                merged[key]["labels"].append(edge["label"])
+        nodes = [
+            {"id": i, "category": by_id[i]["category"], "type": by_id[i].get("type")}
+            for i in sorted(members)
+        ]
+        result = subprocess.run(
+            [_node_exe(), str(_PROBE), str(_MODULE)],
+            input=json.dumps({"nodes": nodes, "edges": list(merged.values())}),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        out[view["key"]] = json.loads(result.stdout)
+    return out
+
+
+@pytest.fixture(scope="module")
+def lanes() -> dict[str, dict[str, Any]]:
+    return _lanes()
+
+
+def _boxes(drawing: dict[str, Any]) -> dict[str, tuple[float, float, float, float]]:
+    return {
+        i: (p["x"], p["y"], p["x"] + p["w"], p["y"] + p["h"])
+        for i, p in drawing["positions"].items()
+    }
+
+
+class TestNothingIsDrawnUnderneathSomethingElse:
+    """The defect: three protocols at one point, and two of them invisible.
+
+    ``assay_lane_layout`` gave a step's satellites the step's own x and every
+    group one shared top, so sibling steps in a rank — which is what #678 made
+    normal — dealt their protocols into the same cell. A reader saw one node and
+    had no way to know two more were behind it.
+    """
+
+    def test_no_two_nodes_share_a_point(self, lanes):
+        for key, drawing in lanes.items():
+            seen: dict[tuple[float, float], str] = {}
+            for node_id, pos in sorted(drawing["positions"].items()):
+                at = (pos["x"], pos["y"])
+                assert at not in seen, f"{key}: {node_id} is drawn on top of {seen[at]} at {at}"
+                seen[at] = node_id
+
+    def test_no_two_nodes_overlap_at_all(self, lanes):
+        """Stronger than distinct corners: a partial overlap hides text too."""
+        for key, drawing in lanes.items():
+            boxes = _boxes(drawing)
+            for (a, ab), (b, bb) in combinations(sorted(boxes.items()), 2):
+                apart = ab[2] <= bb[0] or bb[2] <= ab[0] or ab[3] <= bb[1] or bb[3] <= ab[1]
+                assert apart, f"{key}: {a} {ab} overlaps {b} {bb}"
+
+
+class TestAnAssayIsDrawnEvenWhereItIsIncomplete:
+    """A characterisation run measures cultured material with no exposure.
+
+    The old module required the spine to be one connected component and returned
+    ``null`` otherwise, so the caller fell back to the generic canvas. But the
+    reason a lane matters most is exactly when a step is missing: the empty rank
+    is the finding. Declining hid the work AND the gap.
+    """
+
+    def test_an_exposure_free_assay_still_draws(self, lanes):
+        drawing = lanes["assay-characterisation-assay"]
+        assert drawing["positions"], "an assay with no Exposure was declined"
+
+    def test_the_missing_step_is_named_as_missing(self, lanes):
+        """The rank stays in the sequence, and says nothing was recorded for it."""
+        drawing = lanes["assay-characterisation-assay"]
+        empty = [r["key"] for r in drawing["ranks"] if not r["members"]]
+        # The fixture's characterisation run cultures, measures, and stops: no
+        # exposure and no analysis. Every step it did not run keeps its column.
+        assert empty == ["exposure", "exposed", "analysis", "processed"], drawing["ranks"]
+
+    def test_a_complete_assay_has_no_empty_rank(self, lanes):
+        drawing = lanes["assay-transport-assay"]
+        assert [r["key"] for r in drawing["ranks"] if not r["members"]] == []
+
+
+class TestAStepIsPlacedByWhatItIs:
+    """Rank comes from the ISA-Tox chain, not from a layered pass.
+
+    This is what makes the two defects above unreachable rather than fixed: two
+    CellCultures cannot land in one cell because the rank holds a column, and a
+    missing Exposure leaves a column empty rather than splitting the graph.
+    """
+
+    def test_the_ranks_are_the_chain_in_order(self, lanes):
+        expected = [
+            "cellline",
+            "culture",
+            "cultured",
+            "exposure",
+            "exposed",
+            "readout",
+            "raw",
+            "analysis",
+            "processed",
+        ]
+        for key, drawing in lanes.items():
+            assert [r["key"] for r in drawing["ranks"]] == expected, key
+
+    def test_every_line_gets_its_own_culture_step(self, lanes):
+        """#678's per-line split, seen from the diagram."""
+        drawing = lanes["assay-transport-assay"]
+        ranks = {r["key"]: r["members"] for r in drawing["ranks"]}
+        assert len(ranks["cellline"]) == 3
+        assert len(ranks["culture"]) == 3
+        assert len(ranks["cultured"]) == 3
+
+    def test_a_rank_is_a_column(self, lanes):
+        """Every member of a rank shares an x; ranks march left to right."""
+        for key, drawing in lanes.items():
+            last = -1.0
+            for rank in drawing["ranks"]:
+                xs = {drawing["positions"][i]["x"] for i in rank["members"]}
+                assert len(xs) <= 1, f"{key}: rank {rank['key']} is not a column: {xs}"
+                if xs:
+                    assert xs.pop() > last
+                    last = drawing["positions"][rank["members"][0]]["x"]
+
+
+class TestEveryEdgeReadsWithItsArrow:
+    """The defect: a third of lane edges named the predicate backwards.
+
+    The model draws `input` and `reagent` reversed so the arrow points the way
+    the material moves — deliberate, and the band depends on it. But the label
+    was the un-reversed term, so an arrow from a cell line to the step that
+    consumed it read `schema:object`, asserting the exact inverse of the triple
+    the crate holds.
+    """
+
+    def test_a_reversed_edge_is_marked_as_reversed(self, lanes):
+        drawing = lanes["assay-transport-assay"]
+        reversed_labels = {e["label"] for e in drawing["edges"] if e["reversed"]}
+        assert reversed_labels == {"input", "reagent"}, reversed_labels
+
+    def test_a_forward_edge_is_not(self, lanes):
+        drawing = lanes["assay-transport-assay"]
+        forward = {e["label"] for e in drawing["edges"] if not e["reversed"]}
+        assert "result" in forward
+        assert "executes" in forward
+        assert not forward & {"input", "reagent"}
+
+    def test_the_subject_of_the_triple_is_named(self, lanes):
+        """Not just a flag: the drawing says which end the crate states it from,
+        so a renderer cannot get the direction right by accident and wrong on
+        the next relation added."""
+        drawing = lanes["assay-transport-assay"]
+        for edge in drawing["edges"]:
+            subject = edge["dst"] if edge["reversed"] else edge["src"]
+            assert edge["subject"] == subject, edge
+
+
+class TestTheLaneEarnsItsPlace:
+    """A lane exists to be read left to right in one pass.
+
+    Three real lanes were bigger than the generic layout on BOTH axes, which
+    made the view a cost with no benefit. Fixed ranks trade width — nine columns
+    is the chain, and that is the point — for a chain that stays flat however
+    many lines an assay cultures.
+
+    Edge crossings are deliberately NOT asserted. Measured over all 14 lanes of
+    the reference deposit (v26/v27/v28), the chain crosses itself fewer times
+    than the generic canvas on 12 and marginally more on 2 (10 vs 9, 55 vs 54).
+    A test claiming the lane always wins would pass here and be false there,
+    which is the fixture-only failure this whole module exists to stop
+    repeating. The band's dashed connectors drop through the chain and add more
+    crossings still; folding them to one connector per group at rest is the
+    remaining readability work, not something to assert before it is done.
+    """
+
+    def test_the_chain_is_never_taller_than_the_generic_canvas(self, lanes):
+        """Compared on the half both layouts draw.
+
+        The lane is wider by construction and carries a band the canvas has no
+        equivalent for, so a whole-figure comparison would measure the extra
+        information rather than the packing.
+        """
+        for key, drawing in lanes.items():
+            assert drawing["bandTop"] <= drawing["generic"]["height"], (
+                f"{key}: chain {drawing['bandTop']} vs generic "
+                f"{drawing['generic']['height']}"
+            )
+
+    def test_the_chain_height_does_not_grow_with_the_number_of_lines(self, lanes):
+        """The property the deposit actually needs.
+
+        A layered pass makes the canvas as tall as the widest rank is long, so a
+        three-line assay ran to 1,125 px against this module's 344. Here the
+        chain is as tall as the busiest rank and nothing else, so the two lanes
+        below differ by their line count alone.
+        """
+        three = lanes["assay-transport-assay"]["bandTop"]
+        two = lanes["assay-characterisation-assay"]["bandTop"]
+        # One extra line is one extra row, not a re-ranking of the whole graph.
+        assert three - two == 56, (three, two)

--- a/tests/test_assay_lane_view.py
+++ b/tests/test_assay_lane_view.py
@@ -70,7 +70,15 @@ def _lanes() -> dict[str, dict[str, Any]]:
         ]
         result = subprocess.run(
             [_node_exe(), str(_PROBE), str(_MODULE)],
-            input=json.dumps({"nodes": nodes, "edges": list(merged.values())}),
+            input=json.dumps(
+                {
+                    "nodes": nodes,
+                    "edges": list(merged.values()),
+                    # Which way each relation is really stated — from the crate's
+                    # own relation tables, never a literal in the browser.
+                    "reversed": payload["relations_reversed"],
+                }
+            ),
             capture_output=True,
             text=True,
             check=True,

--- a/tests/test_edge_vocabulary.py
+++ b/tests/test_edge_vocabulary.py
@@ -168,3 +168,54 @@ class TestSelectionBehaviour:
         assert "react-flow__edge-text" in css
         block = css.split("react-flow__edge-text{", 1)[1].split("}", 1)[0]
         assert "paint-order:stroke" in block and "stroke:var(--surface)" in block
+
+
+class TestAnEdgeSaysWhichEndTheCrateStatesItFrom:
+    """Two relations are drawn against the predicate, and the payload says so.
+
+    ``_extract_edges`` flips the endpoints of a ``reverse=True`` relation so the
+    arrow points the way material moves — a cell line into the step that
+    consumed it — and then keeps the label. A renderer that prints the bare term
+    on that arrow says ``schema:object`` from the cell line TO the process,
+    which is the inverse of the triple the crate holds. Measured on the
+    reference deposit: 163 of 495 drawn lane edges, a third of them.
+
+    The flag already exists in ``_PRIMARY_RELATIONS``; ``relation_terms`` threw
+    it away. Derived here for the same reason the terms are — a hand-kept list
+    would be a second copy to drift from the first.
+    """
+
+    def test_the_reversed_relations_are_named(self):
+        from builder.writers.provenance_dag import reversed_relations
+
+        assert reversed_relations() == {"input", "reagent"}
+
+    def test_it_is_derived_from_the_relation_tables(self):
+        """Not a literal: adding a reversed relation must not need a second edit."""
+        from builder.writers.provenance_dag import (
+            _SECONDARY_RELATIONS,
+            reversed_relations,
+        )
+
+        expected = {
+            label
+            for _keys, label, is_reversed in _PRIMARY_RELATIONS + _SECONDARY_RELATIONS
+            if is_reversed
+        }
+        assert reversed_relations() == expected
+
+    def test_every_reversed_relation_still_names_a_property(self):
+        from builder.writers.provenance_dag import reversed_relations
+
+        terms = relation_terms()
+        for label in reversed_relations():
+            assert ":" in terms[label], label
+
+    def test_the_payload_carries_it(self):
+        """The browser must not keep its own copy of which way an edge runs."""
+        from builder.writers.entity_explorer import build_explorer_payload
+        from builder.writers.provenance_dag import reversed_relations
+        from tests.fixtures.crate_graphs import assay_lane_real_shapes_graph
+
+        payload = build_explorer_payload(assay_lane_real_shapes_graph())
+        assert set(payload["relations_reversed"]) == reversed_relations()

--- a/tests/test_explorer_js_integrity.py
+++ b/tests/test_explorer_js_integrity.py
@@ -33,7 +33,7 @@ _PAGE_GLOBALS = ("React", "ReactDOM", "htm", "dagre", "window", "document", "con
 _SCRIPTS = (
     "entity_explorer.js",
     "entity_explorer_layout.js",
-    "assay_lane_layout.js",
+    "assay_lane_view.js",
     "payload_codec.js",
 )
 
@@ -123,7 +123,7 @@ class TestThePageLoadsInABrowser:
 
         section = render_explorer_section(assay_lane_graph())
         bodies = re.findall(r"<script[^>]*>(.*?)</script>", section, re.S)
-        wanted = ("dagre", "root.ExplorerLayout = factory", "root.AssayLaneLayout = factory")
+        wanted = ("dagre", "root.ExplorerLayout = factory", "root.AssayLaneView = factory")
         return [
             body
             for body in bodies
@@ -131,12 +131,12 @@ class TestThePageLoadsInABrowser:
         ]
 
     def test_both_layout_modules_attach_themselves_to_the_window(self):
-        out = self._run(self._geometry_scripts(), ["ExplorerLayout", "AssayLaneLayout"])
-        assert out["defined"] == {"ExplorerLayout": True, "AssayLaneLayout": True}
+        out = self._run(self._geometry_scripts(), ["ExplorerLayout", "AssayLaneView"])
+        assert out["defined"] == {"ExplorerLayout": True, "AssayLaneView": True}
 
     def test_the_lane_takes_its_node_size_from_the_layout_beside_it(self):
         """One component, one set of constants: a lane node and a canvas node
         are the same node, so the two must not be able to drift apart."""
-        out = self._run(self._geometry_scripts(), ["ExplorerLayout", "AssayLaneLayout"])
-        assert out["sizes"]["AssayLaneLayout"] == out["sizes"]["ExplorerLayout"]
+        out = self._run(self._geometry_scripts(), ["ExplorerLayout", "AssayLaneView"])
+        assert out["sizes"]["AssayLaneView"] == out["sizes"]["ExplorerLayout"]
         assert out["sizes"]["ExplorerLayout"] == {"NODE_W": 200, "NODE_H": 44}


### PR DESCRIPTION
Follow-up to #690. The assay lane shipped with 43 tests and four defects, none
of which CI could see: every one of those tests drives `assay_lane_graph`, a
fixture that predates #678 and gives each assay a **single cell line**. A real
deposit cultures each line separately, and runs characterisation assays with no
exposure at all. Neither shape was ever laid out.

Everything below is measured over **all 14 lanes of the reference deposit**
(`svhps22_real_input_crate` v26/v27/v28), by running the shipped JavaScript over
the real payload — not by reading the code.

### What was wrong

| | before | after |
|---|---|---|
| Nodes drawn on top of each other | **15 pairs** | **0** |
| Lanes declined to the generic canvas | **2** | **0** |
| Drawn edges labelled with the inverse triple | **163 of 495 (33%)** | **0** |
| Chain height, TH transport (3 lines) | 1125 px | **344 px** |
| Chain height, deiodinase | 1046 px | **232 px** |

* **Nodes hidden under nodes.** Sibling steps share a rank and therefore an x,
  and every satellite group was dealt from one shared `top`, so all three
  culture protocols in TH transport landed at exactly (314,348) — two of the
  three invisible. This is the failure #690 says it fixed;
  `test_assay_lane_layout.py:152` only ever stacked protocols under **one**
  step, so it never fired.
* **Whole lanes declined.** The old module required the spine to be one
  connected component. A characterisation assay has no Exposure, so nothing
  fans its cultured samples together and the graph is genuinely several
  components — and the lane fell back to the canvas it exists to improve on.
  That is the case where a lane is worth *most*: the missing step is the
  finding.
* **A third of edges named backwards.** `_extract_edges` flips `src`/`dst` for
  a `reverse=True` relation so the arrow points the way material moves, then
  keeps the label. The canvas printed `schema:object` on an arrow running from
  the cell line **to** the step that consumed it — the inverse of the triple the
  crate holds. Same for `bioschemas:reagent` on compounds.

### What changed

`assay_lane_view.js` replaces `assay_lane_layout.js`. It ranks by what a node
**is** in the ISA-Tox chain rather than by where a layered pass lands it:
`cellline · culture · cultured · exposure · exposed · readout · raw · analysis ·
processed`.

Both geometry defects become **unrepresentable** rather than fixed. A rank is a
column, so two CellCultures stack and cannot coincide. A missing step is an
empty column, so an incomplete assay still draws — and the column keeps its
heading with *"not recorded"* under it, which puts the gap where the reader is
already looking.

The columns are named (that is what a fixed rank buys), with a dashed
`LABPROTOCOL` rule between the chain and the band. Headings are furniture, not
entities: no `@id`, not selectable, never in `graph.visible`, so search,
selection and the coverage counts still only ever mean entities.

`reversed_relations()` derives the reversed set from `_PRIMARY_RELATIONS`
instead of restating it; the payload carries it as `relations_reversed`; the
lane module and the canvas both read it from there. The browser keeps no second
copy of which way a relation runs — the rule that already held for the
vocabulary itself. The glyph is the `←` the side panel already uses for an
incoming property.

### What this deliberately does not claim

I had a test asserting the lane crosses fewer edges than the generic canvas. It
passed on the fixture. On the real deposit the chain wins on 12 lanes and loses
narrowly on 2 (10 vs 9, 55 vs 54). **That is the exact fixture-only failure this
PR exists to stop repeating**, so the claim is gone and the real numbers are in
the test's docstring. Folding the band's dashed connectors to one per group at
rest is the remaining readability work; it is not asserted before it is done.

### Root cause, addressed

`assay_lane_real_shapes_graph` carries the two shapes the old fixture lacked —
a three-line assay and an exposure-free one. It is deliberately **not** a copy
of the deposit: the shapes are what matter, and a fixture reproducing one
crate's coincidences would only ever prove that crate.

### Still open, not in this PR

`#Sample_..._MO3.13_cultured` in v28's deiodinase assay is produced by its
CellCulture and consumed by nothing, because `_floor_readout_objects` stops at
the first named input in an exposure-free assay. That is a missing edge in the
**crate**, not the diagram — an upstream `_crate_mapping.py` fix, filed
separately.

### Checks

- `tests/test_assay_lane_view.py` — 13 new, all measured on the shipped module
- lane + explorer + artifact suites — 208 passed, 1 skipped
- `ruff check builder/` and `ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3HYvnv1BibtNEwfbRiup
