### PR TITLE
fix(report): the DSM note cites the workbook it reproduces, and says less

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2207,7 +2207,10 @@ states the question and never the fix, and the generator refuses to emit an asse
 that has no remedy. The section therefore renders for a crate whose validation is clean and whose
 ladder is not, and the FAIR tile's blocker count links into it rather than restating the list.
 Numbered **References**
-close the page (1: FAIRplus DSM / RDA FDMM; 2: tox-maturity-indicators; 3: the Bridge2AI
+close the page (1: FAIRplus DSM / RDA FDMM, plus the workbook the grid reproduces — name, version,
+sheet, the cells that define its arithmetic, deliverable, licence, paper and tool — read from the
+`source`/`scoring` blocks of `fair/dsm_indicators.yaml`, never literals, so the DSM grid's heading
+and one-sentence note both point at it; 2: tox-maturity-indicators; 3: the Bridge2AI
 AI-readiness criteria, named as a preprint and as quoted verbatim under CC BY-ND). There is no FAIR
 pillar detail section and no header verdict pill; the entity explorer, entity coverage, the
 profile-adherence breakdown, **the DSM "% complete" grid**, MIT

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1770,17 +1770,35 @@ def _render_recommendations(
 _RECOMMENDATION_CAP = 8
 
 
-def _render_references() -> str:
+def _render_references(dsm_data: dict[str, Any]) -> str:
     """The numbered notes the page's superscripts point at.
 
     Note 1 names what the DSM ladder is scored against — the FAIRplus Dataset
     Maturity model's crate-assessable indicators (``fair/dsm_indicators.yaml``
-    implements them), itself derived from the RDA FAIR Data Maturity Model.
-    Note 2 names what the domain checklist is: the tox-maturity-indicators
-    FAIR maturity indicators under principle R1.3. Note 3 names the AI-readiness
-    instrument and, deliberately, that it is still a preprint and that its criterion
-    text is quoted verbatim under a no-derivatives licence.
+    implements them), itself derived from the RDA FAIR Data Maturity Model — and
+    cites the workbook the grid reproduces: name, version, sheet and the cells
+    that define its arithmetic, the deliverable and its licence, the paper and
+    the online tool, all read from the YAML's ``source`` and ``scoring`` blocks so
+    bumping the workbook re-cites it. Note 2 names what the domain checklist is:
+    the tox-maturity-indicators FAIR maturity indicators under principle R1.3.
+    Note 3 names the AI-readiness instrument and, deliberately, that it is still
+    a preprint and that its criterion text is quoted verbatim under a
+    no-derivatives licence.
     """
+    src = dsm_data.get("source") or {}
+    spec = src.get("specification") or {}
+    paper = src.get("peer_reviewed") or {}
+    scoring = dsm_data.get("scoring") or {}
+    grid = scoring.get("grid") or [{}]
+    sheet_url = str(src.get("distribution_url") or "")
+
+    def _t(value: object) -> str:
+        return html.escape(str(value or ""))
+
+    def _cite(url: object) -> str:
+        """A link whose text is the bare URL — a citation, not a caption."""
+        return _lk(str(url or ""), str(url or "").split("//", 1)[-1].rstrip("/"))
+
     return (
         '<div class="refs">\n'
         '  <span class="refs-h">References</span>\n'
@@ -1792,9 +1810,20 @@ def _render_references() -> str:
         "hosting-environment and enterprise data-governance capability, which a crate cannot "
         "evidence about the environment that serves it. Scored against "
         "the crate-assessable indicators of the FAIRplus Dataset Maturity (DSM) model &mdash; "
-        + _lk("https://fairplus.github.io/Data-Maturity/", "fairplus.github.io/Data-Maturity")
+        + _cite(src.get("url"))
         + " &mdash; itself derived from the RDA FAIR Data Maturity Model, "
-        + _lk("https://doi.org/10.15497/rda00050", "doi.org/10.15497/rda00050")
+        + _cite((src.get("derived_from") or {}).get("url"))
+        + ". Instrument: "
+        + _lk(sheet_url, sheet_url.rsplit("/", 1)[-1])
+        + f" v{_t(src.get('version'))}, sheet &ldquo;{_t(scoring.get('sheet'))}&rdquo; "
+        f"(validation column {_t(scoring.get('column'))}; grid "
+        f"{_t(grid[0].get('cell'))}&ndash;{_t(grid[-1].get('cell'))}); "
+        f"{_t(spec.get('name'))} ({_t(spec.get('year'))}), "
+        + _cite(spec.get("url"))
+        + f", {_t(src.get('license'))}; {_t(paper.get('citation'))}, "
+        + _cite(f"https://doi.org/{paper.get('doi', '')}")
+        + "; online tool "
+        + _cite(src.get("assessment_tool"))
         + ".</p>\n"
         '  <p id="fn-mit"><span class="ref-n">2</span> The in-vitro toxicology Minimal '
         "Information Table (MIT): every item is a FAIR maturity indicator under principle "
@@ -1881,24 +1910,17 @@ def _render_dsm_grid_section(
         )
     return (
         "<section>\n"
-        '  <div class="sec-h"><h2>FAIRplus Dataset Maturity Model</h2>'
+        '  <div class="sec-h"><h2>FAIRplus Dataset Maturity Model'
+        '<a class="fn" href="#fn-dsm">1</a></h2>'
         f"{meta}</div>\n"
         '  <div class="tbl-scroll"><table class="dsm-grid">\n'
         f"    <thead><tr><th>Level</th>{head}</tr></thead>\n"
         f"    <tbody>{rows}</tbody>\n"
         "  </table></div>\n"
-        '  <p class="dsm-note">'
-        "Percentages are the published sheet&rsquo;s own: satisfied "
-        "&divide; the cell&rsquo;s denominator &times; 100. The sheet has no "
-        "&ldquo;not assessed&rdquo; state &mdash; its validation column is all formulas, "
-        "so a blank scores 0 &mdash; which is why each cell states how many of its "
-        "indicators were actually assessed, and why a cell with none says so rather "
-        "than publishing the number the sheet would compute over blanks. A cell&rsquo;s "
-        "membership is the "
-        "sheet&rsquo;s: higher levels carry lower ones forward, so a statement can be "
-        "counted at more than one level. Hosting-environment indicators describe the "
-        "environment serving the dataset, so a crate cannot evidence them &mdash; the "
-        "published tool asks a person, and so does the checklist below.</p>\n"
+        '  <p class="dsm-note">Percentages are the sheet&rsquo;s own'
+        '<a class="fn" href="#fn-dsm">1</a>: satisfied &divide; members &times; 100; '
+        "an unanswered indicator validates to 0 there, so each cell also states how many "
+        "were assessed.</p>\n"
         "</section>\n"
     )
 
@@ -3040,7 +3062,7 @@ def build_maturity_html(
             stale=stale,
         )
         + crate_card
-        + _render_references()
+        + _render_references(dsm_data)
     )
 
     # ONE pass over the shell, so nothing a substitution inserts is ever scanned

--- a/fair/dsm_indicators.yaml
+++ b/fair/dsm_indicators.yaml
@@ -17,6 +17,7 @@ source:
   repository: https://github.com/FAIRplus/Data-Maturity
   distribution: docs/assessment/FAIR-DSM-Assessment-Sheet-v1.2.xlsx (sheet 'MASTER (Levels View)') — vendored
     as fair/fairplus_dsm_v1.2.xlsx
+  distribution_url: https://github.com/FAIRplus/Data-Maturity/blob/master/docs/assessment/FAIR-DSM-Assessment-Sheet-v1.2.xlsx
   version: '1.2'
   license: CC-BY-4.0
   specification:

--- a/scripts/gen_dsm_indicators.py
+++ b/scripts/gen_dsm_indicators.py
@@ -383,6 +383,11 @@ SOURCE: dict[str, Any] = {
         "docs/assessment/FAIR-DSM-Assessment-Sheet-v1.2.xlsx "
         "(sheet 'MASTER (Levels View)') — vendored as fair/fairplus_dsm_v1.2.xlsx"
     ),
+    # The report's reference 1 links the workbook here (#732).
+    "distribution_url": (
+        "https://github.com/FAIRplus/Data-Maturity/blob/master/docs/assessment/"
+        "FAIR-DSM-Assessment-Sheet-v1.2.xlsx"
+    ),
     "version": "1.2",
     # The MODEL TEXT is CC BY 4.0 and requires attribution. The repository's
     # LICENSE.txt is only the MIT licence of its Just-the-Docs Jekyll theme

--- a/tests/test_dsm_indicators_source.py
+++ b/tests/test_dsm_indicators_source.py
@@ -188,6 +188,11 @@ class TestProvenanceIsRecorded:
         assert "FAIRplus" in src["name"] and "Dataset Maturity" in src["name"]
         assert "fairplus_dsm_v1.2.xlsx" in src["distribution"]
         assert src["repository"] == "https://github.com/FAIRplus/Data-Maturity"
+        # The report cites the workbook by this link (#732).
+        assert src["distribution_url"] == (
+            "https://github.com/FAIRplus/Data-Maturity/blob/master/docs/assessment/"
+            "FAIR-DSM-Assessment-Sheet-v1.2.xlsx"
+        )
 
     def test_it_records_that_the_model_assesses_a_dataset(self):
         """Guards the misreading that DSM scores an organisation's capability."""
@@ -327,7 +332,7 @@ class TestTheModelsOwnPercentCompleteGrid:
         from tests.fixtures.vhps_golden_crates import vhps_fixture_state
 
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
-        assert "FAIRplus Dataset Maturity Model</h2>" in page
+        assert "<h2>FAIRplus Dataset Maturity Model" in page
         # Every level the tool reports is a row label. Level 0 is not one of them.
         for level, name in _yaml()["levels"].items():
             assert (name in page) is (level >= 1), name
@@ -339,10 +344,11 @@ class TestTheModelsOwnPercentCompleteGrid:
         # beside it, so a low number is not mistaken for a measured failure.
         assert "0 of 4 assessed" in page
         assert "not assessed" not in page.split('class="dsm-grid"', 1)[-1].split("</table>", 1)[0]
-        # The two properties a reader needs to interpret the numbers are stated.
-        # The two properties a reader needs to interpret the numbers.
-        assert "a blank scores 0" in page
-        assert "higher levels carry lower ones forward" in page
+        # The two properties a reader needs to interpret the numbers are stated:
+        # the grid's note says an unanswered indicator validates to 0, and the
+        # next section's lead that a level counts the levels below it (#732).
+        assert "validates to 0" in page
+        assert "counts the indicators below it as well as its own" in page
 
 
 class TestNoGraphMeansUnanswered:

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1052,7 +1052,7 @@ class TestFairTileAndRose:
         — a `kpi-sub` line in the grid's own shape, summed from the scores —
         in place of the unsourced scope fragment the note used to open with
         (#735). The two numbers are the section header's own, so the tile and
-        the OECD MIT coverage `sec-meta` cannot disagree."""
+        the MIT coverage `sec-meta` cannot disagree."""
         from builder.state import MITReport
         from builder.writers.maturity_report import _mit_rose_tile
 
@@ -1084,8 +1084,12 @@ class TestFairTileAndRose:
         """The handoff flagged this citation as the thing to confirm: the DSM
         note must name the model ``fair/dsm_indicators.yaml`` implements (the
         FAIRplus DSM, derived from the RDA FDMM), and the MIT note the
-        indicator package the checklist comes from."""
-        from builder.tools.fair_assessment import DSM_INDICATORS_PATH
+        indicator package the checklist comes from. Reference 1 also cites the
+        workbook the grid reproduces — version, sheet, the cells that define
+        the arithmetic, the deliverable, the paper and the tool — read from the
+        YAML's own ``source``/``scoring`` blocks, so a reader can check the
+        grid's note and the note itself has nothing left to explain (#732)."""
+        from builder.tools.fair_assessment import DSM_INDICATORS_PATH, _load_yaml
         from builder.tools.mit_assessment import MIT_INDICATORS_URL
 
         yaml_text = DSM_INDICATORS_PATH.read_text(encoding="utf-8")
@@ -1097,6 +1101,31 @@ class TestFairTileAndRose:
                 f"{url} is not the source the YAML cites"
             )
         assert "Levels are gated" in refs
+        dsm = _load_yaml(DSM_INDICATORS_PATH) or {}
+        src, scoring = dsm["source"], dsm["scoring"]
+        for url in (
+            src["distribution_url"],
+            src["specification"]["url"],
+            f"https://doi.org/{src['peer_reviewed']['doi']}",
+            src["assessment_tool"],
+        ):
+            assert url.startswith("https://") and f'href="{url}"' in refs, url
+        assert src["version"] == "1.2" and " v1.2" in refs
+        assert scoring["sheet"] == "FAIR-DSM Assessment Sheet v1.2" and scoring["sheet"] in refs
+        assert scoring["column"] == "J" and "column J" in refs
+        assert scoring["grid"][0]["cell"] == "P6" and "P6&ndash;P29" in refs
+        # The grid's heading wears the same superscript the KPI tile does, and
+        # its note is one sentence that points at it: the two sentences it lost
+        # were already the lead of the next section.
+        dsm_sec = page[page.index("<h2>FAIRplus Dataset Maturity Model") :]
+        dsm_sec = dsm_sec[: dsm_sec.index("</section>")]
+        assert 'href="#fn-dsm"' in dsm_sec.split("</h2>", 1)[0]
+        note = re.search(r'<p class="dsm-note">(.*?)</p>', dsm_sec, re.S)
+        assert note is not None
+        assert 'href="#fn-dsm"' in note.group(1)
+        text = re.sub(r"<[^>]+>", "", note.group(1))
+        assert text.count(".") == 1 and text.endswith("."), text
+        assert "carry lower ones forward" not in text and "asks a person" not in text
         # The note must NAME both models, not merely link them: the link text
         # is a DOI, and a reader cannot tell which maturity model was scored.
         assert "FAIRplus Dataset Maturity (DSM) model" in refs
@@ -1121,8 +1150,8 @@ class TestFairTileAndRose:
         tool = (_load_yaml(DSM_INDICATORS_PATH) or {})["source"]["assessment_tool"]
         assert tool == "https://fairdsm.biospeak.solutions/assess"
         page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
-        assert "FAIRplus Dataset Maturity Model</h2>" in page
-        sec_h = page[page.index("FAIRplus Dataset Maturity Model</h2>") :].split("</div>", 1)[0]
+        assert "<h2>FAIRplus Dataset Maturity Model" in page
+        sec_h = page[page.index("<h2>FAIRplus Dataset Maturity Model") :].split("</div>", 1)[0]
         assert f'<a class="lk" href="{tool}">' in sec_h
         assert "<h2><a" not in sec_h
 
@@ -3024,6 +3053,7 @@ class TestEveryClassTheReportEmitsIsStyled:
         class NAME, and the page INLINES the stylesheet, so every class matched
         itself in the `<style>` block whether or not the markup used it.
         """
+        from builder.tools.fair_assessment import DSM_INDICATORS_PATH, _load_yaml
         from builder.tools.validation import ValidationReport
         from builder.writers.maturity_report import (
             _render_recommendations,
@@ -3044,7 +3074,9 @@ class TestEveryClassTheReportEmitsIsStyled:
         # Recommendations AND the references block its footnote links point at —
         # both carry classes of their own, so covering only the section would
         # leave exactly the gap this test exists to close.
-        html_out = _render_recommendations(val, None) + _render_references()
+        html_out = _render_recommendations(val, None) + _render_references(
+            _load_yaml(DSM_INDICATORS_PATH) or {}
+        )
         assert 'class="rec-n"' in html_out, "the section did not render; this test is inert"
         assert 'class="refs"' in html_out, "the references did not render; this test is inert"
         return html_out

--- a/tests/test_mit_source.py
+++ b/tests/test_mit_source.py
@@ -1,4 +1,4 @@
-"""The vendored OECD MIT checklist is pinned, and what it drops is counted.
+"""The vendored MIT checklist is pinned, and what it drops is counted.
 
 `mit/invitro_tox.yaml` is the only one of the four vendored instruments with no
 generator: it is a hand-placed copy of `tox-maturity-indicators`' own


### PR DESCRIPTION
## What changed

- **Reference 1 cites the instrument the grid reproduces**, read from `fair/dsm_indicators.yaml`'s own `source:` / `scoring:` blocks instead of literals: the workbook (linked to `FAIR-DSM-Assessment-Sheet-v1.2.xlsx` on FAIRplus/Data-Maturity), `v1.2`, sheet *FAIR-DSM Assessment Sheet v1.2*, validation column `J`, grid `P6`–`P29`, the D2.6 deliverable DOI and its `CC-BY-4.0` licence, the Sci Data paper (doi.org link) and the online tool. Citation data only; the two links Reference 1 already carried now also come from the YAML. Bumping the workbook re-cites it.
- `scripts/gen_dsm_indicators.py`'s `SOURCE` gains `distribution_url` beside the prose `distribution`; `fair/dsm_indicators.yaml` regenerated (one line).
- **The DSM grid heading gets the same `¹` the KPI tile has**, and **the `dsm-note` shrinks to one sentence** that points at it: *Percentages are the sheet's own¹: satisfied ÷ members × 100; an unanswered indicator validates to 0 there, so each cell also states how many were assessed.* The two sentences it lost (membership carries lower levels forward; hosting is asked of a person) are deleted, not moved — the next section's lead already states both.
- AGENTS.md's References contract names what Reference 1 now cites and where it reads it from.
- Two test docstrings drop the "OECD MIT" wording left behind by the #727 rename (`tests/test_mit_source.py`, `tests/test_maturity_report.py`).

## How it was tested

TDD: `test_the_references_cite_what_the_assessors_actually_implement` extended first (an `href` for every URL in `dsm_data["source"]`, the version/sheet/column/cell names, `href="#fn-dsm"` inside the grid's `<h2>`, a one-sentence note without the two deleted phrases) and run red — `KeyError: 'distribution_url'`, then the missing `href` once the YAML was regenerated — before the writer changed. `test_source_block_names_the_distribution_and_licence` pins the new URL; two existing tests that located the heading by `Model</h2>` or asserted the deleted note phrases now locate it by `<h2>…` and assert the properties where they are stated.

- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py tests/test_dsm_indicators_source.py tests/test_mit_source.py` — 223 passed, 1 skipped
- `uvx ruff check .` — clean
- `uvx ruff format --check .` — 40 files would be reformatted, all pre-existing on main (the two touched non-test files flag the same lines on main's copies: `maturity_report.py:401`, `gen_dsm_indicators.py:194`); untouched to keep the diff to the issue
- `uv run ty check` — clean

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NttPxLyw35Kec3bsjdfGf5