### PR TITLE
fix(react): the loop says so when it continues on its own (#758)

### DIFF
--- a/builder/agents/react/agent_loop.py
+++ b/builder/agents/react/agent_loop.py
@@ -860,6 +860,19 @@ def _prompt_hint(reply: str | None, *, open_work: bool) -> str:
     return _HINT_OPEN if open_work else _HINT_DONE
 
 
+def _continuing_line(engine: AgentEngine) -> str:
+    """The line printed when the loop goes on without the user (#758).
+
+    A reply can sound final ("the crate is saved") while the loop has judged
+    the crate unfinished; said nowhere, the continuation left the user unsure
+    whether to type, wait, or quit. Names what is still open — or the failing
+    gates when the actionable checklist is empty — and the way to step in.
+    """
+    outstanding = open_items(engine.state, actionable_only=True)
+    why = f"{len(outstanding)} item(s) still open" if outstanding else "validation not yet passing"
+    return f"· Continuing on my own — {why} · Ctrl+C to step in"
+
+
 def _crate_is_complete(engine: AgentEngine) -> bool:
     """Return True when the crate passes REQUIRED and has nothing left to do.
 
@@ -4980,6 +4993,8 @@ def run_interactive_agent(
                     # Otherwise the agent just narrated/worked → AUTO-CONTINUE with
                     # an internal directive, WITHOUT reading stdin. The cap on the
                     # enclosing range bounds this so it can never spin forever.
+                    # Said, not silent (#758) — under the reply, erased with it.
+                    replies.note(_continuing_line(engine))
                     message = _AUTO_CONTINUE_DIRECTIVE
                 else:
                     # The for-loop exhausted the cap without breaking → check in.

--- a/builder/agents/ui.py
+++ b/builder/agents/ui.py
@@ -1236,6 +1236,24 @@ class TransientReplies:
             except Exception:  # noqa: BLE001 — fall back to leaving it on screen
                 logger.debug("transient reply height failed", exc_info=True)
 
+    def note(self, text: str) -> None:
+        """Print a dim one-liner under the last reply, erased along with it.
+
+        For the loop's own asides ("continuing on my own", #758): printed
+        through the console directly it would either pin a transient reply to
+        the transcript (:meth:`invalidate`) or be cut out from under the next
+        reply. Here it joins the erasable region instead, so a transient reply
+        and its note go together, and after a permanent reply the note alone
+        makes way for what comes next.
+        """
+        renderable = Text(text, style="dim")
+        self._console.print(renderable)
+        if bool(getattr(self._console, "is_terminal", False)):
+            try:
+                self._height += len(self._console.render_lines(renderable, pad=False))
+            except Exception:  # noqa: BLE001 — fall back to leaving it on screen
+                logger.debug("transient note height failed", exc_info=True)
+
 
 def make_status_footer(engine: AgentEngine, console: Console | None = None) -> PinnedFooter:
     """A :class:`PinnedFooter` showing *engine*'s live status line (both arms).

--- a/tests/agents/test_ui.py
+++ b/tests/agents/test_ui.py
@@ -424,3 +424,55 @@ def test_print_goodbye_prints_for_engine(monkeypatch) -> None:
 def test_get_console_is_memoized() -> None:
     assert ui.get_console() is ui.get_console()
     assert isinstance(ui.get_console(), Console)
+
+
+# ---------------------------------------------------------------------------
+# TransientReplies.note — the loop's aside joins the erasable region (#758)
+# ---------------------------------------------------------------------------
+
+_ERASE_ONE_LINE = "\x1b[1A\x1b[2K"
+
+
+def _terminal() -> tuple[Console, io.StringIO]:
+    """A console that believes it is a terminal, so erasing is exercised."""
+    raw = io.StringIO()
+    return Console(width=100, file=raw, force_terminal=True, color_system=None), raw
+
+
+def _reply_height(console: Console, text: str) -> int:
+    return len(console.render_lines(ui.render_reply(text), pad=False))
+
+
+def test_a_transient_reply_and_its_note_are_erased_together() -> None:
+    console, raw = _terminal()
+    replies = ui.TransientReplies(console)
+    replies.print("Let me draft the study.", transient=True)
+    replies.note("· Continuing on my own — 2 item(s) still open · Ctrl+C to step in")
+
+    replies.print("Drafted the study.")
+
+    erased = raw.getvalue().count(_ERASE_ONE_LINE)
+    assert erased == _reply_height(console, "Let me draft the study.") + 1
+
+
+def test_a_note_after_a_permanent_reply_makes_way_alone() -> None:
+    console, raw = _terminal()
+    replies = ui.TransientReplies(console)
+    replies.print("Confirmed. The crate is saved.", transient=False)
+    replies.note("· Continuing on my own — 2 item(s) still open · Ctrl+C to step in")
+
+    replies.print("Next step.")
+
+    assert raw.getvalue().count(_ERASE_ONE_LINE) == 1
+
+
+def test_off_a_terminal_a_note_is_plain_text() -> None:
+    rec = _rec()
+    replies = ui.TransientReplies(rec)
+    replies.print("Working.", transient=True)
+    replies.note("· Continuing on my own — validation not yet passing · Ctrl+C to step in")
+    replies.print("Done.")
+
+    out = rec.export_text()
+    assert "Continuing on my own" in out
+    assert _ERASE_ONE_LINE not in out

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -3034,6 +3034,44 @@ class TestTheBoxSaysWhatItIsWaitingFor:
         assert "or 'continue'" not in out
         assert "Nothing left to do" not in out
 
+    # -- #758: going on without the user is said, not silent --------------------
+
+    def test_a_continuation_says_so_with_the_open_count(self, monkeypatch):
+        """A reply can sound final while the loop has judged the crate unfinished;
+        the continuation is announced before the next turn, not discovered."""
+        from builder.agents.react import agent_loop
+
+        monkeypatch.setattr(agent_loop, "open_items", lambda state, **kw: ["a", "b", "c"])
+        out = self._transcript(
+            monkeypatch,
+            replies=["Confirmed. The final session has been saved.", "Which cell line?"],
+            stdin_lines=["start", "quit"],
+        )
+        line = "· Continuing on my own — 3 item(s) still open · Ctrl+C to step in"
+        assert line in out
+        assert out.index(line) < out.index("Answer the question above")
+
+    def test_a_continuation_with_failing_gates_says_that_instead(self, monkeypatch):
+        from builder.agents.react import agent_loop
+
+        monkeypatch.setattr(agent_loop, "open_items", lambda state, **kw: [])
+        out = self._transcript(
+            monkeypatch,
+            replies=["Working.", "Which cell line?"],
+            stdin_lines=["start", "quit"],
+        )
+        assert "· Continuing on my own — validation not yet passing · Ctrl+C to step in" in out
+
+    def test_completion_and_a_question_continue_nothing(self, monkeypatch):
+        done = self._transcript(
+            monkeypatch, replies=["All done."], stdin_lines=["start", "quit"], complete_after=1
+        )
+        asked = self._transcript(
+            monkeypatch, replies=["Which cell line?"], stdin_lines=["start", "quit"]
+        )
+        assert "Continuing on my own" not in done
+        assert "Continuing on my own" not in asked
+
 
 class TestArgsSchemaAdvertisesArrayItems:
     """#596: the shape of a list parameter's entries reaches the model.


### PR DESCRIPTION
Closes #758.

## What was wrong

ReAct session `20260902_112912`, 11:39: the agent replied "Confirmed. The final session has been saved with the exported crate at: …" and the screen showed nothing after it. The loop had judged the crate unfinished and auto-continued — silently. It kept working for seventeen minutes while the user read a sentence that sounds final and wondered whether to type, wait, or quit. The #745 hint only appears once the loop stops, and up to fifteen silent turns can pass first.

## What changes

- One dim line precedes every autonomous continuation: `· Continuing on my own — 3 item(s) still open · Ctrl+C to step in` (or `validation not yet passing` when the gates fail and the actionable checklist is empty). Same style as the existing guard-stop self-continue line.
- It is printed through a new `TransientReplies.note`, so it joins the erasable region: a transient "Let me…" reply and its note are erased together by the next reply, and after a permanent reply the note alone makes way. Printed straight to the console it would have pinned narration to the transcript or been cut out from under the next reply.
- Nothing extra on completion or on the empty-completion retry.

The churn that this session also exposed (19 exports in 17 minutes toward SHOULD findings the model cannot close) is #759, separate.

## Tests

Three `_LoopHarness` transcript tests in `tests/test_agent_loop.py` (the line and its count before the next turn; the gates wording; silence on completion and on a question) and three `TransientReplies.note` tests in `tests/agents/test_ui.py` (erase accounting on a terminal, plain text off one). ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLYsxLuS8URtfzKqnF7Dqd
