### PR TITLE
feat(report): a DSM level name links to the model's own page for that level

### DIFF
--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -265,6 +265,8 @@ def _load_shell() -> str:
 # site, anchored by the lowercased identifier. Naming an indicator without a route to
 # its definition asks a reader to take our paraphrase of it on trust.
 _DSM_DOCS = "https://fairplus.github.io/Data-Maturity/docs/Indicators/#"
+# The model publishes one page per level, so a level's name links there.
+_DSM_LEVEL_DOCS = "https://fairplus.github.io/Data-Maturity/docs/Levels/Level"
 
 
 def _dsm_lk(ident: str) -> str:
@@ -1789,7 +1791,6 @@ def _render_dsm_grid_section(
     """
     if not grid:
         return ""
-    esc = html.escape
     meta = f'<span class="sec-meta">{_lk(tool, tool.split("//", 1)[-1])}</span>' if tool else ""
     # The published tool's own columns, in its own order and wording.
     cats = (("R", "Representation &amp; Format"), ("C", "Content &amp; Context"),
@@ -1827,7 +1828,8 @@ def _render_dsm_grid_section(
             )
         rows += (
             f'<tr><th scope="row"><b>{level}</b> '
-            f'<span class="dsm-lvl">{esc(levels.get(level, ""))}</span></th>{cells}</tr>'
+            f'<span class="dsm-lvl">{_lk(f"{_DSM_LEVEL_DOCS}{level}/", levels.get(level, ""))}'
+            f"</span></th>{cells}</tr>"
         )
     return (
         "<section>\n"
@@ -1903,7 +1905,7 @@ def _render_dsm_levels(
                 f'<code class="q-id">{_dsm_lk(ident)}</code>'
                 f'<span class="q-txt">{esc(text.get(ident, ""))}</span></li>'
             )
-        name = esc(levels.get(level, ""))
+        name = _lk(f"{_DSM_LEVEL_DOCS}{level}/", levels.get(level, ""))
         tail = (
             f' <span class="lvl-note">{unknown} of them not yet assessed</span>'
             if unknown

--- a/tests/test_dsm_indicators_source.py
+++ b/tests/test_dsm_indicators_source.py
@@ -730,3 +730,21 @@ class TestTheLadderIsReportedAsTheToolReportsIt:
         known = {i["id"].lower() for i in _yaml()["indicators"]}
         assert found and found <= known, f"unknown ids linked: {found - known}"
         assert "dsm-1-h1" in found, "the hosting statements must link out too"
+
+    def test_every_level_name_links_to_the_models_own_page_for_it(self):
+        """The model publishes one page per level; the grid row and the ladder heading
+        both name the level, so both link to it. Level 0 is not a rung."""
+        page = self._page()
+        grid = page[page.index('<table class="dsm-grid">') :].split("</table>", 1)[0]
+        ladder = page[page.index('id="ladder"') :].split("</section>", 1)[0]
+        for level, name in _yaml()["levels"].items():
+            if level < 1:
+                continue
+            link = (
+                '<a class="lk" href="https://fairplus.github.io/Data-Maturity/docs/Levels/'
+                f'Level{level}/">{html.escape(name)}</a>'
+            )
+            row = f'<th scope="row"><b>{level}</b> <span class="dsm-lvl">{link}</span></th>'
+            assert row in grid, level
+            assert f'<span class="lvl-name">{link}</span>' in ladder, level
+        assert "Levels/Level0/" not in page


### PR DESCRIPTION
## What changed

In the maturity report, each DSM level name — *Identifiable Data* … *Managed Data Assets* — now links to the model's own page for that level (`https://fairplus.github.io/Data-Maturity/docs/Levels/Level<n>/`), at both sites that render it: the **FAIRplus Dataset Maturity Model** grid row and the **What each level still needs** block heading.

- `builder/writers/maturity_report.py`: `_DSM_LEVEL_DOCS` beside `_DSM_DOCS`; both sites wrap the raw name in `_lk(...)` (which escapes its text itself, so no double escape). The grid function's now-unused `esc` alias is dropped. Link text is the workbook's name, unchanged; `a.lk` is already styled — no CSS, no new prose.
- Level 0 is not a rung, so nothing links `Levels/Level0/`.

## Why

Every indicator id on the same page already links out; the level names heading those rows were plain text, so a reader had no route to the model's definition of "Standardised Data". Same rule as the `_DSM_DOCS` comment: naming something without a route to its definition asks the reader to take our paraphrase on trust.

## How it was tested

- New `TestTheLadderIsReportedAsTheToolReportsIt::test_every_level_name_links_to_the_models_own_page_for_it` in `tests/test_dsm_indicators_source.py`: for each level 1–5, the grid `<th scope="row">` and the `lvlblock` heading carry the `Levels/Level{n}/` href with link text equal to `_yaml()["levels"][n]`, and `Levels/Level0/` is absent. Run before the fix: fails at the level-1 grid row. After: passes.
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_dsm_indicators_source.py tests/test_maturity_report.py` — 207 passed, 1 skipped.
- `uvx ruff check .` — clean. `uv run ty check` — clean. (`ruff format --check .` reports 40 files of pre-existing drift on main, none of it in the lines touched here; CI gates only `ruff check`.)

No README/AGENTS.md changes: neither documents the DSM links.

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
