### PR TITLE
feat(hitl): every choice prompt takes a typed answer, and one call asks several questions in turn (#596)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1517,7 +1517,8 @@ substituting ours silently would misstate the instrument.
 
 ### Session & HITL Tools
 ```
-present_to_human(context: str, options: [str], questions: [{question: str, options: [str]}]) → HumanResponse
+present_to_human(context: str, options: [str]) → HumanResponse
+present_to_human(context: str, questions: [{question: str, options: [str]}]) → {action: "answered", answers: [{question, answer}]}
 request_input(prompt: str, field_type: str | None = None) → InputResponse
 save_session(label: str) → SessionInfo
 list_sessions() → [SessionInfo]
@@ -1531,9 +1532,10 @@ console appends a final "Something else — let me type an answer" row to every
 prompt except a scan-root escalation, so an answer the caller did not foresee is
 still possible; it comes back as `action: "edited"` with the text in `comments`
 and `edits.value`. With `questions` the tool asks several in turn — each with its
-own `options`, or as a free-text field when it has none — records every exchange
-in `state.user_answers`, and returns `{action: "answered", answers: [{question,
-answer}]}`. `request_input` asks the human for a single free-form value (e.g. a
+own `options`, or as a free-text field when it has none — records every answered
+exchange in `state.user_answers` (a skip is reported, not recorded), and returns
+`{action: "answered", answers: [{question, answer}]}`; an entry not of that shape
+is an error and nothing is asked. `request_input` asks the human for a single free-form value (e.g. a
 compound name, CAS number, or cell line accession) when a lookup needs a missing
 identifier. `list_sessions` and `load_session` drive the resume flow (§7);
 `present_to_human`/`request_input` are engine-routed HITL tools (not in
@@ -1689,9 +1691,7 @@ nothing is reconstructed from a crate's `ro-crate-metadata.json`.
 ### Interaction Model
 1. Agent presents content and a question
 2. User can: **Approve**, **Edit**, **Reject with explanation**, or **Skip**. On
-   the console, **Edit** is the last row of every choice prompt ("Something else
-   — let me type an answer"), which opens the free-text box; a scan-root
-   escalation has no such row (#197)
+   the console, **Edit** is the free-text row every choice prompt ends with (§5)
 3. Agent incorporates feedback and continues
 4. Feedback is applied to the entity in place; a standing answer to a validation
    escalation is recorded on `state.validation_preferences` and asked at most once

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1517,19 +1517,27 @@ substituting ours silently would misstate the instrument.
 
 ### Session & HITL Tools
 ```
-present_to_human(context: str, options: [str]) → HumanResponse
-request_input(prompt: str, field_type: str | None = None) → HumanResponse
+present_to_human(context: str, options: [str], questions: [{question: str, options: [str]}]) → HumanResponse
+request_input(prompt: str, field_type: str | None = None) → InputResponse
 save_session(label: str) → SessionInfo
 list_sessions() → [SessionInfo]
 load_session(session_id: str) → SessionStatus
 get_status() → SessionStatus
 get_hint() → str
 ```
-`present_to_human` offers a choice between `options`; `request_input` asks the
-human for a single free-form value (e.g. a compound name, CAS number, or cell
-line accession) when a lookup needs a missing identifier. `list_sessions` and
-`load_session` drive the resume flow (§7); `present_to_human`/`request_input`
-are engine-routed HITL tools (not in `TOOL_REGISTRY`), the rest are specced.
+`present_to_human` asks one decision: `context` says what was found and
+`options` are the rows the user picks between, the first pre-selected. The
+console appends a final "Something else — let me type an answer" row to every
+prompt except a scan-root escalation, so an answer the caller did not foresee is
+still possible; it comes back as `action: "edited"` with the text in `comments`
+and `edits.value`. With `questions` the tool asks several in turn — each with its
+own `options`, or as a free-text field when it has none — records every exchange
+in `state.user_answers`, and returns `{action: "answered", answers: [{question,
+answer}]}`. `request_input` asks the human for a single free-form value (e.g. a
+compound name, CAS number, or cell line accession) when a lookup needs a missing
+identifier. `list_sessions` and `load_session` drive the resume flow (§7);
+`present_to_human`/`request_input` are engine-routed HITL tools (not in
+`TOOL_REGISTRY`), the rest are specced.
 
 ### Profiling
 Every tool call and graph node execution is automatically timed and recorded by `ProfilingLogger` (see [docs/profiling.md](docs/profiling.md)). Profile data is written to `sessions/<session_id>/profile.ndjson` as newline-delimited JSON with event types including `tool_call`, `node_start`, `node_end`, and `hitl_wait`. This file is the primary input for timing analysis, debugging, and live status in future web UIs.
@@ -1680,7 +1688,10 @@ nothing is reconstructed from a crate's `ro-crate-metadata.json`.
 
 ### Interaction Model
 1. Agent presents content and a question
-2. User can: **Approve**, **Edit**, **Reject with explanation**, or **Skip**
+2. User can: **Approve**, **Edit**, **Reject with explanation**, or **Skip**. On
+   the console, **Edit** is the last row of every choice prompt ("Something else
+   — let me type an answer"), which opens the free-text box; a scan-root
+   escalation has no such row (#197)
 3. Agent incorporates feedback and continues
 4. Feedback is applied to the entity in place; a standing answer to a validation
    escalation is recorded on `state.validation_preferences` and asked at most once

--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ Once in the agent loop, you can type requests like:
 > *"Build the crate and validate it"*
 > *"Assess MIT coverage"*
 
+When the agent needs a decision it shows the choices in a box: Enter confirms the
+highlighted row, ↑/↓ move, and the last row, *Something else — let me type an
+answer*, opens the text box. A question with no choices is a plain text box, and
+a dim line above the `❯` box says what it is waiting for — an answer, a next step
+(or `continue`), or a change.
+
 While iterating, the agent checks conformance with `build_and_validate`, which
 assembles and validates the crate **in memory** (no files written) and returns
 issues keyed to the entity and property that failed. Only when the crate is

--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -1780,14 +1780,18 @@ def _resolve_gap(
                 options=["approve", "reject"],
             )
             action = decision.get("action")
-            if action in ("approved", "edited"):
-                # The user's own value (the console's "let me type an answer"
-                # row, #596) rides in `edits`; a plain approval takes the draft.
-                edits = decision.get("edits") or {}
-                value = str(edits.get("value")) if edits.get("value") else candidate
-                if _apply_value(engine, gap, value, human):
-                    via = "draft-edited" if action == "edited" else "draft-confirmed"
-                    resolved.append({**record, "via": via})
+            if action == "skipped":
+                # A stop word or Ctrl+D at the dialog (#596): the gap is skipped,
+                # not asked again in prose.
+                return False
+            # The user's own value (the console's "let me type an answer" row,
+            # #596) rides in `edits` or `comments`; a plain approval takes the
+            # draft. An edit that carries no value is not one.
+            edits = decision.get("edits") or {}
+            own = str(edits.get("value") or decision.get("comments") or "").strip()
+            if action == "approved" or (action == "edited" and own):
+                if _apply_value(engine, gap, own or candidate, human):
+                    resolved.append({**record, "via": "draft-edited" if own else "draft-confirmed"})
                     return True
                 return False
         # No usable draft, or the user rejected it -> fall through to ask-user.

--- a/builder/agents/pipeline/guidance.py
+++ b/builder/agents/pipeline/guidance.py
@@ -1749,8 +1749,9 @@ def _resolve_gap(
     Dispatches on ``auto_fixable`` / ``fix_hint``:
 
     * **auto_fixable** -> the deterministic repair, no prompt.
-    * **draft** -> draft a value, show it, require confirmation (D5); on reject,
-      fall through to ask-user.
+    * **draft** -> draft a value, show it, require confirmation (D5); a typed
+      answer commits the user's own value instead; on reject, fall through to
+      ask-user.
     * **ask-user** (or any non-auto fallback) -> prompt and apply the answer.
 
     Records the action in ``resolved`` (committed) or ``asked`` (surfaced to the
@@ -1778,12 +1779,15 @@ def _resolve_gap(
                 ),
                 options=["approve", "reject"],
             )
-            if decision.get("action") == "approved":
-                # An edited confirmation may carry the user's own value.
+            action = decision.get("action")
+            if action in ("approved", "edited"):
+                # The user's own value (the console's "let me type an answer"
+                # row, #596) rides in `edits`; a plain approval takes the draft.
                 edits = decision.get("edits") or {}
                 value = str(edits.get("value")) if edits.get("value") else candidate
                 if _apply_value(engine, gap, value, human):
-                    resolved.append({**record, "via": "draft-confirmed"})
+                    via = "draft-edited" if action == "edited" else "draft-confirmed"
+                    resolved.append({**record, "via": via})
                     return True
                 return False
         # No usable draft, or the user rejected it -> fall through to ask-user.

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -16,7 +16,7 @@ from collections import Counter
 from contextvars import ContextVar
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Literal, Sequence, cast, overload
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Sequence, cast, overload
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langgraph.errors import GraphRecursionError
@@ -42,7 +42,12 @@ from builder.agents.react.system_prompt import SYSTEM_PROMPT
 from builder.agents.react.tools_spec import TOOL_SPECS, assert_tool_spec_parity
 from builder.engine import AgentEngine
 from builder.tools.document_discovery import looks_like_publication
-from builder.tools.hitl import CONVERSATION_FIELD_TYPE, answers_are_synthetic, is_interactive
+from builder.tools.hitl import (
+    CONVERSATION_FIELD_TYPE,
+    answers_are_synthetic,
+    choice_stance,
+    is_interactive,
+)
 
 if TYPE_CHECKING:
     from typing import cast
@@ -207,6 +212,21 @@ class _ToolSpinnerCallback(BaseCallbackHandler):
 # ---------------------------------------------------------------------------
 
 
+def _list_of(items: dict[str, Any]) -> Any:
+    """The type of a list parameter whose entry shape must reach the model.
+
+    Validated as a bare ``list`` — the entries reach the tool as the plain dicts
+    the model sent — but advertised with the ``items`` schema written in
+    TOOL_SPECS. It rides on the annotation, not the field: LangChain rebuilds
+    its tool-call schema from the annotations alone, so a field-level schema
+    extra never reaches the model, and the ``questions`` of ``present_to_human``
+    were advertised as ``items: {}`` (#596).
+    """
+    from pydantic import WithJsonSchema
+
+    return Annotated[list, WithJsonSchema({"type": "array", "items": items})]
+
+
 def _build_args_schema(name: str, params: dict[str, Any]) -> type[BaseModel] | None:
     """Dynamically create a pydantic model from a JSON schema dict.
 
@@ -249,6 +269,9 @@ def _build_args_schema(name: str, params: dict[str, Any]) -> type[BaseModel] | N
         py_type = type_map.get(json_type, str)
 
         description = field_schema.get("description", "")
+        items = field_schema.get("items") if json_type == "array" else None
+        if isinstance(items, dict) and items:
+            py_type = _list_of(items)
 
         # If the field has enum values, use a Literal type
         if "enum" in field_schema:
@@ -385,6 +408,15 @@ def _run_validation_escalation(
             options=["yes", "no"],
             purpose=_VALIDATION_ESCALATION_PURPOSE,
         )
+        if response.get("action") == "edited":
+            # Typed at the free-text row (#596): a yes or no in the user's own
+            # words is the answer; anything else is not one, so ask again next
+            # time rather than remember a refusal nobody gave.
+            stance = choice_stance(str(response.get("comments") or ""))
+            if stance is None:
+                return False
+            prefs[tier] = stance
+            return stance
         prefs[tier] = response.get("action") == "approved"
         return prefs[tier]
 
@@ -1594,14 +1626,14 @@ def _idle_nudge(engine: AgentEngine, streak: int, tool_name: str) -> str:
             f"Still nothing changed after {streak} calls. Reading and listing cannot "
             f"advance the crate — only a mutation can.{where} Your NEXT call must be "
             "draft_*, set_fields, link, attach_files, or export_crate. If you genuinely "
-            "cannot proceed, say so in a reply and ask the user the specific question "
-            "you need answered."
+            "cannot proceed, ask the user the specific question you need answered "
+            "through present_to_human."
         )
     return (
         f"Last warning: {streak} calls without a single change.{where} If the next "
         "call is not a mutation or a reply, this turn ends and the user is asked to "
-        "decide. If you are stuck, ending with a question is a better outcome than "
-        "another query."
+        "decide. If you are stuck, a present_to_human question is a better outcome "
+        "than another query."
     )
 
 
@@ -4959,9 +4991,7 @@ def run_interactive_agent(
                     console.print()
                 # The box that follows says what it is for (#596): the reply above
                 # is either a question to answer or work that stopped.
-                prompt_hint = _prompt_hint(
-                    reply, open_work=bool(open_items(engine.state, actionable_only=True))
-                )
+                prompt_hint = _prompt_hint(reply, open_work=not _crate_is_complete(engine))
             except KeyboardInterrupt:
                 # Ctrl+C during a turn / the autonomous run: stop working and return
                 # to the prompt so the user can interject (preserve interruptibility).

--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -812,6 +812,22 @@ def _reply_is_question(reply: str | None) -> bool:
     return any(lowered.startswith(opener) for opener in _INTERROGATIVE_OPENERS)
 
 
+# What the ❯ box is waiting for, printed above it once the agent has stopped
+# (#596). A reply that ends in a question and a reply that ran to the turn cap
+# put the same empty box in front of the user, who then has to guess whether
+# "yes" or "continue" is the answer — so the box says which.
+_HINT_ANSWER = "Answer the question above."
+_HINT_OPEN = "Type what to do next, or 'continue' to let me carry on."
+_HINT_DONE = "Nothing left to do — type a change, or 'quit'."
+
+
+def _prompt_hint(reply: str | None, *, open_work: bool) -> str:
+    """The line above the ❯ box after a stop: answer, steer or continue, or done."""
+    if _reply_is_question(reply):
+        return _HINT_ANSWER
+    return _HINT_OPEN if open_work else _HINT_DONE
+
+
 def _crate_is_complete(engine: AgentEngine) -> bool:
     """Return True when the crate passes REQUIRED and has nothing left to do.
 
@@ -4765,6 +4781,8 @@ def run_interactive_agent(
     # A caller-supplied kickoff drives the first turn in place of the first stdin
     # read (#412); everything after it is an ordinary typed turn. Blank is absent.
     pending_input: str | None = (initial_prompt or "").strip() or None
+    # What the next ❯ box is waiting for (#596); nothing before the first turn.
+    prompt_hint: str | None = None
 
     # The status footer is pinned to the bottom rows for the whole session so
     # entities, validation dots, tokens and cost keep advancing while the agent
@@ -4816,6 +4834,8 @@ def run_interactive_agent(
                     # crate lands (#609).
                     raise EOFError
                 else:
+                    if prompt_hint:
+                        console.print(f"[dim]{prompt_hint}[/dim]")
                     # Rounded input box (Claude Code style); falls back to a plain
                     # prompt when not a TTY. Raises KeyboardInterrupt / EOFError.
                     # prompt_toolkit erases to the end of the screen on every
@@ -4831,6 +4851,7 @@ def run_interactive_agent(
                 _finalize_on_exit()
                 ui.print_goodbye(engine)
                 break
+            prompt_hint = None
 
             if user_input.lower() in ("quit", "exit", "q"):
                 _finalize_on_exit()
@@ -4851,6 +4872,7 @@ def run_interactive_agent(
             # an exception can never escape this loop body.
             try:
                 message = user_input
+                reply = ""
                 empty_streak = 0
                 self_continues = 0
                 # A new user turn gets a fresh strike budget. The counters live on
@@ -4933,11 +4955,13 @@ def run_interactive_agent(
                         "Reached max autonomous turns (%d) — checking in with the user",
                         _MAX_AUTONOMOUS_TURNS,
                     )
-                    console.print(
-                        "[dim]I've worked autonomously for a while — let me know how "
-                        "you'd like to proceed.[/dim]"
-                    )
+                    console.print("[dim]I've worked autonomously for a while.[/dim]")
                     console.print()
+                # The box that follows says what it is for (#596): the reply above
+                # is either a question to answer or work that stopped.
+                prompt_hint = _prompt_hint(
+                    reply, open_work=bool(open_items(engine.state, actionable_only=True))
+                )
             except KeyboardInterrupt:
                 # Ctrl+C during a turn / the autonomous run: stop working and return
                 # to the prompt so the user can interject (preserve interruptibility).

--- a/builder/agents/react/system_prompt.py
+++ b/builder/agents/react/system_prompt.py
@@ -96,8 +96,8 @@ Session & human-in-the-loop:
 - load_session: Load a previously saved session by ID
 - get_status: Get current session status
 - get_hint: Get a hint for next action
-- present_to_human: Present information to the user and get their response
-- request_input: Ask the user for a specific input value (e.g. a CAS number)
+- present_to_human: Ask the user to decide — options they confirm with one key; several open items at once via questions, each with its own options
+- request_input: Ask the user for one free-text value (e.g. a CAS number)
 
 ## Build Strategy: Get a Validatable Crate Fast
 
@@ -170,10 +170,12 @@ as soon as the backbone exists — do **not** leave it to the end:
    These take an entity id or a verified ORCID/ROR IRI and are REJECTED if they
    do not resolve — a bare name is not attribution.
 4. **Confirm with the user.** State what you found and ask them to confirm or
-   correct it: "The metadata names Dr. X (ORCID …, Universiteit Utrecht) as the
-   corresponding person — should they be the crate's contact and publisher?"
-   The corresponding person of an assay is evidence, not proof, of who publishes
-   the dataset. If nothing names them, ASK rather than guess.
+   correct it, through `present_to_human` with the decision as options:
+   context "The metadata names Dr. X (ORCID …, Universiteit Utrecht) as the
+   corresponding person", options "Yes, record Dr. X as the crate's contact and
+   publisher" / "No". The corresponding person of an assay is evidence, not
+   proof, of who publishes the dataset. If nothing names them, ASK rather than
+   guess.
 
 The publication's authors are NOT this. They describe the paper; publisher /
 creator / contact describe the dataset. A crate can list six authors and still
@@ -223,7 +225,7 @@ The key insight: **draft a minimal Investigation, Study, Assay, run `build_and_v
 2. Use `list_entities` only when you need to search for an entity that the preceding tool did not return. Do not repeat identical list queries without an intervening mutation or a changed search.
 3. NEVER fabricate identifiers. Every identifier must be verified against its source.
 4. First, scan the input directory to build your file inventory.
-5. Draft entities conversationally — ask the user for information you need.
+5. Ask through `present_to_human` / `request_input`, never by ending a reply with a question: a tool question gives the user rows to confirm with one key, a prose question leaves them a blank box. One decision per prompt; several open items go in questions, each with its own options; never add an 'Other' option — the user can always type their own answer.
 6. Use lookups to enrich entity metadata whenever possible.
 7. Validate continuously — REQUIRED issues block, SHOULD/MAY are recommendations.
 8. Present entities to the human for review before committing.

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -933,7 +933,7 @@ TOOL_SPECS = [
     },
     {
         "name": "present_to_human",
-        "description": "Ask the user to decide something. context states what you found; options are the answers they choose between — put the expected answer first, it is pre-selected, so one key confirms it. One decision per prompt. The user can always type an answer of their own, so never add an 'Other' or catch-all option. With several open items, pass questions instead — one entry per item, each with its own options (omit them for a free-text value such as a culture medium) — and they are asked one after another; never bundle them into one context. Ask through this tool, never by ending your reply with a question: a prose question leaves the user a blank box with nothing to confirm.",
+        "description": "Ask the user to decide something. context states what you found; options are the answers they choose between — put the expected answer first, it is pre-selected, so one key confirms it. Rows are the answers themselves (a person, a licence, a file); a plain yes/no has exactly two rows and comes back as approved or rejected. One decision per prompt. The user can always type an answer of their own, so never add an 'Other' or catch-all option. With several open items, pass questions instead — one entry per item, each with its own options (omit them for a free-text value such as a culture medium) — and they are asked one after another; never bundle them into one context. Ask through this tool, never by ending your reply with a question: a prose question leaves the user a blank box with nothing to confirm.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -944,7 +944,7 @@ TOOL_SPECS = [
                 "options": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "The answers to choose between, expected answer first. Omitted: a plain yes/no.",
+                    "description": "The answers to choose between, expected answer first. Omitted here (not inside questions): a plain yes/no.",
                 },
                 "questions": {
                     "type": "array",
@@ -952,11 +952,15 @@ TOOL_SPECS = [
                         "type": "object",
                         "properties": {
                             "question": {"type": "string", "description": "One question."},
-                            "options": {"type": "array", "items": {"type": "string"}},
+                            "options": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "The rows for this question; omitted, the question is a free-text box.",
+                            },
                         },
                         "required": ["question"],
                     },
-                    "description": "Several questions, asked one after another, each with its own options; omit the options for a free-text value. Use this instead of packing several questions into context.",
+                    "description": "Several questions, asked one after another; each entry is an object {question, options}. Give an entry its own options, or omit them for a free-text value. Use this instead of packing several questions into context.",
                 },
             },
             "required": ["context"],

--- a/builder/agents/react/tools_spec.py
+++ b/builder/agents/react/tools_spec.py
@@ -933,18 +933,30 @@ TOOL_SPECS = [
     },
     {
         "name": "present_to_human",
-        "description": "Present information to the human user for review and get their response. Use this when you need user input, approval, or guidance.",
+        "description": "Ask the user to decide something. context states what you found; options are the answers they choose between — put the expected answer first, it is pre-selected, so one key confirms it. One decision per prompt. The user can always type an answer of their own, so never add an 'Other' or catch-all option. With several open items, pass questions instead — one entry per item, each with its own options (omit them for a free-text value such as a culture medium) — and they are asked one after another; never bundle them into one context. Ask through this tool, never by ending your reply with a question: a prose question leaves the user a blank box with nothing to confirm.",
         "parameters": {
             "type": "object",
             "properties": {
                 "context": {
                     "type": "string",
-                    "description": "Context or information to present to the user",
+                    "description": "What you found and what needs deciding. With questions, shown once, ahead of the first question.",
                 },
                 "options": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Optional list of options for the user to choose from",
+                    "description": "The answers to choose between, expected answer first. Omitted: a plain yes/no.",
+                },
+                "questions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "question": {"type": "string", "description": "One question."},
+                            "options": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["question"],
+                    },
+                    "description": "Several questions, asked one after another, each with its own options; omit the options for a free-text value. Use this instead of packing several questions into context.",
                 },
             },
             "required": ["context"],

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -1033,6 +1033,44 @@ class AgentEngine:
                 exc_info=True,
             )
 
+    def _ask_each(self, context: str, questions: list[Any]) -> dict[str, Any]:
+        """Ask ``questions`` one at a time through the HITL door (#596).
+
+        The ``questions`` form of ``present_to_human``: an entry with ``options``
+        is a choice prompt, one without is a free-text field, and *context* is
+        shown once, ahead of the first question. Every exchange is recorded with
+        :meth:`CrateState.record_user_answer` the way the single-prompt form
+        records its one answer — a choice as the row picked (or the decision
+        word for a plain yes/no), a free-text field only when it was answered.
+        The result carries each question with its answer, ``"skipped"`` for a
+        free-text field left empty, so the model sees what it did and did not
+        get.
+        """
+        answers: list[dict[str, Any]] = []
+        preamble = str(context or "").strip()
+        for entry in questions:
+            if not isinstance(entry, dict):
+                continue
+            question = str(entry.get("question") or "").strip()
+            if not question:
+                continue
+            shown = f"{preamble}\n\n{question}" if preamble else question
+            preamble = ""
+            options = [str(o).strip() for o in (entry.get("options") or []) if str(o).strip()]
+            if options:
+                decision = self.human_interface.present(shown, options)
+                answer = str(decision.get("comments") or decision.get("action") or "")
+                self.state.record_user_answer(question, answer)
+            else:
+                response = self.human_interface.request_input(shown, "text")
+                if response.get("skipped"):
+                    answer = "skipped"
+                else:
+                    answer = str(response.get("value") or "")
+                    self.state.record_user_answer(question, answer)
+            answers.append({"question": question, "answer": answer})
+        return {"action": "answered", "answers": answers}
+
     def run_tool(self, tool_name: str, **kwargs) -> Any:
         """Execute a tool by name with kwargs.
 
@@ -1178,12 +1216,18 @@ class AgentEngine:
             # invisible to the dashboard's ▶/⏸ status inference.
             if self.profiler is not None:
                 self.profiler.log_event(event="hitl_wait", tool=tool_name)
-            result = self.human_interface.present(kwargs.get("context", ""), kwargs.get("options"))
-            # Persist the answer: it is otherwise only a tool result inside the
-            # graph checkpoint, which a rotated thread discards (#user_answers).
-            if isinstance(result, dict):
-                spoken = result.get("comments") or result.get("action") or ""
-                self.state.record_user_answer(kwargs.get("context", ""), str(spoken))
+            questions = kwargs.get("questions") or []
+            if questions:
+                result = self._ask_each(kwargs.get("context", ""), questions)
+            else:
+                result = self.human_interface.present(
+                    kwargs.get("context", ""), kwargs.get("options")
+                )
+                # Persist the answer: it is otherwise only a tool result inside
+                # the graph checkpoint, which a rotated thread discards.
+                if isinstance(result, dict):
+                    spoken = result.get("comments") or result.get("action") or ""
+                    self.state.record_user_answer(kwargs.get("context", ""), str(spoken))
         elif tool_name == "request_input":
             if self.profiler is not None:
                 self.profiler.log_event(event="hitl_wait", tool=tool_name)

--- a/builder/engine.py
+++ b/builder/engine.py
@@ -1038,29 +1038,36 @@ class AgentEngine:
 
         The ``questions`` form of ``present_to_human``: an entry with ``options``
         is a choice prompt, one without is a free-text field, and *context* is
-        shown once, ahead of the first question. Every exchange is recorded with
-        :meth:`CrateState.record_user_answer` the way the single-prompt form
-        records its one answer — a choice as the row picked (or the decision
-        word for a plain yes/no), a free-text field only when it was answered.
-        The result carries each question with its answer, ``"skipped"`` for a
-        free-text field left empty, so the model sees what it did and did not
-        get.
+        shown once, ahead of the first question. Every answered exchange is
+        recorded with :meth:`CrateState.record_user_answer` the way the
+        single-prompt form records its one answer — a choice as the row picked
+        (or the decision word for a plain yes/no), a skip never. The result
+        carries each question with its answer, ``"skipped"`` for a free-text
+        field left empty, so the model sees what it did and did not get. An
+        entry that is not ``{question: str, options?: [str]}`` is an error and
+        nothing is asked: a silent skip would come back looking answered.
         """
+        entries: list[tuple[str, list[str]]] = []
+        for entry in questions:
+            question = str(entry.get("question") or "").strip() if isinstance(entry, dict) else ""
+            raw = entry.get("options") if isinstance(entry, dict) else None
+            if not question or (raw is not None and not isinstance(raw, list)):
+                return {
+                    "error": "each questions entry must be an object "
+                    "{question: str, options?: [str]} — nothing was asked"
+                }
+            entries.append((question, [str(o).strip() for o in raw or [] if str(o).strip()]))
+
         answers: list[dict[str, Any]] = []
         preamble = str(context or "").strip()
-        for entry in questions:
-            if not isinstance(entry, dict):
-                continue
-            question = str(entry.get("question") or "").strip()
-            if not question:
-                continue
+        for question, options in entries:
             shown = f"{preamble}\n\n{question}" if preamble else question
             preamble = ""
-            options = [str(o).strip() for o in (entry.get("options") or []) if str(o).strip()]
             if options:
                 decision = self.human_interface.present(shown, options)
                 answer = str(decision.get("comments") or decision.get("action") or "")
-                self.state.record_user_answer(question, answer)
+                if decision.get("action") != "skipped":
+                    self.state.record_user_answer(question, answer)
             else:
                 response = self.human_interface.request_input(shown, "text")
                 if response.get("skipped"):
@@ -1224,8 +1231,9 @@ class AgentEngine:
                     kwargs.get("context", ""), kwargs.get("options")
                 )
                 # Persist the answer: it is otherwise only a tool result inside
-                # the graph checkpoint, which a rotated thread discards.
-                if isinstance(result, dict):
+                # the graph checkpoint, which a rotated thread discards. A skip
+                # is not an answer, so it is not one to hold the user to.
+                if isinstance(result, dict) and result.get("action") != "skipped":
                     spoken = result.get("comments") or result.get("action") or ""
                     self.state.record_user_answer(kwargs.get("context", ""), str(spoken))
         elif tool_name == "request_input":

--- a/builder/tools/composites.py
+++ b/builder/tools/composites.py
@@ -34,6 +34,7 @@ from builder.tools.document_discovery import (
     classification_of,
 )
 from builder.tools.drafters import (
+    _ORCID_RE,
     VALID_PROCESS_TYPES,
     _make_entity_id,
     draft_assay,
@@ -1214,7 +1215,13 @@ def _resolve_via_search(
         f"Multiple ORCID candidates for citation author '{given} {family}'. "
         "Pick the correct one (or skip to leave it unresolved):"
     )
-    chosen = _pick_from_human(human.present(context, options), candidates, options)
+    response = human.present(context, options)
+    chosen = _pick_from_human(response, candidates, options)
+    if chosen is None and response.get("action") == "edited":
+        # Typed at the console's free-text row (#596): an ORCID pasted there is
+        # the pick — still verified below (D5). Anything else is not one.
+        typed = _bare_orcid(response.get("comments"))
+        chosen = typed if _ORCID_RE.match(typed) else None
     if chosen is None:
         # Last chance: let the user paste an ORCID directly.
         resp = human.request_input(

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -267,7 +267,7 @@ _AFFIRMATIVE = {"y", "yes", "approve", "approved", "ok", "okay", "confirm", "con
 _NEGATIVE = {"n", "no", "reject", "rejected", "deny", "decline", "cancel"}
 
 
-def _choice_stance(choice: str) -> bool | None:
+def choice_stance(choice: str) -> bool | None:
     """Whether *choice* is a plain yes (True) / no (False), else ``None``.
 
     Recognises both a bare word (the ``["yes", "no"]`` options callers pass) and
@@ -296,7 +296,7 @@ def _default_choice_index(choices: list[str], *, deny_by_default: bool) -> int:
     if not deny_by_default:
         return 0
     for index, choice in enumerate(choices):
-        if _choice_stance(choice) is False:
+        if choice_stance(choice) is False:
             return index
     return len(choices) - 1
 
@@ -311,7 +311,7 @@ def _decision_from_choice(answer: str, *, deny_by_default: bool) -> HumanRespons
     the same way — most of all the ``deny_by_default`` line, where anything that
     is not an explicit affirmative must deny (#197).
     """
-    stance = _choice_stance(answer)
+    stance = choice_stance(answer)
     if stance is not None:
         # A plain yes/no choice is a decision, not a payload: returning "no"
         # as comments used to read as an APPROVAL carrying the text "no".
@@ -341,10 +341,10 @@ def match_choice(raw: str, choices: list[str], default: int) -> int | None:
         return default
     if answer.isdigit() and 1 <= int(answer) <= len(choices):
         return int(answer) - 1
-    stance = _choice_stance(answer)
+    stance = choice_stance(answer)
     if stance is not None:
         for index, choice in enumerate(choices):
-            if _choice_stance(choice) is stance:
+            if choice_stance(choice) is stance:
                 return index
     for index, choice in enumerate(choices):
         if choice.strip().casefold().startswith(answer):
@@ -730,7 +730,7 @@ class SmokeTestHumanInterface:
 
         choices = list(options or []) or list(_APPROVE_CHOICES)
         answer = choices[_default_choice_index(choices, deny_by_default=False)]
-        if _choice_stance(answer) is None:
+        if choice_stance(answer) is None:
             # Not a yes/no: this is a menu of alternatives (candidate authors,
             # say), and no row is pre-selected in any meaningful sense. Returning
             # row 1 would make the harness assert something — which candidate is
@@ -960,6 +960,7 @@ __all__ = [
     "SimulatedHumanInterface",
     "SmokeTestHumanInterface",
     "answers_are_synthetic",
+    "choice_stance",
     "is_interactive",
     "present_to_human",
     "request_input",

--- a/builder/tools/hitl.py
+++ b/builder/tools/hitl.py
@@ -258,6 +258,11 @@ _APPROVE_CHOICES = ["Yes, go ahead", "No, don't do that"]
 # lists the refusal FIRST so the pre-selected answer denies (#197 fail-closed).
 _DENY_ALLOW_CHOICES = ["No, keep the current access", "Yes, allow this folder"]
 
+# The row the console appends to every choice prompt (#596), so an answer the
+# caller did not foresee can still be given, in the user's own words. Last, so
+# the pre-selected row and the number keys of the offered choices are unchanged.
+OWN_ANSWER_CHOICE = "Something else — let me type an answer"
+
 _AFFIRMATIVE = {"y", "yes", "approve", "approved", "ok", "okay", "confirm", "continue"}
 _NEGATIVE = {"n", "no", "reject", "rejected", "deny", "decline", "cancel"}
 
@@ -488,10 +493,17 @@ class ConsoleHumanInterface:
         question: the expected answer starts selected and the user arrows to
         another, so the decision is unambiguous both ways.
 
+        Every prompt but a scan-root escalation ends with :data:`OWN_ANSWER_CHOICE`
+        (#596): picking it reads the free-text box, and the text comes back as an
+        ``edited`` decision — in ``comments`` and in ``edits["value"]`` — so a
+        caller that only knows its offered rows sees neither an approval nor a
+        rejection it was not given. An empty line there is a skip.
+
         Fail-closed is preserved for a scan-root escalation: its default lands on
         the denying choice, so an accidental Enter never widens filesystem
         access. It is also the one prompt whose choices are stated as an explicit
-        allow/deny rather than a yes/no.
+        allow/deny rather than a yes/no — and the one with no free-text row,
+        because widening access is a decision, not prose (#197).
         """
         deny_by_default = purpose == SCAN_ROOT_PURPOSE
         choices = list(options or [])
@@ -500,12 +512,20 @@ class ConsoleHumanInterface:
         # The safe answer is first except when denying by default, where it is
         # the refusal — whatever it is, it must be the pre-selected row.
         default_index = _default_choice_index(choices, deny_by_default=deny_by_default)
+        own_answer = not deny_by_default
+        if own_answer:
+            choices = [*choices, OWN_ANSWER_CHOICE]
 
         # Suspend any active terminal spinner so the prompt is readable and stdin
         # is not fighting a Rich Live repaint (ReAct loop scan-root approval).
         with suspend_console_animation():
             self._show(context)
             chosen = self._select(choices, default_index)
+            if own_answer and chosen == len(choices) - 1:
+                typed = self._read_answer("text")
+                if typed is None:
+                    return {"action": "skipped", "comments": None, "edits": None}
+                return {"action": "edited", "comments": typed, "edits": {"value": typed}}
 
         if chosen is None:
             # Cancelled / EOF: decline without ending guidance, and fail closed.
@@ -554,17 +574,26 @@ class ConsoleHumanInterface:
         """
         with suspend_console_animation():
             self._show(prompt)
-            try:
-                value = self._read(field_type).strip()
-            except EOFError:
-                self._done = True
-                value = ""
-        if self._is_stop_command(value):
-            self._done = True
-            return {"value": None, "skipped": True}
-        if not value:
+            value = self._read_answer(field_type)
+        if value is None:
             return {"value": None, "skipped": True}
         return {"value": value, "skipped": False}
+
+    def _read_answer(self, field_type: str) -> str | None:
+        """One line from the box; ``None`` is a skip — empty, EOF, or a stop word.
+
+        EOF and a stop word also end guidance (:meth:`is_done`): a closed stdin
+        will never answer anything else, and "build" means build.
+        """
+        try:
+            value = self._read(field_type).strip()
+        except EOFError:
+            self._done = True
+            return None
+        if self._is_stop_command(value):
+            self._done = True
+            return None
+        return value or None
 
 
 # The single literal every open field gets in smoke-test mode. It is affirmative
@@ -918,6 +947,7 @@ def request_input(
 
 __all__ = [
     "CONVERSATION_FIELD_TYPE",
+    "OWN_ANSWER_CHOICE",
     "SCAN_ROOT_PURPOSE",
     "SMOKE_TEST_ANSWER",
     "SMOKE_TEST_CONVERSATION_TURNS",

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2942,3 +2942,64 @@ class TestHeadlessSessions:
             interactive=False,
         )
         assert h.run() == {"stop_reason": "completed", "error": None}
+
+
+class TestTheBoxSaysWhatItIsWaitingFor:
+    """#596: a stop never leaves the user guessing between "confirm" and "continue".
+
+    One dim line is printed above the ❯ box after the agent stops, naming what
+    the box is for: an answer to the question above, a next step (or
+    ``continue``) while work is open, or a change once nothing is left.
+    """
+
+    def _transcript(self, monkeypatch, *, replies, stdin_lines, **kw) -> str:
+        import io
+
+        from rich.console import Console
+
+        h = _LoopHarness(monkeypatch, replies=replies, stdin_lines=stdin_lines, **kw)
+        buf = io.StringIO()
+        monkeypatch.setattr(
+            h.agent_loop.ui,
+            "get_console",
+            lambda: Console(file=buf, width=200, force_terminal=False, color_system=None),
+        )
+        h.run()
+        return buf.getvalue()
+
+    def test_a_prose_question_asks_for_an_answer(self, monkeypatch):
+        out = self._transcript(
+            monkeypatch,
+            replies=["Which cell line did you use?"],
+            stdin_lines=["start", "quit"],
+        )
+        assert "Answer the question above" in out
+
+    def test_a_stop_with_open_work_offers_continue(self, monkeypatch):
+        from builder.agents.react import agent_loop
+
+        monkeypatch.setattr(
+            agent_loop, "open_items", lambda state, **kw: ["Study needs a description"]
+        )
+        out = self._transcript(
+            monkeypatch,
+            replies=["Working."] * (agent_loop._MAX_AUTONOMOUS_TURNS + 1),
+            stdin_lines=["start", "quit"],
+        )
+        assert "or 'continue'" in out
+
+    def test_a_finished_crate_says_so(self, monkeypatch):
+        out = self._transcript(
+            monkeypatch,
+            replies=["All done."],
+            stdin_lines=["start", "quit"],
+            complete_after=1,
+        )
+        assert "Nothing left to do" in out
+
+    def test_the_first_prompt_carries_no_hint(self, monkeypatch):
+        """Before any turn there is nothing to answer or continue."""
+        out = self._transcript(monkeypatch, replies=[], stdin_lines=["quit"])
+        assert "Answer the question above" not in out
+        assert "or 'continue'" not in out
+        assert "Nothing left to do" not in out

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -2952,20 +2952,34 @@ class TestTheBoxSaysWhatItIsWaitingFor:
     ``continue``) while work is open, or a change once nothing is left.
     """
 
+    BOX = "<the box>"
+
     def _transcript(self, monkeypatch, *, replies, stdin_lines, **kw) -> str:
+        """The console transcript, with every ❯ box read marked by ``BOX``."""
         import io
 
         from rich.console import Console
 
         h = _LoopHarness(monkeypatch, replies=replies, stdin_lines=stdin_lines, **kw)
         buf = io.StringIO()
-        monkeypatch.setattr(
-            h.agent_loop.ui,
-            "get_console",
-            lambda: Console(file=buf, width=200, force_terminal=False, color_system=None),
+        console = Console(file=buf, width=200, force_terminal=False, color_system=None)
+        monkeypatch.setattr(h.agent_loop.ui, "get_console", lambda: console)
+        h.install()
+        real_box = h.agent_loop.ui.boxed_input
+
+        def marked_box(console, label="❯", **kwargs):
+            console.print(self.BOX)
+            return real_box(console, label, **kwargs)
+
+        monkeypatch.setattr(h.agent_loop.ui, "boxed_input", marked_box)
+        h.agent_loop.run_interactive_agent(
+            h.engine, initial_prompt=h.initial_prompt, interactive=h.interactive
         )
-        h.run()
         return buf.getvalue()
+
+    def _line_above_the_last_box(self, out: str) -> str:
+        lines = [line.strip() for line in out.splitlines() if line.strip()]
+        return lines[len(lines) - 1 - lines[::-1].index(self.BOX) - 1]
 
     def test_a_prose_question_asks_for_an_answer(self, monkeypatch):
         out = self._transcript(
@@ -2973,7 +2987,7 @@ class TestTheBoxSaysWhatItIsWaitingFor:
             replies=["Which cell line did you use?"],
             stdin_lines=["start", "quit"],
         )
-        assert "Answer the question above" in out
+        assert self._line_above_the_last_box(out) == "Answer the question above."
 
     def test_a_stop_with_open_work_offers_continue(self, monkeypatch):
         from builder.agents.react import agent_loop
@@ -2986,7 +3000,23 @@ class TestTheBoxSaysWhatItIsWaitingFor:
             replies=["Working."] * (agent_loop._MAX_AUTONOMOUS_TURNS + 1),
             stdin_lines=["start", "quit"],
         )
-        assert "or 'continue'" in out
+        assert "or 'continue'" in self._line_above_the_last_box(out)
+
+    def test_open_required_issues_are_open_work_even_with_an_empty_checklist(
+        self, monkeypatch
+    ):
+        """Completion is the gates AND the checklist, as the loop itself decides
+        it — a crate that still fails REQUIRED is never 'nothing left to do'."""
+        from builder.agents.react import agent_loop
+
+        monkeypatch.setattr(agent_loop, "open_items", lambda state, **kw: [])
+        out = self._transcript(
+            monkeypatch,
+            replies=["Working."] * (agent_loop._MAX_AUTONOMOUS_TURNS + 1),
+            stdin_lines=["start", "quit"],
+        )
+        assert "or 'continue'" in self._line_above_the_last_box(out)
+        assert "Nothing left to do" not in out
 
     def test_a_finished_crate_says_so(self, monkeypatch):
         out = self._transcript(
@@ -2995,7 +3025,7 @@ class TestTheBoxSaysWhatItIsWaitingFor:
             stdin_lines=["start", "quit"],
             complete_after=1,
         )
-        assert "Nothing left to do" in out
+        assert self._line_above_the_last_box(out).startswith("Nothing left to do")
 
     def test_the_first_prompt_carries_no_hint(self, monkeypatch):
         """Before any turn there is nothing to answer or continue."""
@@ -3003,3 +3033,100 @@ class TestTheBoxSaysWhatItIsWaitingFor:
         assert "Answer the question above" not in out
         assert "or 'continue'" not in out
         assert "Nothing left to do" not in out
+
+
+class TestArgsSchemaAdvertisesArrayItems:
+    """#596: the shape of a list parameter's entries reaches the model.
+
+    The wrapper validates a list as a bare ``list`` (entries arrive as the plain
+    dicts the model sent), so pydantic used to advertise ``items: {}`` and the
+    ``questions`` entries of ``present_to_human`` had no shape at all.
+    """
+
+    def _tool(self, engine):
+        from builder.agents.react.agent_loop import _build_langchain_tools
+
+        return {t.name: t for t in _build_langchain_tools(engine)}["present_to_human"]
+
+    def test_the_entry_shape_is_in_the_advertised_schema(self):
+        from builder.engine import AgentEngine
+
+        questions = self._tool(AgentEngine()).args["questions"]
+        array = next(b for b in questions.get("anyOf", [questions]) if b.get("type") == "array")
+        assert array["items"]["required"] == ["question"]
+        assert array["items"]["properties"]["options"]["items"] == {"type": "string"}
+
+    def test_entries_still_reach_the_engine_as_plain_dicts(self):
+        from builder.engine import AgentEngine
+
+        class _Spy:
+            def __init__(self):
+                self.inputs: list[tuple[str, str]] = []
+
+            def present(self, context, options=None, purpose=None):
+                return {"action": "approved", "comments": None, "edits": None}
+
+            def request_input(self, prompt, field_type="text"):
+                self.inputs.append((prompt, field_type))
+                return {"value": "DMEM", "skipped": False}
+
+        spy = _Spy()
+        engine = AgentEngine(human_interface=spy)
+        result = self._tool(engine).invoke(
+            {"context": "One thing.", "questions": [{"question": "Medium?"}]}
+        )
+
+        assert spy.inputs == [("One thing.\n\nMedium?", "text")]
+        assert result["answers"] == [{"question": "Medium?", "answer": "DMEM"}]
+
+
+class TestATypedAnswerAtTheValidationTierPrompt:
+    """#596: the "run the recommended checks?" prompt now ends with the free-text
+    row. A yes or no typed there is the standing answer; anything else is no
+    answer, so the tier is not run now and the question is asked again later —
+    never remembered as a refusal nobody gave."""
+
+    def _escalate(self, monkeypatch, typed: list[str]):
+        from builder.agents.react.agent_loop import _run_validation_escalation
+        from builder.engine import AgentEngine
+
+        class _Types:
+            is_interactive = True
+
+            def __init__(self) -> None:
+                self.asked = 0
+
+            def present(self, context, options=None, purpose=None):
+                self.asked += 1
+                text = typed.pop(0)
+                return {"action": "edited", "comments": text, "edits": {"value": text}}
+
+            def request_input(self, prompt, field_type="text"):
+                return {"value": None, "skipped": True}
+
+        human = _Types()
+        engine = AgentEngine(human_interface=human)
+        engine.state.add_entity(Entity(entity_id="e0", type="Investigation"))
+        ran: list[str] = []
+
+        def fake_run_tool(tool_name, **kwargs):
+            ran.append(str(kwargs.get("severity")))
+            return {"ok": True, "issues": [], "conformance": {"base": True}}
+
+        monkeypatch.setattr(engine, "run_tool", fake_run_tool)
+        summary = _run_validation_escalation(engine, {"ok": True})
+        return summary, engine.state.validation_preferences, ran, human
+
+    def test_a_typed_yes_is_the_standing_answer(self, monkeypatch):
+        _summary, prefs, ran, human = self._escalate(monkeypatch, ["yes please", "no thanks"])
+
+        assert prefs == {"recommended": True, "optional": False}
+        assert ran == ["recommended"]
+        assert human.asked == 2
+
+    def test_typed_prose_is_no_answer_and_is_not_remembered(self, monkeypatch):
+        summary, prefs, ran, _human = self._escalate(monkeypatch, ["later, once it builds"])
+
+        assert summary is not None and summary["recommended"]["status"] == "declined_by_user"
+        assert prefs == {}, "no refusal is recorded for an answer that was not one"
+        assert ran == []

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -466,7 +466,90 @@ class TestDraftable:
 
         assert _get(engine, "st1").fields.get("description") == typed
         assert human.inputs == [], "a typed answer must not fall through to ask-user"
-        assert any(r.get("via") == "draft-edited" for r in summary["resolved"])
+        assert summary["resolved"], "the gap counts as resolved"
+
+    def test_an_edit_that_carries_no_value_falls_through_to_ask_user(self, monkeypatch):
+        """A frontend may answer "edited" with field-keyed edits and no value; that
+        is not the user's value, so the draft is not committed under its name."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        draft_gap = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="st1",
+            entity_type="Study",
+            property="description",
+            message="Draftable description.",
+            suggestion="hint",
+            fix_hint="draft",
+            auto_fixable=False,
+        )
+        reports = iter(
+            [
+                GapReport(
+                    gaps=[draft_gap],
+                    counts={"must_open": 0, "should_open": 1, "may_open": 0},
+                ),
+                GapReport(gaps=[], counts={"must_open": 0, "should_open": 0, "may_open": 0}),
+            ]
+        )
+        monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
+        monkeypatch.setattr(
+            guidance,
+            "draft_entity_fields",
+            lambda *_a, **_k: {"description": "A drafted value."},
+        )
+
+        human = ScriptedHuman(
+            present_answers=[{"action": "edited", "comments": None, "edits": {"name": "X"}}],
+            input_answers=[_value("Typed at the follow-up.")],
+        )
+        run_guidance(engine, human, max_rounds=5)
+
+        assert human.inputs, "an empty edit must fall through to ask-user"
+        assert _get(engine, "st1").fields.get("description") == "Typed at the follow-up."
+
+    def test_a_skip_at_the_draft_dialog_skips_the_gap(self, monkeypatch):
+        """A stop word or Ctrl+D at the dialog ends the exchange; it is not
+        followed by the same question in prose."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        draft_gap = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="st1",
+            entity_type="Study",
+            property="description",
+            message="Draftable description.",
+            suggestion="hint",
+            fix_hint="draft",
+            auto_fixable=False,
+        )
+        monkeypatch.setattr(
+            guidance,
+            "assess_gaps",
+            lambda _state: GapReport(
+                gaps=[draft_gap], counts={"must_open": 0, "should_open": 1, "may_open": 0}
+            ),
+        )
+        monkeypatch.setattr(
+            guidance,
+            "draft_entity_fields",
+            lambda *_a, **_k: {"description": "A drafted value."},
+        )
+
+        before = _get(engine, "st1").fields.get("description")
+        human = ScriptedHuman(
+            present_answers=[{"action": "skipped", "comments": None, "edits": None}]
+        )
+        run_guidance(engine, human, max_rounds=2)
+
+        assert human.inputs == [], "a skip must not be re-asked as a free-text question"
+        assert _get(engine, "st1").fields.get("description") == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agents_guidance.py
+++ b/tests/test_agents_guidance.py
@@ -424,6 +424,50 @@ class TestDraftable:
             == "The user's own description."
         )
 
+    def test_a_typed_answer_at_the_draft_dialog_is_committed_instead(self, monkeypatch):
+        """#596: the console's "let me type an answer" row comes back as an
+        *edit*; the dialog commits that value, with no second prompt."""
+        from builder.agents.pipeline import guidance
+        from builder.agents.pipeline.guidance import run_guidance
+
+        engine = AgentEngine(state=_backbone())
+        draft_gap = Gap(
+            tier="SHOULD",
+            source="mit",
+            entity_id="st1",
+            entity_type="Study",
+            property="description",
+            message="Draftable description.",
+            suggestion="hint",
+            fix_hint="draft",
+            auto_fixable=False,
+        )
+        reports = iter(
+            [
+                GapReport(
+                    gaps=[draft_gap],
+                    counts={"must_open": 0, "should_open": 1, "may_open": 0},
+                ),
+                GapReport(gaps=[], counts={"must_open": 0, "should_open": 0, "may_open": 0}),
+            ]
+        )
+        monkeypatch.setattr(guidance, "assess_gaps", lambda _state: next(reports))
+        monkeypatch.setattr(
+            guidance,
+            "draft_entity_fields",
+            lambda *_a, **_k: {"description": "A drafted value."},
+        )
+
+        typed = "The study's own words."
+        human = ScriptedHuman(
+            present_answers=[{"action": "edited", "comments": typed, "edits": {"value": typed}}]
+        )
+        summary = run_guidance(engine, human, max_rounds=5)
+
+        assert _get(engine, "st1").fields.get("description") == typed
+        assert human.inputs == [], "a typed answer must not fall through to ask-user"
+        assert any(r.get("via") == "draft-edited" for r in summary["resolved"])
+
 
 # ---------------------------------------------------------------------------
 # (d) termination: max_rounds + no-progress guards; MUST before SHOULD/MAY

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -549,20 +549,50 @@ class TestPresentToHumanAsksSeveralQuestionsInTurn:
 
         assert result["answers"] == [{"question": "Record Dr X?", "answer": "approved"}]
 
-    def test_blank_entries_are_dropped_and_an_empty_list_is_the_single_prompt(self):
+    def test_a_malformed_entry_is_an_error_and_nothing_is_asked(self):
+        """A silent skip would come back looking answered while the user was
+        never asked — so the model is told, before any prompt is shown."""
         mock = MockHumanInterface()
         engine = AgentEngine(human_interface=mock)
 
-        engine.run_tool(
-            "present_to_human",
-            context="Ctx",
-            questions=[{"question": "   "}, {"question": "Real one?", "options": ["A"]}],
-        )
-        assert mock.present_calls == [("Ctx\n\nReal one?", ["A"])]
+        for bad in (
+            ["Which medium?"],  # a bare string, not an object
+            [{"question": "Real one?", "options": ["A"]}, {"text": "wrong key"}],
+            [{"question": "   "}],  # blank
+            [{"question": "Medium?", "options": "DMEM"}],  # a scalar, not rows
+        ):
+            result = engine.run_tool("present_to_human", context="Ctx", questions=bad)
+            assert "error" in result and "answers" not in result, bad
+        assert mock.present_calls == [] and mock.input_calls == []
+        assert engine.state.user_answers == []
 
-        mock.present_calls.clear()
+    def test_an_empty_list_is_the_single_prompt(self):
+        mock = MockHumanInterface()
+        engine = AgentEngine(human_interface=mock)
+
         result = engine.run_tool(
             "present_to_human", context="Ctx", options=["A", "B"], questions=[]
         )
         assert mock.present_calls == [("Ctx", ["A", "B"])]
         assert result["action"] == "edited"
+
+    def test_a_skipped_choice_is_reported_but_not_remembered(self):
+        """A skip is not something the user told us, in either form."""
+
+        class _Skips:
+            def present(self, context, options=None, purpose=None):
+                return {"action": "skipped", "comments": None, "edits": None}
+
+            def request_input(self, prompt, field_type="text"):
+                return {"value": None, "skipped": True}
+
+        engine = AgentEngine(human_interface=_Skips())
+
+        result = engine.run_tool(
+            "present_to_human", context="Ctx", questions=[{"question": "Q?", "options": ["A"]}]
+        )
+        assert result["answers"] == [{"question": "Q?", "answer": "skipped"}]
+        assert engine.state.user_answers == []
+
+        engine.run_tool("present_to_human", context="Single?", options=["A", "B"])
+        assert engine.state.user_answers == []

--- a/tests/test_tools_hitl.py
+++ b/tests/test_tools_hitl.py
@@ -355,3 +355,214 @@ class TestConsoleAnimationSuspension:
             unregister_console_animation(anim)
 
         assert events == ["pause", "body", "resume"]
+
+
+class TestPresentLetsTheUserTypeTheirOwnAnswer:
+    """#596: a choice prompt can always be answered with words of the user's own.
+
+    The console appends one row to every prompt except a scan-root escalation;
+    picking it reads the shared ❯ box and the text comes back as an *edit*, so
+    a caller that only understands the offered rows sees neither an approval
+    nor a rejection it did not get.
+    """
+
+    def test_the_row_comes_after_the_callers_choices_and_the_default_stays(self):
+        from builder.tools.hitl import OWN_ANSWER_CHOICE
+
+        seen: dict[str, object] = {}
+
+        def fake_select(choices: list[str], default: int) -> int:
+            seen["choices"] = list(choices)
+            seen["default"] = default
+            return 0
+
+        resp = ConsoleHumanInterface(select_func=fake_select).present(
+            "Proceed?", options=["Yes, go ahead", "No, don't do that"]
+        )
+
+        assert seen["choices"] == ["Yes, go ahead", "No, don't do that", OWN_ANSWER_CHOICE]
+        assert seen["default"] == 0
+        assert resp["action"] == "approved"
+
+    def test_picking_the_row_reads_the_box_and_returns_the_text_as_an_edit(self):
+        shown: list[str] = []
+        human = ConsoleHumanInterface(
+            show_func=shown.append,
+            select_func=lambda choices, _default: len(choices) - 1,
+            prompt_func=lambda _ft: "  The corresponding author, not the PI  ",
+        )
+
+        resp = human.present("Who publishes the crate?", options=["Dr X", "RIVM"])
+
+        assert resp == {
+            "action": "edited",
+            "comments": "The corresponding author, not the PI",
+            "edits": {"value": "The corresponding author, not the PI"},
+        }
+        # The question is shown once, ahead of the choices — not again for the box.
+        assert shown == ["Who publishes the crate?"]
+
+    def test_the_row_is_there_when_the_caller_offered_no_choices(self):
+        from builder.tools.hitl import OWN_ANSWER_CHOICE
+
+        seen: dict[str, list[str]] = {}
+
+        def fake_select(choices: list[str], default: int) -> int:
+            seen["choices"] = list(choices)
+            return len(choices) - 1
+
+        resp = ConsoleHumanInterface(
+            select_func=fake_select, prompt_func=lambda _ft: "neither"
+        ).present("Review entity")
+
+        assert seen["choices"][-1] == OWN_ANSWER_CHOICE
+        assert len(seen["choices"]) == 3
+        assert resp["action"] == "edited" and resp["comments"] == "neither"
+
+    def test_an_empty_typed_answer_is_a_skip(self):
+        human = ConsoleHumanInterface(
+            select_func=lambda choices, _default: len(choices) - 1,
+            prompt_func=lambda _ft: "   ",
+        )
+        assert human.present("Proceed?") == {"action": "skipped", "comments": None, "edits": None}
+
+    def test_eof_in_the_box_is_a_skip_that_ends_guidance(self):
+        def _raise(_ft: str) -> str:
+            raise EOFError
+
+        human = ConsoleHumanInterface(
+            select_func=lambda choices, _default: len(choices) - 1, prompt_func=_raise
+        )
+        assert human.present("Proceed?")["action"] == "skipped"
+        assert human.is_done()
+
+    def test_a_typed_stop_word_ends_guidance(self):
+        human = ConsoleHumanInterface(
+            select_func=lambda choices, _default: len(choices) - 1,
+            prompt_func=lambda _ft: "build",
+        )
+        assert human.present("Proceed?")["action"] == "skipped"
+        assert human.is_done()
+
+    def test_a_scan_root_escalation_stays_a_plain_allow_or_deny(self):
+        """Widening filesystem access is one fail-closed decision, never prose (#197)."""
+        from builder.tools.hitl import OWN_ANSWER_CHOICE, SCAN_ROOT_PURPOSE
+
+        seen: dict[str, list[str]] = {}
+
+        def fake_select(choices: list[str], default: int) -> int:
+            seen["choices"] = list(choices)
+            return default
+
+        resp = ConsoleHumanInterface(select_func=fake_select).present(
+            "Approve /etc?", purpose=SCAN_ROOT_PURPOSE
+        )
+
+        assert OWN_ANSWER_CHOICE not in seen["choices"]
+        assert len(seen["choices"]) == 2
+        assert resp["action"] == "rejected"
+
+    def test_a_typed_answer_at_the_plain_terminal_fallback(self, monkeypatch):
+        """No injected box: the numbered chooser still offers the row, and the
+        value is read with a second ``input()``."""
+        answers = iter(["3", "my own words"])
+        monkeypatch.setattr("builtins.input", lambda *_a: next(answers))
+
+        resp = ConsoleHumanInterface().present("Proceed?")
+
+        assert resp["action"] == "edited"
+        assert resp["edits"] == {"value": "my own words"}
+
+
+class TestPresentToHumanAsksSeveralQuestionsInTurn:
+    """#596: a model with three open items asks three questions, not one bundle.
+
+    ``questions`` is asked one entry at a time through the same HITL door: an
+    entry with ``options`` is a choice prompt, one without is a free-text field.
+    Every exchange lands in ``user_answers`` and the tool result carries them all.
+    """
+
+    def test_each_question_is_asked_through_its_own_channel(self):
+        mock = MockHumanInterface()
+        engine = AgentEngine(human_interface=mock)
+
+        result = engine.run_tool(
+            "present_to_human",
+            context="The workbook names Dr X at RIVM.",
+            questions=[
+                {"question": "Record Dr X as publisher?", "options": ["Yes", "No"]},
+                {"question": "Culture medium for the uptake culture?"},
+            ],
+        )
+
+        # The shared context is shown once, ahead of the first question only.
+        assert mock.present_calls == [
+            ("The workbook names Dr X at RIVM.\n\nRecord Dr X as publisher?", ["Yes", "No"])
+        ]
+        assert mock.input_calls == [("Culture medium for the uptake culture?", "text")]
+        assert result == {
+            "action": "answered",
+            "answers": [
+                {"question": "Record Dr X as publisher?", "answer": "fix it"},
+                {"question": "Culture medium for the uptake culture?", "answer": "42"},
+            ],
+        }
+
+    def test_every_exchange_is_remembered(self):
+        engine = AgentEngine(human_interface=MockHumanInterface())
+
+        engine.run_tool(
+            "present_to_human",
+            context="Two things.",
+            questions=[
+                {"question": "Publisher?", "options": ["Dr X", "RIVM"]},
+                {"question": "Medium?"},
+            ],
+        )
+
+        assert engine.state.user_answers == [
+            {"question": "Publisher?", "answer": "fix it"},
+            {"question": "Medium?", "answer": "42"},
+        ]
+
+    def test_a_skipped_free_text_question_says_so_and_is_not_remembered(self):
+        engine = AgentEngine()  # the simulated interface skips every input
+
+        result = engine.run_tool(
+            "present_to_human", context="One thing.", questions=[{"question": "Medium?"}]
+        )
+
+        assert result == {
+            "action": "answered",
+            "answers": [{"question": "Medium?", "answer": "skipped"}],
+        }
+        assert engine.state.user_answers == []
+
+    def test_a_yes_no_question_with_no_comment_reports_the_decision(self):
+        engine = AgentEngine()  # the simulated interface approves every choice
+
+        result = engine.run_tool(
+            "present_to_human",
+            context="One thing.",
+            questions=[{"question": "Record Dr X?", "options": ["Yes", "No"]}],
+        )
+
+        assert result["answers"] == [{"question": "Record Dr X?", "answer": "approved"}]
+
+    def test_blank_entries_are_dropped_and_an_empty_list_is_the_single_prompt(self):
+        mock = MockHumanInterface()
+        engine = AgentEngine(human_interface=mock)
+
+        engine.run_tool(
+            "present_to_human",
+            context="Ctx",
+            questions=[{"question": "   "}, {"question": "Real one?", "options": ["A"]}],
+        )
+        assert mock.present_calls == [("Ctx\n\nReal one?", ["A"])]
+
+        mock.present_calls.clear()
+        result = engine.run_tool(
+            "present_to_human", context="Ctx", options=["A", "B"], questions=[]
+        )
+        assert mock.present_calls == [("Ctx", ["A", "B"])]
+        assert result["action"] == "edited"

--- a/tests/test_tools_publication_authors.py
+++ b/tests/test_tools_publication_authors.py
@@ -747,3 +747,50 @@ class TestRegistration:
 
         # The engine routed the injected interface through to the tool.
         assert human.present_calls, "engine should have injected the HITL adapter"
+
+
+class TestAnOrcidTypedAtTheCandidateMenu:
+    """#596: the console's free-text row is a third way to answer the candidate
+    menu. An ORCID typed there is the pick — verified like any other (D5) — and
+    the user is not asked to paste it a second time."""
+
+    def _search(self, typed: str, looked_up: list[str]):
+        from builder.tools.composites import _resolve_via_search
+
+        class _Types:
+            def __init__(self) -> None:
+                self.inputs: list[str] = []
+
+            def present(self, context, options=None, purpose=None):
+                return {"action": "edited", "comments": typed, "edits": {"value": typed}}
+
+            def request_input(self, prompt, field_type="text"):
+                self.inputs.append(prompt)
+                return {"value": None, "skipped": True}
+
+        def by_name(given, family, affiliation=None):
+            return [
+                {"given": "A.", "family": family, "orcid": "0000-0001-0000-0001"},
+                {"given": "Alice", "family": family, "orcid": "0000-0002-0000-0002"},
+            ]
+
+        def lookup(orcid_id):
+            looked_up.append(orcid_id)
+            return {"found": True, "data": {"familyName": "Smith", "givenNames": "Alice"}}
+
+        human = _Types()
+        return _resolve_via_search("Alice", "Smith", None, human, lookup, by_name), human
+
+    def test_a_typed_orcid_is_the_pick_and_is_verified(self):
+        looked_up: list[str] = []
+        chosen, human = self._search("https://orcid.org/0000-0003-0000-0003", looked_up)
+
+        assert chosen == "0000-0003-0000-0003"
+        assert looked_up == ["0000-0003-0000-0003"], "a typed ORCID is verified before use"
+        assert human.inputs == [], "no second prompt for what was just typed"
+
+    def test_typed_prose_still_falls_back_to_the_paste_prompt(self):
+        chosen, human = self._search("the second one I think", [])
+
+        assert chosen is None
+        assert len(human.inputs) == 1

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -547,3 +547,22 @@ class TestExportIsDescribedAsAFinalStep:
     def test_it_says_conformance_is_not_completion(self):
         text = self._description().casefold()
         assert "required" in text and "not completion" in text
+
+
+def test_present_to_human_can_carry_several_questions_each_with_its_own_options():
+    """#596: the schema must not invite bundling three questions into one
+    context with one catch-all option — it offers a per-question form instead."""
+    from typing import Any, cast
+
+    spec = next(s for s in TOOL_SPECS if s["name"] == "present_to_human")
+    params = cast(dict[str, Any], spec["parameters"])
+
+    questions = params["properties"]["questions"]
+    assert questions["type"] == "array"
+    entry = questions["items"]
+    assert entry["type"] == "object"
+    assert entry["required"] == ["question"]
+    assert entry["properties"]["question"]["type"] == "string"
+    assert entry["properties"]["options"] == {"type": "array", "items": {"type": "string"}}
+    # A prompt without `questions` is still the single decision it always was.
+    assert params["required"] == ["context"]

--- a/tests/test_tools_spec.py
+++ b/tests/test_tools_spec.py
@@ -563,6 +563,7 @@ def test_present_to_human_can_carry_several_questions_each_with_its_own_options(
     assert entry["type"] == "object"
     assert entry["required"] == ["question"]
     assert entry["properties"]["question"]["type"] == "string"
-    assert entry["properties"]["options"] == {"type": "array", "items": {"type": "string"}}
+    assert entry["properties"]["options"]["type"] == "array"
+    assert entry["properties"]["options"]["items"]["type"] == "string"
     # A prompt without `questions` is still the single decision it always was.
     assert params["required"] == ["context"]


### PR DESCRIPTION
Closes #596.

## What was wrong

A ReAct session with three open items asked them in one prose reply (or in one `present_to_human` call with one catch-all row) and left the user at a bare `❯` box, unsure whether "yes" or "continue" was the answer. The console select box had no way to type an answer of one's own, and `present_to_human` had no way to carry several questions.

## What changes

- **Every choice prompt takes a typed answer.** `ConsoleHumanInterface.present` appends a final row, *Something else — let me type an answer*, to every prompt except a scan-root escalation (#197 stays a plain allow/deny). Picking it opens the shared box; the text comes back as `action: "edited"` with the value in `comments` and `edits.value`. An empty line is a skip.
- **One call asks several questions in turn.** `present_to_human(context, questions=[{question, options}])`: an entry with options is a choice box, one without is the free-text box; the shared `context` is shown once, ahead of the first. Every answered exchange lands in `user_answers`; the result is `{action: "answered", answers: [{question, answer}]}`. A malformed entry is an error and nothing is asked.
- **The model actually sees that shape.** The ReAct wrapper validated every list parameter as a bare `list` and so advertised `items: {}`; the items schema now rides on the annotation (LangChain rebuilds its tool-call schema from annotations alone). `draft_process_chain.chain` gains the same as a side effect.
- **The model is told how to ask.** Tool description and system prompt: one decision per prompt, rows are the answers themselves, several open items go in `questions`, never an "Other" row, and never a question in prose. The idle nudges point at `present_to_human` too.
- **Consumers read a typed answer.** The guidance draft dialog commits it (and a skip skips the gap, an empty edit falls through to ask-user); the validation-tier prompt takes a typed yes/no as the standing answer and holds nothing for anything else; the ORCID candidate menu takes a typed ORCID (still verified, D5).
- **The box says what it is waiting for.** After a stop the ReAct loop prints one dim line above the box: *Answer the question above.*, *Type what to do next, or 'continue' to let me carry on.*, or *Nothing left to do — type a change, or 'quit'.* (completion is the loop's own predicate, gates included).

## Docs

AGENTS.md §5 states the two forms and their returns once; §8 points at it. README says how to answer a prompt.

## Tests

TDD throughout; new tests in `test_tools_hitl.py`, `test_tools_spec.py`, `test_agent_loop.py`, `test_agents_guidance.py` and `test_tools_publication_authors.py`. Locally the HITL/spec/prompt/smoke/author suites and the loop/guidance/main/build/pipeline suites pass, ruff and ty are clean. An adversarial multi-agent review of the first cut produced the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYsxLuS8URtfzKqnF7Dqd
