### PR TITLE
fix(crate): a characterisation readout measures every line its assay cultured

### DIFF
--- a/builder/tools/_crate_mapping.py
+++ b/builder/tools/_crate_mapping.py
@@ -3077,6 +3077,45 @@ def _set_refs(node: Any, prop: str, entities: list[Any]) -> None:
     node[prop] = [{"@id": getattr(e, "id", e)} for e in entities]
 
 
+def _widen_to_every_cultured_line(
+    readout: Any,
+    consumed: list[Any],
+    cultured: list[Any],
+    cultured_ids: set[Any],
+    *,
+    exposed: bool,
+) -> None:
+    """Let a characterisation readout measure every line its assay cultured.
+
+    With no Exposure in the assay, :func:`_chain_processes` returns before its
+    own "hanging off the culture" rule can fire, and the caller skips any readout
+    that already names AN input. Since #678 cultured each line separately, that
+    leaves the other lines' samples produced and consumed by nothing — in the
+    reference deposit's Deiodinase assay, MO3.13's cultured sample appears in
+    ``ro-crate-metadata.json`` exactly twice: as its own node, and as its
+    culture's ``output``.
+
+    This asserts nothing the caller does not already assert. Its empty-input
+    branch states that a characterisation run measures the cultured material;
+    #678 only made "the cultured material" plural, and a line an assay cultured
+    but measured with nothing would have no reason to be in the assay at all.
+
+    Bounded by the same subset test :func:`_chain_processes` uses: a readout
+    naming anything that is NOT cultured material of this assay is stating
+    something the build did not derive, and knows better than we do (D5). An
+    assay that exposed material is left alone entirely — there the cultured
+    samples are the exposure's to consume.
+    """
+    if exposed or not cultured:
+        return
+    consumed_ids = {getattr(n, "id", None) for n in consumed}
+    if not consumed_ids <= cultured_ids:
+        return
+    missing = [n for n in cultured if getattr(n, "id", None) not in consumed_ids]
+    if missing:
+        _set_refs(readout, "input", consumed + missing)
+
+
 def _floor_readout_objects(crate: ROCrate, built: list[tuple[Any, str, Any]]) -> None:
     """A readout names what it measured, even with nothing upstream to name.
 
@@ -3117,8 +3156,21 @@ def _floor_readout_objects(crate: ROCrate, built: list[tuple[Any, str, Any]]) ->
             for n in _linked_nodes(proc, "output", "result")
             if _is_sample_node(n)
         ]
+        cultured_ids = {getattr(n, "id", None) for n in cultured}
+        # Whether anything in this assay exposed material. Where something did,
+        # the readout consumes what the exposure produced and the cultured
+        # samples are the exposure's to consume, so nothing below applies.
+        exposed = any(
+            _is_sample_node(n)
+            for proc in by_type.get("Exposure", [])
+            for n in _linked_nodes(proc, "output", "result")
+        )
         for readout in by_type.get("EndpointReadout", []):
-            if _linked_nodes(readout, "input", "object"):
+            consumed = _linked_nodes(readout, "input", "object")
+            if consumed:
+                _widen_to_every_cultured_line(
+                    readout, consumed, cultured, cultured_ids, exposed=exposed
+                )
                 continue
             if cultured:
                 _set_refs(readout, "input", cultured)

--- a/tests/test_tox_shape_floors.py
+++ b/tests/test_tox_shape_floors.py
@@ -189,6 +189,192 @@ class TestEndpointReadoutInputFloor:
         )
 
 
+
+    def test_a_characterisation_readout_measures_every_line_it_cultured(self):
+        """The cultured sample nothing consumes (#678 + this floor).
+
+        With no Exposure in the assay, `_chain_processes` returns before its own
+        "hanging off the culture" rule can fire, and this floor skips any readout
+        that already names AN input. Since #678 cultured each line separately
+        that leaves the others produced and consumed by nothing: in the reference
+        deposit's Deiodinase assay,
+        `#LabProcess_proc_culture_deiodinase_assay_cells_MO3.13_cultured`
+        appears exactly twice in `ro-crate-metadata.json` — as its own node, and
+        as its culture's `output`.
+
+        The claim the floor already makes when the input is EMPTY — "a
+        characterisation run measures the cultured material" — is the same claim
+        here; #678 simply made "the cultured material" plural. Widening it is
+        therefore not a new assertion, and it is bounded by the subset test
+        `_chain_processes` uses: a readout naming anything that is NOT cultured
+        material still knows better than we do.
+        """
+        from builder.tools.builder import assemble_crate
+        from builder.tools.composites import scaffold_isa_backbone
+
+        state = CrateState()
+        state.metadata.title = "Characterisation probe"
+        ids = scaffold_isa_backbone(
+            state,
+            investigation={"name": "Inv", "description": "d", "identifier": "INV-1"},
+            study={"name": "Study", "description": "d"},
+            assay={"name": "Characterisation assay", "description": "d"},
+        )
+        for slug, name in (("a", "SK-N-AS"), ("b", "MO3.13")):
+            state.add_entity(
+                Entity(
+                    entity_id=f"cell_{slug}",
+                    type="CellLineSample",
+                    fields={"name": name},
+                    _provenance=EntityProvenance(created_by="llm"),
+                )
+            )
+        # The deposit's own shape: one culture names a Sample the state already
+        # holds, the readout names THAT, and the other line's sample is minted.
+        state.add_entity(
+            Entity(
+                entity_id="sample_out",
+                type="Sample",
+                fields={"name": "Cultured cells"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="proc_culture",
+                type="LabProcess",
+                fields={
+                    "process_type": "CellCulture",
+                    "name": "Culture cells",
+                    "cell_line": ["cell_a", "cell_b"],
+                    "culture_medium": "DMEM + 10% FBS",
+                    "output": "sample_out",
+                    "assay": ids["assay_id"],
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="proc_readout",
+                type="LabProcess",
+                fields={
+                    "process_type": "EndpointReadout",
+                    "name": "Characterisation readout",
+                    "endpoint": "Deiodinase activity",
+                    "measured_entity": "T3",
+                    "object": "sample_out",
+                    "assay": ids["assay_id"],
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+
+        graph = assemble_crate(
+            state, output_dir=None, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+
+        def _ids(value):
+            items = value if isinstance(value, list) else [value]
+            return {i.get("@id") for i in items if isinstance(i, dict)}
+
+        cultures = [n for n in graph if n.get("additionalType") == "CellCulture"]
+        assert len(cultures) == 2, "the per-line split (#678) did not fire"
+        produced = set()
+        for culture in cultures:
+            produced |= _ids(culture.get("output")) | _ids(culture.get("result"))
+
+        # Consumed by anything OTHER than the step that produced it.
+        producers = {c["@id"] for c in cultures}
+        consumed = set()
+        for node in graph:
+            if node["@id"] in producers:
+                continue
+            for key, value in node.items():
+                if not key.startswith("@"):
+                    consumed |= _ids(value)
+
+        assert produced - consumed == set(), (
+            "a cultured sample is produced and consumed by nothing: "
+            f"{sorted(produced - consumed)}"
+        )
+
+    def test_a_readout_naming_material_of_its_own_is_left_alone(self):
+        """The bound on the rule above.
+
+        Widening applies only where the readout is already measuring cultured
+        material. One that names a File — a run whose measurements are the
+        input — is stating something the build did not derive, and the floor
+        must not add samples beside it.
+        """
+        from builder.tools.builder import assemble_crate
+        from builder.tools.composites import scaffold_isa_backbone
+
+        state = CrateState()
+        state.metadata.title = "Knows better probe"
+        ids = scaffold_isa_backbone(
+            state,
+            investigation={"name": "Inv", "description": "d", "identifier": "INV-1"},
+            study={"name": "Study", "description": "d"},
+            assay={"name": "Characterisation assay", "description": "d"},
+        )
+        state.add_entity(
+            Entity(
+                entity_id="cell_a",
+                type="CellLineSample",
+                fields={"name": "SK-N-AS"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="own_material",
+                type="Sample",
+                fields={"name": "Material the readout brought itself"},
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="proc_culture",
+                type="LabProcess",
+                fields={
+                    "process_type": "CellCulture",
+                    "name": "Culture cells",
+                    "cell_line": ["cell_a"],
+                    "culture_medium": "DMEM + 10% FBS",
+                    "assay": ids["assay_id"],
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+        state.add_entity(
+            Entity(
+                entity_id="proc_readout",
+                type="LabProcess",
+                fields={
+                    "process_type": "EndpointReadout",
+                    "name": "Characterisation readout",
+                    "endpoint": "Deiodinase activity",
+                    "object": "own_material",
+                    "assay": ids["assay_id"],
+                },
+                _provenance=EntityProvenance(created_by="llm"),
+            )
+        )
+
+        graph = assemble_crate(
+            state, output_dir=None, materialize_payload=False, include_all_scanned=False
+        ).metadata.generate()["@graph"]
+
+        def _ids(value):
+            items = value if isinstance(value, list) else [value]
+            return {i.get("@id") for i in items if isinstance(i, dict)}
+
+        readout = next(n for n in graph if n.get("additionalType") == "EndpointReadout")
+        consumed = _ids(readout.get("input")) | _ids(readout.get("object"))
+        assert consumed == {"#Sample_own_material"}, consumed
+
 class TestInputRequiredTypesIsJustifiedByTheBuildNotTheShapes:
     """`_INPUT_REQUIRED_TYPES` excludes three types the shapes DO constrain.
 


### PR DESCRIPTION
The last of the four defects the #703 audit verified, and the only one whose
honest fix is in the crate rather than the diagram.

### The orphan

In the reference deposit's Deiodinase assay,
`#LabProcess_proc_culture_deiodinase_assay_cells_MO3.13_cultured` occurs in
`output/svhps22_real_input_crate_v28/ro-crate-metadata.json` **exactly twice**:
as its own node, and as the `output` of the CellCulture that produced it.
Nothing else in the graph mentions it. The crate describes growing a cell line
and then says nothing was ever done with it.

Two passes each decline to act, and between them the sample falls through:

* `_chain_processes` rewires a readout only where its assay has an Exposure that
  emitted a Sample. This assay has no Exposure, so it returns at `if not
  exposed: continue` — **before** its own "a readout hanging off the culture is
  the defect" rule can fire.
* `_floor_readout_objects` then skips any readout that already names AN input.
  This one names SK-N-AS's cultured sample, so it is skipped.

Since #678 cultured each line separately there are now N cultured samples where
there was one, and only the named one is ever consumed.

### The fix, and why it asserts nothing new

`_floor_readout_objects` has always stated, in its empty-input branch, that *a
characterisation run measures the cultured material*. #678 only made "the
cultured material" plural. A line an assay cultured but measured with nothing
would have no reason to be in the assay at all.

`_widen_to_every_cultured_line` is bounded by the **same subset test
`_chain_processes` already uses**:

* a readout naming anything that is NOT cultured material of its own assay is
  stating something the build did not derive, and is left alone (D5);
* an assay that exposed material is skipped entirely — there the cultured
  samples are the exposure's to consume, and widening would rebuild the star
  #650 took apart.

### Tests

The widening test reproduces the deposit's exact shape rather than a convenient
one: one culture names a `Sample` the state already holds, the readout names
that one, and the second line's sample is minted by the build. It fails on the
orphan before the fix and passes after.

The bound has a test of its own — a readout naming material the build did not
derive — and **passed on arrival**. That is called out rather than disguised: a
guard that is green the moment it is written is doing its job, and a reviewer
seeing it should know it was expected.

### Checks

- `tests/test_tox_shape_floors.py` — 17 passed
- chain / validator / pipeline / lane suites — 91 passed, 1 xpassed
  (the xpass is `test_identical_graph_hash_across_runs`, the known
  nondeterministic spine test tracked under #179 — unrelated)
- `ruff check builder/` and `ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3HYvnv1BibtNEwfbRiup
