### PR TITLE
fix(fair): the two F1 indicators ask their two published questions

### DIFF
--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -7,9 +7,11 @@ and computes DSM level from fair/dsm_indicators.yaml check results.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from builder.state import CrateState, FAIRReport, MITReport
 
@@ -119,19 +121,86 @@ def _payload_files(graph: Graph) -> tuple[list[dict[str, Any]], set[str]]:
     return found, seen
 
 
-def _root_pid(graph: Graph) -> str:
-    """The persistent identifier the crate claims for itself, or ``""``.
+# Hosts whose operator publishes a standing commitment to keep the identifier
+# resolving — a redirection service, not a web server that happens to be up today.
+# This is what makes an identifier *persistent* rather than merely unique, and it is
+# the only property RDA-F1-01M asks about (10.15497/rda00050 §4.2: "The persistence of
+# an identifier is determined by the commitment of the organisation issuing it").
+_PERSISTENT_HOSTS = frozenset(
+    {
+        "doi.org", "dx.doi.org", "hdl.handle.net", "n2t.net", "identifiers.org",
+        "w3id.org", "purl.org", "purl.oclc.org", "purl.obolibrary.org", "arks.org",
+    }
+)
+# A DOI written without a resolver prefix. The registrant code is 4-9 digits, so
+# "10.happy" is not one — the old `startswith("10.")` accepted it.
+_BARE_DOI = re.compile(r"^10\.\d{4,9}/\S+$")
+# urn:<nid>:<nss> — the NID partitions the namespace across issuers.
+_URN = re.compile(r"^urn:[a-z0-9][a-z0-9-]{0,30}:\S+$", re.IGNORECASE)
+_UUID = re.compile(
+    r"^(urn:uuid:)?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
-    A DOI, or any absolute IRI. A bare accession like ``S-VHPS22`` does not qualify:
-    it is unique inside BioStudies and ambiguous outside it, and the whole point of
-    the indicator is identification that survives leaving the source repository.
+
+def _root_ids(graph: Graph) -> list[str]:
+    """Every identifier the Root Data Entity claims for itself, in priority order.
+
+    ``identifier`` first because it is the assigned one; the ``@id`` only after, since
+    in a packaged crate that is usually ``./`` — a location inside this ZIP.
     """
     root = _root_node(graph)
-    for value in (root.get("identifier"), root.get("@id")):
-        text = _ref_id(value) or str(value or "")
-        if text.startswith(("http://", "https://", "10.")) or "doi" in text.lower():
-            return text
-    return ""
+    out = [
+        text
+        for value in _values(root, "identifier")
+        if (text := _ref_id(value) or str(value or ""))
+    ]
+    if root_id := str(root.get("@id") or ""):
+        out.append(root_id)
+    return out
+
+
+def _is_globally_unique_id(text: str) -> bool:
+    """RDA-F1-02M's question: was this minted in a namespace partitioned across issuers?
+
+    A property of the *mechanism*, not of anyone's intentions — DNS partitions http(s)
+    IRIs by authority, a URN's NID partitions URN space, a DOI prefix partitions the
+    handle system, and a UUID is unique by construction. A bare accession like
+    ``S-VHPS22`` is not: it is unique inside BioStudies and ambiguous the moment it
+    leaves, which is the whole point of the indicator.
+    """
+    if _URN.match(text) or _UUID.match(text) or _BARE_DOI.match(text):
+        return True
+    parts = urlsplit(text)
+    return parts.scheme in ("http", "https") and "." in parts.netloc and " " not in parts.netloc
+
+
+def _is_persistent_id(text: str) -> bool:
+    """RDA-F1-01M's question: has the issuing organisation promised it will resolve?
+
+    Strictly narrower than :func:`_is_globally_unique_id`, and deliberately so: the two
+    indicators are separate rows of the published model, and answering the same
+    question twice would leave one of them carrying no information. A repository
+    landing page is globally unique and persistent only by that repository's goodwill;
+    a DOI, handle, ARK or NBN is minted under a scheme that states the commitment.
+    """
+    if _BARE_DOI.match(text) or text.lower().startswith(("urn:nbn:", "ark:/")):
+        return True
+    parts = urlsplit(text)
+    if parts.scheme not in ("http", "https"):
+        return False
+    host = parts.netloc.lower().removeprefix("www.")
+    return host in _PERSISTENT_HOSTS or parts.path.startswith("/ark:/")
+
+
+def _root_pid(graph: Graph) -> str:
+    """The *persistent* identifier the crate claims for itself, or ``""``.
+
+    Shared by RDA-F1-01M, RDA-F1-02D and DSM-1-C0, all three of which ask for a
+    persistent identifier by name. RDA-F1-02M asks the weaker question and reads
+    :func:`_is_globally_unique_id` instead.
+    """
+    return next((text for text in _root_ids(graph) if _is_persistent_id(text)), "")
 
 
 # ---------------------------------------------------------------------------
@@ -477,9 +546,24 @@ def _column_is_described(column: dict[str, Any], prescribed: set[str]) -> bool:
     )
 
 
-def _check_root_global_id(state: CrateState) -> bool:
-    """Check that the crate has a globally unique identifier (accession or session_id)."""
-    return bool(state.metadata.accession or state.session_id)
+def _check_root_global_id(state: CrateState, graph: Graph = None) -> bool | None:
+    """RDA-F1-02M — the *metadata* is identified by a globally unique identifier.
+
+    Was ``bool(state.metadata.accession or state.session_id)``. ``session_id`` is a
+    timestamp this tool mints for itself and no reader ever receives, and every entry
+    point sets it before anything can be scored, so the check was true of every build
+    that ran (#712) — the same expression :func:`_check_unique_id` already records as
+    discredited.
+
+    It now reads the assembled root, and asks the namespace question rather than the
+    persistence one: :func:`_is_globally_unique_id`, not :func:`_root_pid`. The two F1
+    indicators are separate published rows and must stay separate predicates — a
+    repository landing page answers this one True and RDA-F1-01M False, which is
+    exactly the state a crate is in before it earns a DOI.
+    """
+    if _needs_graph(graph):
+        return None
+    return any(_is_globally_unique_id(text) for text in _root_ids(graph))
 
 
 def _check_every_entity_has_id(state: CrateState, graph: Graph = None) -> bool | None:
@@ -2498,6 +2582,8 @@ def _state_check(fn: Callable[[CrateState], bool]) -> DsmCheck:
 # see #665 for why the licence indicators moved first and what a wider move would cost.
 _GRAPH_AWARE_FAIR_CHECKS: frozenset[str] = frozenset(
     {
+        # #712: was true on `session_id` alone, a handle no reader receives.
+        "root_global_id",
         "license_present",
         "license_standard",
         "license_machine",

--- a/tests/test_fair_indicators_source.py
+++ b/tests/test_fair_indicators_source.py
@@ -213,7 +213,7 @@ class TestFairIndicatorsDerivedFromRda:
         rep = assess_fair_maturity(state, graph={"@graph": _assemble_graph(state) or []})
         got = {r["id"]: (r.get("passed"), r.get("scope", "")) for r in rep.indicator_results}
         expected = {
-            "RDA-F1-02M": (True, ""),
+            "RDA-F1-02M": (False, ""),
             "RDA-F1-02D": (False, ""),
             "RDA-F1-01M": (False, ""),
             "RDA-F2-01M": (True, ""),
@@ -268,19 +268,22 @@ class TestFairIndicatorsDerivedFromRda:
         rep = assess_fair_maturity(state, graph={"@graph": _assemble_graph(state) or []})
         met = sum(1 for r in rep.indicator_results if r.get("passed") is True)
         failed = sum(1 for r in rep.indicator_results if r.get("passed") is False)
-        # 11/7 is the post-#670 baseline, pinned indicator-by-indicator in the test
-        # above (13/5 before; F1-02D and R1-01M now fail for stated reasons).
+        # 10/8 since #712: F1-02M asks the crate for a globally unique identifier
+        # instead of reading `session_id`, and this crate carries none. 11/7 before
+        # that, 13/5 before #670 (F1-02D and R1-01M fail for stated reasons).
         # R1.3-01D reads False here because no MIT report is passed.
-        assert (met, failed) == (11, 7), "the verdicts moved; only the denominator should"
+        assert (met, failed) == (10, 8), "the verdicts moved; only the denominator should"
         assert len(rep.indicator_results) == 41, "the whole model is reported"
 
     def test_the_graph_is_what_makes_the_score_answerable(self):
-        """#670: ten indicators read the crate, so state alone cannot answer them.
+        """#670: eleven indicators read the crate, so state alone cannot answer them.
 
         Not a redundant restatement of the pin above — it fixes *which* input the
         number belongs to. A caller passing no graph gets "not assessed" for those
-        ten, and 4 met is a smaller, honest claim rather than the same claim guessed
-        from a session object no reader receives.
+        eleven, and 3 met is a smaller, honest claim rather than the same claim guessed
+        from a session object no reader receives. RDA-F1-02M joined them in #712: it
+        used to answer True from `session_id`, which is neither the crate nor an
+        identifier anyone receives.
         """
         from builder.tools.fair_assessment import assess_fair_maturity
         from tests.fixtures.vhps_golden_crates import vhps_fixture_state
@@ -292,4 +295,4 @@ class TestFairIndicatorsDerivedFromRda:
             for r in rep.indicator_results
             if r.get("passed") is None and r.get("scope") != "out_of_scope"
         )
-        assert (met, in_scope_unanswered) == (4, 10)
+        assert (met, in_scope_unanswered) == (3, 11)

--- a/tests/test_tools_fair_assessment.py
+++ b/tests/test_tools_fair_assessment.py
@@ -426,3 +426,80 @@ class TestTheAgentAndTheReportScoreTheSameCrate:
     def test_the_dsm_level_agrees(self) -> None:
         agent, report = self._both_paths()
         assert agent.dsm_level == report.dsm_level
+
+
+class TestTheTwoF1IndicatorsAskTwoQuestions:
+    """RDA-F1-01M and RDA-F1-02M are different questions about different actors.
+
+    The published model (10.15497/rda00050 §4.2) separates them: *persistent* is a
+    promise by the issuing organisation that the identifier will keep resolving;
+    *globally unique* is a structural property of the namespace it was minted in, so
+    no other issuer could ever produce the same string. Neither implies the other — a
+    UUID is globally unique and nobody has promised anything about it — and the model
+    scores both Essential.
+
+    The old `root_global_id` check was `bool(state.metadata.accession or
+    state.session_id)`, true after every run that got as far as being scored (#712).
+    The obvious repair — point it at `_root_pid` like RDA-F1-01M — would answer the
+    persistence question twice under two published ids, which is why the two
+    predicates are pinned here by the case that separates them.
+    """
+
+    @staticmethod
+    def _graph(identifier: str | None) -> dict:
+        root: dict = {"@id": "./", "@type": "Dataset", "name": "A crate"}
+        if identifier is not None:
+            root["identifier"] = identifier
+        return {
+            "@graph": [
+                {"@id": "ro-crate-metadata.json", "@type": "CreativeWork",
+                 "about": {"@id": "./"}},
+                root,
+            ]
+        }
+
+    def _f1(self, identifier: str | None) -> tuple:
+        """(persistent, globally unique) for a root carrying *identifier*."""
+        state = CrateState()
+        state.session_id = "20260101_000000"  # the handle the old check passed on
+        rep = assess_fair_maturity(state, graph=self._graph(identifier))
+        got = {r["id"]: r["passed"] for r in rep.indicator_results}
+        return got["RDA-F1-01M"], got["RDA-F1-02M"]
+
+    def test_a_repository_url_is_unique_without_being_persistent(self) -> None:
+        """The case that keeps the two indicators from collapsing into one, and the
+        crate the tool's own remedy proposes: a landing page in a DNS-partitioned
+        namespace, issued by a body that has promised nothing about keeping it."""
+        assert self._f1("https://www.ebi.ac.uk/biostudies/studies/S-VHPS22") == (False, True)
+
+    def test_a_doi_is_both(self) -> None:
+        assert self._f1("https://doi.org/10.6019/S-VHPS22") == (True, True)
+
+    def test_a_bare_accession_is_neither(self) -> None:
+        """Unique inside BioStudies, ambiguous outside it."""
+        assert self._f1("S-VHPS22") == (False, False)
+
+    def test_a_uuid_is_unique_with_no_promise_attached(self) -> None:
+        assert self._f1("urn:uuid:8f1e2a3b-4c5d-6e7f-8091-a2b3c4d5e6f7") == (False, True)
+
+    def test_a_national_library_urn_is_persistent(self) -> None:
+        assert self._f1("urn:nbn:nl:ui:13-abcdef") == (True, True)
+
+    def test_the_substring_doi_is_not_a_scheme(self) -> None:
+        """Measured false positives of the old `_root_pid`: it accepted anything
+        containing "doi" and anything starting "10.", so a note to self scored as a
+        persistent identifier."""
+        assert self._f1("my_doi_notes") == (False, False)
+        assert self._f1("10.happy") == (False, False)
+
+    def test_a_session_handle_carries_neither(self) -> None:
+        """No reader ever receives `session_id`; a crate with no identifier at all
+        must fail both however the run was launched."""
+        assert self._f1(None) == (False, False)
+
+    def test_no_graph_is_not_assessed(self) -> None:
+        state = CrateState()
+        state.session_id = "20260101_000000"
+        rep = assess_fair_maturity(state)
+        got = {r["id"]: r["passed"] for r in rep.indicator_results}
+        assert got["RDA-F1-01M"] is None and got["RDA-F1-02M"] is None


### PR DESCRIPTION
`_check_root_global_id` (RDA-F1-02M, "Metadata is identified by a globally unique identifier") was:

```python
return bool(state.metadata.accession or state.session_id)
```

`session_id` is a timestamp this tool mints for itself, no reader ever receives it, and all three entry points set it before anything can be scored. **It passed 32 of the 32 crates in `output/`**, including ones carrying no identifier at all. The repo already knew — `_check_unique_id`'s docstring, four hundred lines below, names that exact expression as the discredited one.

## Why the obvious fix is wrong

#712 proposes routing it through `_root_pid`, like RDA-F1-01M. But `_check_pid_form` **is already** `bool(_root_pid(graph))`, so that would answer one question under two published ids and leave one indicator carrying no information.

The model separates them (10.15497/rda00050 §4.2), and the two questions are about different actors:

| | asks about | answer |
|---|---|---|
| **RDA-F1-01M** persistent | the **issuer** | has the minting organisation published a commitment to keep it resolving? |
| **RDA-F1-02M** globally unique | the **namespace** | was it minted in a space partitioned across all issuers? |

Neither implies the other — a UUID is globally unique and nobody has promised anything about it — and both are Essential.

## What landed

- `_root_pid` is now a persistence test: bare DOI, a resolver host that states the commitment (`doi.org`, `hdl.handle.net`, `n2t.net`, `w3id.org`, `purl.org`, …), `urn:nbn:`, `ark:/`.
- `_check_root_global_id` reads the assembled root through the new `_is_globally_unique_id`: absolute IRI with a DNS authority, `urn:<nid>:`, bare DOI, or UUID. No graph → not assessed.
- `"root_global_id"` joins `_GRAPH_AWARE_FAIR_CHECKS` — **without this the dispatcher still calls it state-only and the fix is dead code.**

## The test that matters

The corpus cannot see the difference: 31 of 32 crates carry a bare accession or a minted slug, the 32nd carries the DOI, so **both predicates read 1/32 today**. Judged on `output/` alone this pair looks like one predicate.

So the divergence is asserted directly, on the identifier this tool's own remedy proposes minting:

```
https://www.ebi.ac.uk/biostudies/studies/S-VHPS22  →  F1-02M True, F1-01M False
https://doi.org/10.6019/S-VHPS22                   →  both True
urn:uuid:8f1e…                                     →  unique, not persistent
urn:nbn:nl:ui:13-abcdef                            →  both
S-VHPS22                                           →  neither
```

That is exactly the state a crate is in before it earns a DOI, and it is the report line a depositor can act on. Without this test the pair can silently collapse back into one.

## Two false positives dropped for free

`_root_pid`'s docstring claimed "a DOI, or any absolute IRI" while the code was `startswith(("http://","https://","10.")) or "doi" in text.lower()`. Measured: it accepted **`10.happy`** and **`my_doi_notes`**, and rejected `urn:nbn:` and `urn:uuid:`. No published number moves from that half — `_root_pid` returned non-empty on exactly one crate before and after.

## Baselines that move, all honest

| | before | after |
|---|---|---|
| golden crate RDA-F1-02M | True | **False** |
| golden crate met / failed | 11 / 7 | **10 / 8** |
| no graph: met / not-assessed | 4 / 10 | **3 / 11** |

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_fair_indicators_source.py \
  tests/test_fair_metrics_can_fail.py tests/test_tools_fair_assessment.py -q
  → 108 passed, 3 xfailed
… + test_maturity_report, test_e2e_agent_eval, test_remediation_grouping,
    test_crate_reads_back                                     → 226 passed
```

`uvx ruff check` and `uv run ty check builder/ tests/` clean.

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf