### PR TITLE
fix(report): the study card states no Identifier when the DOI fills `identifier` and the accession sits in `accession`

### DIFF
--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -442,16 +442,21 @@ def _study_facts(
         facts["licence"] = (name or ref.rstrip("/").rsplit("/", 1)[-1], url or None)
         break
 
-    for value in _ref_ids(root, "identifier"):
+    # ``accession`` is ``schema:identifier`` under the crate's context; the
+    # deposit DOI takes ``identifier`` (#682), so the citable token may sit in
+    # either key, in either order (#757). Root only — never the Study node's.
+    token = None
+    for value in _ref_ids(root, "identifier") + _ref_ids(root, "accession"):
         raw = value
         if raw in nodes:  # a PropertyValue entity
             raw = str(nodes[raw].get("value") or "")
         doi = _doi_url(raw)
         if doi:
-            facts["dataset_doi"] = doi
-            break
-        if raw:  # not a DOI: the accession the crate states (#719)
-            facts["accession"] = raw
+            facts["dataset_doi"] = facts["dataset_doi"] or doi
+        elif raw:  # not a DOI: the accession the crate states (#719)
+            token = token or raw
+    if token:
+        facts["accession"] = token
 
     articles = build_citation_inventory(graph)["articles"]
     cited = [a for a in articles if a["state"] == "cited"] or articles

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -313,6 +313,35 @@ class TestHeaderAndCards:
         assert "<h1>RO-Crate</h1>" not in page
         assert "<title>RO-Crate" not in page
 
+    @pytest.mark.parametrize(
+        "root_ids",
+        [
+            {"identifier": "https://doi.org/10.6019/S-VHPS22", "accession": "S-VHPS22"},
+            {"identifier": ["https://doi.org/10.6019/S-VHPS22", "S-VHPS22"]},
+            {"identifier": ["S-VHPS22", "https://doi.org/10.6019/S-VHPS22"]},
+        ],
+        ids=["accession-key", "doi-first", "doi-last"],
+    )
+    def test_the_card_states_the_accession_beside_the_dataset_doi(
+        self, root_ids: dict[str, Any]
+    ) -> None:
+        """A built crate keeps the deposit DOI in ``identifier`` and the
+        accession in ``accession`` — both ``schema:identifier`` under the
+        crate's context — and a list may put the DOI first (#757)."""
+        graph = {"@graph": [
+            {"@id": "ro-crate-metadata.json", "about": {"@id": "./"}},
+            {"@id": "./", "@type": "Dataset", "name": "Neural cell screening models",
+             **root_ids},
+        ]}
+
+        page = build_maturity_html(CrateState(), graph=graph)
+
+        assert "<h1>Neural cell screening models</h1>" in page
+        card = page.split('<div class="hcard-h">About this study</div>', 1)[1]
+        card = card.split('<div class="kgrid">', 1)[0]
+        assert '<span class="hlabel">Identifier</span>S-VHPS22' in card
+        assert 'href="https://doi.org/10.6019/S-VHPS22"' in card
+
     def test_the_headline_and_tab_are_the_study_name(self) -> None:
         """The accession is the study card's to state (#719); a subhead that
         would repeat the headline is not rendered."""


### PR DESCRIPTION
## What changed

`builder/writers/maturity_report.py`, the study-card identifier loop (#754): it now reads the root's `identifier` **and** `accession` — both `schema:identifier` under the crate's context (`profiles/context.py`) — records the first DOI, and keeps scanning for the citable token instead of breaking on the DOI. The card renders `Identifier: S-VHPS22` beside the Dataset DOI row on every crate built since #682.

Per the #739 constraint recorded on the issue: only the **root's** `accession`/`identifier` are read, never the Study node's.

AGENTS.md's sentence ("the root's `schema:identifier`") is accurate after the fix, so it is untouched. No new prose in the report.

## How it was tested

- New `tests/test_maturity_report.py::TestHeaderAndCards::test_the_card_states_the_accession_beside_the_dataset_doi`, parametrized over the three root shapes the issue names (`identifier: <DOI>` + `accession`, `identifier: [<DOI>, token]`, `identifier: [token, <DOI>]`). Ran red first: 2 of 3 failed (`accession-key`, `doi-first`), exactly the two the issue predicts; green after the fix. The h1 stays the study name and the DOI row stays linked.
- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py` — 173 passed.
- Rendered the writer over `output/svhps22_real_input_crate_v31/ro-crate-metadata.json` (the crate #719 was filed on): Identifier cell present, DOI row present, h1 = study name.
- `uvx ruff check .` clean, `uv run ty check` clean. `ruff format --check` reports 40 pre-existing files on main (none of the flagged lines are in this diff; CI runs `ruff check` only).

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5
