### PR TITLE
feat(mit): the checklist's own denominator is published beside ours

### DIFF
--- a/builder/state.py
+++ b/builder/state.py
@@ -816,6 +816,13 @@ class MITReport:
             ``standards`` keys (e.g. ``oecd_gd211``), same bucket shape.
             Documents overlap — one parameter can be required by several — so
             buckets do not sum to the checklist total.
+        published_total: How many parameters the checklist itself defines, against
+            the ``total`` that was scored. They differ because a parameter with no
+            ``crate_slot`` names nothing a crate field could hold, so it is outside
+            every denominator here (44 of 220 — see ``iter_scorable_params``). The
+            page prints both; reporting only ours would restate the instrument.
+        published_module_totals: The same figure per module, which is where it
+            matters: one module is scored over a sixth of what it defines.
         standard_module_scores: Each document's bucket split by module —
             ``{document_key: {module_name: {"completed", "total"}}}``. A
             document's module buckets partition its ``standard_scores`` bucket
@@ -828,16 +835,29 @@ class MITReport:
     overall_score: float = 0.0
     standard_scores: dict[str, dict[str, int]] = field(default_factory=dict)
     standard_module_scores: dict[str, dict[str, dict[str, int]]] = field(default_factory=dict)
+    published_total: int = 0
+    published_module_totals: dict[str, int] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "module_scores": dict(self.module_scores),
             "overall_score": self.overall_score,
+            "published_total": self.published_total,
+            "published_module_totals": dict(self.published_module_totals),
             "standard_scores": dict(self.standard_scores),
             "standard_module_scores": {
                 key: dict(by_module) for key, by_module in self.standard_module_scores.items()
             },
         }
+
+    def published_total_for(self, module_name: str) -> int:
+        """How many parameters the checklist defines for *module_name*.
+
+        Falls back to what was scored, so a report serialised before these counts
+        existed reads as though nothing was dropped rather than as though everything
+        was."""
+        scored = self.module_scores.get(module_name, {}).get("total", 0)
+        return self.published_module_totals.get(module_name, scored)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MITReport:
@@ -846,6 +866,8 @@ class MITReport:
             overall_score=data.get("overall_score", 0.0),
             standard_scores=data.get("standard_scores", {}),
             standard_module_scores=data.get("standard_module_scores", {}),
+            published_total=data.get("published_total", 0),
+            published_module_totals=data.get("published_module_totals", {}),
         )
 
 

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -403,11 +403,25 @@ def _score_modules(
                 mbucket["completed"] += 1
 
     overall_score = total_completed / total_required if total_required > 0 else 0.0
+    # What the checklist defines, beside what could be scored. The gap is the
+    # parameters carrying no `crate_slot`, and it is not spread evenly: it is the
+    # difference between a module's bar meaning "most of this module" and meaning
+    # "the sixth of it we can see". A module with no scorable parameter still has no
+    # row, so it is keyed here only when it is keyed above.
+    published_module_totals = {
+        name: len(unique_module_params(module))
+        for module in mit_data.get("modules", [])
+        if (name := module.get("name", module.get("id", "unknown"))) in module_scores
+    }
     return MITReport(
         module_scores=module_scores,
         overall_score=overall_score,
         standard_scores=standard_scores,
         standard_module_scores=standard_module_scores,
+        published_total=sum(
+            len(unique_module_params(module)) for module in mit_data.get("modules", [])
+        ),
+        published_module_totals=published_module_totals,
     )
 
 

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1401,6 +1401,22 @@ def _mit_module_colour(name: str) -> str:
     return MIT_MODULE_STYLES.get(name, MIT_MODULE_FALLBACK_COLOUR)
 
 
+def _mit_scope_note(mit: MITReport, scored: int) -> str:
+    """"44 of 220 have no crate slot", when the two denominators differ.
+
+    The percentage beside it is of what could be scored: a parameter carrying no
+    ``crate_slot`` names nothing a crate field could hold, so it is outside every
+    denominator here (`mit_assessment.iter_scorable_params`). Printing only our
+    figure under a heading that names the OECD checklist restates the instrument.
+    A clause rather than a sentence because the section carries one lead and no
+    more; the per-module split, which is the sharper number, rides on each bar's
+    accessible name. Empty for a report serialised before these counts existed.
+    """
+    if not mit.published_total or mit.published_total <= scored:
+        return ""
+    return f" · {mit.published_total - scored} of {mit.published_total} have no crate slot"
+
+
 def _render_mit_section(mit: MITReport) -> str:
     """The OECD MIT coverage card — six module rows, each in its own colour —
     followed by a sibling "Per guidance document" card: one bar per guidance
@@ -1449,18 +1465,28 @@ def _render_mit_section(mit: MITReport) -> str:
             f'<span class="den">/{sc.get("total", 0)}</span></div></div>'
         )
 
-    def plain_bar(sc: dict[str, int], meter_class: str, fill_class: str) -> str:
+    def plain_bar(
+        sc: dict[str, int], meter_class: str, fill_class: str, extra: str = ""
+    ) -> str:
         width = round(sc.get("completed", 0) / sc["total"] * 100) if sc.get("total") else 0
         return (
             f'<div class="{meter_class}" role="img" '
-            f'aria-label="{sc.get("completed", 0)} of {sc.get("total", 0)}">'
+            f'aria-label="{sc.get("completed", 0)} of {sc.get("total", 0)}{esc(extra)}">'
             f'<i class="{fill_class}" style="width:{width}%"></i></div>'
         )
 
     def module_row(name: str, sc: dict[str, int]) -> str:
+        # The bar is drawn over what could be scored; where that is less than the
+        # module the checklist defines, its accessible name says so. Two modules'
+        # bars are otherwise indistinguishable when one covers 98% of its module
+        # and the other 17%.
+        published = mit.published_total_for(name)
+        scoped = ""
+        if published > sc.get("total", 0):
+            scoped = f'; {sc.get("total", 0)} of the checklist\'s {published} for this module'
         return mrow(
             name,
-            plain_bar(sc, "meter mod", "fill-mod"),
+            plain_bar(sc, "meter mod", "fill-mod", extra=scoped),
             sc,
             style=f' style="--mod:{_mit_module_colour(name)}"',
         )
@@ -1516,7 +1542,8 @@ def _render_mit_section(mit: MITReport) -> str:
     section = (
         "<section>\n"
         '  <div class="sec-h"><h2>OECD MIT coverage</h2>'
-        f'<span class="sec-meta"><b>{completed_all}/{total_all}</b> fields · {pct}%</span></div>\n'
+        f'<span class="sec-meta"><b>{completed_all}/{total_all}</b> fields'
+        f'{_mit_scope_note(mit, total_all)} · {pct}%</span></div>\n'
         '  <p class="lead">Coverage of the in-vitro toxicology MIT checklist — each item is a '
         f'FAIR maturity indicator as defined in <a href="{MIT_INDICATORS_URL}">'
         "tox-maturity-indicators</a>.</p>\n"

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1447,13 +1447,23 @@ class TestMitModuleColours:
             row = self._row(section, name)
             assert f'<div class="mrow" style="--mod:{MIT_MODULE_STYLES[name]}">' in row, name
             fill = re.search(
-                r'<div class="meter mod" role="img" aria-label="(\d+) of (\d+)">'
+                r'<div class="meter mod" role="img" aria-label="(\d+) of (\d+)([^"]*)">'
                 r'<i class="fill-mod" style="width:([\d.]+)%"></i></div>',
                 row,
             )
             assert fill, name
             assert (int(fill.group(1)), int(fill.group(2))) == (sc["completed"], sc["total"])
-            assert abs(float(fill.group(3)) - sc["completed"] / sc["total"] * 100) < 0.6, name
+            assert abs(float(fill.group(4)) - sc["completed"] / sc["total"] * 100) < 0.6, name
+            # The bar is drawn over what could be scored. Where the checklist defines
+            # more for this module, the accessible name says so — otherwise a bar over
+            # a sixth of its module reads exactly like one over all of another (#714).
+            published = mit.published_total_for(name)
+            if published > sc["total"]:
+                assert f"of the checklist&#x27;s {published} for this module" in fill.group(3), (
+                    name
+                )
+            else:
+                assert fill.group(3) == "", name
             seen_at.append(section.index(row))
         assert seen_at == sorted(seen_at), "module rows are not in the scorer's order"
 

--- a/tests/test_mit_source.py
+++ b/tests/test_mit_source.py
@@ -1,0 +1,137 @@
+"""The vendored OECD MIT checklist is pinned, and what it drops is counted.
+
+`mit/invitro_tox.yaml` is the only one of the four vendored instruments with no
+generator: it is a hand-placed copy of `tox-maturity-indicators`' own
+`invitro_tox.yaml`, and until this file nothing asserted anything about it. A
+re-vendoring could change the checklist's size, its module split or its
+`crate_slot` coverage — every denominator this tool publishes — and no test would
+notice (#714). #313 tracks replacing the copy with the package's loader; this pins
+the copy meanwhile, and the numbers below are what that swap has to reproduce.
+
+The per-module table is the finding, not the total: **Analysis and Statistics is 7
+scorable of 41**. Its bar on the maturity report is drawn over a sixth of the
+module the checklist defines, next to five bars drawn over nearly all of theirs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+
+import yaml
+
+from builder.tools.mit_assessment import (
+    iter_scorable_params,
+    load_mit_yaml,
+    parse_crate_slots,
+    unique_module_params,
+)
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+MIT_YAML = REPO / "mit" / "invitro_tox.yaml"
+
+# The vendored bytes. Change this only with the counts below, in the same commit.
+MIT_YAML_MD5 = "e7d649b1792e979ab1fb0ce99a8b4aa3"
+
+# module name -> (parameters carrying a parseable crate_slot, parameters defined)
+MODULE_SHAPE = {
+    "General Information": (21, 28),
+    "Chemical Information": (17, 18),
+    "Biological Model Information": (53, 53),
+    "Exposure Information": (21, 22),
+    "Endpoint Read Out Information": (57, 58),
+    "Analysis and Statistics": (7, 41),
+}
+
+
+def test_the_vendored_bytes_are_the_ones_these_counts_were_measured_on() -> None:
+    assert hashlib.md5(MIT_YAML.read_bytes()).hexdigest() == MIT_YAML_MD5, (
+        "the checklist changed; re-measure every count in this file and in the "
+        "report's own declaration before updating the pin"
+    )
+
+
+def test_the_checklist_is_220_parameters_in_six_modules() -> None:
+    data = load_mit_yaml()
+    assert data is not None
+    modules = data["modules"]
+    assert len(modules) == 6
+    published = [p for m in modules for p in unique_module_params(m)]
+    assert len(published) == 220
+
+
+def test_44_parameters_carry_no_crate_slot_and_leave_every_denominator() -> None:
+    """Not a defect of the checklist — a limit of this tool's mapping. It has to be
+    stated, because the page prints a percentage of the 176 under a heading naming
+    the 220."""
+    data = load_mit_yaml()
+    assert data is not None
+    published = [p for m in data["modules"] for p in unique_module_params(m)]
+    scorable = list(iter_scorable_params(data))
+    assert len(scorable) == 176
+    assert len(published) - len(scorable) == 44
+
+
+def test_the_module_split_is_uneven_and_analysis_is_the_outlier() -> None:
+    data = load_mit_yaml()
+    assert data is not None
+    measured = {}
+    for module in data["modules"]:
+        params = unique_module_params(module)
+        slotted = [p for p in params if parse_crate_slots(p.get("crate_slot", ""))]
+        measured[module["name"]] = (len(slotted), len(params))
+    assert measured == MODULE_SHAPE
+    scorable, published = measured["Analysis and Statistics"]
+    assert scorable * 5 < published, "the one module whose bar is mostly unmeasurable"
+
+
+def test_every_standards_flag_is_a_boolean() -> None:
+    """#705 rests on this: a guidance document flags a parameter or does not, with no
+    weight and no threshold, so "in compliance with the guideline" has no predicate
+    the checklist could answer."""
+    data = yaml.safe_load(MIT_YAML.read_text())
+    flags = [
+        value
+        for module in data["modules"]
+        for param in unique_module_params(module)
+        for value in (param.get("standards") or {}).values()
+    ]
+    assert flags, "the checklist flags parameters against guidance documents"
+    assert all(isinstance(v, bool) for v in flags)
+
+
+class TestTheReportSaysWhatItLeftOut:
+    """A percentage of 176 printed under a heading that names the 220.
+
+    The skip is honest and documented at the traversal (`iter_scorable_params`),
+    but it stopped there: `MITReport` carried only what was scored, so the page
+    could not say how much of the checklist it was scoring. Same shape as AIR's
+    `published_pct`/`pct` pair and the RDA `scoring` block — the instrument's
+    denominator and ours, both stated.
+    """
+
+    def _report(self):
+        from builder.state import CrateState
+        from builder.tools.mit_assessment import assess_mit_coverage
+
+        return assess_mit_coverage(CrateState(), graph={"@graph": []})
+
+    def test_the_report_carries_the_checklists_own_total(self) -> None:
+        assert self._report().published_total == 220
+
+    def test_the_report_carries_the_published_total_per_module(self) -> None:
+        published = self._report().published_module_totals
+        assert published == {name: total for name, (_, total) in MODULE_SHAPE.items()}
+
+    def test_a_deserialised_report_keeps_them(self) -> None:
+        from builder.state import MITReport
+
+        report = self._report()
+        assert MITReport.from_dict(report.to_dict()).published_total == 220
+
+    def test_the_page_states_both_denominators(self) -> None:
+        from builder.writers.maturity_report import _render_mit_section
+
+        html = _render_mit_section(self._report())
+        assert "176" in html and "220" in html, "both denominators on the page"
+        assert "41" in html, "the module whose bar is mostly unmeasurable"


### PR DESCRIPTION
The MIT section prints a percentage of **176** under a heading that names the OECD checklist, which defines **220**.

The gap is the parameters carrying no `crate_slot` — they name nothing a crate field could hold, so counting them would mark them permanently uncoverable. `iter_scorable_params` has said so in its docstring since #357. **It stopped there:** `MITReport` carried only what was scored, so no page could state what it was scoring.

## The per-module split is the real finding

`44 of 220` is not spread evenly:

| module | scored | the checklist defines |
|---|---|---|
| General Information | 21 | 28 |
| Chemical Information | 17 | 18 |
| Biological Model Information | 53 | 53 |
| Exposure Information | 21 | 22 |
| Endpoint Read Out Information | 57 | 58 |
| **Analysis and Statistics** | **7** | **41** |

**Analysis and Statistics is scored over a sixth of its module**, beside five bars drawn over nearly all of theirs — and nothing on the page distinguished them. That module is also the one **#658** measures as the checklist's own weakest axis: the *interpretation* of a result rather than its setup. The number we cannot see is the one that matters most.

## What landed

`MITReport` gains `published_total` and `published_module_totals`, counted in the traversal that was already walking the checklist. The header states the total (`0/176 fields · 44 of 220 have no crate slot · 0%`) and each bar's **accessible name** carries its own module's split, since that is where the difference lives.

The section keeps its **one lead sentence** — the user's call, pinned by `test_the_section_carries_one_sentence_of_prose`. The declaration is a clause in the header aggregate, not new prose.

## `tests/test_mit_source.py` — the first test of the vendored checklist

MIT is the only one of the four vendored instruments with **no generator**: `mit/invitro_tox.yaml` is a hand-placed copy, and until now nothing asserted anything about it. A re-vendoring could change the checklist's size, its module split, or its slot coverage — every denominator this tool publishes — and no test would notice.

It pins the md5, the 6 modules, the 220 parameters, the 176 scorable, the per-module table, and that **every `standards` flag is a boolean** — which is what #705 rests on. #313 tracks replacing the copy with the package's own loader; these are the numbers that swap has to reproduce.

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_mit_source.py \
  tests/test_tools_mit_assessment.py tests/test_maturity_report.py \
  tests/test_state_serializer.py tests/test_tools_fair_assessment.py \
  tests/test_fair_metrics_can_fail.py -q      → 315 passed, 3 xfailed
… + tests/test_tools_gap_analysis.py                → 47 passed
```

`uvx ruff check` and `uv run ty check builder/ tests/` clean. Rebased on `809e65b`. No score moves — the numerator and denominator on the page are unchanged; what changes is that the page now says what the denominator *is*.

One existing assertion changes on purpose: the module-row regex in `test_module_rows_wear_their_own_colour_in_the_checklists_order` now allows the extra clause, and asserts it appears **exactly** where the two denominators differ.

Refs #714 — its first limb (no generator) stays with #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf