### PR TITLE
feat(report): the Graph tile says where each entity lives — carried in the crate, described in its metadata, or looked up elsewhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2168,7 +2168,8 @@ from a list kept by hand, so only a tier that could have failed is allowed to pa
 outranks that state: one filed at a tier the profile defines no check at still reads ✗, the FAIR ladder (the *next* rung dashed red
 and filled to the ratio of indicators met, so a gated 0 never reads as "nothing done"), the **FAIR
 principle 1.3** rose (one wedge per MIT module: angle = share of the checklist, radius = fill;
-faint full wedges carry the share), a graph tile (linked / total entities) and the AI-readiness
+faint full wedges carry the share), a graph tile (where the entities live: the explorer payload's
+own residence tally, `carried` / `record` / `elsewhere` / `named`, pinned to it by test) and the AI-readiness
 profile (met of assessed, with the seven dimensions as bars; a dimension nothing could be assessed
 in is drawn hollow rather than at zero).
 Each **Entity coverage** block is a fold (#629): the section is an inventory of a whole crate — the

--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -628,6 +628,23 @@ __CATEGORY_STYLES__
 }
 .mat .airbar i { display:block; width:100%; background:var(--accent); border-radius:2px; }
 .mat .airbar.na { background:none; border:1px dashed var(--na-ink); }
+/* Graph tile (#720): one bar of where the entities live, nearest the crate
+   first and fainter the further away — carried solid, record and elsewhere
+   paler, a named-only id hollow, as the explorer draws an entity it has no
+   record for. The key beneath is the figure's four counts. */
+.mat .res { display:flex; gap:2px; height:8px; margin-top:.45rem; }
+.mat .res i { display:block; min-width:2px; border-radius:2px; background:var(--accent);
+  print-color-adjust:exact; -webkit-print-color-adjust:exact; forced-color-adjust:none; }
+.mat .res .record, .mat .res-keys .record { opacity:.55; }
+.mat .res .elsewhere, .mat .res-keys .elsewhere { opacity:.25; }
+.mat .res .named, .mat .res-keys .named { background:none; border:1px dashed var(--na-ink);
+  box-sizing:border-box; opacity:1; }
+.mat .res-keys { display:flex; flex-wrap:wrap; gap:.15rem .7rem; font-size:.74rem;
+  color:var(--muted); }
+.mat .res-keys b { color:var(--ink); font-weight:650; }
+.mat .res-keys i { display:inline-block; width:.55rem; height:.55rem; border-radius:2px;
+  background:var(--accent); margin-right:.3rem; vertical-align:-.03em; }
+
 .mat .air-grid td:first-of-type + td .dsm-pct { font-weight:650; }
 .mat .air-theirs { color:var(--muted); font-weight:550; }
 .mat .air-na { color:var(--na-ink); font-weight:500; font-style:italic; }

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -45,6 +45,8 @@ from __future__ import annotations
 import html
 import logging
 import re
+from collections import Counter
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -66,6 +68,7 @@ from builder.tools.mit_assessment import (
     mit_was_assessed,
 )
 from builder.writers.provenance_dag import (
+    RESIDENCES,
     category_css,
 )
 
@@ -1054,29 +1057,51 @@ def _render_kpis(
     blockers: list[tuple[str, str, str]],
     mit: MITReport,
     air: AIRReport,
-    graph_counts: tuple[int, int] | None,
+    residence: Mapping[str, int] | None,
     *,
     ceiling: dict[str, Any] | None = None,
     grid: dict[int, dict[str, Any]] | None = None,
     stale: bool = False,
 ) -> str:
     """The KPI grid: the profile × tier conformance matrix, FAIR maturity, the
-    domain-coverage rose (spanning both rows), the graph tile (linked / total
-    entities, only when a graph was supplied) and the AI-readiness profile."""
+    domain-coverage rose (spanning both rows), the graph tile (where the
+    entities live, only when a graph was supplied) and the AI-readiness
+    profile."""
     tiles = _profile_matrix_tile(val, tiers, stale)
     tiles += _fair_tile(fair, blockers, ceiling, grid)
     tiles += _mit_rose_tile(mit)
-    if graph_counts is not None:
-        linked, total = graph_counts
-        tiles += (
-            '<article class="kpi">'
-            '<div class="kpi-h"><span class="eyebrow">Graph</span></div>'
-            f'<div class="kpi-v"><b>{linked}</b><span class="den">/ {total}</span></div>'
-            '<div class="kpi-sub">number linked and retrieved entities</div>'
-            "</article>"
-        )
-    tiles += _air_tile(air, wide=graph_counts is None)
+    if residence is not None:
+        tiles += _graph_tile(residence)
+    tiles += _air_tile(air, wide=residence is None)
     return f'<div class="kgrid">{tiles}</div>\n'
+
+
+def _graph_tile(residence: Mapping[str, int]) -> str:
+    """Where the crate's entities live — the explorer payload's residence tally
+    (#720) — as one bar and its four figures.
+
+    Orphans are the explorer legend's and the coverage blocks' to report; what
+    no other figure states is *where* the entities are. A residence no entity
+    has draws no segment and reads 0, so a crate with nothing looked up says so.
+    """
+    total = sum(residence.values())
+    counts = [(key, residence.get(key, 0)) for key in RESIDENCES]
+    segments = "".join(
+        f'<i class="{key}" style="flex-grow:{n}" title="{n} {key}"></i>' for key, n in counts if n
+    )
+    keys = "".join(
+        f'<span title="{RESIDENCES[key]}"><i class="{key}"></i><b>{n}</b> {key}</span>'
+        for key, n in counts
+    )
+    described = ", ".join(f"{n} {key}" for key, n in counts)
+    return (
+        '<article class="kpi">'
+        '<div class="kpi-h"><span class="eyebrow">Graph</span></div>'
+        f'<div class="kpi-v"><b>{total}</b> <span class="tag-inline">entities</span></div>'
+        f'<div class="res" role="img" aria-label="{total} entities: {described}">{segments}</div>'
+        f'<div class="res-keys">{keys}</div>'
+        "</article>"
+    )
 
 
 # The three profile layers in fix order: base must pass before ISA is
@@ -2870,7 +2895,7 @@ def build_maturity_html(
     explorer_section = ""
     lane_section = ""
     explorer_style = ""
-    graph_counts: tuple[int, int] | None = None
+    residence: Counter[str] | None = None
     if graph is not None:
         from builder.writers.assay_lane import render_assay_lane_section
         from builder.writers.entity_explorer import explorer_css, render_explorer_section
@@ -2890,10 +2915,11 @@ def build_maturity_html(
         # to draw returns nothing rather than an empty heading.
         lane_section = render_assay_lane_section(graph)
         explorer_style = explorer_css()
-        nodes = build_crate_graph(graph).get("nodes", [])
-        total = len(nodes)
-        linked = total - sum(1 for n in nodes if n.get("orphan"))
-        graph_counts = (linked, total)
+        # The same model the explorer's payload is cut from — `all_edges` so the
+        # named-only stubs a secondary edge reaches are counted, as they are there.
+        residence = Counter(
+            n["residence"] for n in build_crate_graph(graph, all_edges=True)["nodes"]
+        )
     from builder.tools.air_assessment import assess_air_readiness
     from builder.tools.fair_assessment import (
         DSM_INDICATORS_PATH,
@@ -2931,7 +2957,7 @@ def build_maturity_html(
         dsm_reach["blocked_by"],
         mit,
         air,
-        graph_counts,
+        residence,
         ceiling=dsm_reach,
         grid=dsm_cells,
         stale=stale,

--- a/builder/writers/provenance_dag.py
+++ b/builder/writers/provenance_dag.py
@@ -176,6 +176,16 @@ def _is_uri(value: Any) -> bool:
     return isinstance(value, str) and "://" in value
 
 
+# The four answers to "where does this entity live", each with what it means in
+# words, nearest the crate first — the order a figure stating them draws them in.
+RESIDENCES: dict[str, str] = {
+    "carried": "bytes in the crate directory",
+    "record": "described in the metadata, no bytes",
+    "elsewhere": "described here, resolvable outside the crate",
+    "named": "referenced by id, described nowhere in the crate",
+}
+
+
 def _residence(nid: str) -> str:
     """Where an entity's bytes live, read off its ``@id`` (#687).
 

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -444,21 +444,52 @@ class TestHeaderAndCards:
         other = {"@graph": graph["@graph"] + [{"@id": "#x", "@type": "Thing", "name": "x"}]}
         assert _report_id(state, other) != rid
 
-    def test_the_graph_tile_counts_linked_over_total(self) -> None:
+    def test_the_graph_tile_states_where_each_entity_lives(self) -> None:
+        """The tile's four figures are the explorer payload's own residence
+        tally (#720) — pinned to it the way the view chips are held to the
+        coverage blocks — and the orphan ratio it used to headline is gone: the
+        explorer's legend and the coverage blocks already report orphans."""
+        from collections import Counter
+
+        from builder.writers.entity_explorer import build_explorer_payload
+
         graph = {"@graph": [
             {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
-            {"@id": "./", "@type": "Dataset", "name": "T", "hasPart": [{"@id": "#f"}]},
-            {"@id": "#f", "@type": "File", "name": "a.csv"},
+            {"@id": "./", "@type": "Dataset", "name": "T",
+             "hasPart": [{"@id": "data/a.csv"}, {"@id": "#sample"}],
+             "mentions": [{"@id": "https://www.wikidata.org/wiki/Q42"}],
+             "author": [{"@id": "#nobody"}]},
+            {"@id": "data/a.csv", "@type": "File", "name": "a.csv"},
+            {"@id": "#sample", "@type": "Sample", "name": "a record"},
+            {"@id": "https://www.wikidata.org/wiki/Q42", "@type": "DefinedTerm", "name": "Q42"},
             {"@id": "#orphan", "@type": "Sample", "name": "loose"},
         ]}
         page = build_maturity_html(CrateState(), graph=graph)
         tile = re.search(r'<span class="eyebrow">Graph</span></div>(.*?)</article>', page, re.S)
         assert tile
-        m = re.search(r'<b>(\d+)</b><span class="den">/ (\d+)</span>', tile.group(1))
-        assert m
-        linked, total = int(m.group(1)), int(m.group(2))
-        assert total == linked + 1, "exactly the orphan is unlinked"
-        assert "number linked and retrieved entities" in tile.group(1)
+        shown = {
+            key: int(n)
+            for n, key in re.findall(
+                r"<b>(\d+)</b> (carried|record|elsewhere|named)", tile.group(1)
+            )
+        }
+        # The oracle is the shape rule, not the tile: `./` and the file are
+        # carried, the two #fragments records, the IRI elsewhere, the author
+        # nothing describes named — the orphan is a record like any other.
+        assert shown == {"carried": 2, "record": 2, "elsewhere": 1, "named": 1}
+        payload = build_explorer_payload(graph)
+        assert shown == Counter(n["residence"] for n in payload["nodes"])
+        assert f"<b>{len(payload['nodes'])}</b>" in tile.group(1), "the headline is the total"
+        # The bar carries the same four counts as its segment widths, in the
+        # same order, so the figure and its key cannot disagree.
+        assert re.findall(r'<i class="(\w+)" style="flex-grow:(\d+)"', tile.group(1)) == [
+            ("carried", "2"),
+            ("record", "2"),
+            ("elsewhere", "1"),
+            ("named", "1"),
+        ]
+        assert "linked and retrieved" not in tile.group(1)
+        assert '<span class="den">' not in tile.group(1), "no orphan ratio"
         # No graph, no tile — a count nobody measured is not rendered as 0.
         assert '<span class="eyebrow">Graph</span>' not in build_maturity_html(CrateState())
 


### PR DESCRIPTION
## What changed

The Graph tile headlined `318 / 326 — number linked and retrieved entities`. Nothing is retrieved: the ratio was non-orphan over described nodes, and the orphan count is already reported by the explorer's dashed-border legend key and the Entity coverage blocks.

The tile now states **where the crate's entities live** — the residence every explorer node already carries:

- headline: the total, `<b>342</b> entities`
- one bar, four segments sized by count: `carried` solid, `record` and `elsewhere` paler, `named` hollow-dashed (the explorer's own treatment of an entity it has no record for)
- a key of the four figures, each tooltipped with what it means (`bytes in the crate directory`, `described in the metadata, no bytes`, …)

No prose: the caption is gone, the meaning is in the figure. A residence no entity has draws no segment and reads `0`, so a crate with nothing looked up says so.

- `builder/writers/provenance_dag.py` — `RESIDENCES`, the one ordered registry of the four values and their meanings, beside the `_residence` rule that assigns them.
- `builder/writers/maturity_report.py` — `_graph_tile(residence)`; the tally is `Counter(n["residence"])` over `build_crate_graph(graph, all_edges=True)` — the same model the explorer payload is cut from, `all_edges` so the named-only stubs it shows are counted here too.
- `builder/writers/maturity_report.css` — `.res` / `.res-keys`, tokens only, print-colour pinned like the other bars.
- `AGENTS.md` — the KPI-grid sentence names the tile's contract.

## How it was tested

TDD: `tests/test_maturity_report.py::TestHeaderAndCards::test_the_graph_tile_states_where_each_entity_lives` replaces the old linked-over-total test. It failed first (`shown == {}`), then passed. It pins the tile's four figures to an explicit oracle from the shape rule (`{"carried": 2, "record": 2, "elsewhere": 1, "named": 1}` on a fixture exercising all four), to `Counter(node["residence"])` over `build_explorer_payload(graph)["nodes"]` — parity with the explorer, the way the view chips are held to the coverage blocks — and to the bar's segment widths; asserts the headline is the payload's node count, that the old caption and the `/ total` ratio are gone, and that no graph still means no tile.

- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py tests/test_entity_residence.py tests/test_entity_explorer.py` — 269 passed
- `uvx ruff check .` — clean; `uv run ty check` — clean (whole tree)
- `uvx ruff format --check` — the new code is clean; the only drifted files are the 40 already drifted on `main` (format is not a gate)

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
