### PR TITLE
feat(fair): the RDA workbook's own scoring is recorded, and the substitution declared

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -680,6 +680,19 @@ output and to the source workbook.
 Note the DSM model text is **CC-BY-4.0**; the FAIRplus repository's MIT `LICENSE.txt`
 covers only its Jekyll theme and does not license the model.
 
+**Where an instrument's own arithmetic is not reproduced, the YAML says so.** The RDA
+workbook computes a maturity level per FAIR area (`calc!C13:F13`, Level 0-5 gated on
+essential / important / useful thresholds); this tool publishes a met/failed count and
+no level. `fair/indicators.yaml`'s `scoring:` block records both, with the formulas
+**read from the sheet** rather than restated, and states the reason: every level above
+0 requires all of an area's essential indicators to be met, an `out_of_scope` indicator
+can never be met, and Accessibility is 12 of 12 `out_of_scope` — so the ladder would
+report the hosting repository's properties as the crate's failure. The per-indicator
+boolean is a different case and the block says so too: the sheet's own column J
+collapses its five-way metric all-or-nothing, so met/failed *is* the instrument's, not
+a coarsening of it. AIR carries the same shape of declaration; the DSM reproduces its
+instrument's grid outright and needs none.
+
 **A check reads the crate, not the session.** An indicator is scored against the
 assembled `@graph` — the bytes a reader receives — so a third party scoring the
 published crate reaches our published number. Given no graph a check answers *not

--- a/fair/indicators.yaml
+++ b/fair/indicators.yaml
@@ -43,6 +43,53 @@ sources:
     name: Nanosafety data reusability (NSDRA)
     citation: Ammar, Evelo & Willighagen 2024, Scientific Data 11:503
     doi: 10.1038/s41597-024-03324-x
+scoring:
+  metric:
+  - 0 – not applicable
+  - 1 – not being considered this yet
+  - 2 – under consideration or in planning phase
+  - 3 – in implementation phase
+  - 4 – fully implemented
+  per_indicator:
+    cell: '''FAIR Indicators_v0.05''!J2'
+    formula: =IF(OR($H2=DATA!$L$1,$H2=DATA!$L$2,$H2=DATA!$L$3,$H2=DATA!$L$4,$H2=0),0,1)
+    note: Only '4 - fully implemented' scores 1. Every partial state scores 0, and so does a blank — the
+      trailing $H2=0 term. This tool's met/failed verdict is this column, not a coarsening of it.
+  ladder:
+    cell: calc!C13:F13
+    formula: =IF(AND(C$7=C$6,C$9=C8,C$11=C$10),DATA!$E$6,IF(AND(C$7=C$6,C$9=C$8,C$11>=C$10/2),DATA!$E$5,IF(AND(C$7=C$6,C$9=C$8),DATA!$E$4,IF(AND(C$7=C$6,C$9>=C$8/2),DATA!$E$3,IF(C$7=C$6,DATA!$E$2,DATA!$E$1)))))
+    areas:
+    - FINDABLE
+    - ACCESSIBLE
+    - INTEROPERABLE
+    - REUSABLE
+    priorities:
+    - Essential
+    - Important
+    - Useful
+    levels:
+    - name: Level 0
+      definition: Not FAIR
+    - name: Level 1
+      definition: FAIR essential criteria only
+    - name: Level 2
+      definition: FAIR essential criteria + 50 % of important criteria
+    - name: Level 3
+      definition: FAIR essential criteria + 100% of important criteria
+    - name: Level 4
+      definition: FAIR essential criteria + 100% of important criteria + 50% of useful criteria
+    - name: Level 5
+      definition: FAIR essential criteria + 100% of important criteria + 100% of useful criteria
+  published_output: one maturity level per FAIR area, from the met and total counts per priority tier
+    within that area (calc!C6:F11)
+  local_output: a met / failed / not-assessed count over all 41 indicators, and no level
+  deviation_note: 'The ladder gates every level above 0 on ALL essential indicators in the area being
+    met, and an indicator this tool reports out_of_scope can never be met. Measured on the model as carried:
+    Accessibility is 12 of 12 out_of_scope, so its level would read 0 on every crate forever; Findability
+    carries two out_of_scope essentials (RDA-F1-01D, RDA-F4-01M), so it could not reach Level 1 on a perfect
+    crate. Publishing the ladder would report the hosting repository''s properties as the crate''s failure,
+    which is the reading this tool refuses everywhere else. The substitution is a flat count — declared
+    here rather than left to be inferred from a missing key.'
 indicators:
 - id: RDA-F1-01M
   dimension: F

--- a/scripts/gen_fair_indicators.py
+++ b/scripts/gen_fair_indicators.py
@@ -8,9 +8,12 @@ so they cannot silently drift. The *local* decision — which indicators this to
 assess intrinsically from a single RO-Crate, and with which check function — lives in
 :data:`LOCAL_SCOPE` below; that is inherently repo-specific and stays here.
 
-FAIR *scoring* stays local and offline: every automated FAIR evaluator (F-UJI, the
-FAIR Evaluator, FAIROS) needs a published, resolvable URL and cannot score a local,
-pre-publication crate. Only the indicator definitions are externalised.
+The workbook's own **scoring** is now read too, into a ``scoring:`` block — not to
+compute it, but so that what this tool substitutes is stated rather than implied.
+That third-party FAIR evaluators (F-UJI, the FAIR Evaluator, FAIROS) need a published,
+resolvable URL and cannot score a pre-publication crate is true and irrelevant: the
+instrument vendored two directories away needs neither, and :func:`_load_scoring`
+records what it computes and why this tool does not.
 
 The FAIRplus DSM ladder (``fair/dsm_indicators.yaml``) is generated from its own
 vendored assessment workbook by ``scripts/gen_dsm_indicators.py`` — not touched here.
@@ -46,6 +49,10 @@ OUT = REPO / "fair" / "indicators.yaml"
 # RDA indicator sheet: header row 0; columns PRINCIPLE(3), INDICATOR_ID(4),
 # INDICATORS/text(5), PRIORITY(6).
 _SHEET = "FAIR Indicators_v0.05"
+# The workbook's other three sheets, all of which the scoring model spans.
+_CALC_SHEET = "calc"
+_LEVELS_SHEET = "LEVELS"
+_DATA_SHEET = "DATA"
 
 # Every published indicator is carried, in report order: indicator id ->
 # (check-function name, reason-it-is-not-checked). Exactly one of the pair is set.
@@ -211,6 +218,86 @@ def _load_rda() -> dict[str, dict[str, str]]:
     return out
 
 
+def _load_scoring() -> dict[str, Any]:
+    """What the workbook computes from the 41 answers — read from its cells, not restated.
+
+    Two things, and this tool reproduces exactly one of them.
+
+    **The per-indicator boolean is the workbook's own.** Its native answer is a five-way
+    maturity metric (column H, a dropdown over ``DATA!L1:L5``), but column J collapses it
+    all-or-nothing: ``1`` only for "4 - fully implemented", ``0`` for every partial state
+    *and* for a blank. That is precisely what a met/failed verdict here means, so the
+    boolean is not a coarsening of the instrument — it is the instrument's own column.
+    The 0-4 shading survives only in the workbook's radar pictures.
+
+    **The ladder is not reproduced.** ``calc!C13:F13`` computes a maturity level per FAIR
+    area from the met/total counts per priority tier, and this tool publishes no level at
+    all. Recording the formula verbatim rather than a parsed threshold table is
+    deliberate: one fact stated twice is how a generated file and its source drift.
+    """
+    wb = openpyxl.load_workbook(RDA_XLSX, data_only=False)
+    ind, calc = wb[_SHEET], wb[_CALC_SHEET]
+    levels_sheet, data = wb[_LEVELS_SHEET], wb[_DATA_SHEET]
+
+    metric = [str(data.cell(row=r, column=12).value) for r in range(1, 6)]
+    priorities = [str(data.cell(row=r, column=3).value) for r in range(1, 4)]
+    areas = [str(calc.cell(row=5, column=c).value) for c in range(3, 7)]
+    levels = [
+        {
+            "name": str(data.cell(row=r, column=5).value),
+            "definition": str(levels_sheet.cell(row=r + 4, column=5).value),
+        }
+        for r in range(1, 7)
+    ]
+    per_indicator, ladder = str(ind["J2"].value), str(calc["C13"].value)
+
+    # Generation fails loudly rather than emitting a model the sheet does not hold.
+    if not all(f"DATA!$L${n}" in per_indicator for n in (1, 2, 3, 4)):
+        raise ValueError(f"J2 no longer collapses the four sub-4 metrics: {per_indicator}")
+    if not all(f"DATA!$E${n}" in ladder for n in range(1, 7)):
+        raise ValueError(f"calc!C13 no longer names all six levels: {ladder}")
+    if [lvl["name"] for lvl in levels] != [f"Level {n}" for n in range(6)]:
+        raise ValueError(f"DATA!E1:E6 is not the six levels: {levels}")
+    if len(metric) != 5 or len(priorities) != 3 or len(areas) != 4:
+        raise ValueError("the sheet's metric / priority / area vocabularies changed")
+
+    return {
+        "metric": metric,
+        "per_indicator": {
+            "cell": f"'{_SHEET}'!J2",
+            "formula": per_indicator,
+            "note": (
+                "Only '4 - fully implemented' scores 1. Every partial state scores 0, and "
+                "so does a blank — the trailing $H2=0 term. This tool's met/failed verdict "
+                "is this column, not a coarsening of it."
+            ),
+        },
+        "ladder": {
+            "cell": f"{_CALC_SHEET}!C13:F13",
+            "formula": ladder,
+            "areas": areas,
+            "priorities": priorities,
+            "levels": levels,
+        },
+        "published_output": (
+            "one maturity level per FAIR area, from the met and total counts per priority "
+            "tier within that area (calc!C6:F11)"
+        ),
+        "local_output": "a met / failed / not-assessed count over all 41 indicators, and no level",
+        "deviation_note": (
+            "The ladder gates every level above 0 on ALL essential indicators in the area "
+            "being met, and an indicator this tool reports out_of_scope can never be met. "
+            "Measured on the model as carried: Accessibility is 12 of 12 out_of_scope, so "
+            "its level would read 0 on every crate forever; Findability carries two "
+            "out_of_scope essentials (RDA-F1-01D, RDA-F4-01M), so it could not reach Level "
+            "1 on a perfect crate. Publishing the ladder would report the hosting "
+            "repository's properties as the crate's failure, which is the reading this "
+            "tool refuses everywhere else. The substitution is a flat count — declared "
+            "here rather than left to be inferred from a missing key."
+        ),
+    }
+
+
 def build_data() -> dict[str, Any]:
     """The full ``indicators.yaml`` payload: sources + all 41 RDA indicators."""
     rda = _load_rda()
@@ -248,7 +335,7 @@ def build_data() -> dict[str, Any]:
             entry["reason"] = reason
         entry["text"] = d["text"]
         indicators.append(entry)
-    return {"sources": SOURCES, "indicators": indicators}
+    return {"sources": SOURCES, "scoring": _load_scoring(), "indicators": indicators}
 
 
 def format_report(data: dict[str, Any]) -> str:

--- a/tests/test_air_criteria_source.py
+++ b/tests/test_air_criteria_source.py
@@ -20,6 +20,7 @@ import hashlib
 import importlib.util
 import pathlib
 
+import openpyxl
 import pytest
 import yaml
 
@@ -185,7 +186,28 @@ class TestTheScoringModelIsTheAuthors:
     """Seven percentages, no aggregate — the authors refuse one and so do we."""
 
     def test_the_worksheet_formula_is_recorded(self, data):
+        """It is recorded *and* checked against the cell it was copied from.
+
+        The name promised parity and the body asserted only our own paraphrase, so the
+        literal in the generator had never been compared with the workbook (#715). It
+        matches — this is a guard, not a repair — but nothing was holding it there, and
+        the md5 pin below only catches a change to the vendored bytes, not a
+        re-vendoring that bumps the pin and leaves the literal behind.
+        """
         assert data["scoring"]["per_dimension"] == "met / total * 100"
+        sheet = openpyxl.load_workbook(WORKSHEET, data_only=False)["Blank"]
+        assert data["scoring"]["formula"] == sheet["E4"].value
+        assert data["scoring"]["input"] == sheet["D3"].value
+
+    def test_the_recorded_formula_is_one_dimension_of_seven(self, data):
+        """`formula` is dimension 0's cell, and the seven are NOT interchangeable —
+        the same block's note says the denominators are deliberately unequal. E4 spans
+        four criteria, E12 spans five. Pinned so the singular key cannot be read as the
+        instrument's one formula."""
+        sheet = openpyxl.load_workbook(WORKSHEET, data_only=False)["Blank"]
+        assert "D4:D7" in data["scoring"]["formula"], "dimension 0, four criteria"
+        assert "D12:D16" in sheet["E12"].value, "Characterization, five"
+        assert "deliberately unequal" in data["scoring"]["note"]
 
     def test_there_is_no_aggregate_score(self, data):
         """Verbatim: "We do not score it pass/fail overall"."""

--- a/tests/test_fair_indicators_source.py
+++ b/tests/test_fair_indicators_source.py
@@ -17,10 +17,17 @@ import openpyxl
 import pytest
 import yaml
 
+from builder.state import CrateState
+
 REPO = pathlib.Path(__file__).resolve().parents[1]
 INDICATORS_YAML = REPO / "fair" / "indicators.yaml"
 RDA_XLSX = REPO / "fair" / "rda_fdmm.xlsx"
 GEN = REPO / "scripts" / "gen_fair_indicators.py"
+
+
+def _yaml_data() -> dict:
+    """The committed indicators.yaml."""
+    return yaml.safe_load(INDICATORS_YAML.read_text())
 
 
 def _load_generator():
@@ -296,3 +303,74 @@ class TestFairIndicatorsDerivedFromRda:
             if r.get("passed") is None and r.get("scope") != "out_of_scope"
         )
         assert (met, in_scope_unanswered) == (3, 11)
+
+
+class TestTheWorkbooksOwnScoringIsRecorded:
+    """The RDA workbook computes something, and this tool computes something else.
+
+    Until #715 the YAML carried no `scoring` block at all, so the substitution was
+    visible only as a missing key — and the generator's stated reason (third-party
+    evaluators need a resolvable URL) is about services, not about the instrument
+    vendored beside it. The block now records what the sheet does, read from its own
+    cells, and these tests are what keep the record true.
+    """
+
+    @staticmethod
+    def _sheet(name: str):
+        return openpyxl.load_workbook(RDA_XLSX, data_only=False)[name]
+
+    def test_the_per_indicator_formula_is_the_workbooks(self) -> None:
+        """Not a hand-copied literal: byte-for-byte the cell it names."""
+        block = _yaml_data()["scoring"]["per_indicator"]
+        assert block["formula"] == self._sheet("FAIR Indicators_v0.05")["J2"].value
+
+    def test_the_ladder_formula_is_the_workbooks(self) -> None:
+        block = _yaml_data()["scoring"]["ladder"]
+        assert block["formula"] == self._sheet("calc")["C13"].value
+
+    def test_the_level_definitions_are_the_workbooks_own_words(self) -> None:
+        levels = _yaml_data()["scoring"]["ladder"]["levels"]
+        sheet = self._sheet("LEVELS")
+        assert [lvl["definition"] for lvl in levels] == [
+            sheet.cell(row=r, column=5).value for r in range(5, 11)
+        ]
+        assert levels[0]["definition"] == "Not FAIR"
+
+    def test_our_boolean_is_the_sheets_own_column_not_a_coarsening(self) -> None:
+        """The sheet's native answer is a five-way metric, and it collapses it itself:
+        column J scores 1 only for "fully implemented" and 0 for every partial state
+        and for a blank. So met/failed is the instrument's, and the `scoring` block
+        must not claim otherwise."""
+        scoring = _yaml_data()["scoring"]
+        assert len(scoring["metric"]) == 5, "the published metric is 0-4"
+        formula = scoring["per_indicator"]["formula"]
+        assert formula.endswith(",0,1)"), "1 only when none of the sub-4 states match"
+        assert "$H2=0" in formula, "a blank scores 0 — the sheet has no unanswered state"
+
+    def test_the_deviation_note_measures_what_it_claims(self) -> None:
+        """The note says the ladder would report the repository's properties as the
+        crate's failure. That rests on two counts over the model as carried, and if
+        either changes the note is wrong and must be rewritten."""
+        data = _yaml_data()
+        by_dim: dict[str, list[dict]] = {}
+        for ind in data["indicators"]:
+            by_dim.setdefault(ind["dimension"], []).append(ind)
+        out = {
+            dim: [i for i in inds if i.get("scope") == "out_of_scope"]
+            for dim, inds in by_dim.items()
+        }
+        assert len(out["A"]) == len(by_dim["A"]) == 12, "Accessibility is wholly out of scope"
+        f_essential = [i["id"] for i in out["F"] if i["priority"] == "essential"]
+        assert sorted(f_essential) == ["RDA-F1-01D", "RDA-F4-01M"], (
+            "Findability's two out-of-scope essentials are what put Level 1 out of reach"
+        )
+        note = data["scoring"]["deviation_note"]
+        assert "12 of 12" in note and "RDA-F1-01D" in note
+
+    def test_no_level_is_published(self) -> None:
+        """The declaration has to match the code: this tool reports counts, not levels."""
+        from builder.tools.fair_assessment import assess_fair_maturity
+
+        rep = assess_fair_maturity(CrateState())
+        assert not hasattr(rep, "area_levels") and not hasattr(rep, "rda_level")
+        assert _yaml_data()["scoring"]["local_output"].startswith("a met / failed")


### PR DESCRIPTION
`fair/indicators.yaml` had two top-level keys — `sources` and `indicators` — so the fact that the vendored workbook computes something this tool does not was visible only as a *missing key*. The generator's stated reason (third-party evaluators need a resolvable URL and cannot score a pre-publication crate) is true of those services and irrelevant to the instrument vendored two directories away, which needs no network at all.

## What the workbook actually does — and one of the two, we already do

`_load_scoring` reads it out of the sheet's own cells rather than restating it:

| cell | what it computes | do we? |
|---|---|---|
| `'FAIR Indicators_v0.05'!J2` | collapses the five-way METRIC to a boolean — **1 only for "4 – fully implemented"**, 0 for every partial state *and* for a blank | **yes — this is our met/failed verdict** |
| `calc!C13:F13` | a maturity **level per FAIR area** from met/total per priority tier | **no** |

That first row reverses the issue's premise. I filed #715 saying our boolean was a coarser substitution; it is not. The sheet coarsens its own metric, in its own column J, and the 0–4 shading survives only in its radar pictures. What we genuinely don't reproduce is the ladder.

Formulas are recorded **verbatim**, not parsed into a threshold table — one fact stated twice is how a generated file and its source drift.

## Why we publish no level, measured

Every level above 0 gates on **all** of an area's essential indicators being met, and an `out_of_scope` indicator can never be met:

- **Accessibility is 12 of 12 `out_of_scope`** → its level reads 0 on every crate, forever.
- **Findability carries two out-of-scope essentials** (`RDA-F1-01D`, `RDA-F4-01M`) → it could not reach Level 1 on a perfect crate.

Publishing the ladder would report the hosting repository's properties as the crate's failure — the reading this tool refuses everywhere else. That reason is in the `deviation_note`, and **both counts are asserted**, so the note cannot outlive the model it describes.

## The AIR half of the same issue

`test_the_worksheet_formula_is_recorded` promised parity and asserted only our own paraphrase (`per_dimension == "met / total * 100"`), so the formula literal in `gen_air_criteria.py` had **never been compared with cell E4**.

It matches byte-for-byte, all 37 characters including the space after the comma — so this is a guard, not a repair. Worth having anyway: the md5 pin beside it catches a change to the vendored bytes, not a re-vendoring that bumps the pin and leaves the literal behind. A second test pins the naming trap the audit surfaced — `formula` is dimension 0's cell (`D4:D7`), while `E12` spans five criteria, and the same block's note says the denominators are *deliberately* unequal.

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_fair_indicators_source.py \
  tests/test_air_criteria_source.py tests/test_fair_metrics_can_fail.py \
  tests/test_tools_fair_assessment.py tests/test_maturity_report.py -q
  → 314 passed, 3 xfailed
```

`uvx ruff check` and `uv run ty check builder/ tests/ scripts/` clean. No published number moves — this adds a declaration and the tests that keep it true.

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf