### PR TITLE
fix(report): a line-style legend key reads its meaning, not "dashed:" — the swatch already draws the pattern

### DIFF
--- a/builder/writers/assay_lane_app.js
+++ b/builder/writers/assay_lane_app.js
@@ -533,8 +533,8 @@
     // not run together in one strip — and a style key shows only when the lane
     // holds a box drawn that way.
     var styles = [];
-    if (orphaned) styles.push(['orphan', 'dashed: unreachable from the root']);
-    if (outside) styles.push(['outside', 'dotted: described outside the crate']);
+    if (orphaned) styles.push(['orphan', 'unreachable from the root']);
+    if (outside) styles.push(['outside', 'described outside the crate']);
     if (styles.length) {
       var sep = tag('span', 'ex-sep');
       sep.setAttribute('aria-hidden', 'true');

--- a/builder/writers/entity_explorer.js
+++ b/builder/writers/entity_explorer.js
@@ -406,8 +406,8 @@
       if (n.status !== 'described') outside = true;
     });
     var styles = [];
-    if (orphaned) styles.push(['orphan', 'dashed: unreachable from the root']);
-    if (outside) styles.push(['outside', 'dotted: described outside the crate']);
+    if (orphaned) styles.push(['orphan', 'unreachable from the root']);
+    if (outside) styles.push(['outside', 'described outside the crate']);
 
     // The whole-crate view leads and is fenced off from the rest: it is the way
     // back, not a peer of "Chemicals". The others are questions about parts of

--- a/tests/test_assay_lane_section.py
+++ b/tests/test_assay_lane_section.py
@@ -313,6 +313,22 @@ class TestTheLegendIsTheExplorersOwn:
             assert "legend_title" in source
             assert ".legend" in source
 
+    def test_a_style_key_reads_the_inspector_s_tag_for_that_node(self) -> None:
+        """The hollow swatch already draws the pattern, so the label says only
+        what it means — in the words the inspector uses for the same node."""
+        from builder.writers.entity_explorer import _app_js as explorer_app
+        from builder.writers.entity_explorer import _inspector_js
+
+        inspector = _inspector_js()
+        assert "'unreachable from the root'" in inspector
+        assert "'described outside the crate'" in inspector
+
+        for source in (explorer_app(), _app_js()):
+            assert "['orphan', 'unreachable from the root']" in source
+            assert "['outside', 'described outside the crate']" in source
+            assert "dashed:" not in source
+            assert "dotted:" not in source
+
 
 class TestOneInspectorForBothViewers:
     """A reader who clicks an entity wants the same answer whichever picture they


### PR DESCRIPTION
## What changed

The two line-style keys in the legend under the entity explorer and under the assay lanes read **dashed: unreachable from the root** and **dotted: described outside the crate**, next to a hollow swatch already drawn with that border. The `dashed: ` / `dotted: ` prefixes are dropped from all four literals (`builder/writers/entity_explorer.js`, `builder/writers/assay_lane_app.js`), so each key reads exactly the tag the inspector puts on the same node (`unreachable from the root`, `described outside the crate`). The divider, the hollow swatch and the show-only-where-drawn rule from #709 are untouched.

## Why

The swatch *is* the channel; the colour keys beside it read `LabProcess`, `Sample`, `File` and never "green: LabProcess". The legend and the inspector should say the same thing about the same node.

## How it was tested

- New test `tests/test_assay_lane_section.py::TestTheLegendIsTheExplorersOwn::test_a_style_key_reads_the_inspector_s_tag_for_that_node`: for both app sources the style-key literals are the inspector's own strings (checked against `_inspector_js()`), and neither source contains `dashed:` or `dotted:`. Written first and confirmed failing on the old literals; changing either file alone reddens it.
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_assay_lane_section.py tests/test_assay_lane.py tests/test_assay_lane_view.py tests/test_entity_explorer.py tests/test_entity_explorer_layout.py tests/test_explorer_js_integrity.py tests/test_maturity_report.py` — 361 passed, 2 skipped.
- `uvx ruff check .` clean; `uv run ty check` clean. (`uvx ruff format --check .` reports 40 pre-existing files, including untouched lines of this test module; unchanged by this PR and not gated by CI.)

Not done: carrying the two strings in the payload beside `categories` (the issue's optional variant) — the test now pins all four literals to the inspector's strings, which is the drift guard that change would have bought.

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
