### PR TITLE
fix(report): the AI-readiness header drops its "seven dimensions, no overall score" caption

### DIFF
--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1967,8 +1967,7 @@ def _render_air_section(air: AIRReport) -> str:
         )
     return (
         "<section>\n"
-        '  <div class="sec-h"><h2>AI-readiness &mdash; the Bridge2AI profile</h2>'
-        '<span class="sec-meta">seven dimensions, no overall score</span></div>\n'
+        '  <div class="sec-h"><h2>AI-readiness &mdash; the Bridge2AI profile</h2></div>\n'
         '  <div class="tbl-scroll"><table class="dsm-grid air-grid">\n'
         "    <thead><tr><th>Dimension</th><th>of assessed</th><th>published</th>"
         "<th>met</th></tr></thead>\n"

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -3147,6 +3147,47 @@ class TestAnUnreadableInstrumentIsSaidNotHidden:
         assert _render_air_section(AIRReport()) == ""
 
 
+class TestTheAIReadinessHeaderCarriesNoCaption:
+    """The seven rows and the note already say "seven dimensions, no overall score";
+    a caption beside the heading said it a third time (#728). The header holds the
+    `<h2>` alone, as every other section's does."""
+
+    def _air(self) -> Any:
+        from builder.state import AIRReport
+
+        return AIRReport(
+            criterion_results=[
+                {"id": "D1.1", "dimension": "D1", "text": "a criterion", "passed": True}
+            ],
+            dimensions=[
+                {
+                    "dimension": f"D{i}",
+                    "name": f"Dimension {i}",
+                    "met": 1,
+                    "assessed": 1,
+                    "total": 2,
+                    "pct": 100.0,
+                    "published_pct": 50.0,
+                }
+                for i in range(1, 8)
+            ],
+        )
+
+    def test_the_header_is_the_heading_alone(self) -> None:
+        from builder.writers.maturity_report import _render_air_section
+
+        section = _render_air_section(self._air())
+        assert "the Bridge2AI profile</h2></div>" in section
+        assert 'class="sec-meta"' not in section
+
+    def test_the_rows_and_the_note_still_stand(self) -> None:
+        from builder.writers.maturity_report import _render_air_section
+
+        section = _render_air_section(self._air())
+        assert section.count('<th scope="row">') == 7
+        assert 'class="dsm-note"' in section
+
+
 class TestTheRecommendationsCloseTheReport:
     """Assessment first, then what to do about it: Recommendations follows the
     evidence sections and only References stands after it. The jump link that


### PR DESCRIPTION
## What changed

`_render_air_section` in `builder/writers/maturity_report.py` no longer emits the `<span class="sec-meta">seven dimensions, no overall score</span>` beside the AI-readiness heading. The `sec-h` now holds the `<h2>` alone, as Entity explorer, Assay lanes, Profile adherence, FAIRplus Dataset Maturity Model, Per guidance document and Recommendations already do. The table, the unmet-criteria details and the `dsm-note` are untouched.

## Why

The span was a string literal — nothing in it came from `AIRReport`. The other `sec-meta` spans carry state (the MIT one a count, the FAIR ones a staleness flag); this one was prose, and the report's rule is that captions go: meaning lives in the figure. The seven rows under the heading and the note's verbatim authors' sentence already say what it said. The no-aggregate contract is the data's (`AIRReport`, `air/criteria.yaml`, AGENTS.md) and is unaffected.

## How it was tested

- New `TestTheAIReadinessHeaderCarriesNoCaption` in `tests/test_maturity_report.py`: over an `AIRReport` with criterion results, the section contains `the Bridge2AI profile</h2></div>` and no `class="sec-meta"`; the seven dimension rows and the `dsm-note` are still present. Written first, failed on main, passes after the fix.
- The existing ordering test (`the Bridge2AI profile</h2>` before `Recommendations</h2>`) is unchanged.
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py` — 165 passed.
- `uvx ruff check .` clean; `uv run ty check` clean. `uvx ruff format --check .` reports 40 files on main already drifted (pre-existing, CI runs only `ruff check`); the added lines are formatter-clean.

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
