### PR TITLE
test(dsm): the parity harness drives the state the sheet cannot hold

### DIFF
--- a/tests/test_dsm_sheet_parity.py
+++ b/tests/test_dsm_sheet_parity.py
@@ -13,6 +13,15 @@ trusts. The evaluator below instead interprets the sheet's *formula text* direct
 a generator that drops a repeated member, reads the wrong denominator or mis-parses a
 promotion chain produces a YAML the scorer believes and this evaluator contradicts.
 
+**What an answer vector may hold.** Three values, not two: 1, 0, and *unanswered* —
+the state this tool can report and the sheet cannot. The sheet's position is that there
+is no third state (column J is entirely ``=H{row}``, so a blank is numeric 0), and that
+is a claim about arithmetic, so it is checked against the workbook like every other:
+:class:`TestAnUnansweredIndicatorIsABlank` drives blanks through both sides. Vectors
+that answer every row cannot see the difference — a scorer that drops unanswered rows
+from the denominator agrees with one that counts them as 0 whenever there is nothing to
+drop, which is how that bug survived this file once already (#717).
+
 **Why a hand-rolled evaluator.** openpyxl has no calculation engine. The vendored file
 does carry Excel's cached values, but only for the shipped answer vector, which is
 degenerate (every Level-0 row 1, everything else 0). That one vector is still worth
@@ -100,12 +109,27 @@ def _evaluate(sheet, answers: dict[int, int]) -> dict[str, float]:
     return out
 
 
-def _our_grid(data: dict, rows: dict[int, str], answers: dict[int, int]) -> dict[str, dict]:
-    """Our own arithmetic over the same answer vector, keyed by sheet cell."""
-    verdicts = {ident: Verdict(bool(answers[row]), "") for row, ident in rows.items()}
+def _our_grid(data: dict, rows: dict[int, str], answers: dict[int, int | None]) -> dict[str, dict]:
+    """Our own arithmetic over the same answer vector, keyed by sheet cell.
+
+    ``None`` is the state the sheet cannot hold: an indicator nothing measured. It
+    reaches the scorer as ``Verdict(None)`` and reaches the sheet as the blank it is
+    (:func:`_blank_is_zero`), which is the whole comparison in
+    :class:`TestAnUnansweredIndicatorIsABlank`.
+    """
+    verdicts = {
+        ident: Verdict(None if answers[row] is None else bool(answers[row]), "")
+        for row, ident in rows.items()
+    }
     _apply_promotion(verdicts, data["scoring"]["promotion"])
     grid = dsm_grid(CrateState(), data, None, answers=verdicts)
     return {cell["cell"]: cell for by_cat in grid.values() for cell in by_cat.values()}
+
+
+def _blank_is_zero(answers: dict[int, int | None]) -> dict[int, int]:
+    """The same vector as the workbook holds it: column J is entirely ``=H{row}``, so
+    an empty H evaluates to numeric 0. There is no third value to give the evaluator."""
+    return {row: 0 if value is None else value for row, value in answers.items()}
 
 
 def _vector(rows: dict[int, str], fill) -> dict[int, int]:
@@ -139,7 +163,7 @@ class TestOurGridEqualsTheSheets:
     def test_the_extremes(self, sheet, rows, data, name):
         answers = _vector(rows, lambda _row: 1 if name == "all-yes" else 0)
         ours = _our_grid(data, rows, answers)
-        theirs = _evaluate(sheet, answers)
+        theirs = _evaluate(sheet, _blank_is_zero(answers))
         for cell_name, cell in ours.items():
             assert cell["published_pct"] == pytest.approx(theirs[cell_name], abs=0.05), cell_name
 
@@ -148,23 +172,25 @@ class TestOurGridEqualsTheSheets:
         rng = random.Random(seed)
         answers = _vector(rows, lambda _row: rng.randint(0, 1))
         ours = _our_grid(data, rows, answers)
-        theirs = _evaluate(sheet, answers)
+        theirs = _evaluate(sheet, _blank_is_zero(answers))
         for cell_name, cell in ours.items():
             assert cell["published_pct"] == pytest.approx(theirs[cell_name], abs=0.05), cell_name
 
     def test_each_promotion_rule_is_exercised_on_its_own(self, sheet, rows, data):
-        """One vector per rule: source met, target not, everything else unanswered.
+        """One vector per rule: source met, everything else unanswered.
 
         A scorer that ignores promotion entirely passes every other vector in this file
-        often enough to look healthy; these nine do not let it.
+        often enough to look healthy; these nine do not let it. The rest of the vector is
+        genuinely unanswered rather than failed, which is what ``IF(J5=1,1,H4)`` acts on:
+        the rule fires over a blank target exactly as it fires over a zero.
         """
         by_id = {ident: row for row, ident in rows.items()}
         for rule in data["scoring"]["promotion"]:
-            answers = _vector(rows, lambda _row: 0)
+            answers = _vector(rows, lambda _row: None)
             answers[by_id[rule["when"]]] = 1
             answers[75] = answers[70]
             ours = _our_grid(data, rows, answers)
-            theirs = _evaluate(sheet, answers)
+            theirs = _evaluate(sheet, _blank_is_zero(answers))
             for cell_name, cell in ours.items():
                 assert cell["published_pct"] == pytest.approx(theirs[cell_name], abs=0.05), (
                     f"{rule['cell']} ({rule['when']} promotes {rule['then']}): {cell_name}"
@@ -197,3 +223,65 @@ class TestTheFixturesOwnConstraints:
         grid_with = dsm_grid(CrateState(), data, None, answers=verdicts)
         flat = {c["cell"]: c["published_pct"] for by in grid_with.values() for c in by.values()}
         assert flat == {name: c["published_pct"] for name, c in grid_without.items()}
+
+
+class TestAnUnansweredIndicatorIsABlank:
+    """The state the sheet has no cell for.
+
+    Every vector above answers every row, so none of them can tell a scorer that counts
+    a blank as 0 from one that drops it out of the denominator — the two agree wherever
+    there is nothing to drop. That is the bug #704 fixed, and the shape this file could
+    not see (#717).
+
+    The sheet's position is unambiguous: column J is entirely ``=H{row}`` formulas, so
+    an empty H is numeric 0 and ``COUNT`` counts it. So an unanswered indicator must
+    move ``published_pct`` exactly as a failed one does — and at Level 0, where the
+    statements are negative and ``COUNTIFS(...,0)`` counts zeros, it must count as
+    **satisfied**. Nothing else the tool publishes may follow from not having looked.
+    """
+
+    def test_nothing_answered_reads_as_the_sheet_reads_blanks(self, sheet, rows, data):
+        answers = _vector(rows, lambda _row: None)
+        ours = _our_grid(data, rows, answers)
+        theirs = _evaluate(sheet, _blank_is_zero(answers))
+        for cell_name, cell in ours.items():
+            assert cell["published_pct"] == pytest.approx(theirs[cell_name], abs=0.05), cell_name
+
+    def test_level_zero_reads_100_off_nothing_and_says_so(self, rows, data):
+        """The number that made this worth pinning: a Level-0 cell nobody measured
+        publishes 100% — the sheet's own arithmetic, saying the deposit escaped the
+        pre-FAIRification state on the strength of never having been asked. It is only
+        honest beside ``assessed``, so both are asserted together."""
+        ours = _our_grid(data, rows, _vector(rows, lambda _row: None))
+        zero_row = [cell for name, cell in ours.items() if cell["cell"] in {"P6", "P7", "P8", "P9"}]
+        assert zero_row, "the Level-0 row is P6-P9"
+        for cell in zero_row:
+            assert cell["published_pct"] == 100.0, cell["cell"]
+            assert cell["assessed"] == 0, cell["cell"]
+            assert cell["pct"] is None, cell["cell"]
+
+    def test_an_unanswered_row_scores_like_a_failed_one(self, sheet, rows, data):
+        """Not a claim about our code — a claim about the sheet, checked against it.
+        The same vector with blanks and with zeros must produce the same grid."""
+        blanks = _vector(rows, lambda row: None if row % 3 else 1)
+        zeros = {row: 0 if value is None else value for row, value in blanks.items()}
+        ours_blank = _our_grid(data, rows, blanks)
+        ours_zero = _our_grid(data, rows, zeros)
+        theirs = _evaluate(sheet, zeros)
+        for cell_name, cell in ours_blank.items():
+            assert cell["published_pct"] == ours_zero[cell_name]["published_pct"], cell_name
+            assert cell["published_pct"] == pytest.approx(theirs[cell_name], abs=0.05), cell_name
+
+    @pytest.mark.parametrize("seed", range(3))
+    def test_the_shape_a_real_crate_produces(self, sheet, rows, data, seed):
+        """The production vector: the 39 indicators no crate can evidence are `na` and
+        stay unanswered unless a depositor supplies them, so nearly half of every real
+        assessment is blank. That is the vector parity most needs to hold on."""
+        rng = random.Random(seed)
+        na = {i["id"] for i in data["indicators"] if i.get("scope") == "na"}
+        assert len(na) > 30, "the unanswered half is the point of this test"
+        answers = _vector(rows, lambda row: None if rows[row] in na else rng.randint(0, 1))
+        ours = _our_grid(data, rows, answers)
+        theirs = _evaluate(sheet, _blank_is_zero(answers))
+        for cell_name, cell in ours.items():
+            assert cell["published_pct"] == pytest.approx(theirs[cell_name], abs=0.05), cell_name

--- a/tests/test_dsm_sheet_parity.py
+++ b/tests/test_dsm_sheet_parity.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import pathlib
 import random
 import re
+from collections.abc import Mapping
 
 import openpyxl
 import pytest
@@ -109,7 +110,9 @@ def _evaluate(sheet, answers: dict[int, int]) -> dict[str, float]:
     return out
 
 
-def _our_grid(data: dict, rows: dict[int, str], answers: dict[int, int | None]) -> dict[str, dict]:
+def _our_grid(
+    data: dict, rows: dict[int, str], answers: Mapping[int, int | None]
+) -> dict[str, dict]:
     """Our own arithmetic over the same answer vector, keyed by sheet cell.
 
     ``None`` is the state the sheet cannot hold: an indicator nothing measured. It
@@ -126,14 +129,16 @@ def _our_grid(data: dict, rows: dict[int, str], answers: dict[int, int | None]) 
     return {cell["cell"]: cell for by_cat in grid.values() for cell in by_cat.values()}
 
 
-def _blank_is_zero(answers: dict[int, int | None]) -> dict[int, int]:
+def _blank_is_zero(answers: Mapping[int, int | None]) -> dict[int, int]:
     """The same vector as the workbook holds it: column J is entirely ``=H{row}``, so
     an empty H evaluates to numeric 0. There is no third value to give the evaluator."""
     return {row: 0 if value is None else value for row, value in answers.items()}
 
 
-def _vector(rows: dict[int, str], fill) -> dict[int, int]:
-    """An answer per sheet row. Rows 70 and 75 both carry DSM-4-H2 (see the test)."""
+def _vector(rows: dict[int, str], fill) -> dict[int, int | None]:
+    """An answer per sheet row — 1, 0, or ``None`` for unanswered.
+
+    Rows 70 and 75 both carry DSM-4-H2 (see the test), so they answer together."""
     answers = {row: fill(row) for row in rows}
     answers[75] = answers[70]
     return answers
@@ -148,7 +153,9 @@ class TestTheWorkbooksOwnArithmetic:
         scorer that counts 1s rather than 0s reads 100 where the sheet reads 0.
         """
         answers = _vector(rows, lambda row: int(sheet.cell(row=row, column=8).value or 0))
-        assert sum(answers.values()) == 11, "the shipped H column is the Level-0 states"
+        assert sum(_blank_is_zero(answers).values()) == 11, (
+            "the shipped H column is the Level-0 states"
+        )
 
         ours = _our_grid(data, rows, answers)
         for cell_name, cell in ours.items():


### PR DESCRIPTION
`tests/test_dsm_sheet_parity.py` promises parity with the published sheet "cell for cell". It could not see the one state where the two disagree.

Every vector in the file answered **every** row, so none of them could tell a scorer that counts a blank as 0 from one that drops it out of the denominator — those two agree wherever there is nothing to drop. That is the bug #704 fixed, and reverting it left the whole file green.

## What changed

An answer may now be `None`. It reaches the scorer as `Verdict(None)` and reaches the workbook as the blank it is (`_blank_is_zero`), because column J is entirely `=H{row}` and an empty H is numeric 0 — so **the sheet's own arithmetic decides, not a claim about it**.

Four new tests:

| | |
|---|---|
| `test_nothing_answered_reads_as_the_sheet_reads_blanks` | the whole grid off an empty vector |
| `test_level_zero_reads_100_off_nothing_and_says_so` | the number that made this worth pinning |
| `test_an_unanswered_row_scores_like_a_failed_one` | blanks vs the same vector zeroed, both against the sheet |
| `test_the_shape_a_real_crate_produces` | the 39 `na` indicators unanswered — nearly half of every real assessment |

The Level-0 case is asserted on its own because of what it says: a cell nobody measured publishes **100%** — the sheet stating the deposit escaped the pre-FAIRification state on the strength of never having been asked. `assessed == 0` and `pct is None` are asserted beside it, since that number is only honest with them.

`test_each_promotion_rule_is_exercised_on_its_own` now leaves the rest of its vector genuinely unanswered rather than failed — what its own docstring already claimed, and what `IF(J5=1,1,H4)` actually acts on. It gained coverage as a side effect.

## Mutation-tested

Reintroducing the bug — `if value is wanted` for the met count, dropping the `None → 0` coercion:

```
7 failed, 10 passed        ← with this PR
0 failed                   ← before it
```

The seven: the promotion test, and all six of the new ones.

No production code changes. `uvx ruff check` clean; `pytest tests/test_dsm_sheet_parity.py tests/test_dsm_indicators_source.py tests/test_fair_metrics_can_fail.py` → 120 passed, 3 xfailed.

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf