### PR TITLE
fix(report): a bar drawn over less than the checklist defines says so on the page

### DIFF
--- a/builder/writers/maturity_report.css
+++ b/builder/writers/maturity_report.css
@@ -183,6 +183,10 @@ __CATEGORY_STYLES__
 .mat .mname { font-size:.82rem; color:var(--ink-2); }
 .mat .mfrac { font-size:.8rem; color:var(--muted); font-variant-numeric:tabular-nums; min-width:3.2rem;
   text-align:right; }
+/* How much of the module (or of the document) the bar beside it is drawn over,
+   when the checklist defines more than carries a crate slot. Its own line so the
+   fraction above stays the row's number. */
+.mat .mfrac .mscope { display:block; font-size:.68rem; color:var(--na-ink); white-space:nowrap; }
 .mat p.lead a { color:var(--accent); text-underline-offset:2px; }
 /* Module colours arrive as `--mod`, set inline from the renderer's
    MIT_MODULE_STYLES registry (#606) — the one place they are written; nothing

--- a/builder/writers/maturity_report.py
+++ b/builder/writers/maturity_report.py
@@ -1494,14 +1494,35 @@ def _render_mit_section(mit: MITReport) -> str:
     completed_all, total_all = _mit_totals(mit)
     pct = round(mit.overall_score * 100)
 
-    def mrow(name: str, bar: str, sc: dict[str, int], style: str = "", url: str = "") -> str:
+    def mrow(
+        name: str,
+        bar: str,
+        sc: dict[str, int],
+        style: str = "",
+        url: str = "",
+        scope: str = "",
+    ) -> str:
         label = _lk(url, name) if url else esc(name)
         return (
             f'<div class="mrow"{style}><div class="mname">{label}</div>'
             f'<div class="mbar">{bar}</div>'
             f'<div class="mfrac">{sc.get("completed", 0)}'
-            f'<span class="den">/{sc.get("total", 0)}</span></div></div>'
+            f'<span class="den">/{sc.get("total", 0)}</span>{scope}</div></div>'
         )
+
+    def mscope(covered: int, published: int) -> str:
+        """"7 of 41 mapped" — the visible half of the shortfall the bar's
+        accessible name spells out.
+
+        Without it "Analysis and Statistics 7/7" reads as a finished module when
+        34 of the 41 parameters the checklist defines for it were never scored.
+        Empty when the checklist defines no more than we scored, and for a report
+        serialised before these counts existed (they arrive as 0) — an absent
+        count is not a shortfall.
+        """
+        if published <= covered:
+            return ""
+        return f'<span class="mscope">{covered} of {published} mapped</span>'
 
     def plain_bar(
         sc: dict[str, int], meter_class: str, fill_class: str, extra: str = ""
@@ -1527,6 +1548,7 @@ def _render_mit_section(mit: MITReport) -> str:
             plain_bar(sc, "meter mod", "fill-mod", extra=scoped),
             sc,
             style=f' style="--mod:{_mit_module_colour(name)}"',
+            scope=mscope(sc.get("total", 0), published),
         )
 
     def module_span(name: str, b: dict[str, int], doc_total: int) -> str:
@@ -1564,8 +1586,15 @@ def _render_mit_section(mit: MITReport) -> str:
         # the same way each module's does. Silent, the bar reads as the document.
         published = mit.published_total_for_standard(key)
         scoped = f"; {doc_total} of the {published} it flags" if published > doc_total else ""
+        seen = mscope(doc_total, published)
         if not by_module or not doc_total:
-            return mrow(label, plain_bar(sc, "meter", "fill-cov", extra=scoped), sc, url=url)
+            return mrow(
+                label,
+                plain_bar(sc, "meter", "fill-cov", extra=scoped),
+                sc,
+                url=url,
+                scope=seen,
+            )
         # The scorer's module order (the checklist's), then anything the split
         # names that the module rows do not — kept, not dropped. A bucket with
         # nothing in it draws nothing and is not described either.
@@ -1583,7 +1612,7 @@ def _render_mit_section(mit: MITReport) -> str:
             f'{esc(scoped)}">'
             f"{spans}</div>"
         )
-        return mrow(label, bar, sc, url=url)
+        return mrow(label, bar, sc, url=url, scope=seen)
 
     # Reached only when there ARE module scores — `mit_was_assessed` is exactly
     # "has module scores", so the old empty-scores fallback row is unreachable.
@@ -1594,7 +1623,10 @@ def _render_mit_section(mit: MITReport) -> str:
         f'<span class="sec-meta"><b>{completed_all}/{total_all}</b> fields'
         f'{_mit_scope_note(mit, total_all)} · {pct}%</span></div>\n'
         '  <p class="lead">Each item is a FAIR maturity indicator as defined in '
-        f'<a href="{MIT_INDICATORS_URL}">tox-maturity-indicators</a>.</p>\n'
+        f'<a href="{MIT_INDICATORS_URL}">tox-maturity-indicators</a>. '
+        "Where a row covers fewer parameters than the checklist defines for it, "
+        "no crate field is mapped to the rest, so nothing in the crate could "
+        'satisfy or fail them and they are outside its denominator.</p>\n'
         f'  <div class="mit">{rows}</div>\n'
         "</section>\n"
     )
@@ -1883,12 +1915,15 @@ def _render_dsm_grid_section(
         cells = ""
         for code, _label in cats:
             cell = grid[level].get(code)
-            if not cell or not cell.get("total"):
-                cells += '<td class="dsm-na">—</td>'
-                continue
-            pct = cell.get("published_pct")
-            if pct is None:
-                cells += '<td class="dsm-na">—</td>'
+            pct = cell.get("published_pct") if cell else None
+            # A dash, not a zero and not "not assessed": the sheet publishes no
+            # number here at all. Level 5 / Hosting is cell P28, which it hardcodes
+            # over an empty membership. Bare, the dash reads as any of the three.
+            if not cell or not cell.get("total") or pct is None:
+                cells += (
+                    '<td class="dsm-na" '
+                    'title="the model defines no indicators for it">—</td>'
+                )
                 continue
             assessed, total = cell["assessed"], cell["total"]
             # The sheet's own number, unconditionally: an unanswered indicator

--- a/tests/test_dsm_indicators_source.py
+++ b/tests/test_dsm_indicators_source.py
@@ -45,6 +45,11 @@ def _load_generator():
     return mod
 
 
+_DASH_CELL = (
+    '<td class="dsm-na" title="the model defines no indicators for it">—</td>'
+)
+
+
 def _yaml() -> dict:
     return yaml.safe_load(DSM_YAML.read_text())
 
@@ -343,6 +348,25 @@ class TestTheModelsOwnPercentCompleteGrid:
         # The two properties a reader needs to interpret the numbers.
         assert "a blank scores 0" in page
         assert "higher levels carry lower ones forward" in page
+
+    def test_a_cell_the_sheet_defines_nothing_for_says_so(self):
+        """Level 5 / Hosting is cell ``P28`` and the sheet hardcodes it — no indicator
+        is a member, so there is nothing to assess and nothing to divide by.
+
+        It renders as an em dash, which alone is indistinguishable from 0%, from
+        "not assessed", and from a column this tool chose to skip. The cell carries
+        the reason and the note under the table states it.
+        """
+        from builder.writers.maturity_report import build_maturity_html
+        from tests.fixtures.vhps_golden_crates import vhps_fixture_state
+
+        empty = [c for c in _yaml()["scoring"]["grid"] if not c.get("members")]
+        assert [c["cell"] for c in empty] == ["P28"], "the sheet's one empty cell moved"
+        page = build_maturity_html(vhps_fixture_state("S-VHPS21"))
+        grid = page[page.index('<table class="dsm-grid">') :].split("</table>", 1)[0]
+        assert grid.count(_DASH_CELL) == len(empty)
+        assert "—</td>" not in grid.replace(_DASH_CELL, ""), "a bare dash remains"
+        assert "the model defines no indicators for it" in page
 
 
 class TestNoGraphMeansUnanswered:

--- a/tests/test_maturity_report.py
+++ b/tests/test_maturity_report.py
@@ -1636,9 +1636,14 @@ class TestMitModuleColours:
         assert docs_with_two_modules >= 1
         assert docs_with_both_states >= 1
 
-    def test_the_section_carries_one_sentence_of_prose(self, tmp_path: Path) -> None:
-        """The user's call: the bars explain themselves. One lead sentence
-        naming the indicators, no legend, no lead under the sub-heading."""
+    def test_the_section_carries_one_lead_and_no_legend(self, tmp_path: Path) -> None:
+        """The user's call: the bars explain themselves. One lead, no legend, no
+        lead under the sub-heading.
+
+        Two sentences, not one. The bars cannot explain the parameters they are
+        *not* drawn over: the second sentence is what a shortfall means, and
+        without it "7 of 41 mapped" on a row is a number with no referent.
+        """
         from builder.tools.mit_assessment import MIT_INDICATORS_URL
 
         _mit, page = self._scored(tmp_path)
@@ -1646,7 +1651,10 @@ class TestMitModuleColours:
         leads = re.findall(r'<p class="lead">(.*?)</p>', section, re.S)
         assert leads == [
             "Each item is a FAIR maturity indicator as defined in "
-            f'<a href="{MIT_INDICATORS_URL}">tox-maturity-indicators</a>.'
+            f'<a href="{MIT_INDICATORS_URL}">tox-maturity-indicators</a>. '
+            "Where a row covers fewer parameters than the checklist defines for it, "
+            "no crate field is mapped to the rest, so nothing in the crate could "
+            "satisfy or fail them and they are outside its denominator."
         ]
         assert 'class="mit-key"' not in section and "<legend" not in section
 
@@ -1760,6 +1768,81 @@ class TestMitModuleColours:
 
         assert set(MIT_STANDARD_SOURCES) <= set(MIT_STANDARD_LABELS)
         assert all(url.startswith("https://") for url in MIT_STANDARD_SOURCES.values())
+
+
+class TestTheMitCardSaysWhatItCouldNotScore:
+    """A bar drawn over fewer parameters than the checklist defines says so ON THE
+    PAGE, and the card says why.
+
+    #714 landed both facts in the bars' ``aria-label`` only. A sighted reader saw
+    "Analysis and Statistics 7/7" — a finished module. The checklist defines 41
+    parameters there; 34 carry no ``crate_slot``, so no crate field is mapped to
+    them and nothing in the crate could satisfy or fail them. The same holds for
+    every guidance document but LINCS (Nature flags 14 and 7 reach the page).
+    """
+
+    @staticmethod
+    def _clause(covered: int, published: int) -> str:
+        return f'<span class="mscope">{covered} of {published} mapped</span>'
+
+    def test_a_module_row_states_how_much_of_its_module_it_covers(
+        self, tmp_path: Path
+    ) -> None:
+        mit, page = TestMitModuleColours._scored(tmp_path)
+        section = TestMitModuleColours._mit_section(page)
+        shown = 0
+        for name, sc in mit.module_scores.items():
+            row = TestMitModuleColours._row(section, name)
+            published = mit.published_total_for(name)
+            if published > sc["total"]:
+                assert self._clause(sc["total"], published) in row, name
+                shown += 1
+            else:
+                assert 'class="mscope"' not in row, name
+        assert shown >= 1, "no module has a shortfall; this test is inert"
+
+    def test_a_guidance_document_row_states_how_much_of_it_it_covers(
+        self, tmp_path: Path
+    ) -> None:
+        from builder.tools.mit_assessment import MIT_STANDARD_LABELS
+
+        mit, page = TestMitModuleColours._scored(tmp_path)
+        section = TestMitModuleColours._docs_section(page)
+        shown = 0
+        for key, sc in mit.standard_scores.items():
+            row = TestMitModuleColours._row(section, MIT_STANDARD_LABELS[key])
+            published = mit.published_total_for_standard(key)
+            if published > sc["total"]:
+                assert self._clause(sc["total"], published) in row, key
+                shown += 1
+            else:
+                assert 'class="mscope"' not in row, key
+        assert shown >= 1, "no document has a shortfall; this test is inert"
+
+    def test_the_card_says_why_those_parameters_are_outside_the_denominator(
+        self, tmp_path: Path
+    ) -> None:
+        """The number alone is not the answer: "44 of 220 have no crate slot" states
+        a fact a reader cannot act on without knowing what a crate slot is."""
+        _mit, page = TestMitModuleColours._scored(tmp_path)
+        section = TestMitModuleColours._mit_section(page)
+        lead = " ".join(re.findall(r'<p class="lead">(.*?)</p>', section, re.S))
+        assert "no crate field is mapped to the rest" in lead
+        assert "satisfy or fail" in lead
+
+    def test_a_report_without_the_published_counts_states_no_shortfall(self) -> None:
+        """A session serialised before the counts existed carries none of them, and
+        an absent count is not a shortfall of zero — the row stays as it was."""
+        from builder.state import MITReport
+        from builder.writers.maturity_report import MIT_MODULE_STYLES, _render_mit_section
+
+        known = next(iter(MIT_MODULE_STYLES))
+        report = MITReport(
+            module_scores={known: {"completed": 1, "total": 4}},
+            overall_score=0.25,
+            standard_scores={"oecd_gd211": {"completed": 1, "total": 4}},
+        )
+        assert 'class="mscope"' not in _render_mit_section(report)
 
 
 class TestUnassessedMITIsNotRenderedAsZero:


### PR DESCRIPTION
## What changed

**Each MIT module row and guidance-document row states, in text, what its bar is drawn over.**

```
Analysis and Statistics    ▁▁▁▁▁▁▁▁    0/7
                                       7 of 41 mapped
```

#714 (PRs #753/#762) computed both shortfalls correctly and put them on the bars' `aria-label`. A screen reader got them; nobody looking at the page did — and "Analysis and Statistics 7/7" on the previous build read as the one finished module in the report. The visible clause and the accessible name are now built from the same `published_total_for` / `published_total_for_standard` numbers, so they cannot disagree. Five of six modules and every guidance document but LINCS carry one; a report serialised before those counts existed carries none, because an absent count is not a shortfall of zero.

**The card's lead says why those parameters are outside the denominator** — one sentence: *where a row covers fewer parameters than the checklist defines for it, no crate field is mapped to the rest, so nothing in the crate could satisfy or fail them and they are outside its denominator.* The header's "44 of 220 have no crate slot" was a fact nobody outside this repo could act on.

**The DSM grid's em dash says what it is.** Level 5 / Hosting is cell `P28`, which the model hardcodes over an empty membership — nothing to assess, nothing to divide by. Bare, the dash was indistinguishable from 0%, from "not assessed", and from a column this tool chose to skip.

Deliberately **not** the `dsm-note`: #732 / PR #764 is shrinking that paragraph to one sentence, and my first draft added a clause to it. Reverted — this branch merges clean into #764 (`git merge-tree`, verified).

## How it was tested

TDD. `TestTheMitCardSaysWhatItCouldNotScore` written first and run red (3 of 4 failing; the fourth is the no-published-counts guard, which must pass in both states), then the writer. Both row tests drive off the scorer's own numbers and assert the clause is **absent** where the checklist defines no more — and each carries an inert-test guard, so a checklist with no shortfall anywhere fails the test rather than passing it vacuously.

`test_the_section_carries_one_sentence_of_prose` → `test_the_section_carries_one_lead_and_no_legend`: the lead is two sentences now, and the docstring says why the user's "the bars explain themselves" does not cover it — the bars cannot explain the parameters they are *not* drawn over.

- `VITRO_VALIDATE_SERIAL=1 uv run pytest tests/test_maturity_report.py tests/test_dsm_indicators_source.py tests/test_dsm_sheet_parity.py tests/test_fair_metrics_can_fail.py tests/test_tools_fair_assessment.py tests/test_mit_source.py tests/test_tools_mit_assessment.py` — **371 passed, 3 xfailed**
- `uv run ruff check builder/ tests/` — clean · `uv run ty check builder/ tests/` — clean
- Rendered S-VHPS21 and read the emitted markup, not the source: `<div class="mfrac">0<span class="den">/7</span><span class="mscope">7 of 41 mapped</span></div>`, and `Biological Model Information 4/53` / `LINCS 2/40` carry no clause because 53 and 40 are the published totals.

## One thing this does not fix

Once #764 lands, the DSM grid's Hosting column reads `0% · 0 of 4 assessed` with **no reason inside that section** — #764 deletes the sentence that carried it, on the grounds that the next section's lead already states it (it does, under the `?` legend). That is fine while the two sections are adjacent, and #731 would fold them together. Flagging it rather than adding a competing sentence to a paragraph another PR is deliberately shrinking.

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EVN9SaTmcF2F23VgXWMFf
