### PR TITLE
fix(fair): the agent and the report score the same crate, MIT included

### DIFF
--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -3081,11 +3081,16 @@ def _assess_fair_maturity_tool(state: CrateState) -> FAIRReport:
     publishes for the same crate. Assembling here fixes that at the boundary where it
     is wrong, and leaves the assessor's own contract alone: given no graph it still
     declines to guess, which is what the #670 floor tests hold it to.
+
+    MIT rides along for the same reason. ``state.mit_assessment`` is populated on
+    neither path, so an unscored `mit=` leaves RDA-R1.3-01D False for the agent while
+    the page publishes True for the same bytes (#713). Both are measured against the
+    one graph assembled here, so the two callers cannot disagree about the crate.
     """
-    from builder.tools.mit_assessment import scoring_graph
+    from builder.tools.mit_assessment import assess_mit_coverage, scoring_graph
 
     graph = scoring_graph(state)
-    return assess_fair_maturity(state, graph=graph)
+    return assess_fair_maturity(state, mit=assess_mit_coverage(state, graph=graph), graph=graph)
 
 
 TOOL_REGISTRY.register("assess_fair_maturity", _assess_fair_maturity_tool, takes_state=True)

--- a/tests/test_tools_fair_assessment.py
+++ b/tests/test_tools_fair_assessment.py
@@ -387,3 +387,42 @@ class TestDsmBlockers:
             assert ind["scope"] != "na"
             assert text == ind["text"]
             assert DSM_CHECKS[ind["check"]](state, None) is False
+
+
+class TestTheAgentAndTheReportScoreTheSameCrate:
+    """One crate, one FAIR number — whoever asks.
+
+    The tool spec exposes no parameters, so a model reaches ``assess_fair_maturity``
+    with nothing but the state; ``_assess_fair_maturity_tool`` assembles the crate at
+    that boundary so the graph-aware indicators can answer. That fixed the graph and
+    left the second argument: the report also computes MIT against the same graph and
+    feeds it back in, because ``state.mit_assessment`` is never populated on either
+    path. Miss it and RDA-R1.3-01D is False for the agent and True on the page, for the
+    same bytes (#713).
+
+    Asserting the whole result rather than that one indicator is the point: the two
+    call sites drifted because nothing compared them, and a third argument would drift
+    the same way.
+    """
+
+    def _both_paths(self) -> tuple[FAIRReport, FAIRReport]:
+        from builder.tools.fair_assessment import _assess_fair_maturity_tool
+        from builder.tools.mit_assessment import assess_mit_coverage, scoring_graph
+
+        state = vhps_fixture_state("S-VHPS21")
+        graph = scoring_graph(state)
+        # What build_maturity_html does (maturity_report.py), spelled out.
+        report = assess_fair_maturity(
+            state, mit=assess_mit_coverage(state, graph=graph), graph=graph
+        )
+        return _assess_fair_maturity_tool(state), report
+
+    def test_every_indicator_agrees(self) -> None:
+        agent, report = self._both_paths()
+        assert {i["id"]: i["passed"] for i in agent.indicator_results} == {
+            i["id"]: i["passed"] for i in report.indicator_results
+        }
+
+    def test_the_dsm_level_agrees(self) -> None:
+        agent, report = self._both_paths()
+        assert agent.dsm_level == report.dsm_level


### PR DESCRIPTION
`_assess_fair_maturity_tool` was added in #704 so a model calling the tool gets the crate scored instead of "not assessed" everywhere — the tool spec exposes no parameters, so the assessor would otherwise see no graph. It assembled the graph and stopped there.

The report passes a **second** thing: MIT, measured against that same graph and fed back in, because `state.mit_assessment` is populated on neither path. Without it the `mit_coverage` branch falls back to that empty field:

| path | RDA-R1.3-01D |
|---|---|
| the tool | **False** |
| the report | **True** |

Same crate, same bytes. Measured on `S-VHPS21`: 40 of 41 indicators agreed, that one did not.

One line fixes it — both are now measured against the one graph assembled at the boundary.

## The test is worth more than the fix

Nothing anywhere compared the two call sites, which is exactly why they drifted. So the test asserts the **whole result** — every indicator plus the DSM level — rather than the one indicator that happened to break. A third argument would drift the same way, and this catches that one too.

Confirmed it fails before the fix, on precisely `{'RDA-R1.3-01D': False} != {'RDA-R1.3-01D': True}` with 40 identical items omitted.

## Not in scope

`air_assessment.py:783` does the same assembly for AIR and has no second argument to miss — fine today by luck rather than by check. Left alone: there is nothing to disagree about yet.

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_tools_fair_assessment.py \
  tests/test_fair_metrics_can_fail.py tests/test_tool_reachability.py -q
  → 95 passed, 3 xfailed          (the #670 floor unmoved)

… + test_maturity_report, test_tools_mit_assessment, test_e2e_agent_eval
  → 199 passed
```

`uvx ruff check` and `uv run ty check` clean.

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf