### PR TITLE
fix(fair): the shared primitives state no instrument's arithmetic

### DIFF
--- a/builder/tools/assessment_graph.py
+++ b/builder/tools/assessment_graph.py
@@ -35,9 +35,11 @@ class Verdict(NamedTuple):
     whose whole point is that an assessor can say *why*. ``evidence`` records what was
     looked for and what was found, so every cell in the report is inspectable.
 
-    ``value`` is tri-state: ``True`` / ``False`` / ``None`` for "not assessed" — the
-    workbook's blank cell, which leaves the denominator rather than counting against
-    the dataset.
+    ``value`` is tri-state: ``True`` / ``False`` / ``None``. ``None`` says the check
+    could not answer — which is not the same statement as ``False``, and keeping the
+    two apart is the whole reason this is not a ``bool``. What an instrument then
+    *does* with an unanswered indicator is that instrument's own arithmetic, and they
+    do not agree; each scorer states its own.
     """
 
     value: bool | None
@@ -87,8 +89,8 @@ def needs_graph(graph: Graph) -> bool:
 
     Returning ``False`` in that case would be a lie of exactly the kind this module
     exists to prevent: it reads as "the crate fails this indicator" when the truth is
-    "nothing was assessed". Callers turn ``None`` into an *unanswered cell* — excluded
-    from the denominator, never counted against the dataset.
+    "nothing was assessed". Callers record ``None`` as unanswered and let their own
+    instrument decide what that is worth.
     """
     return not nodes(graph)
 

--- a/tests/test_assessment_graph_is_instrument_agnostic.py
+++ b/tests/test_assessment_graph_is_instrument_agnostic.py
@@ -1,0 +1,66 @@
+"""``assessment_graph`` is the shared primitives module; it states no instrument's sums.
+
+Its own docstring says why it exists: the tri-state verdict shape lives here "rather
+than in one instrument's module" so the axes cannot drift apart. Prose describing how
+*one* spreadsheet aggregates has no business here — it is out of place whether it is
+true or false, and a copy left behind here propagates to every scorer that imports it.
+
+That is what this guard checks, and it is a **location** rule, not a truth check: a
+general "docstring asserts X, code does Y" checker is not buildable offline (free prose
+has no machine-readable projection, and #117 rules out the LLM that would be needed).
+Naming the instruments is fine — describing their arithmetic is not.
+
+It has a specific failure to its name: the claim that an unanswered indicator "leaves
+the denominator" survived here through #704, which corrected it in the four other
+places it appeared, precisely because nobody looks for one instrument's arithmetic in
+the module that belongs to none of them (#710).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import tokenize
+from pathlib import Path
+
+MODULE = Path(__file__).resolve().parents[1] / "builder" / "tools" / "assessment_graph.py"
+
+# Each pattern names a way one instrument counts. Reasons are the assertion message.
+ARITHMETIC = {
+    r"denominat|numerat": "how an instrument divides is that instrument's business",
+    r"\bCOUNTA?\b|COUNTIFS": "a spreadsheet function is one workbook's implementation",
+    r"blank cell|workbook": "the shape of one instrument's answer sheet",
+    r"\b[HIJPQ]\d{1,3}\b": "a worksheet cell reference",
+    r"percentage|% complete": "an aggregate, which every instrument computes its own way",
+}
+
+
+def _prose() -> list[tuple[int, str]]:
+    """Every docstring and comment in the module, as (line number, text)."""
+    source = MODULE.read_text(encoding="utf-8")
+    found = [
+        (getattr(node, "lineno", 1), ast.get_docstring(node) or "")
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef)
+    ]
+    with MODULE.open("rb") as handle:
+        found += [
+            (token.start[0], token.string)
+            for token in tokenize.tokenize(handle.readline)
+            if token.type == tokenize.COMMENT
+        ]
+    return found
+
+
+def test_the_shared_primitives_state_no_instrument_s_arithmetic() -> None:
+    offences = [
+        f"{MODULE.name}:{line}: {reason}\n    {text.strip()[:200]}"
+        for line, text in _prose()
+        for pattern, reason in ARITHMETIC.items()
+        if re.search(pattern, text, re.IGNORECASE)
+    ]
+    assert not offences, (
+        "Prose in the module every instrument imports describes one instrument's "
+        "aggregation. State it in that instrument's own module:\n\n"
+        + "\n".join(offences)
+    )


### PR DESCRIPTION
`builder/tools/assessment_graph.py` is imported by the DSM, RDA and AIR scorers alike, and it carried a **fifth copy** of the claim #704 refuted in four other places — that an unanswered indicator *"leaves the denominator"*.

Two things wrong with it, not one:

1. **It is false for the DSM.** The FAIRplus sheet's validation column is entirely formulas (`=H{row}`), so a blank evaluates to numeric `0` and `COUNT` counts it. A `None` verdict *is* counted against the crate in `published_pct` — the number the report leads with.
2. **It was stated as though true of every instrument.** What an unanswered indicator is worth is exactly what the three do not agree on. AIR genuinely does exclude its `na` criteria — and says so in `gen_air_criteria.py`, its own module, where that sentence belongs.

Both docstrings now state the *shape* (`None` is not `False`, which is the whole reason this is not a `bool`) and leave the aggregation to the scorer that owns it.

## The guard

`tests/test_assessment_graph_is_instrument_agnostic.py`, ~20 lines.

It is a **location** rule, not a truth check. A general "docstring asserts X, code does Y" checker is not buildable here — free prose has no machine-readable projection, and #117 rules out the LLM that would be needed. But prose describing one spreadsheet's sums is out of place in the module that belongs to none of them **whether it is true or false**, and that is a thing a regex over the module's docstrings and comments can decide.

Naming the instruments stays fine; naming their arithmetic does not — `denominator`, `COUNT`/`COUNTIFS`, `blank cell`, a worksheet cell reference, a percentage. Each pattern carries the reason it is out of place, and the reason is the assertion message.

Confirmed it fails on the old prose (both lines, before the fix) and passes after.

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_assessment_graph_is_instrument_agnostic.py \
  tests/test_tools_fair_assessment.py tests/test_fair_metrics_can_fail.py \
  tests/test_dsm_sheet_parity.py -q
94 passed, 3 xfailed
```

`uvx ruff check` and `uv run ty check` report nothing in tracked files. No published number moves — this is prose plus a test.

## Not in this PR

Two more copies survive in AGENTS.md (`:687`, `:1497`). They are already itemised in **#716**, which should land before #321 deletes and repoints those sections.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf