### PR TITLE
fix(report): every guidance-document bar says what it is drawn over

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1567,7 +1567,7 @@ The dashboard derives a live **▶ / ⏸ / ⏹** agent-status badge from these e
 | ISA-Tox Profile | SHOULD | Recommended tox fields | Fix if data available |
 | ISA-Tox Profile | MAY | Optional tox fields | Note for user |
 | Data content (Frictionless) | REQUIRED | Payload conformance (CSV rows vs CSVW/Frictionless `tableSchema`) | MUST fix offending cell |
-| MIT Coverage | Score | % of recommended fields | Improvement suggestions |
+| MIT Coverage | Score | % of the checklist parameters that carry a crate slot | Improvement suggestions |
 | FAIR Indicators | Score | FAIR maturity | Guidance for improvement |
 
 ### Data-Content Layer (Frictionless, Issue #95)
@@ -2183,7 +2183,7 @@ read from the validator's own requirement registry (`profiles.validator.tiers_de
 from a list kept by hand, so only a tier that could have failed is allowed to pass. A finding
 outranks that state: one filed at a tier the profile defines no check at still reads ✗, the FAIR ladder (the *next* rung dashed red
 and filled to the ratio of indicators met, so a gated 0 never reads as "nothing done"), the **FAIR
-principle 1.3** rose (one wedge per MIT module: angle = share of the checklist, radius = fill;
+principle 1.3** rose (one wedge per MIT module: angle = share of the parameters this tool can score, radius = fill;
 faint full wedges carry the share), a graph tile (where the entities live: the explorer payload's
 own residence tally, `carried` / `record` / `elsewhere` / `named`, pinned to it by test) and the AI-readiness
 profile (met of assessed, with the seven dimensions as bars; a dimension nothing could be assessed

--- a/builder/state.py
+++ b/builder/state.py
@@ -823,6 +823,9 @@ class MITReport:
             page prints both; reporting only ours would restate the instrument.
         published_module_totals: The same figure per module, which is where it
             matters: one module is scored over a sixth of what it defines.
+        published_standard_totals: And per guidance document — how many parameters
+            that document flags, against the ``standard_scores`` total we could
+            score. Every document but LINCS is short, by 7 to 24 parameters.
         standard_module_scores: Each document's bucket split by module —
             ``{document_key: {module_name: {"completed", "total"}}}``. A
             document's module buckets partition its ``standard_scores`` bucket
@@ -837,6 +840,7 @@ class MITReport:
     standard_module_scores: dict[str, dict[str, dict[str, int]]] = field(default_factory=dict)
     published_total: int = 0
     published_module_totals: dict[str, int] = field(default_factory=dict)
+    published_standard_totals: dict[str, int] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -844,11 +848,21 @@ class MITReport:
             "overall_score": self.overall_score,
             "published_total": self.published_total,
             "published_module_totals": dict(self.published_module_totals),
+            "published_standard_totals": dict(self.published_standard_totals),
             "standard_scores": dict(self.standard_scores),
             "standard_module_scores": {
                 key: dict(by_module) for key, by_module in self.standard_module_scores.items()
             },
         }
+
+    def published_total_for_standard(self, key: str) -> int:
+        """How many parameters *key*'s guidance document flags.
+
+        Falls back to what was scored, so a report serialised before these counts
+        existed reads as though nothing was dropped rather than as though everything
+        was."""
+        scored = self.standard_scores.get(key, {}).get("total", 0)
+        return self.published_standard_totals.get(key, scored)
 
     def published_total_for(self, module_name: str) -> int:
         """How many parameters the checklist defines for *module_name*.
@@ -868,6 +882,7 @@ class MITReport:
             standard_module_scores=data.get("standard_module_scores", {}),
             published_total=data.get("published_total", 0),
             published_module_totals=data.get("published_module_totals", {}),
+            published_standard_totals=data.get("published_standard_totals", {}),
         )
 
 

--- a/builder/tools/mit_assessment.py
+++ b/builder/tools/mit_assessment.py
@@ -413,6 +413,16 @@ def _score_modules(
         for module in mit_data.get("modules", [])
         if (name := module.get("name", module.get("id", "unknown"))) in module_scores
     }
+    # And per guidance document. A document's bar is its own parameter list
+    # intersected with the ones we curated a slot for, so without this the page
+    # prints our subset under the document's name — 7 of Nature's 14, and it read
+    # as 7 of 7.
+    published_standard_totals: dict[str, int] = {}
+    for module in mit_data.get("modules", []):
+        for param in unique_module_params(module):
+            for key, flagged in (param.get("standards") or {}).items():
+                if flagged is True:
+                    published_standard_totals[key] = published_standard_totals.get(key, 0) + 1
     return MITReport(
         module_scores=module_scores,
         overall_score=overall_score,
@@ -422,6 +432,7 @@ def _score_modules(
             len(unique_module_params(module)) for module in mit_data.get("modules", [])
         ),
         published_module_totals=published_module_totals,
+        published_standard_totals=published_standard_totals,
     )
 
 

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -909,9 +909,18 @@ def _mit_totals(mit: MITReport) -> tuple[int, int]:
 
 def _mit_rose_svg(mit: MITReport) -> str:
     """The MIT coverage rose: one wedge per module, angle = the module's share
-    of the checklist, radius = how much of that module is filled. A faint
-    full-radius wedge behind each carries the share, so an empty module still
-    shows the ground it owes. Pure trigonometry over the scorer's own buckets.
+    of the parameters this tool can score, radius = how much of that module is
+    filled. A faint full-radius wedge behind each carries the share, so an empty
+    module still shows the ground it owes. Pure trigonometry over the scorer's
+    own buckets.
+
+    **Not the module's share of the checklist**, which is a different picture: the
+    checklist defines 220 parameters and 176 carry a ``crate_slot``, unevenly — 41
+    of Analysis and Statistics' parameters against the 7 this wedge is sized by, so
+    that module's true share is over five times its wedge. Sizing wedges by the
+    published share would make the drawing honest about weight and dishonest about
+    fill in the same stroke (a 100%-radius wedge over 7 of 41), so the drawing keeps
+    what it can measure and the section below states the shortfall per module.
 
     Each module is one ``<g>`` holding its pale share wedge, its filled wedge,
     a ``<title>`` (the native tooltip, and what a screen reader reads) and a
@@ -1537,11 +1546,21 @@ def _render_mit_section(mit: MITReport) -> str:
         )
 
     def document_row(
-        label: str, sc: dict[str, int], by_module: dict[str, dict[str, int]], url: str = ""
+        label: str,
+        key: str,
+        sc: dict[str, int],
+        by_module: dict[str, dict[str, int]],
+        url: str = "",
     ) -> str:
         doc_total = sc.get("total", 0)
+        # The bar is drawn over the parameters this document flags THAT WE CURATED a
+        # slot for. Every document but LINCS flags more, by 7 to 24 — Nature flags 14
+        # and 7 reach the page — so the shortfall rides on the bar's accessible name,
+        # the same way each module's does. Silent, the bar reads as the document.
+        published = mit.published_total_for_standard(key)
+        scoped = f"; {doc_total} of the {published} it flags" if published > doc_total else ""
         if not by_module or not doc_total:
-            return mrow(label, plain_bar(sc, "meter", "fill-cov"), sc, url=url)
+            return mrow(label, plain_bar(sc, "meter", "fill-cov", extra=scoped), sc, url=url)
         # The scorer's module order (the checklist's), then anything the split
         # names that the module rows do not — kept, not dropped. A bucket with
         # nothing in it draws nothing and is not described either.
@@ -1555,7 +1574,8 @@ def _render_mit_section(mit: MITReport) -> str:
         )
         bar = (
             f'<div class="meter stack" role="img" '
-            f'aria-label="{sc.get("completed", 0)} of {doc_total}: {esc(described)}">'
+            f'aria-label="{sc.get("completed", 0)} of {doc_total}: {esc(described)}'
+            f'{esc(scoped)}">'
             f"{spans}</div>"
         )
         return mrow(label, bar, sc, url=url)
@@ -1581,6 +1601,7 @@ def _render_mit_section(mit: MITReport) -> str:
         srows = "".join(
             document_row(
                 MIT_STANDARD_LABELS.get(k, k),
+                k,
                 mit.standard_scores[k],
                 mit.standard_module_scores.get(k) or {},
                 url=MIT_STANDARD_SOURCES.get(k, ""),
@@ -1588,9 +1609,11 @@ def _render_mit_section(mit: MITReport) -> str:
             for k in ordered
         )
         # No lead and no header aggregate: the bars explain themselves (the
-        # module card directly above is the key), and rows overlap by design —
-        # a document's numbers are its own, never a share of the checklist
-        # total, so any sum in the header would double-count.
+        # module card directly above is the key), and rows overlap by design — one
+        # parameter can be flagged by several documents, so any sum in the header
+        # would double-count. A row is that document's own parameters MINUS the ones
+        # no crate slot reaches; "its own numbers" defended that silently until #714,
+        # and each bar's accessible name now carries the shortfall.
         section += (
             "<section>\n"
             '  <div class="sec-h"><h2>Per guidance document</h2></div>\n'

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1561,10 +1561,20 @@ class TestMitModuleColours:
             described = ", ".join(
                 f"{m} {by_module[m]['completed']} of {by_module[m]['total']}" for m in order
             )
+            # The shortfall clause is present exactly where the document flags more
+            # parameters than carry a crate slot — every document but LINCS (#714).
+            published = mit.published_total_for_standard(key)
+            scoped = (
+                f"; {doc['total']} of the {published} it flags"
+                if published > doc["total"]
+                else ""
+            )
             assert (
                 f'<div class="meter stack" role="img" '
-                f'aria-label="{doc["completed"]} of {doc["total"]}: {_html.escape(described)}">'
+                f'aria-label="{doc["completed"]} of {doc["total"]}: '
+                f'{_html.escape(described)}{_html.escape(scoped)}">'
             ) in row, label
+            assert bool(scoped) == (published > doc["total"]), label
             spans = span_re.findall(row)
             assert [c for c, _w, _i in spans] == [MIT_MODULE_STYLES[m] for m in order], label
             # The shares are the field counts themselves, so the pills sum to

--- a/tests/test_mit_source.py
+++ b/tests/test_mit_source.py
@@ -33,6 +33,18 @@ MIT_YAML = REPO / "mit" / "invitro_tox.yaml"
 # The vendored bytes. Change this only with the counts below, in the same commit.
 MIT_YAML_MD5 = "e7d649b1792e979ab1fb0ce99a8b4aa3"
 
+# guidance document -> (parameters we can score, parameters the document flags).
+# Every one of these bars is drawn over the left number under a label naming the right.
+DOCUMENT_SHAPE = {
+    "oecd_gd211": (33, 42),
+    "toxtemp": (34, 41),
+    "oecd_gd34": (64, 88),
+    "oecd_gd417": (81, 98),
+    "oecd_oht201": (48, 55),
+    "lincs": (40, 40),
+    "nature": (7, 14),
+}
+
 # module name -> (parameters carrying a parseable crate_slot, parameters defined)
 MODULE_SHAPE = {
     "General Information": (21, 28),
@@ -135,3 +147,47 @@ class TestTheReportSaysWhatItLeftOut:
         html = _render_mit_section(self._report())
         assert "176" in html and "220" in html, "both denominators on the page"
         assert "41" in html, "the module whose bar is mostly unmeasurable"
+
+
+class TestTheDocumentBarsSayWhatTheyAreDrawnOver:
+    """Each "per guidance document" bar intersects the document's parameter list with
+    the parameters we curated a slot for, and printed the result under the document's
+    name. Nature reads 7 where the document flags 14 — half — and nothing said so.
+
+    Same defect as the section header's, three places over, and the same fix: the
+    instrument's denominator beside ours.
+    """
+
+    def _report(self):
+        from builder.state import CrateState
+        from builder.tools.mit_assessment import assess_mit_coverage
+
+        return assess_mit_coverage(CrateState(), graph={"@graph": []})
+
+    def test_the_scored_denominators_are_what_the_page_draws(self) -> None:
+        scored = {k: v["total"] for k, v in self._report().standard_scores.items()}
+        assert scored == {k: s for k, (s, _p) in DOCUMENT_SHAPE.items()}
+
+    def test_the_report_carries_each_documents_own_total(self) -> None:
+        published = self._report().published_standard_totals
+        assert published == {k: p for k, (_s, p) in DOCUMENT_SHAPE.items()}
+
+    def test_only_one_document_is_fully_curated(self) -> None:
+        """LINCS is 40 of 40; every other bar is short, by 7 to 24 parameters."""
+        short = {k: p - s for k, (s, p) in DOCUMENT_SHAPE.items() if p > s}
+        assert set(DOCUMENT_SHAPE) - set(short) == {"lincs"}
+        assert max(short.values()) == 24 and min(short.values()) == 7
+
+    def test_the_bar_says_it_on_the_page(self) -> None:
+        from builder.writers.maturity_report import _render_mit_section
+
+        html = _render_mit_section(self._report())
+        assert "of the 14 it flags" in html, "Nature's bar states the document's own total"
+
+    def test_a_deserialised_report_keeps_them(self) -> None:
+        from builder.state import MITReport
+
+        report = self._report()
+        assert MITReport.from_dict(report.to_dict()).published_standard_totals == (
+            report.published_standard_totals
+        )


### PR DESCRIPTION
#753 disclosed the checklist's denominator in the section header and on each module's bar. **The same subset was still printed as the document in three other places.**

## The per-guidance-document bars

Each is that document's parameter list intersected with the ones we curated a `crate_slot` for — rendered under the document's own name:

| document | drawn over | the document flags |
|---|---|---|
| OECD GD 211 | 33 | 42 |
| ToxTemp | 34 | 41 |
| OECD GD 34 | 64 | 88 |
| OECD GD 417 | 81 | 98 |
| IUCLID OHT 201 | 48 | 55 |
| **Nature** | **7** | **14** |
| LINCS | 40 | 40 — the only fully curated one |

**Nature's bar was drawn over half its document and read as whole.**

`MITReport` now carries `published_standard_totals`, counted in the same walk that already tallies the flags, and each bar's accessible name states the shortfall — the shape the module bars already use. The comment that defended those numbers (*"a document's numbers are its own"*) now says what they are.

## The rose

Its docstring said the wedge angle is *"the module's share of the checklist"*. It is the share of the 176 we can score, and the two differ by **more than five times** on Analysis and Statistics — 7 parameters sized against the 41 the checklist defines.

The drawing is unchanged and the sentence now says which share it is, with the reason not to resize written down: a wedge sized by the *published* share and filled by what we scored would be honest about weight and dishonest about fill in one stroke — a full-radius wedge over 7 of 41. Weight is stated in words, where it can be stated exactly.

If you'd rather see the rose redrawn by published weight, that's a visual change worth looking at before it lands, not a docstring fix.

## AGENTS.md

It called the axis **"% of recommended fields"**. The checklist defines no requirement levels at all — `standards` values are strictly booleans, which is what #705 rests on — so there were no recommended fields for the percentage to be *of*.

## Verification

```
VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_mit_source.py \
  tests/test_maturity_report.py -q                     → 184 passed
… + test_tools_mit_assessment, test_state_serializer,
    test_agents_doc_toolbox, test_tool_reachability,
    test_fair_metrics_can_fail                         → 118 passed, 3 xfailed
```

Five new tests pin the per-document table, that LINCS is the only complete one, and that the clause appears **exactly** where the two denominators differ. One existing assertion widens on purpose — the document-bar aria-label regex — and now asserts the clause is present iff the shortfall is.

`uvx ruff check` and `uv run ty check builder/ tests/` clean. No score moves.

Refs #714 — its remaining limb, a generator for the vendored checklist, is #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf