### PR TITLE
feat(report): the DSM section heading links to the published assessment tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2202,7 +2202,9 @@ any sheet of the assessment workbook computes an achieved maturity level. The re
 therefore leads with the grid the sheet computes — level x {content, representation,
 hosting, total} (`fair_assessment.dsm_grid`) — and carries the gated level beside it
 labelled **derived**, because "how far up the ladder" is the question depositors ask and
-it is deliberately harsh: one failing level-1 indicator hides everything above it.
+it is deliberately harsh: one failing level-1 indicator hides everything above it. The
+section heading links the published assessment tool; its URL is recorded once, as the
+YAML's `source.assessment_tool`, and the writer reads it from there.
 
 **The grid is the sheet's arithmetic, read from the sheet.** `scripts/gen_dsm_indicators.py`
 carries the workbook's own scoring into `fair/dsm_indicators.yaml` under `scoring` —

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ build embeds a **maturity report** (`ro-crate-metadata-maturity.html`): profile
 conformance, FAIR maturity, OECD MIT coverage, reproducibility readiness — and an
 **interactive entity explorer**. The FAIRplus DSM section reproduces the published
 assessment sheet's own percentage grid, cell for cell, so the numbers are ones an
-outside assessor can reach by filling the same sheet in by hand. The explorer draws the crate's whole entity graph,
+outside assessor can reach by filling the same sheet in by hand or answering the
+online tool its heading links. The explorer draws the crate's whole entity graph,
 with views you turn on and off and combine (Researcher, Files, Assays,
 LabProcesses, Chemicals, Biological models, Persons & Organisations,
 Citations), a search box, and a panel that shows any entity's properties, its

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1749,13 +1749,16 @@ def _render_references() -> str:
     )
 
 
-def _render_dsm_grid_section(grid: dict[int, dict[str, Any]], levels: dict[int, str]) -> str:
+def _render_dsm_grid_section(
+    grid: dict[int, dict[str, Any]], levels: dict[int, str], tool: str = ""
+) -> str:
     """The DSM's own **"% Complete" grid** — the published instrument's only output.
 
     No formula in the assessment workbook computes an achieved maturity level; what it
     computes is this grid, six levels x {content, representation, hosting} plus a total.
     So this is the section a depositor can check: fill the sheet in by hand, or answer
-    the online tool, and these percentages are the ones that come back.
+    the online tool, and these percentages are the ones that come back. The heading's
+    meta links that tool — ``tool`` is the YAML's ``source.assessment_tool``.
 
     **The headline number is the sheet's.** Its validation column is entirely formulas,
     so an unanswered indicator evaluates to 0 and counts against the score — the
@@ -1772,6 +1775,7 @@ def _render_dsm_grid_section(grid: dict[int, dict[str, Any]], levels: dict[int, 
     if not grid:
         return ""
     esc = html.escape
+    meta = f'<span class="sec-meta">{_lk(tool, tool.split("//", 1)[-1])}</span>' if tool else ""
     # The published tool's own columns, in its own order and wording.
     cats = (("R", "Representation &amp; Format"), ("C", "Content &amp; Context"),
             ("H", "Hosting Environment Capabilities"), ("TOTAL", "Overall Level % Completion"))
@@ -1813,7 +1817,7 @@ def _render_dsm_grid_section(grid: dict[int, dict[str, Any]], levels: dict[int, 
     return (
         "<section>\n"
         '  <div class="sec-h"><h2>FAIRplus Dataset Maturity Model</h2>'
-        '</div>\n'
+        f"{meta}</div>\n"
         '  <div class="tbl-scroll"><table class="dsm-grid">\n'
         f"    <thead><tr><th>Level</th>{head}</tr></thead>\n"
         f"    <tbody>{rows}</tbody>\n"
@@ -2918,7 +2922,11 @@ def build_maturity_html(
     dsm_reach = dsm_ceiling(state, dsm_data, graph, dsm_answers)
     dsm_cells = dsm_grid(state, dsm_data, graph, answers=dsm_answers)
 
-    dsm_section = _render_dsm_grid_section(dsm_cells, dsm_data.get("levels") or {})
+    dsm_section = _render_dsm_grid_section(
+        dsm_cells,
+        dsm_data.get("levels") or {},
+        str((dsm_data.get("source") or {}).get("assessment_tool") or ""),
+    )
     dsm_section += _render_dsm_levels(dsm_data, dsm_answers, dsm_data.get("levels") or {})
     # The indicators standing before the next level, worded as instructions and ranked
     # against the conformance findings in one list — see _render_recommendations.

--- a/fair/dsm_indicators.yaml
+++ b/fair/dsm_indicators.yaml
@@ -30,7 +30,7 @@ source:
     citation: Welter D, Juty N, Rocca-Serra P, et al. FAIR in action - a flexible framework to guide FAIRification.
       Sci Data 10:291 (2023)
     doi: 10.1038/s41597-023-02167-2
-  assessment_tool: https://fairdsm.biospeak.solutions/
+  assessment_tool: https://fairdsm.biospeak.solutions/assess
   derived_from:
     name: RDA FAIR Data Maturity Model
     doi: 10.15497/rda00050

--- a/scripts/gen_dsm_indicators.py
+++ b/scripts/gen_dsm_indicators.py
@@ -407,7 +407,7 @@ SOURCE: dict[str, Any] = {
         ),
         "doi": "10.1038/s41597-023-02167-2",
     },
-    "assessment_tool": "https://fairdsm.biospeak.solutions/",
+    "assessment_tool": "https://fairdsm.biospeak.solutions/assess",
     # The DSM is built on the RDA FAIR Data Maturity Model: the workbook ships an
     # "RDA indicators" sheet and 27 of the 83 indicators carry an explicit
     # `REF RDA indicator(s)` cross-reference, surfaced per indicator as `rda_ref`.

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1024,6 +1024,22 @@ class TestFairTileAndRose:
         assert f'href="{MIT_INDICATORS_URL}"' in refs
         assert "principle R1.3" in refs
 
+    def test_the_dsm_heading_links_the_published_assessment_tool(self) -> None:
+        """The grid mirrors the tool's output; its heading leads to the tool.
+
+        The URL is the one the YAML records under ``source.assessment_tool`` — the
+        same discipline reference 1 is held to — and the h2 itself stays plain text.
+        """
+        from builder.tools.fair_assessment import DSM_INDICATORS_PATH, _load_yaml
+
+        tool = (_load_yaml(DSM_INDICATORS_PATH) or {})["source"]["assessment_tool"]
+        assert tool == "https://fairdsm.biospeak.solutions/assess"
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
+        assert "FAIRplus Dataset Maturity Model</h2>" in page
+        sec_h = page[page.index("FAIRplus Dataset Maturity Model</h2>") :].split("</div>", 1)[0]
+        assert f'<a class="lk" href="{tool}">' in sec_h
+        assert "<h2><a" not in sec_h
+
 
 class TestStaleValidation:
     """A verdict recorded against a DIFFERENT crate is never reported as a pass.


### PR DESCRIPTION
## What changed

The **FAIRplus Dataset Maturity Model** heading now carries a link to the published assessment tool in its `sec-meta` slot — `fairdsm.biospeak.solutions/assess`, rendered with the report's `_lk` link styling and no sentence. The h2 text is unchanged and is not itself an anchor, like every other heading on the page.

- `builder/writers/maturity_report.py` — `_render_dsm_grid_section` takes the tool URL (`tool: str = ""`) and fills the meta slot with it; `build_maturity_html` reads it from the loaded YAML's `source.assessment_tool`. An absent URL leaves the slot empty, and `_lk` already refuses non-http targets.
- `scripts/gen_dsm_indicators.py` — the `assessment_tool` literal points at `/assess` (the tool's assessment route; the root is a landing page whose primary button routes there). `fair/dsm_indicators.yaml` regenerated — a one-line diff.
- `README.md`, `AGENTS.md` — one sentence each: the heading links the tool, and the URL is recorded once, in the YAML.

## Why

The section reproduces the tool's grid and the next section its checklist, but nothing on the page led to the tool; the URL was already in the repo and never reached the writer.

## How it was tested

- New `tests/test_maturity_report.py::TestFairTileAndRose::test_the_dsm_heading_links_the_published_assessment_tool` — asserts the DSM `sec-h` carries `<a class="lk" href="https://fairdsm.biospeak.solutions/assess">`, that the href equals the YAML's `source.assessment_tool`, that `FAIRplus Dataset Maturity Model</h2>` still matches, and that the h2 is not an anchor. Written first and seen failing (the YAML still said `/` and the slot was empty), then passing.
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py tests/test_dsm_indicators_source.py tests/test_dsm_sheet_parity.py` — 224 passed, 1 skipped (the source test confirms the committed YAML equals the generator's output).
- `uvx ruff check .` clean; `uv run ty check` clean over the whole tree; `ruff format --check` reports only the 40 files already unformatted on main — none of this PR's hunks.

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
