### PR TITLE
fix(report): a named, accessioned crate is headlined "RO-Crate" — the writer reads state metadata the pipeline never fills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2142,18 +2142,17 @@ cost to export — validation stays a separate step), FAIR indicators + DSM leve
 level), OECD MIT
 coverage (`assess_mit_coverage`), and AI-readiness (`assess_air_readiness`).
 
-The page follows the maturity-report design handoff (PR #607 records it): a header whose headline is the **accession** (subhead: the
-publication's name when the crate has one, else the study title), an **About this study** card
+The page follows the maturity-report design handoff (PR #607 records it): a header whose headline is the **study name** — the root
+Dataset's `name`, read off the graph the writer is handed (`state.metadata.title` only without one) — with the
+publication's name as subhead when the crate cites one, an **About this study** card
 (identifier/contact/affiliation/funder/licence/publication+dataset DOI — every value a fact the crate holds or
 an honest *not stated*, never a guess) and an **About this RO-Crate** card (the build facts behind
 the crate's own `vitro-crate build` CreateAction, plus a provenance note carrying the report id
 `MR-<date>-<hash6>`, rendered only when the report is built with the crate's graph — a state-only
-render cannot claim its figures come from the crate's metadata). The headline is the accession, because that is what a reader cites — but only while it reads as one
-(`state.looks_like_identifier`: one compact token, no whitespace, no longer than a DOI URL). A crate
-reached this report headlined a filename slug sitting in the root's `identifier` where a registry
-accession belongs (#628), so a value that fails that test is demoted rather than dropped — the title
-leads, and the study card states the identifier, since a reader who cannot see it cannot question
-it. `set_crate_metadata` applies the same test and warns rather than refusing: the crate carries the
+render cannot claim its figures come from the crate's metadata). The identifier never headlines (#719): the study card
+states it whatever its shape — the root's `schema:identifier`, or without a graph the session's accession — since a
+reader who cannot see it cannot question it. `set_crate_metadata` tests a value's shape (`state.looks_like_identifier`:
+one compact token, no whitespace, no longer than a DOI URL) and warns rather than refusing: the crate carries the
 value as `schema:identifier` whatever its shape, and the tool cannot tell a weak identifier from a
 real one it has never heard of. Then a **KPI grid**: a profile ×
 requirement-level conformance **matrix** (rows the three layers linked to their specs — IRIs pinned

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -56,7 +56,6 @@ from builder.state import (
     FAIRReport,
     MITReport,
     ValidationReport,
-    looks_like_identifier,
 )
 from builder.tools.fair_assessment import assess_fair_maturity
 from builder.tools.mit_assessment import (
@@ -285,21 +284,18 @@ def _lk(url: str, text: str) -> str:
 _NOT_STATED = '<span class="not-stated">not stated</span>'
 
 
-def _render_header(title: str, accession: str, subhead: str) -> str:
-    """The page header: eyebrow, the accession as the headline, and a subhead —
-    the publication's name when the crate has one, else the study title.
+def _render_header(title: str, subhead: str) -> str:
+    """The page header: eyebrow, the study name as the headline, and a subhead —
+    the publication's name when the crate cites one.
 
-    The accession leads because it is what a reader cites — but only while it
-    reads as one (:func:`state.looks_like_identifier`). A crate reached this
-    report headlined a filename slug sitting where a registry accession belongs
-    (#628); the title leads instead, and the study card reports the identifier
-    either way, since a reader who cannot see it cannot question it.
+    The name leads (#719); the identifier, whatever its shape, is the study
+    card's to state, since a reader who cannot see it cannot question it.
 
     No verdict pill, no chips, no scope caveats: conformance lives in the
     Profile conformance tile and the caveats with the findings they qualify
     (the #607 design handoff)."""
     esc = html.escape
-    h1 = accession if looks_like_identifier(accession) else (title or accession)
+    h1 = title
     sub = f'<p class="subhead">{esc(subhead)}</p>\n' if subhead and subhead != h1 else ""
     return (
         "<header>\n"
@@ -365,7 +361,6 @@ def _study_facts(
         "publication": None,  # (doi url|None, display text, article name)
         "dataset_doi": None,
         "description": state.metadata.description or "",
-        # Reported whether or not it headlines the page (see `leads_the_page`).
         "accession": (state.metadata.accession or "").strip(),
     }
     if graph is None:
@@ -448,6 +443,8 @@ def _study_facts(
         if doi:
             facts["dataset_doi"] = doi
             break
+        if raw:  # not a DOI: the accession the crate states (#719)
+            facts["accession"] = raw
 
     articles = build_citation_inventory(graph)["articles"]
     cited = [a for a in articles if a["state"] == "cited"] or articles
@@ -2820,11 +2817,15 @@ def build_maturity_html(
             leaves). What it is never again is 0% for a crate nobody scored.
     """
     esc = html.escape
-    title = state.metadata.title or "RO-Crate"
-    accession = state.metadata.accession or ""
-    # The tab is the same claim in a smaller place, so it follows the same rule.
-    headline = accession if looks_like_identifier(accession) else (title or accession)
-    page_title = f"{headline} — vitro-crate maturity report"
+    # The crate's own name: the root Dataset of the graph the writer is handed.
+    # The session's metadata is what a state-only render has (#719).
+    root_name = _root_of(_raw_nodes(graph)).get("name")
+    title = (
+        (root_name.strip() if isinstance(root_name, str) else "")
+        or state.metadata.title
+        or "RO-Crate"
+    )
+    page_title = f"{title} — vitro-crate maturity report"
     # MIT is scored against the assembled @graph — the crate_slot vocabulary
     # describes the serialized crate, not CrateState (#311). The export path
     # passes the graph it already built; without one the assessor assembles its
@@ -2855,7 +2856,7 @@ def build_maturity_html(
     study = _study_facts(state, graph)
     publication = study.get("publication")
     subhead = (publication[2] if publication and publication[2] else "") or title
-    header = _render_header(title, accession, subhead)
+    header = _render_header(title, subhead)
     study_card = _render_study_card(study)
     crate_card = _render_crate_card(
         state,

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -281,7 +281,7 @@ class TestEmbeddedInCrate:
 
 
 class TestHeaderAndCards:
-    """#607 design handoff: accession headline, subhead, and the two header cards."""
+    """#607 design handoff: study-name headline, subhead, and the two header cards."""
 
     def _state(self) -> CrateState:
         state = vhps_fixture_state("S-VHPS21")
@@ -293,12 +293,36 @@ class TestHeaderAndCards:
         state.generator.ended_at = "2026-08-19T20:14:00+00:00"
         return state
 
-    def test_the_headline_is_the_accession_and_the_subhead_the_title(self) -> None:
-        page = build_maturity_html(self._state())
-        assert "<h1>S-VHPS21</h1>" in page
-        assert '<p class="subhead">' in page
+    def test_a_named_root_headlines_over_an_empty_state(self) -> None:
+        """The pipeline never writes ``state.metadata``; the crate's root carries
+        the name and the identifier, and the writer is handed that graph (#719).
+        The name headlines and the tab; the identifier sits in the study card."""
+        graph = {"@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {"@id": "./", "@type": "Dataset", "name": "Neural cell screening models",
+             "identifier": "S-VHPS22"},
+        ]}
+
+        page = build_maturity_html(CrateState(), graph=graph)
+
+        assert "<h1>Neural cell screening models</h1>" in page
+        assert "<title>Neural cell screening models — vitro-crate maturity report</title>" in page
+        card = page.split('<div class="hcard-h">About this study</div>', 1)[1]
+        card = card.split("</div>\n", 1)[0]
+        assert '<span class="hlabel">Identifier</span>S-VHPS22' in card
+        assert "<h1>RO-Crate</h1>" not in page
+        assert "<title>RO-Crate" not in page
+
+    def test_the_headline_and_tab_are_the_study_name(self) -> None:
+        """The accession is the study card's to state (#719); a subhead that
+        would repeat the headline is not rendered."""
+        state = self._state()
+        page = build_maturity_html(state)
+        assert f"<h1>{state.metadata.title}</h1>" in page
+        assert f"<title>{state.metadata.title} — vitro-crate maturity report</title>" in page
+        assert '<p class="subhead">' not in page
         assert "vitro-crate maturity report</span>" in page
-        assert "<title>S-VHPS21 — vitro-crate maturity report</title>" in page
+        assert '<span class="hlabel">Identifier</span>S-VHPS21' in page
 
     def test_a_crate_without_accession_headlines_the_title_without_subhead(self) -> None:
         state = CrateState()
@@ -349,22 +373,21 @@ class TestHeaderAndCards:
 
         assert "<h1>The real title</h1>" in page
 
-    def test_a_real_accession_still_leads(self) -> None:
-        """The rule refuses a slug, not an identifier. `S-VHPS21` is what people
-        cite this deposit by, and it stays the headline."""
-        page = build_maturity_html(self._state())
-
-        assert "<h1>S-VHPS21</h1>" in page
-
-    def test_a_doi_still_leads(self) -> None:
-        """Long, but a citable identifier — the bound is not merely "short"."""
+    @pytest.mark.parametrize(
+        "accession", ["S-VHPS21", "https://doi.org/10.1007/s00204-024-03787-2"]
+    )
+    def test_a_citable_accession_stays_in_the_card(self, accession: str) -> None:
+        """What a reader cites is stated where the deposit's DOI already is; the
+        headline is the study's name whatever the identifier's shape (#719)."""
         state = CrateState()
         state.metadata.title = "A study"
-        state.metadata.accession = "https://doi.org/10.1007/s00204-024-03787-2"
+        state.metadata.accession = accession
 
         page = build_maturity_html(state)
 
-        assert f"<h1>{state.metadata.accession}</h1>" in page
+        assert "<h1>A study</h1>" in page
+        assert f"<h1>{accession}</h1>" not in page
+        assert f'<span class="hlabel">Identifier</span>{accession}' in page
 
     def test_an_identifier_that_does_not_headline_is_still_reported(self) -> None:
         """Demoted, never dropped: it is what the crate claims to be identified
@@ -543,13 +566,11 @@ class TestStudyCardReadsTheGraph:
         assert "doi.org/10.21945/S-VHPS22" in cell.group(1)
 
     def test_the_subhead_prefers_the_publication_name(self) -> None:
-        state = CrateState()
-        state.metadata.title = "The study title"
-        page = build_maturity_html(state, graph=self._graph())
+        page = build_maturity_html(CrateState(), graph=self._graph())
+        assert "<h1>T</h1>" in page
+        # The SUBHEAD is the publication, never a second copy of the name.
         assert '<p class="subhead">Thyroid disruption in vitro</p>' in page
-        # The h1 is the title only because this state has no accession; the
-        # SUBHEAD is the publication, never a second copy of the title.
-        assert page.count("The study title") == 2  # <title> and <h1>
+        assert page.count('<p class="subhead">') == 1
 
     def test_a_bare_string_contact_is_not_reported_as_not_stated(self) -> None:
         graph = {"@graph": [


### PR DESCRIPTION
## What changed

The maturity report's `<h1>` and `<title>` are now the **study name**, read off the root Dataset of the `@graph` the writer already receives (`state.metadata.title` only for a state-only render). The identifier never headlines: the **About this study** card states it whatever its shape — the root's non-DOI `identifier`, or without a graph the session's accession — beside the Dataset DOI row it already carried. This supersedes the #641 rule "the accession leads when it looks like an identifier"; `looks_like_identifier` keeps its one remaining caller, `set_crate_metadata`.

## Why

A named, accessioned pipeline crate was headlined **"RO-Crate"** — the writer's fallback literal — because the headline was read from `state.metadata`, which the pipeline arm never writes, even though the graph handed to the writer carried the root's `name` and `identifier` all along. The colophon's claim that every figure comes from `ro-crate-metadata.json` was false for the first line on the page.

## How it was tested

- TDD: `tests/test_maturity_report.py::TestHeaderAndCards::test_a_named_root_headlines_over_an_empty_state` — a graph whose root has `name` X and `identifier` Y with an empty `CrateState`: `<h1>` and `<title>` carry X, the study card carries Y, "RO-Crate" does not headline. Failed before the fix (h1 was "RO-Crate"), passes after.
- The four tests that encoded the superseded accession-leads rule were rewritten to the new contract (accession of any shape stays in the card; the subhead is the publication, never a copy of the name).
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py` — 164 passed.
- `uvx ruff check .` and `uv run ty check` — clean. (`ruff format --check` reports the same 40 pre-existing files as main; not a gate.)

## Docs

AGENTS.md §maturity report: the header contract now states the headline is the study name and the identifier is the study card's to state.

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
