### PR TITLE
docs: sixteen sentences that describe behaviour the code no longer has

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -696,10 +696,16 @@ instrument's grid outright and needs none.
 **A check reads the crate, not the session.** An indicator is scored against the
 assembled `@graph` — the bytes a reader receives — so a third party scoring the
 published crate reaches our published number. Given no graph a check answers *not
-assessed* (`None`), which leaves the denominator, rather than guessing from
-`CrateState`; `_GRAPH_AWARE_FAIR_CHECKS` names the RDA checks that hold to this,
-every DSM check registered unwrapped in `DSM_CHECKS` holds to it too, and
-`assessment_graph.needs_graph` states why the alternative is a lie. `_state_check`
+assessed* (`None`) rather than guessing from `CrateState`, and where that answer lands is
+the instrument's own arithmetic: the RDA count carries not-assessed as a bucket beside met
+and failed, while a DSM cell drops it from `pct` and scores it 0 in `published_pct`, because
+the published sheet has no such state; `_GRAPH_AWARE_FAIR_CHECKS` names the RDA checks that read the graph, and
+every DSM check registered unwrapped in `DSM_CHECKS` reads it too;
+`assessment_graph.needs_graph` states why the alternative is a lie. The licence predicates
+are the one deliberate exception: `_effective_license` falls back to
+`state.metadata.license`, because a licence the deposit itself declared (#535) is a crate
+fact wherever it is read from, so the three of them — five registry entries, the DSM reusing
+two — answer a bool with no graph rather than `None`. `_state_check`
 marks what is left — a **burn-down**, enumerated with the reason each rewrite was
 refuted in `tests/test_fair_metrics_can_fail.py`, which may shrink and may not grow.
 Two indicators asking one question share one function, so the axes cannot disagree
@@ -1506,7 +1512,10 @@ All three score published instruments and share one shape: a tri-state verdict p
 item carrying the evidence behind it (`builder/tools/assessment_graph.Verdict`), read
 from the assembled `@graph` rather than from `CrateState` — the domain content exists
 only after assembly. An item the tool cannot assess from a crate is reported *not
-assessed*, never failed, and leaves the denominator.
+assessed*, never failed, and leaves the denominator of what was assessed — never the
+instrument's own. Where a published formula has no *not assessed* state, the report carries
+both numbers: `pct` over the criteria assessed, `published_pct` over every criterion
+(`AIRReport`, `fair_assessment.dsm_grid`).
 
 `AIRReport` carries **no aggregate score**. The Bridge2AI authors state that
 AI-readiness is not scored pass/fail overall, so the axis is seven per-dimension
@@ -2171,9 +2180,11 @@ requirement-level conformance **matrix** (rows the three layers linked to their 
 to `_crate_mapping`'s `conformsTo` constants by test — cells ✓/✗/– with counts on `title`; the
 Required column is the report's one headline verdict). A `–` carries two different sentences:
 *not assessed* where the sweep did not reach that tier, and *no checks defined at this level*
-where the profile has no rule there at all — the ISA and ISA-Tox profiles declare no `sh:Info`
-shape, so their Optional column can only ever come back empty, and an empty result is the
-profile's silence rather than the crate's cleanliness. Which tiers a layer can report at is
+where nothing in the row's layer chain declares a rule there at all, because an empty result
+then is the profiles' silence rather than the crate's cleanliness. ISA and ISA-Tox declare no
+`sh:Info` shape of their own, but each row is cumulative over `PROFILE_LAYER_CHAIN` and they
+extend a profile that declares twelve, so their Optional column is answerable and a clean
+crate reads a tick there. Which tiers a layer can report at is
 read from the validator's own requirement registry (`profiles.validator.tiers_defined`), never
 from a list kept by hand, so only a tier that could have failed is allowed to pass. A finding
 outranks that state: one filed at a tier the profile defines no check at still reads ✗, the FAIR ladder (the *next* rung dashed red
@@ -2243,7 +2254,8 @@ deposit as it arrived — the one moment the state holds nothing but a file inve
 any licence the deposit declared — and stores the verdicts on `CrateState.pre_assessment`,
 because `crate_state.json` is overwritten on every save and that moment is otherwise
 unrecoverable. `assessment_graph.as_received_graph` is its evidence: one `File` per
-scanned file and a root carrying `hasPart` and nothing else. It **mints nothing** — no
+scanned file and a root carrying `hasPart` and, only where the deposit declared one, a
+`license`. It **mints nothing** — no
 descriptor node, no root identifier, name, description or `conformsTo`, no structure —
 because each of those would score the input for work the FAIRification has not done;
 `tests/test_fair_metrics_can_fail.py` pins both the shape and the exact set of indicators

--- a/builder/tools/fair_assessment.py
+++ b/builder/tools/fair_assessment.py
@@ -575,9 +575,10 @@ def _check_every_entity_has_id(state: CrateState, graph: Graph = None) -> bool |
 
     A File is globally identified when its own ``@id`` or ``contentUrl`` is an
     absolute IRI, or when the root carries a PID the crate-relative paths compose
-    against. On this corpus that is false everywhere, because nothing writes a DOI to
-    the root — the same root cause as RDA-F1-01M, and the two flip together when it is
-    fixed. False for a stated reason is a finding; true for no reason is not.
+    against. The second limb is the one that usually decides: this and RDA-F1-01M read
+    the same :func:`_root_pid`, so a deposit declaring a DOI turns both True together
+    and a deposit declaring none leaves both False. False for a stated reason is a
+    finding; true for no reason is not.
     """
     if _needs_graph(graph):
         return None
@@ -972,21 +973,24 @@ def _check_unique_id(state: CrateState, graph: Graph = None) -> Verdict | None:
     The old check was ``bool(state.session_id or state.metadata.accession)`` — a session
     handle no reader receives, true of every build that ran.
 
-    **Reachable, and false today.** No crate on hand reaches it: 62 of 62 roots carry a
-    minted slug or a bare accession, none an IRI. It is not *unreachable*.
-    ``_populate_isa_backbone`` copies ``inv.fields["identifier"]`` onto the root verbatim
-    and ``readers.existing_crate`` copies an ingested root ``identifier`` into
-    ``metadata.accession``, so an Investigation — or an input crate — declaring a DOI
-    produces a root PID with no code change (measured: True).
+    **What makes it true.** The root's persistent identifier is the DOI the deposit
+    declares: ``engine._read_declared_doi`` reads it from the deposit's own descriptor
+    and ``_crate_mapping._populate_root_and_conformance`` writes it to the root
+    ``identifier``, where a DOI outranks a bare accession because only the DOI still
+    identifies the deposit outside the repository it came from (#682). A deposit that
+    declares none leaves this False, and the evidence string says which limb failed.
 
-    It gates Level 1, so until something mints one the DSM ladder reads 0 for every
-    crate, and :func:`dsm_ceiling` reports DSM-1-C0 as the blocker. That is the finding
-    RDA-F1-01M and RDA-F1-02D already publish; what changes is that the two axes stop
-    contradicting each other, where before the DSM awarded Level 2 on the strength of a
-    ``session_id``. The route out is one the tool owns: 15 of these crates carry the real
-    BioStudies accession ``S-VHPS22``, and emitting it as
-    ``https://www.ebi.ac.uk/biostudies/studies/S-VHPS22`` — the identifier it already
-    has, written so it resolves — would satisfy this with no depositor action.
+    It gates Level 1, so a crate with no root PID cannot reach the first rung and
+    :func:`dsm_ceiling` names DSM-1-C0 among its blockers. RDA-F1-01M and RDA-F1-02D
+    publish the same finding from the same :func:`_root_pid`, which is the point of
+    sharing it: the two axes must not contradict each other about whether this crate is
+    identified.
+
+    Composing a landing page from an accession is not a substitute.
+    ``https://www.ebi.ac.uk/biostudies/studies/S-VHPS22`` is globally unique but not
+    persistent (:func:`_is_persistent_id`), so it answers RDA-F1-02M and not this one;
+    and writing it at all means inferring which repository issued the accession, the
+    repository-dialect special-casing AGENTS.md §Input Formats forbids.
 
     **Stated limitations, all measured.** :func:`_root_pid` accepts any text containing
     ``doi`` or starting with ``10.``, so ``10.happy`` reads as a persistent identifier;
@@ -2582,12 +2586,12 @@ def _state_check(fn: Callable[[CrateState], bool]) -> DsmCheck:
 # see #665 for why the licence indicators moved first and what a wider move would cost.
 _GRAPH_AWARE_FAIR_CHECKS: frozenset[str] = frozenset(
     {
-        # #712: was true on `session_id` alone, a handle no reader receives.
-        "root_global_id",
         "license_present",
         "license_standard",
         "license_machine",
-        # #670: these four asked their question of CrateState and could not fail. They
+        # #712: was true on `session_id` alone, a handle no reader receives.
+        "root_global_id",
+        # #670: these five asked their question of CrateState and could not fail. They
         # now read the crate a reader receives, and answer "not assessed" rather than
         # guess when no graph was supplied.
         "pid_form",
@@ -2642,14 +2646,16 @@ DSM_CHECKS: dict[str, DsmCheck] = {
     "standard_identifiers": _check_standard_identifiers,
     "linked_data": _check_linked_data,
     "machine_interpretable": _check_machine_interpretable,
+    # DSM-1-C3 left the burn-down below when it stopped passing on `session_id` (#706);
+    # it reads the crate like everything above it.
+    "access_info": _check_access_info,
     # --- still scored from CrateState: the rewrites #670 could not land honestly ---
-    # Nine refuted rewrites over these eight entries — ``domain_model`` backs both
+    # Eight refuted rewrites over these seven entries — ``domain_model`` backs both
     # DSM-2-C1 and DSM-2-R1, and both proposals for it were rejected. Each resisted two
     # rounds of adversarial review, and each was refuted by an edit that carries no
     # information: deleting a declaration, retyping a node, or truncating an IRI raised
     # the score. ``test_every_dsm_check_reads_the_crate`` pins the list with the reason
     # for each; it is a burn-down, so the number may only go down.
-    "access_info": _check_access_info,
     "has_descriptor": _state_check(_check_has_descriptor),
     "context_fields": _state_check(_check_context_fields),
     "value_level_metadata": _state_check(_check_value_level_metadata),
@@ -2895,10 +2901,14 @@ def load_dsm_answers(path: Path | str) -> dict[str, bool]:
 def pre_verdicts(state: CrateState) -> dict[str, Verdict]:
     """The stored as-received verdicts — the sheet's "Pre-FAIRification" column.
 
-    Captured once by ``AgentEngine.initialize`` and carried in the session, so a report
-    rendered days later still states what the deposit looked like on arrival. Empty for
-    a session written before the baseline existed, and for a run given no input to scan;
-    callers render the post column alone rather than inventing a baseline.
+    Captured once by ``AgentEngine.initialize`` and carried in the session, because
+    ``crate_state.json`` is overwritten on every save and the deposit's arrival state is
+    otherwise unrecoverable. Empty for a session written before the baseline existed,
+    and for a run given no input to scan.
+
+    No page reads it: the maturity report draws the post column alone, pinned by
+    ``test_the_baseline_is_captured_but_not_drawn``. This is the read path for a paper
+    or an eval, not for the report (#711).
     """
     return {
         ident: Verdict(stored.get("value"), str(stored.get("evidence", "")))

--- a/builder/tools/remediation.py
+++ b/builder/tools/remediation.py
@@ -156,9 +156,11 @@ class Action:
         subject: What the action is about — an entity label, or a property name.
         entity_ids: Every entity the action touches.
         findings: The finding messages this action would clear.
-        tier: The strongest tier among those findings
-            (REQUIRED > RECOMMENDED > OPTIONAL — the validator's own
-            vocabulary, so it lines up with the conformance table).
+        tier: The strongest tier among those findings — REQUIRED > MATURITY >
+            RECOMMENDED > OPTIONAL. Three are the validator's own vocabulary, so
+            they line up with the conformance table; MATURITY is this module's,
+            carried by the DSM blockers :func:`group_dsm_blockers` mints, and it
+            outranks a recommendation while yielding to a conformance failure.
         actionable: False for a finding that is deliberately left open.
         note: Why it is not actionable, when it is not.
     """
@@ -206,7 +208,7 @@ class Action:
 
 
 def _strongest(tiers: list[str]) -> str:
-    """The most severe tier in *tiers* — REQUIRED beats RECOMMENDED beats OPTIONAL.
+    """The most severe tier in *tiers*, ranked by ``_TIER_RANK``.
 
     An unrecognised tier sorts last rather than raising: a new validator severity
     should make an action rank low, not crash the report. It is the DEFAULT that
@@ -389,7 +391,8 @@ def group_findings(
             "Zhongli Chen" rather than "#CitationAuthor_Zhongli_Chen".
 
     Returns:
-        Actions sorted by tier, then by how many findings each clears.
+        Actions sorted by tier, then by reuse impact (``Action.impact``), then by
+        how many findings each clears, with the subject as a stable tiebreak.
         Deliberately-open findings are returned too, flagged ``actionable=False``
         so a caller can show them as answered rather than outstanding.
     """

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -11,7 +11,7 @@ assets) covering the four axes from the issue:
   ``issue_records`` each severity row unfolds its own findings, grouped by profile
   layer inside (#510); a pre-records verdict falls back to the flat list;
 * **FAIR** — the gated FAIRplus Dataset Maturity level on a ladder whose next rung
-  shows the ratio of RDA-style indicators already met, plus what blocks the next level;
+  shows the DSM grid's own Total for that level, plus what blocks it;
 * **OECD MIT coverage** — per-module coverage of the in-vitro tox MIT checklist;
 * **AI-readiness** — the NIH Bridge2AI criteria as a seven-dimension profile,
   with the authors' own per-dimension percentage reported beside ours.
@@ -148,9 +148,10 @@ def _severity_tiers(val: ValidationReport) -> list[dict[str, str]]:
     REQUIRED is the build gate, so it is assessed whenever validation has run; it
     passes only when all three profiles pass with no REQUIRED issues. The SHOULD
     and MAY tiers are populated only by a full validation sweep — the fast in-loop
-    path stops at REQUIRED and leaves them empty. An empty SHOULD/MAY tier is
-    therefore reported as "not assessed" (``"na"``), never as a green zero: doing
-    otherwise would be a false pass for a tier that was never evaluated.
+    path stops at REQUIRED and leaves them empty. Emptiness is not the test:
+    ``assessed_tiers`` is. A tier the sweep reached and found clean renders a green
+    "0 issues"; a tier nobody evaluated renders "not assessed" (``"na"``), never a
+    green zero for a tier that was never looked at.
 
     Called only when :func:`_validation_has_signal` is True (otherwise the whole
     section renders the "not yet validated" branch).
@@ -824,9 +825,8 @@ def _fair_tile(
     of that level the sheet already scores as complete (a gated 0 must not read as
     "nothing done"), and — in red — how many indicators stand before it.
 
-    The rung is filled from the DSM grid's own Total for the level in question. It used
-    to be filled from the RDA indicator set, so a DSM-labelled bar reported a number
-    from a different instrument entirely.
+    The rung is filled from the DSM grid's own Total for the level in question: every
+    number on a DSM-labelled bar is the DSM's, never the RDA indicator set's.
     """
     # The denominator is the highest level a crate can REACH, not the model's top
     # rung: Level 5 is scored entirely on hosting and enterprise data governance, so
@@ -1906,7 +1906,8 @@ def _render_dsm_levels(
         '  <p class="lead">Each level counts the indicators below it as well as its own, '
         "so a statement can appear at more than one level. Every identifier links to the "
         "model&rsquo;s definition of it. A <b>?</b> marks an indicator no crate can "
-        "evidence &mdash; the hosting environment and enterprise-governance statements the "
+        "evidence &mdash; the hosting environment, enterprise governance, and compliance "
+        "with a Minimum Information Reporting Guideline &mdash; which the "
         "published tool puts to a person; answer those in a YAML file "
         "(<code>DSM-1-H1: true</code>, one per line) and pass it as "
         "<code>--dsm-answers</code>.</p>\n"


### PR DESCRIPTION
Every claim in #716 re-read against the code beneath it — **on today's tree, not the one the issue was filed against.** Six PRs merged in between and moved some of this ground, so two of the sixteen came back different: one was already fixed, and one was right about the count and wrong about the cause.

## The refuted denominator claim, in its last two homes

AGENTS.md said an unanswered indicator "leaves the denominator" in two separate sections. It depends on the instrument, and both now say which:

| | an unanswered indicator |
|---|---|
| RDA | a bucket beside met and failed |
| DSM | dropped from `pct`, scored **0** in `published_pct` — the sheet has no such state |
| AIR | excluded, by declaration (`published_pct` / `pct`) |

## Claims the merged work falsified

- **DSM-1-C0** said *"Reachable, and false today. No crate on hand reaches it"* and proposed composing a BioStudies landing page as the route out. #682 mints a root PID from the deposit's own DOI. The docstring now says what makes the indicator true — and why that proposed route is dead **twice over**: the URL is globally unique but *not persistent*, so it answers RDA-F1-02M and not this one; and building it means inferring which repository issued the accession, the special-casing `document_discovery` records deleting.
- **RDA-F1-02D** said *"on this corpus that is false everywhere… the two flip together when it is fixed."* They flipped. Executed over the 32 crates in `output/`: **31 False, 1 True — the same crate for both indicators.**
- **The "still scored from CrateState" heading** counted eight entries and nine refuted rewrites. `access_info` left that list in #706, so it is **seven and eight** — and the registration moves out of the block rather than leaving the heading false of its own first member.
- **"#670: these four asked their question of CrateState"** precedes **five** names, and has since the commit that wrote it.
- **`pre_verdicts`** said "callers render the post column alone". It has no callers (#711).
- **The report module docstring** said the ladder rung shows RDA indicators. It shows the DSM grid's own Total — which the function's own docstring already said, *while calling the module's version the bug*.
- **"An empty SHOULD/MAY tier is reported as not assessed"** stopped being true when `assessed_tiers` arrived. Confirmed by rendering: a tier the sweep reached and found clean shows a green "0 issues".
- **The DSM legend** said **?** marks the hosting and governance statements. DSM-3-C1 is a *Content* indicator about Minimum Information Reporting Guidelines, `na` for a measured reason (#705).
- **`group_findings`** said "sorted by tier, then by how many findings each clears" — reuse impact sits between them, and the module spends forty lines on why. **`Action.tier`** said "REQUIRED > RECOMMENDED > OPTIONAL — the validator's own vocabulary": there is a fourth, `MATURITY`, that this module defines and assigns, and it outranks a recommendation.
- **AGENTS.md** said the ISA and ISA-Tox profiles "can never" tick an Optional cell. Each row is cumulative over `PROFILE_LAYER_CHAIN` and they extend a profile declaring twelve `sh:Info` shapes, so a clean crate reads a tick there.

## Two the issue got wrong

- The **pre-FAIRification paragraph** was already corrected in #723; only a residual sentence about the as-received root needed fixing here.
- **§4.2.6's "five checks guess from CrateState"** is the right count for the wrong reason. It is not the burn-down — it is the **licence fallback**, and that is deliberate: a licence the deposit itself declared is a crate fact wherever it is read from (#535). Three RDA entries plus the two the DSM reuses. The burn-down sentence beside it is accurate today, and **open #743 proposes changing that behaviour**, so it is left alone rather than documented twice and rewritten next week.

## One drafted patch was wrong, and caught

The correction for the `CrateState` heading, as drafted, deleted the `"access_info": _check_access_info` registration along with the comment — which would have dropped DSM-1-C3 from every report. It moves instead.

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_fair_metrics_can_fail.py \
  tests/test_tools_fair_assessment.py tests/test_maturity_report.py \
  tests/test_remediation_grouping.py tests/test_dsm_indicators_source.py \
  tests/test_fair_indicators_source.py tests/test_dsm_sheet_parity.py \
  tests/test_agents_doc_toolbox.py tests/test_tool_reachability.py -q
  → 402 passed, 3 xfailed
```

`uvx ruff check` and `uv run ty check builder/ tests/` clean. No behaviour changes — prose, plus one registration moved within a dict.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf