### PR TITLE
fix(report): the FAIR principle 1.3 tile's note opens with an unsourced fragment — state what the percentage counts

### DIFF
--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -894,6 +894,16 @@ def _wrap_label(text: str, width: int = 20) -> list[str]:
     return [line for line in lines if line]
 
 
+def _mit_totals(mit: MITReport) -> tuple[int, int]:
+    """``(completed, total)`` over the module buckets — the one sum the rose
+    tile's sub-line, the rose's wedges and the OECD MIT coverage section header
+    all read, so the three cannot disagree. ``overall_score`` is this ratio
+    (see ``_score_modules``)."""
+    completed = sum(sc.get("completed", 0) for sc in mit.module_scores.values())
+    total = sum(sc.get("total", 0) for sc in mit.module_scores.values())
+    return completed, total
+
+
 def _mit_rose_svg(mit: MITReport) -> str:
     """The MIT coverage rose: one wedge per module, angle = the module's share
     of the checklist, radius = how much of that module is filled. A faint
@@ -910,7 +920,7 @@ def _mit_rose_svg(mit: MITReport) -> str:
     """
     import math
 
-    total_all = sum(sc.get("total", 0) for sc in mit.module_scores.values())
+    _, total_all = _mit_totals(mit)
     if not total_all:
         return ""
     cx = cy = 87.0
@@ -982,9 +992,9 @@ def _mit_rose_tile(mit: MITReport) -> str:
             "</article>"
         )
     pct = round(mit.overall_score * 100)
+    completed, total = _mit_totals(mit)
     note = (
-        '<div class="tile-note">for in vitro toxicology research datasets, assays, as well '
-        "as cell-based toxicity test methods.<br>NB: this score does not ensure data quality "
+        '<div class="tile-note">NB: this score does not ensure data quality '
         "or assess whether the science is right. It does measure how completely the domain "
         "reporting fields are filled.</div>"
     )
@@ -993,6 +1003,7 @@ def _mit_rose_tile(mit: MITReport) -> str:
         + head
         + f'<div class="kpi-v"><b>{pct}</b><span class="den">%</span></div>'
         f'<div class="rose-wrap">{_mit_rose_svg(mit)}</div>'
+        f'<div class="kpi-sub">{completed} of {total} MIT checklist fields filled</div>'
         f"{note}"
         "</article>"
     )
@@ -1425,8 +1436,7 @@ def _render_mit_section(mit: MITReport) -> str:
             "not be assembled to score against. This is not a score of zero.</p>\n"
             "</section>\n"
         )
-    completed_all = sum(sc.get("completed", 0) for sc in mit.module_scores.values())
-    total_all = sum(sc.get("total", 0) for sc in mit.module_scores.values())
+    completed_all, total_all = _mit_totals(mit)
     pct = round(mit.overall_score * 100)
 
     def mrow(name: str, bar: str, sc: dict[str, int], style: str = "") -> str:

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -995,6 +995,34 @@ class TestFairTileAndRose:
             assert '<span class="eyebrow">FAIR principle 1.3' in tile
         assert ".chip-link" not in _CSS_PATH.read_text(encoding="utf-8")
 
+    def test_the_rose_tile_states_what_its_percentage_counts(self) -> None:
+        """The only tile whose number is a bare percentage says what it counts
+        — a `kpi-sub` line in the grid's own shape, summed from the scores —
+        in place of the unsourced scope fragment the note used to open with
+        (#735). The two numbers are the section header's own, so the tile and
+        the OECD MIT coverage `sec-meta` cannot disagree."""
+        from builder.state import MITReport
+        from builder.writers.maturity_report import _mit_rose_tile
+
+        tile = _mit_rose_tile(
+            MITReport(
+                module_scores={
+                    "A": {"completed": 1, "total": 2},
+                    "B": {"completed": 2, "total": 4},
+                },
+                overall_score=0.5,
+            )
+        )
+        assert '<div class="kpi-sub">3 of 6 MIT checklist fields filled</div>' in tile
+        assert "cell-based" not in tile
+        assert "not assessed" in _mit_rose_tile(MITReport())
+
+        body = _body(build_maturity_html(vhps_fixture_state("S-VHPS21")))
+        tile_m = re.search(r'kpi-sub">(\d+) of (\d+) MIT checklist fields filled', body)
+        meta_m = re.search(r'sec-meta"><b>(\d+)/(\d+)</b> fields', body)
+        assert tile_m is not None and meta_m is not None
+        assert tile_m.groups() == meta_m.groups()
+
     def test_the_footnote_superscripts_resolve(self) -> None:
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
         for fn in ("fn-dsm", "fn-mit", "fn-air"):


### PR DESCRIPTION
## What changed

- `builder/writers/maturity_report.py`
  - `_mit_rose_tile`: the note's unsourced opening fragment ("for in vitro toxicology research datasets, assays, as well as cell-based toxicity test methods.") is gone. In its place, in the grid's own shape and sourced from the scores: `<div class="kpi-sub">88 of 176 MIT checklist fields filled</div>`. The NB stays as it was. The unassessed branch ("not assessed", never 0 %, #311) is untouched.
  - New `_mit_totals(mit) -> (completed, total)`: the one sum the tile's sub-line, the rose's wedges (`_mit_rose_svg`) and the OECD MIT coverage `sec-meta` (`_render_mit_section`) all read, so the three cannot disagree.

## Why

The tile was the only one whose number is a bare percentage and it said nothing about what it counts; the fragment it opened with asserted a scope that appears in neither the checklist's README nor this repo. The sibling tiles that carry a number over a total already say what they count in a `kpi-sub` line. Whether the NB's last clause survives is the owner's call, per the issue.

## How it was tested

- New `tests/test_maturity_report.py::TestFairTileAndRose::test_the_rose_tile_states_what_its_percentage_counts` — written first and confirmed failing on the missing line; asserts `3 of 6 MIT checklist fields filled` and no `cell-based` for `{A: 1/2, B: 2/4}`, `not assessed` for an empty `MITReport`, and over the S-VHPS21 fixture that the tile's two numbers equal the OECD MIT coverage `sec-meta`'s.
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py` — 164 passed.
- `uvx ruff check .` clean; `uv run ty check` clean over the whole tree. `ruff format --check` flags only hunks already present on main, none in the changed regions.

No README/AGENTS.md change: neither describes the tile's note, and the report's design is unchanged.

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
