### PR TITLE
feat(report): each guidance-document row links to the document it scores against

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2264,8 +2264,10 @@ single evaluation pass — the level, the grid and the ceiling all read it, so t
 disagree, and the report evaluates it once per render. The MIT axis keeps the
 aggregate score as the headline and additionally breaks coverage out per guidance document (#491):
 each checklist parameter's `standards` map buckets it under the documents that require it
-(`MITReport.standard_scores`, labels from `MIT_STANDARD_LABELS`); documents overlap, so the
-per-document rows deliberately do not sum to the checklist total. The section says what it scores:
+(`MITReport.standard_scores`, labels from `MIT_STANDARD_LABELS`, each row's name linked to the
+document it scores against by `MIT_STANDARD_SOURCES` — a column with no registered source stays
+plain text); documents overlap, so the per-document rows deliberately do not sum to the checklist
+total. The section says what it scores:
 every checklist item is a FAIR maturity indicator as defined in tox-maturity-indicators
 (`MIT_INDICATORS_URL`), which the lead links.
 

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -57,6 +57,19 @@ MIT_STANDARD_LABELS: dict[str, str] = {
     "oecd_oht201": "IUCLID OHT 201",
 }
 
+# Where each guidance document lives, keyed like MIT_STANDARD_LABELS. Copied
+# verbatim from the `identifier_to_hash` of upstream tox-maturity-indicators'
+# `source/standards.yaml` (the _PROFILE_SPEC_URLS precedent): the package's
+# runtime data ships no source URLs, so the vendored YAML cannot carry them.
+# A column absent here (upstream has dropped it) renders as plain text.
+MIT_STANDARD_SOURCES: dict[str, str] = {
+    "oecd_gd211": "https://doi.org/10.1787/9789264274730-en",
+    "toxtemp": "https://doi.org/10.14573/altex.1909271",
+    "oecd_gd34": "https://doi.org/10.1787/e1f1244b-en",
+    "oecd_gd417": "https://doi.org/10.1787/8d49ec1d-en",
+    "oecd_oht201": "https://www.oecd.org/en/topics/assessment-of-chemicals/harmonised-templates-intermediate-effects.html",
+}
+
 
 def load_mit_yaml() -> dict[str, Any] | None:
     """Load and parse the MIT YAML file.

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -62,6 +62,7 @@ from builder.tools.fair_assessment import assess_fair_maturity
 from builder.tools.mit_assessment import (
     MIT_INDICATORS_URL,
     MIT_STANDARD_LABELS,
+    MIT_STANDARD_SOURCES,
     assess_mit_coverage,
     mit_was_assessed,
 )
@@ -1429,9 +1430,10 @@ def _render_mit_section(mit: MITReport) -> str:
     total_all = sum(sc.get("total", 0) for sc in mit.module_scores.values())
     pct = round(mit.overall_score * 100)
 
-    def mrow(name: str, bar: str, sc: dict[str, int], style: str = "") -> str:
+    def mrow(name: str, bar: str, sc: dict[str, int], style: str = "", url: str = "") -> str:
+        label = _lk(url, name) if url else esc(name)
         return (
-            f'<div class="mrow"{style}><div class="mname">{esc(name)}</div>'
+            f'<div class="mrow"{style}><div class="mname">{label}</div>'
             f'<div class="mbar">{bar}</div>'
             f'<div class="mfrac">{sc.get("completed", 0)}'
             f'<span class="den">/{sc.get("total", 0)}</span></div></div>'
@@ -1474,10 +1476,12 @@ def _render_mit_section(mit: MITReport) -> str:
             f'flex-grow:{total}">{segments}</span>'
         )
 
-    def document_row(label: str, sc: dict[str, int], by_module: dict[str, dict[str, int]]) -> str:
+    def document_row(
+        label: str, sc: dict[str, int], by_module: dict[str, dict[str, int]], url: str = ""
+    ) -> str:
         doc_total = sc.get("total", 0)
         if not by_module or not doc_total:
-            return mrow(label, plain_bar(sc, "meter", "fill-cov"), sc)
+            return mrow(label, plain_bar(sc, "meter", "fill-cov"), sc, url=url)
         # The scorer's module order (the checklist's), then anything the split
         # names that the module rows do not — kept, not dropped. A bucket with
         # nothing in it draws nothing and is not described either.
@@ -1494,7 +1498,7 @@ def _render_mit_section(mit: MITReport) -> str:
             f'aria-label="{sc.get("completed", 0)} of {doc_total}: {esc(described)}">'
             f"{spans}</div>"
         )
-        return mrow(label, bar, sc)
+        return mrow(label, bar, sc, url=url)
 
     # Reached only when there ARE module scores — `mit_was_assessed` is exactly
     # "has module scores", so the old empty-scores fallback row is unreachable.
@@ -1519,6 +1523,7 @@ def _render_mit_section(mit: MITReport) -> str:
                 MIT_STANDARD_LABELS.get(k, k),
                 mit.standard_scores[k],
                 mit.standard_module_scores.get(k) or {},
+                url=MIT_STANDARD_SOURCES.get(k, ""),
             )
             for k in ordered
         )

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -175,7 +175,7 @@ class TestBuildMaturityHtml:
         for key, bucket in mit.standard_scores.items():
             label = MIT_STANDARD_LABELS[key]
             m = re.search(
-                re.escape(label) + r'</div>.*?(\d+)<span class="den">/(\d+)</span>',
+                re.escape(label) + r'(?:</a>)?</div>.*?(\d+)<span class="den">/(\d+)</span>',
                 page,
                 re.S,
             )
@@ -1239,9 +1239,11 @@ class TestMitModuleColours:
 
     @staticmethod
     def _row(section: str, label: str) -> str:
-        """The ``mrow`` whose name cell is *label* (exactly)."""
+        """The ``mrow`` whose name cell is *label* (exactly), linked or not."""
         m = re.search(
-            r'<div class="mrow"[^>]*>\s*<div class="mname">' + re.escape(label) + r"</div>.*?"
+            r'<div class="mrow"[^>]*>\s*<div class="mname">(?:<a class="lk" href="[^"]*">)?'
+            + re.escape(label)
+            + r"(?:</a>)?</div>.*?"
             r'<div class="mfrac">.*?</div>\s*</div>',
             section,
             re.S,
@@ -1577,6 +1579,36 @@ class TestMitModuleColours:
         doc = self._row(_render_mit_section(report), "OECD GD 211")
         assert '<i class="fill-cov" style="width:25%"></i>' in doc
         assert 'class="mod"' not in doc
+
+    def test_each_guidance_document_row_links_its_source(self, tmp_path: Path) -> None:
+        """A document row's name is a link to the document it scores against
+        (#729); a column with no registered source keeps the plain label, and
+        the module rows above link nothing."""
+        from builder.tools.mit_assessment import MIT_STANDARD_LABELS, MIT_STANDARD_SOURCES
+
+        mit, page = self._scored(tmp_path)
+        docs = self._docs_section(page)
+        assert set(MIT_STANDARD_SOURCES) & set(mit.standard_scores)
+        for key, label in MIT_STANDARD_LABELS.items():
+            assert key in mit.standard_scores, key
+            url = MIT_STANDARD_SOURCES.get(key)
+            cell = (
+                f'<div class="mname"><a class="lk" href="{url}">{label}</a></div>'
+                if url
+                else f'<div class="mname">{label}</div>'
+            )
+            assert cell in docs, label
+        modules = self._mit_section(page)
+        for name in mit.module_scores:
+            assert "<a" not in self._row(modules, name), name
+
+    def test_every_source_names_a_labelled_column_over_https(self) -> None:
+        """Drift guard: a source is keyed by a checklist column the label map
+        knows, and is a web URL — anything else ``_lk`` renders as text."""
+        from builder.tools.mit_assessment import MIT_STANDARD_LABELS, MIT_STANDARD_SOURCES
+
+        assert set(MIT_STANDARD_SOURCES) <= set(MIT_STANDARD_LABELS)
+        assert all(url.startswith("https://") for url in MIT_STANDARD_SOURCES.values())
 
 
 class TestUnassessedMITIsNotRenderedAsZero:


### PR DESCRIPTION
## What changed

- `builder/tools/mit_assessment.py`: `MIT_STANDARD_SOURCES` beside `MIT_STANDARD_LABELS` — the five hrefs copied verbatim from upstream `tox-maturity-indicators` `source/standards.yaml` (`identifier_to_hash`), with a comment naming that file as the source. `lincs` and `nature` have no source (upstream dropped them) and get none.
- `builder/writers/maturity_report.py`: `mrow` takes an optional `url` and renders the name as `_lk(url, name) if url else esc(name)`; `document_row` passes `MIT_STANDARD_SOURCES.get(key, "")`, module rows pass nothing. Labels, order, bars, tooltips and `aria-label` unchanged; no new text on the page.
- `AGENTS.md`: the per-document contract now states the link.
- `tests/test_maturity_report.py`: the `_row` locator and the per-document regex admit the anchor.

## Why

The "Per guidance document" card named seven documents and linked none, while the checklist card, the profile matrix, every DSM indicator and the References all link their sources. A reader who does not know what "GD 417" is had nothing to click.

## How it was tested

TDD: `test_each_guidance_document_row_links_its_source` (renders the scored S-VHPS21 fixture; every sourced key's row carries `<div class="mname"><a class="lk" href="{url}">{label}</a></div>`, unsourced keys carry the plain label, the six module rows carry no `<a`) and the drift guard `test_every_source_names_a_labelled_column_over_https` failed before the fix (ImportError, then the missing anchor) and pass after.

- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py tests/test_tools_mit_assessment.py` — 195 passed
- `uvx ruff check .` — clean; `uv run ty check` — clean
- `uvx ruff format --check .` — 40 pre-existing files flagged on `main` too; none of this PR's hunks

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
